### PR TITLE
Fix bundle UI builds in Docker + update Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint & Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -32,7 +32,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -49,7 +49,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -64,7 +64,7 @@ jobs:
     needs: [test-unit, test-integration]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -38,8 +38,8 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: actions/checkout@v6
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
@@ -81,10 +81,10 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,12 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production --ignore-scripts
 
 COPY src/ src/
+
+# Build bundle UIs (dist/ is gitignored, must build in container)
+RUN for ui in src/bundles/*/ui; do \
+      [ -f "$ui/package.json" ] && (cd "$ui" && bun install && bun run build && rm -rf node_modules); \
+    done
+
 RUN chown -R nimblebrain:nimblebrain /app
 
 USER 1000

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "dev:web": "cd web && bun run dev",
     "dev:tui": "bun run src/cli/index.ts -c .nimblebrain/nimblebrain.json",
     "start": "bun run src/cli/index.ts serve",
+    "build:bundles": "for ui in src/bundles/*/ui; do [ -f \"$ui/package.json\" ] && (cd \"$ui\" && bun install && bun run build); done",
     "test:unit": "bun test test/unit/",
     "test:integration": "bun test test/integration/",
     "test": "bun test test/unit/ test/integration/",


### PR DESCRIPTION
## Summary
- Auto-discover and build bundle UIs (`src/bundles/*/ui`) during Docker build — fixes "UI not built" error on deployed instances
- Add `build:bundles` script for local dev parity
- Bump GitHub Actions to latest majors: checkout v6, configure-aws-credentials v6, action-gh-release v3

## Context
Bundle UI `dist/` directories are gitignored. Previously worked locally because `COPY src/ src/` picked up locally-built dist files, but CI/Docker builds from clean checkout had no dist to copy.

## Test plan
- [ ] `bun run build:bundles` builds both home and automations UIs locally
- [ ] Docker build includes bundle UI dist files
- [ ] CI passes with updated action versions
- [ ] Deploy to staging and verify homepage renders correctly