### PR TITLE
Group parallel tool calls into an accordion; fix card width

### DIFF
--- a/web/src/components/FlashCardGroup.tsx
+++ b/web/src/components/FlashCardGroup.tsx
@@ -245,12 +245,7 @@ interface GroupedFlashCardProps {
   uniqueNames: string[];
 }
 
-function GroupedFlashCard({
-  toolCalls,
-  visuals,
-  groupName,
-  uniqueNames,
-}: GroupedFlashCardProps) {
+function GroupedFlashCard({ toolCalls, visuals, groupName, uniqueNames }: GroupedFlashCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const anyRunning = visuals.some((v) => v.status === "running");
@@ -281,9 +276,7 @@ function GroupedFlashCard({
           <span className="text-[13px] text-muted-foreground truncate">
             {label}
             {errorCount > 0 && (
-              <span className="text-destructive ml-1.5 text-[11px]">
-                ({errorCount} failed)
-              </span>
+              <span className="text-destructive ml-1.5 text-[11px]">({errorCount} failed)</span>
             )}
           </span>
           {isMixed && (
@@ -307,12 +300,7 @@ function GroupedFlashCard({
       {expanded && (
         <div className="border-t border-border max-h-64 overflow-y-auto">
           {toolCalls.map((tc, i) => (
-            <GroupedRow
-              key={tc.id}
-              toolCall={tc}
-              visual={visuals[i]}
-              showName={isMixed}
-            />
+            <GroupedRow key={tc.id} toolCall={tc} visual={visuals[i]} showName={isMixed} />
           ))}
         </div>
       )}

--- a/web/src/components/FlashCardGroup.tsx
+++ b/web/src/components/FlashCardGroup.tsx
@@ -1,11 +1,10 @@
 import { Check, ChevronDown, Copy } from "lucide-react";
-import { type MouseEvent, useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import type { ToolCallDisplay } from "../hooks/useChat";
 import type { VisualStatus } from "../hooks/useMinDisplayTime";
 import { useMinDisplayTime } from "../hooks/useMinDisplayTime";
 import { formatDuration, stripServerPrefix } from "../lib/format";
 import { partitionToolCalls } from "../lib/tool-grouping";
-import type { DisplayDetail } from "./ToolCallIndicator";
 
 /** Summarize tool input as a one-line preview (e.g., "query: SELECT * FROM...") */
 function summarizeInput(input: Record<string, unknown>): string | null {
@@ -54,6 +53,62 @@ function cardClass(status: "running" | "done" | "error"): string {
   return "flash-card";
 }
 
+// ─── Shared primitives ────────────────────────────────────────────
+
+/** Copy-to-clipboard state with a 1.5s "copied" flash. */
+function useCopyable(result: unknown): { copied: boolean; handleCopy: () => void } {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    if (result == null) return;
+    navigator.clipboard.writeText(formatResult(result));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }, [result]);
+  return { copied, handleCopy };
+}
+
+/** Expandable result panel shared by both the standalone card and the grouped row. */
+function ToolResultPanel({ result, density }: { result: unknown; density: "card" | "row" }) {
+  const { copied, handleCopy } = useCopyable(result);
+  const containerClass =
+    density === "card" ? "border-t border-border" : "bg-muted/20 border-t border-border/60";
+  const headerPadding = density === "card" ? "px-3 py-1.5" : "px-3 py-1";
+  const preMaxH = density === "card" ? "max-h-48" : "max-h-40";
+  const preBg = density === "card" ? "bg-muted/30" : "";
+  const labelMuted = density === "card" ? "text-muted-foreground" : "text-muted-foreground/70";
+  const innerBorder = density === "card" ? "border-border" : "border-border/60";
+
+  return (
+    <div className={containerClass}>
+      <div className={`flex items-center justify-between ${headerPadding}`}>
+        <span className={`text-[10px] font-semibold ${labelMuted} uppercase tracking-wide`}>
+          Result
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="text-[10px] text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
+        >
+          {copied ? (
+            <>
+              <Check className="w-3 h-3" /> copied
+            </>
+          ) : (
+            <>
+              <Copy className="w-3 h-3" /> copy
+            </>
+          )}
+        </button>
+      </div>
+      <div className={`${preMaxH} w-0 min-w-full overflow-auto border-t ${innerBorder} ${preBg}`}>
+        <pre className="px-3 py-2 text-[11px] leading-relaxed font-mono text-muted-foreground whitespace-pre">
+          {formatResult(result)}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
 // ─── Individual FlashCard ─────────────────────────────────────────
 
 interface FlashCardProps {
@@ -63,21 +118,7 @@ interface FlashCardProps {
 
 function FlashCard({ toolCall, visual }: FlashCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const [copied, setCopied] = useState(false);
   const hasResult = toolCall.result != null;
-
-  const handleCopy = useCallback(
-    (e: MouseEvent) => {
-      e.stopPropagation();
-      if (toolCall.result != null) {
-        navigator.clipboard.writeText(formatResult(toolCall.result));
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      }
-    },
-    [toolCall.result],
-  );
-
   const inputPreview = toolCall.input ? summarizeInput(toolCall.input) : null;
 
   return (
@@ -85,6 +126,7 @@ function FlashCard({ toolCall, visual }: FlashCardProps) {
       <button
         type="button"
         onClick={() => hasResult && setExpanded((prev) => !prev)}
+        aria-expanded={hasResult ? expanded : undefined}
         className={`flex items-center gap-2 w-full text-left px-3 py-2 ${
           hasResult ? "cursor-pointer hover:bg-muted/50 transition-colors" : "cursor-default"
         }`}
@@ -112,35 +154,7 @@ function FlashCard({ toolCall, visual }: FlashCardProps) {
         )}
       </button>
 
-      {expanded && hasResult && (
-        <div className="border-t border-border">
-          <div className="flex items-center justify-between px-3 py-1.5">
-            <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
-              Result
-            </span>
-            <button
-              type="button"
-              onClick={handleCopy}
-              className="text-[10px] text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
-            >
-              {copied ? (
-                <>
-                  <Check className="w-3 h-3" /> copied
-                </>
-              ) : (
-                <>
-                  <Copy className="w-3 h-3" /> copy
-                </>
-              )}
-            </button>
-          </div>
-          <div className="border-t border-border bg-muted/30 max-h-48 w-0 min-w-full overflow-auto">
-            <pre className="px-3 py-2 text-[11px] leading-relaxed font-mono text-muted-foreground whitespace-pre">
-              {formatResult(toolCall.result)}
-            </pre>
-          </div>
-        </div>
-      )}
+      {expanded && hasResult && <ToolResultPanel result={toolCall.result} density="card" />}
     </div>
   );
 }
@@ -155,29 +169,17 @@ interface GroupedRowProps {
 
 function GroupedRow({ toolCall, visual, showName }: GroupedRowProps) {
   const [expanded, setExpanded] = useState(false);
-  const [copied, setCopied] = useState(false);
   const hasResult = toolCall.result != null;
   const inputPreview = toolCall.input ? summarizeInput(toolCall.input) : null;
   const label = inputPreview ?? toolCall.id;
   const name = stripServerPrefix(toolCall.name);
-
-  const handleCopy = useCallback(
-    (e: MouseEvent) => {
-      e.stopPropagation();
-      if (toolCall.result != null) {
-        navigator.clipboard.writeText(formatResult(toolCall.result));
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      }
-    },
-    [toolCall.result],
-  );
 
   return (
     <div className="border-t border-border/60 first:border-t-0">
       <button
         type="button"
         onClick={() => hasResult && setExpanded((prev) => !prev)}
+        aria-expanded={hasResult ? expanded : undefined}
         className={`flex items-center gap-2 w-full text-left px-3 py-1.5 ${
           hasResult ? "cursor-pointer hover:bg-muted/40 transition-colors" : "cursor-default"
         }`}
@@ -203,35 +205,7 @@ function GroupedRow({ toolCall, visual, showName }: GroupedRowProps) {
         )}
       </button>
 
-      {expanded && hasResult && (
-        <div className="bg-muted/20 border-t border-border/60">
-          <div className="flex items-center justify-between px-3 py-1">
-            <span className="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-wide">
-              Result
-            </span>
-            <button
-              type="button"
-              onClick={handleCopy}
-              className="text-[10px] text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
-            >
-              {copied ? (
-                <>
-                  <Check className="w-3 h-3" /> copied
-                </>
-              ) : (
-                <>
-                  <Copy className="w-3 h-3" /> copy
-                </>
-              )}
-            </button>
-          </div>
-          <div className="max-h-40 w-0 min-w-full overflow-auto border-t border-border/60">
-            <pre className="px-3 py-2 text-[11px] leading-relaxed font-mono text-muted-foreground whitespace-pre">
-              {formatResult(toolCall.result)}
-            </pre>
-          </div>
-        </div>
-      )}
+      {expanded && hasResult && <ToolResultPanel result={toolCall.result} density="row" />}
     </div>
   );
 }
@@ -241,11 +215,13 @@ function GroupedRow({ toolCall, visual, showName }: GroupedRowProps) {
 interface GroupedFlashCardProps {
   toolCalls: ToolCallDisplay[];
   visuals: VisualStatus[];
-  groupName: string; // tool name if homogeneous, or "__mixed__"
-  uniqueNames: string[];
+  /** Stripped tool name (homogeneous) or null for a mixed group. */
+  name: string | null;
+  /** Only set for mixed groups — the distinct tool names to show as a subtitle. */
+  uniqueNames: string[] | null;
 }
 
-function GroupedFlashCard({ toolCalls, visuals, groupName, uniqueNames }: GroupedFlashCardProps) {
+function GroupedFlashCard({ toolCalls, visuals, name, uniqueNames }: GroupedFlashCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const anyRunning = visuals.some((v) => v.status === "running");
@@ -259,16 +235,15 @@ function GroupedFlashCard({ toolCalls, visuals, groupName, uniqueNames }: Groupe
       ? "error"
       : "done";
 
-  const isMixed = groupName === "__mixed__";
-  const label = isMixed
-    ? `${count} tool calls`
-    : `${count} ${groupName} call${count !== 1 ? "s" : ""}`;
+  const isMixed = name === null;
+  const label = isMixed ? `${count} tool calls` : `${count} ${name} call${count !== 1 ? "s" : ""}`;
 
   return (
     <div className={cardClass(aggregateStatus)}>
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
         className="flex items-center gap-2 w-full text-left px-3 py-2 cursor-pointer hover:bg-muted/50 transition-colors"
       >
         <div className={dotClass(aggregateStatus)} />
@@ -279,7 +254,7 @@ function GroupedFlashCard({ toolCalls, visuals, groupName, uniqueNames }: Groupe
               <span className="text-destructive ml-1.5 text-[11px]">({errorCount} failed)</span>
             )}
           </span>
-          {isMixed && (
+          {isMixed && uniqueNames && (
             <span className="text-[11px] text-muted-foreground/50 truncate font-mono">
               {uniqueNames.join(", ")}
             </span>
@@ -312,13 +287,12 @@ function GroupedFlashCard({ toolCalls, visuals, groupName, uniqueNames }: Groupe
 
 interface FlashCardGroupProps {
   toolCalls: ToolCallDisplay[];
-  displayDetail: DisplayDetail;
 }
 
-export function FlashCardGroup({ toolCalls, displayDetail }: FlashCardGroupProps) {
+export function FlashCardGroup({ toolCalls }: FlashCardGroupProps) {
   const visualStatuses = useMinDisplayTime(toolCalls);
 
-  if (displayDetail === "quiet" || toolCalls.length === 0) return null;
+  if (toolCalls.length === 0) return null;
 
   const units = partitionToolCalls(toolCalls);
 
@@ -326,19 +300,25 @@ export function FlashCardGroup({ toolCalls, displayDetail }: FlashCardGroupProps
     <div className="flex flex-col gap-2 w-full min-w-0">
       {units.map((unit, idx) => {
         if (unit.kind === "single") {
-          const tc = unit.calls[0];
-          const visual = visualStatuses[unit.indexes[0]];
-          return <FlashCard key={tc.id} toolCall={tc} visual={visual} />;
+          return (
+            <FlashCard
+              key={unit.call.id}
+              toolCall={unit.call}
+              visual={visualStatuses[unit.index]}
+            />
+          );
         }
         const visuals = unit.indexes.map((i) => visualStatuses[i]);
+        const name = unit.kind === "homogeneous" ? unit.name : null;
+        const uniqueNames = unit.kind === "mixed" ? unit.uniqueNames : null;
         return (
           <GroupedFlashCard
             // biome-ignore lint/suspicious/noArrayIndexKey: units are positionally stable within a message block
             key={`group-${idx}-${unit.calls[0].id}`}
             toolCalls={unit.calls}
             visuals={visuals}
-            groupName={unit.groupName!}
-            uniqueNames={unit.uniqueNames ?? []}
+            name={name}
+            uniqueNames={uniqueNames}
           />
         );
       })}

--- a/web/src/components/FlashCardGroup.tsx
+++ b/web/src/components/FlashCardGroup.tsx
@@ -1,16 +1,16 @@
 import { Check, ChevronDown, Copy } from "lucide-react";
-import { useCallback, useState } from "react";
+import { type MouseEvent, useCallback, useState } from "react";
 import type { ToolCallDisplay } from "../hooks/useChat";
 import type { VisualStatus } from "../hooks/useMinDisplayTime";
 import { useMinDisplayTime } from "../hooks/useMinDisplayTime";
 import { formatDuration, stripServerPrefix } from "../lib/format";
+import { partitionToolCalls } from "../lib/tool-grouping";
 import type { DisplayDetail } from "./ToolCallIndicator";
 
 /** Summarize tool input as a one-line preview (e.g., "query: SELECT * FROM...") */
 function summarizeInput(input: Record<string, unknown>): string | null {
   const keys = Object.keys(input);
   if (keys.length === 0) return null;
-  // Pick the most interesting key (prefer content-like keys)
   const priority = [
     "query",
     "source",
@@ -28,7 +28,6 @@ function summarizeInput(input: Record<string, unknown>): string | null {
   if (val == null) return null;
   const str = typeof val === "string" ? val : JSON.stringify(val);
   const preview = str.length > 48 ? `${str.slice(0, 48)}…` : str;
-  // Collapse whitespace for readability
   return `${key}: ${preview.replace(/\s+/g, " ")}`;
 }
 
@@ -55,6 +54,8 @@ function cardClass(status: "running" | "done" | "error"): string {
   return "flash-card";
 }
 
+// ─── Individual FlashCard ─────────────────────────────────────────
+
 interface FlashCardProps {
   toolCall: ToolCallDisplay;
   visual: VisualStatus;
@@ -65,20 +66,22 @@ function FlashCard({ toolCall, visual }: FlashCardProps) {
   const [copied, setCopied] = useState(false);
   const hasResult = toolCall.result != null;
 
-  const handleCopy = useCallback(() => {
-    if (toolCall.result != null) {
-      navigator.clipboard.writeText(formatResult(toolCall.result));
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    }
-  }, [toolCall.result]);
+  const handleCopy = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      if (toolCall.result != null) {
+        navigator.clipboard.writeText(formatResult(toolCall.result));
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }
+    },
+    [toolCall.result],
+  );
 
-  // Build a one-line input preview (e.g., "query: SELECT * FROM...")
   const inputPreview = toolCall.input ? summarizeInput(toolCall.input) : null;
 
   return (
     <div className={cardClass(visual.status)}>
-      {/* Summary row */}
       <button
         type="button"
         onClick={() => hasResult && setExpanded((prev) => !prev)}
@@ -109,7 +112,6 @@ function FlashCard({ toolCall, visual }: FlashCardProps) {
         )}
       </button>
 
-      {/* Expanded result */}
       {expanded && hasResult && (
         <div className="border-t border-border">
           <div className="flex items-center justify-between px-3 py-1.5">
@@ -143,6 +145,183 @@ function FlashCard({ toolCall, visual }: FlashCardProps) {
   );
 }
 
+// ─── Grouped accordion row (inside expanded group) ────────────────
+
+interface GroupedRowProps {
+  toolCall: ToolCallDisplay;
+  visual: VisualStatus;
+  showName: boolean;
+}
+
+function GroupedRow({ toolCall, visual, showName }: GroupedRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const hasResult = toolCall.result != null;
+  const inputPreview = toolCall.input ? summarizeInput(toolCall.input) : null;
+  const label = inputPreview ?? toolCall.id;
+  const name = stripServerPrefix(toolCall.name);
+
+  const handleCopy = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      if (toolCall.result != null) {
+        navigator.clipboard.writeText(formatResult(toolCall.result));
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }
+    },
+    [toolCall.result],
+  );
+
+  return (
+    <div className="border-t border-border/60 first:border-t-0">
+      <button
+        type="button"
+        onClick={() => hasResult && setExpanded((prev) => !prev)}
+        className={`flex items-center gap-2 w-full text-left px-3 py-1.5 ${
+          hasResult ? "cursor-pointer hover:bg-muted/40 transition-colors" : "cursor-default"
+        }`}
+      >
+        <div className={dotClass(visual.status)} style={{ width: 4, height: 4 }} />
+        {showName && (
+          <span className="text-[11px] text-muted-foreground/80 font-mono shrink-0">{name}</span>
+        )}
+        <span className="text-[11px] text-muted-foreground/60 truncate flex-1 font-mono">
+          {label}
+        </span>
+        {visual.ms != null && visual.ms > 0 && (
+          <span className="text-[10px] text-muted-foreground/50 tabular-nums shrink-0">
+            {formatDuration(visual.ms)}
+          </span>
+        )}
+        {hasResult && (
+          <ChevronDown
+            className={`w-3 h-3 text-muted-foreground/40 shrink-0 transition-transform duration-200 ${
+              expanded ? "rotate-180" : ""
+            }`}
+          />
+        )}
+      </button>
+
+      {expanded && hasResult && (
+        <div className="bg-muted/20 border-t border-border/60">
+          <div className="flex items-center justify-between px-3 py-1">
+            <span className="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-wide">
+              Result
+            </span>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="text-[10px] text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3 h-3" /> copied
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3 h-3" /> copy
+                </>
+              )}
+            </button>
+          </div>
+          <div className="max-h-40 w-0 min-w-full overflow-auto border-t border-border/60">
+            <pre className="px-3 py-2 text-[11px] leading-relaxed font-mono text-muted-foreground whitespace-pre">
+              {formatResult(toolCall.result)}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Grouped FlashCard (accordion) ────────────────────────────────
+
+interface GroupedFlashCardProps {
+  toolCalls: ToolCallDisplay[];
+  visuals: VisualStatus[];
+  groupName: string; // tool name if homogeneous, or "__mixed__"
+  uniqueNames: string[];
+}
+
+function GroupedFlashCard({
+  toolCalls,
+  visuals,
+  groupName,
+  uniqueNames,
+}: GroupedFlashCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const anyRunning = visuals.some((v) => v.status === "running");
+  const errorCount = toolCalls.filter((tc) => tc.status === "error").length;
+  const totalMs = toolCalls.reduce((sum, tc) => sum + (tc.ms ?? 0), 0);
+  const count = toolCalls.length;
+
+  const aggregateStatus: "running" | "done" | "error" = anyRunning
+    ? "running"
+    : errorCount > 0
+      ? "error"
+      : "done";
+
+  const isMixed = groupName === "__mixed__";
+  const label = isMixed
+    ? `${count} tool calls`
+    : `${count} ${groupName} call${count !== 1 ? "s" : ""}`;
+
+  return (
+    <div className={cardClass(aggregateStatus)}>
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex items-center gap-2 w-full text-left px-3 py-2 cursor-pointer hover:bg-muted/50 transition-colors"
+      >
+        <div className={dotClass(aggregateStatus)} />
+        <div className="flex flex-col flex-1 min-w-0">
+          <span className="text-[13px] text-muted-foreground truncate">
+            {label}
+            {errorCount > 0 && (
+              <span className="text-destructive ml-1.5 text-[11px]">
+                ({errorCount} failed)
+              </span>
+            )}
+          </span>
+          {isMixed && (
+            <span className="text-[11px] text-muted-foreground/50 truncate font-mono">
+              {uniqueNames.join(", ")}
+            </span>
+          )}
+        </div>
+        {!anyRunning && totalMs > 0 && (
+          <span className="text-[11px] text-muted-foreground/60 tabular-nums shrink-0">
+            {formatDuration(totalMs)}
+          </span>
+        )}
+        <ChevronDown
+          className={`w-3.5 h-3.5 text-muted-foreground/60 shrink-0 transition-transform duration-200 ${
+            expanded ? "rotate-180" : ""
+          }`}
+        />
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border max-h-64 overflow-y-auto">
+          {toolCalls.map((tc, i) => (
+            <GroupedRow
+              key={tc.id}
+              toolCall={tc}
+              visual={visuals[i]}
+              showName={isMixed}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main export ──────────────────────────────────────────────────
+
 interface FlashCardGroupProps {
   toolCalls: ToolCallDisplay[];
   displayDetail: DisplayDetail;
@@ -153,11 +332,28 @@ export function FlashCardGroup({ toolCalls, displayDetail }: FlashCardGroupProps
 
   if (displayDetail === "quiet" || toolCalls.length === 0) return null;
 
+  const units = partitionToolCalls(toolCalls);
+
   return (
-    <div className="flex flex-col gap-2">
-      {toolCalls.map((tc, i) => (
-        <FlashCard key={tc.id} toolCall={tc} visual={visualStatuses[i]} />
-      ))}
+    <div className="flex flex-col gap-2 w-full min-w-0">
+      {units.map((unit, idx) => {
+        if (unit.kind === "single") {
+          const tc = unit.calls[0];
+          const visual = visualStatuses[unit.indexes[0]];
+          return <FlashCard key={tc.id} toolCall={tc} visual={visual} />;
+        }
+        const visuals = unit.indexes.map((i) => visualStatuses[i]);
+        return (
+          <GroupedFlashCard
+            // biome-ignore lint/suspicious/noArrayIndexKey: units are positionally stable within a message block
+            key={`group-${idx}-${unit.calls[0].id}`}
+            toolCalls={unit.calls}
+            visuals={visuals}
+            groupName={unit.groupName!}
+            uniqueNames={unit.uniqueNames ?? []}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -319,10 +319,9 @@ export function MessageList({
                           return (
                             // biome-ignore lint/suspicious/noArrayIndexKey: blocks are append-only and don't reorder
                             <div key={blockIdx} className="flex flex-col gap-3">
-                              <FlashCardGroup
-                                toolCalls={block.toolCalls}
-                                displayDetail={displayDetail}
-                              />
+                              {displayDetail !== "quiet" && (
+                                <FlashCardGroup toolCalls={block.toolCalls} />
+                              )}
                               {blockWidgets.map((tc) => {
                                 const match = tc.resourceUri!.match(/^ui:\/\/[^/]+\/(.+)$/);
                                 const resourcePath = match ? match[1] : "primary";

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -413,6 +413,7 @@
   border-radius: var(--radius-lg);
   background: var(--card);
   overflow: hidden;
+  width: 100%;
   max-width: 100%;
   transition: border-color 200ms, background-color 200ms;
 }

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -4,9 +4,10 @@ export function stripServerPrefix(name: string): string {
   return idx === -1 ? name : name.slice(idx + 2);
 }
 
-/** Format duration: <1000ms → "340ms", >=1000ms → "1.2s" */
+/** Format duration: <0.5ms → "<1ms", <1000ms → "340ms", >=1000ms → "1.2s" */
 export function formatDuration(ms: number): string {
   const rounded = Math.round(ms);
+  if (rounded === 0 && ms > 0) return "<1ms";
   if (rounded < 1000) return `${rounded}ms`;
   return `${(rounded / 1000).toFixed(1)}s`;
 }

--- a/web/src/lib/tool-grouping.ts
+++ b/web/src/lib/tool-grouping.ts
@@ -1,0 +1,99 @@
+import type { ToolCallDisplay } from "../hooks/useChat";
+import { stripServerPrefix } from "./format";
+
+export const GROUP_THRESHOLD = 3;
+
+export interface RenderUnit {
+  kind: "single" | "group";
+  calls: ToolCallDisplay[];
+  /** Indexes into the original toolCalls array (for visual-status lookup). */
+  indexes: number[];
+  /** Tool name for homogeneous groups, "__mixed__" for mixed groups. Unset for singles. */
+  groupName?: string;
+  /** Distinct tool names present in the group. Unset for singles. */
+  uniqueNames?: string[];
+}
+
+/**
+ * Partition a batch of tool calls into render units.
+ *
+ * Rules:
+ * 1. Scan left-to-right for runs of consecutive same-name calls.
+ *    A run of length >= GROUP_THRESHOLD becomes a homogeneous group.
+ * 2. After that pass, any remaining contiguous stretch of singles of length
+ *    >= GROUP_THRESHOLD is coalesced into a single mixed group (so e.g. six
+ *    alternating tool names collapse into one "6 tool calls" card instead of
+ *    leaking six individual cards into the message stream).
+ * 3. Everything else stays as individual singles.
+ *
+ * Order is preserved. Each original tool call appears exactly once across the
+ * returned units.
+ */
+export function partitionToolCalls(toolCalls: ToolCallDisplay[]): RenderUnit[] {
+  if (toolCalls.length === 0) return [];
+
+  // Pass 1: detect homogeneous runs.
+  const units: RenderUnit[] = [];
+  const n = toolCalls.length;
+  let i = 0;
+
+  while (i < n) {
+    const currentName = stripServerPrefix(toolCalls[i].name);
+    let runEnd = i + 1;
+    while (
+      runEnd < n &&
+      stripServerPrefix(toolCalls[runEnd].name) === currentName
+    ) {
+      runEnd++;
+    }
+    const runLength = runEnd - i;
+
+    if (runLength >= GROUP_THRESHOLD) {
+      units.push({
+        kind: "group",
+        calls: toolCalls.slice(i, runEnd),
+        indexes: Array.from({ length: runLength }, (_, k) => i + k),
+        groupName: currentName,
+        uniqueNames: [currentName],
+      });
+    } else {
+      for (let k = i; k < runEnd; k++) {
+        units.push({ kind: "single", calls: [toolCalls[k]], indexes: [k] });
+      }
+    }
+    i = runEnd;
+  }
+
+  // Pass 2: coalesce runs of singles into mixed groups.
+  const coalesced: RenderUnit[] = [];
+  let j = 0;
+  while (j < units.length) {
+    if (units[j].kind === "single") {
+      let k = j;
+      while (k < units.length && units[k].kind === "single") k++;
+      const singleCount = k - j;
+      if (singleCount >= GROUP_THRESHOLD) {
+        const groupCalls = units.slice(j, k).flatMap((u) => u.calls);
+        const groupIdx = units.slice(j, k).flatMap((u) => u.indexes);
+        const names = [
+          ...new Set(groupCalls.map((c) => stripServerPrefix(c.name))),
+        ];
+        coalesced.push({
+          kind: "group",
+          calls: groupCalls,
+          indexes: groupIdx,
+          groupName: "__mixed__",
+          uniqueNames: names,
+        });
+      } else {
+        for (let m = j; m < k; m++) coalesced.push(units[m]);
+      }
+      j = k;
+    } else {
+      coalesced.push(units[j]);
+      j++;
+    }
+  }
+
+  return coalesced;
+}

--- a/web/src/lib/tool-grouping.ts
+++ b/web/src/lib/tool-grouping.ts
@@ -3,16 +3,23 @@ import { stripServerPrefix } from "./format";
 
 export const GROUP_THRESHOLD = 3;
 
-export interface RenderUnit {
-  kind: "single" | "group";
-  calls: ToolCallDisplay[];
-  /** Indexes into the original toolCalls array (for visual-status lookup). */
-  indexes: number[];
-  /** Tool name for homogeneous groups, "__mixed__" for mixed groups. Unset for singles. */
-  groupName?: string;
-  /** Distinct tool names present in the group. Unset for singles. */
-  uniqueNames?: string[];
-}
+/** A contiguous slice of tool calls that renders as one unit in the chat. */
+export type RenderUnit =
+  | { kind: "single"; call: ToolCallDisplay; index: number }
+  | {
+      kind: "homogeneous";
+      calls: ToolCallDisplay[];
+      indexes: number[];
+      /** Stripped tool name, shared by every call in the group. */
+      name: string;
+    }
+  | {
+      kind: "mixed";
+      calls: ToolCallDisplay[];
+      indexes: number[];
+      /** Distinct stripped tool names present in the group, in first-seen order. */
+      uniqueNames: string[];
+    };
 
 /**
  * Partition a batch of tool calls into render units.
@@ -32,8 +39,8 @@ export interface RenderUnit {
 export function partitionToolCalls(toolCalls: ToolCallDisplay[]): RenderUnit[] {
   if (toolCalls.length === 0) return [];
 
-  // Pass 1: detect homogeneous runs.
-  const units: RenderUnit[] = [];
+  // Pass 1: detect homogeneous runs, emit singles for anything below threshold.
+  const pass1: RenderUnit[] = [];
   const n = toolCalls.length;
   let i = 0;
 
@@ -46,49 +53,44 @@ export function partitionToolCalls(toolCalls: ToolCallDisplay[]): RenderUnit[] {
     const runLength = runEnd - i;
 
     if (runLength >= GROUP_THRESHOLD) {
-      units.push({
-        kind: "group",
+      pass1.push({
+        kind: "homogeneous",
         calls: toolCalls.slice(i, runEnd),
         indexes: Array.from({ length: runLength }, (_, k) => i + k),
-        groupName: currentName,
-        uniqueNames: [currentName],
+        name: currentName,
       });
     } else {
       for (let k = i; k < runEnd; k++) {
-        units.push({ kind: "single", calls: [toolCalls[k]], indexes: [k] });
+        pass1.push({ kind: "single", call: toolCalls[k], index: k });
       }
     }
     i = runEnd;
   }
 
   // Pass 2: coalesce runs of singles into mixed groups.
-  const coalesced: RenderUnit[] = [];
+  const out: RenderUnit[] = [];
   let j = 0;
-  while (j < units.length) {
-    if (units[j].kind === "single") {
-      let k = j;
-      while (k < units.length && units[k].kind === "single") k++;
-      const singleCount = k - j;
-      if (singleCount >= GROUP_THRESHOLD) {
-        const groupCalls = units.slice(j, k).flatMap((u) => u.calls);
-        const groupIdx = units.slice(j, k).flatMap((u) => u.indexes);
-        const names = [...new Set(groupCalls.map((c) => stripServerPrefix(c.name)))];
-        coalesced.push({
-          kind: "group",
-          calls: groupCalls,
-          indexes: groupIdx,
-          groupName: "__mixed__",
-          uniqueNames: names,
-        });
-      } else {
-        for (let m = j; m < k; m++) coalesced.push(units[m]);
-      }
-      j = k;
-    } else {
-      coalesced.push(units[j]);
+  while (j < pass1.length) {
+    if (pass1[j].kind !== "single") {
+      out.push(pass1[j]);
       j++;
+      continue;
     }
+
+    let k = j;
+    while (k < pass1.length && pass1[k].kind === "single") k++;
+    const runSingles = pass1.slice(j, k) as Extract<RenderUnit, { kind: "single" }>[];
+
+    if (runSingles.length >= GROUP_THRESHOLD) {
+      const calls = runSingles.map((u) => u.call);
+      const indexes = runSingles.map((u) => u.index);
+      const uniqueNames = [...new Set(calls.map((c) => stripServerPrefix(c.name)))];
+      out.push({ kind: "mixed", calls, indexes, uniqueNames });
+    } else {
+      out.push(...runSingles);
+    }
+    j = k;
   }
 
-  return coalesced;
+  return out;
 }

--- a/web/src/lib/tool-grouping.ts
+++ b/web/src/lib/tool-grouping.ts
@@ -40,10 +40,7 @@ export function partitionToolCalls(toolCalls: ToolCallDisplay[]): RenderUnit[] {
   while (i < n) {
     const currentName = stripServerPrefix(toolCalls[i].name);
     let runEnd = i + 1;
-    while (
-      runEnd < n &&
-      stripServerPrefix(toolCalls[runEnd].name) === currentName
-    ) {
+    while (runEnd < n && stripServerPrefix(toolCalls[runEnd].name) === currentName) {
       runEnd++;
     }
     const runLength = runEnd - i;
@@ -75,9 +72,7 @@ export function partitionToolCalls(toolCalls: ToolCallDisplay[]): RenderUnit[] {
       if (singleCount >= GROUP_THRESHOLD) {
         const groupCalls = units.slice(j, k).flatMap((u) => u.calls);
         const groupIdx = units.slice(j, k).flatMap((u) => u.indexes);
-        const names = [
-          ...new Set(groupCalls.map((c) => stripServerPrefix(c.name))),
-        ];
+        const names = [...new Set(groupCalls.map((c) => stripServerPrefix(c.name)))];
         coalesced.push({
           kind: "group",
           calls: groupCalls,

--- a/web/test/format.test.ts
+++ b/web/test/format.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { formatDuration, stripServerPrefix } from "../src/lib/format";
+
+describe("formatDuration", () => {
+  it("renders <1ms for sub-millisecond values that round to 0", () => {
+    expect(formatDuration(0.1)).toBe("<1ms");
+    expect(formatDuration(0.4)).toBe("<1ms");
+    expect(formatDuration(0.499)).toBe("<1ms");
+  });
+
+  it("rounds normally for values >= 0.5ms", () => {
+    expect(formatDuration(0.5)).toBe("1ms");
+    expect(formatDuration(0.9)).toBe("1ms");
+    expect(formatDuration(1)).toBe("1ms");
+    expect(formatDuration(42.3)).toBe("42ms");
+  });
+
+  it("renders exactly 0ms (not <1ms) for a true zero", () => {
+    // Engine uses ms: 0 as an explicit error/fallback sentinel. We must not
+    // misrepresent that as <1ms.
+    expect(formatDuration(0)).toBe("0ms");
+  });
+
+  it("renders milliseconds under 1 second", () => {
+    expect(formatDuration(340)).toBe("340ms");
+    expect(formatDuration(999)).toBe("999ms");
+    expect(formatDuration(999.4)).toBe("999ms");
+  });
+
+  it("switches to seconds at 1000ms with one decimal", () => {
+    expect(formatDuration(1000)).toBe("1.0s");
+    expect(formatDuration(1500)).toBe("1.5s");
+    expect(formatDuration(12345)).toBe("12.3s");
+  });
+});
+
+describe("stripServerPrefix", () => {
+  it("leaves tool names without a prefix untouched", () => {
+    expect(stripServerPrefix("read")).toBe("read");
+    expect(stripServerPrefix("manage_skill")).toBe("manage_skill");
+  });
+
+  it("strips the first __-separated prefix", () => {
+    expect(stripServerPrefix("docs__read")).toBe("read");
+    expect(stripServerPrefix("server__manage_skill")).toBe("manage_skill");
+  });
+
+  it("only strips the first __ boundary (preserves the rest)", () => {
+    expect(stripServerPrefix("a__b__c")).toBe("b__c");
+  });
+});

--- a/web/test/tool-grouping.test.ts
+++ b/web/test/tool-grouping.test.ts
@@ -16,7 +16,10 @@ describe("partitionToolCalls", () => {
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(1);
     expect(units[0].kind).toBe("single");
-    expect(units[0].indexes).toEqual([0]);
+    if (units[0].kind === "single") {
+      expect(units[0].index).toBe(0);
+      expect(units[0].call).toBe(calls[0]);
+    }
   });
 
   it("keeps two calls as two singles (below threshold)", () => {
@@ -26,39 +29,46 @@ describe("partitionToolCalls", () => {
     expect(units.every((u) => u.kind === "single")).toBe(true);
   });
 
-  it("groups 3+ consecutive same-named calls into a homogeneous group", () => {
+  it("groups 3+ consecutive same-named calls into a homogeneous unit", () => {
     const calls = [tc("read", "a"), tc("read", "b"), tc("read", "c")];
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(1);
-    expect(units[0].kind).toBe("group");
-    expect(units[0].groupName).toBe("read");
-    expect(units[0].uniqueNames).toEqual(["read"]);
-    expect(units[0].calls.map((c) => c.id)).toEqual(["a", "b", "c"]);
-    expect(units[0].indexes).toEqual([0, 1, 2]);
+    expect(units[0].kind).toBe("homogeneous");
+    if (units[0].kind === "homogeneous") {
+      expect(units[0].name).toBe("read");
+      expect(units[0].calls.map((c) => c.id)).toEqual(["a", "b", "c"]);
+      expect(units[0].indexes).toEqual([0, 1, 2]);
+    }
   });
 
   it("strips server prefixes when matching names", () => {
     const calls = [tc("docs__read"), tc("other__read"), tc("read")];
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(1);
-    expect(units[0].kind).toBe("group");
-    expect(units[0].groupName).toBe("read");
+    expect(units[0].kind).toBe("homogeneous");
+    if (units[0].kind === "homogeneous") {
+      expect(units[0].name).toBe("read");
+    }
   });
 
-  it("coalesces 3+ mixed singles into a mixed group", () => {
+  it("coalesces 3+ mixed singles into a mixed unit", () => {
     const calls = [tc("status"), tc("search"), tc("list")];
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(1);
-    expect(units[0].kind).toBe("group");
-    expect(units[0].groupName).toBe("__mixed__");
-    expect(units[0].uniqueNames).toEqual(["status", "search", "list"]);
+    expect(units[0].kind).toBe("mixed");
+    if (units[0].kind === "mixed") {
+      expect(units[0].uniqueNames).toEqual(["status", "search", "list"]);
+    }
   });
 
-  it("dedupes uniqueNames in a mixed group", () => {
+  it("dedupes uniqueNames in a mixed unit", () => {
     const calls = [tc("status"), tc("search"), tc("status")];
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(1);
-    expect(units[0].uniqueNames).toEqual(["status", "search"]);
+    expect(units[0].kind).toBe("mixed");
+    if (units[0].kind === "mixed") {
+      expect(units[0].uniqueNames).toEqual(["status", "search"]);
+    }
   });
 
   it("does not coalesce 2 mixed singles", () => {
@@ -69,29 +79,31 @@ describe("partitionToolCalls", () => {
   });
 
   it("keeps homogeneous groups separate from adjacent singles", () => {
-    // [status, read×3] → single status, group of 3 reads
+    // [status, read×3] → single status, homogeneous read×3
     const calls = [tc("status"), tc("read"), tc("read"), tc("read")];
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(2);
     expect(units[0].kind).toBe("single");
-    expect(units[0].calls[0].name).toBe("status");
-    expect(units[1].kind).toBe("group");
-    expect(units[1].groupName).toBe("read");
-    expect(units[1].calls).toHaveLength(3);
+    if (units[0].kind === "single") expect(units[0].call.name).toBe("status");
+    expect(units[1].kind).toBe("homogeneous");
+    if (units[1].kind === "homogeneous") {
+      expect(units[1].name).toBe("read");
+      expect(units[1].calls).toHaveLength(3);
+    }
   });
 
   it("keeps group-then-single order and indexing", () => {
-    // [read×3, status] → group of 3 reads, single status
+    // [read×3, status] → homogeneous read×3, single status
     const calls = [tc("read"), tc("read"), tc("read"), tc("status")];
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(2);
-    expect(units[0].kind).toBe("group");
-    expect(units[0].indexes).toEqual([0, 1, 2]);
+    expect(units[0].kind).toBe("homogeneous");
+    if (units[0].kind === "homogeneous") expect(units[0].indexes).toEqual([0, 1, 2]);
     expect(units[1].kind).toBe("single");
-    expect(units[1].indexes).toEqual([3]);
+    if (units[1].kind === "single") expect(units[1].index).toBe(3);
   });
 
-  it("emits two homogeneous groups when two 3+ runs are adjacent", () => {
+  it("emits two homogeneous units when two 3+ runs are adjacent", () => {
     const calls = [
       tc("read"),
       tc("read"),
@@ -102,14 +114,20 @@ describe("partitionToolCalls", () => {
     ];
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(2);
-    expect(units[0].groupName).toBe("read");
-    expect(units[0].calls).toHaveLength(3);
-    expect(units[1].groupName).toBe("search");
-    expect(units[1].calls).toHaveLength(3);
+    expect(units[0].kind).toBe("homogeneous");
+    if (units[0].kind === "homogeneous") {
+      expect(units[0].name).toBe("read");
+      expect(units[0].calls).toHaveLength(3);
+    }
+    expect(units[1].kind).toBe("homogeneous");
+    if (units[1].kind === "homogeneous") {
+      expect(units[1].name).toBe("search");
+      expect(units[1].calls).toHaveLength(3);
+    }
   });
 
   it("coalesces singletons that wrap around homogeneous groups", () => {
-    // [a, b, read×3, c, d, e] → 2 singles (below threshold), group, mixed group of 3
+    // [a, b, read×3, c, d, e] → 2 singles (below threshold), homogeneous, mixed of 3
     const calls = [
       tc("a"),
       tc("b"),
@@ -124,11 +142,12 @@ describe("partitionToolCalls", () => {
     expect(units).toHaveLength(4);
     expect(units[0].kind).toBe("single");
     expect(units[1].kind).toBe("single");
-    expect(units[2].kind).toBe("group");
-    expect(units[2].groupName).toBe("read");
-    expect(units[3].kind).toBe("group");
-    expect(units[3].groupName).toBe("__mixed__");
-    expect(units[3].uniqueNames).toEqual(["c", "d", "e"]);
+    expect(units[2].kind).toBe("homogeneous");
+    if (units[2].kind === "homogeneous") expect(units[2].name).toBe("read");
+    expect(units[3].kind).toBe("mixed");
+    if (units[3].kind === "mixed") {
+      expect(units[3].uniqueNames).toEqual(["c", "d", "e"]);
+    }
   });
 
   it("preserves every call exactly once across units", () => {
@@ -143,18 +162,33 @@ describe("partitionToolCalls", () => {
       tc("manage", "m1"),
     ];
     const units = partitionToolCalls(calls);
-    const seenIds = units.flatMap((u) => u.calls.map((c) => c.id));
+    const seenIds = units.flatMap((u) =>
+      u.kind === "single" ? [u.call.id] : u.calls.map((c) => c.id),
+    );
     expect(seenIds).toEqual(["s1", "s2", "s3", "r1", "r2", "r3", "r4", "m1"]);
-    const seenIdx = units.flatMap((u) => u.indexes);
+    const seenIdx = units.flatMap((u) =>
+      u.kind === "single" ? [u.index] : u.indexes,
+    );
     expect(seenIdx).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
   });
 
   it("handles a pure mixed-group scenario with more than threshold", () => {
-    // All different names, 5 total → one mixed group of 5
+    // All different names, 5 total → one mixed unit of 5
     const calls = [tc("a"), tc("b"), tc("c"), tc("d"), tc("e")];
     const units = partitionToolCalls(calls);
     expect(units).toHaveLength(1);
-    expect(units[0].groupName).toBe("__mixed__");
-    expect(units[0].calls).toHaveLength(5);
+    expect(units[0].kind).toBe("mixed");
+    if (units[0].kind === "mixed") expect(units[0].calls).toHaveLength(5);
+  });
+
+  it("treats a tool literally named 'mixed' as a normal tool, not a magic sentinel", () => {
+    // Regression guard: pre-discriminator code used "__mixed__" as a groupName
+    // sentinel on the group record. The discriminator replaces it so no tool
+    // name can ever collide with the mixed-group marker.
+    const calls = [tc("mixed"), tc("mixed"), tc("mixed")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(1);
+    expect(units[0].kind).toBe("homogeneous");
+    if (units[0].kind === "homogeneous") expect(units[0].name).toBe("mixed");
   });
 });

--- a/web/test/tool-grouping.test.ts
+++ b/web/test/tool-grouping.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "bun:test";
+import type { ToolCallDisplay } from "../src/hooks/useChat";
+import { partitionToolCalls } from "../src/lib/tool-grouping";
+
+function tc(name: string, id = `id-${Math.random()}`): ToolCallDisplay {
+  return { id, name, status: "done" };
+}
+
+describe("partitionToolCalls", () => {
+  it("returns an empty array for no calls", () => {
+    expect(partitionToolCalls([])).toEqual([]);
+  });
+
+  it("keeps a single call as a single", () => {
+    const calls = [tc("read")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(1);
+    expect(units[0].kind).toBe("single");
+    expect(units[0].indexes).toEqual([0]);
+  });
+
+  it("keeps two calls as two singles (below threshold)", () => {
+    const calls = [tc("read"), tc("read")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(2);
+    expect(units.every((u) => u.kind === "single")).toBe(true);
+  });
+
+  it("groups 3+ consecutive same-named calls into a homogeneous group", () => {
+    const calls = [tc("read", "a"), tc("read", "b"), tc("read", "c")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(1);
+    expect(units[0].kind).toBe("group");
+    expect(units[0].groupName).toBe("read");
+    expect(units[0].uniqueNames).toEqual(["read"]);
+    expect(units[0].calls.map((c) => c.id)).toEqual(["a", "b", "c"]);
+    expect(units[0].indexes).toEqual([0, 1, 2]);
+  });
+
+  it("strips server prefixes when matching names", () => {
+    const calls = [tc("docs__read"), tc("other__read"), tc("read")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(1);
+    expect(units[0].kind).toBe("group");
+    expect(units[0].groupName).toBe("read");
+  });
+
+  it("coalesces 3+ mixed singles into a mixed group", () => {
+    const calls = [tc("status"), tc("search"), tc("list")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(1);
+    expect(units[0].kind).toBe("group");
+    expect(units[0].groupName).toBe("__mixed__");
+    expect(units[0].uniqueNames).toEqual(["status", "search", "list"]);
+  });
+
+  it("dedupes uniqueNames in a mixed group", () => {
+    const calls = [tc("status"), tc("search"), tc("status")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(1);
+    expect(units[0].uniqueNames).toEqual(["status", "search"]);
+  });
+
+  it("does not coalesce 2 mixed singles", () => {
+    const calls = [tc("status"), tc("search")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(2);
+    expect(units.every((u) => u.kind === "single")).toBe(true);
+  });
+
+  it("keeps homogeneous groups separate from adjacent singles", () => {
+    // [status, read×3] → single status, group of 3 reads
+    const calls = [tc("status"), tc("read"), tc("read"), tc("read")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(2);
+    expect(units[0].kind).toBe("single");
+    expect(units[0].calls[0].name).toBe("status");
+    expect(units[1].kind).toBe("group");
+    expect(units[1].groupName).toBe("read");
+    expect(units[1].calls).toHaveLength(3);
+  });
+
+  it("keeps group-then-single order and indexing", () => {
+    // [read×3, status] → group of 3 reads, single status
+    const calls = [tc("read"), tc("read"), tc("read"), tc("status")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(2);
+    expect(units[0].kind).toBe("group");
+    expect(units[0].indexes).toEqual([0, 1, 2]);
+    expect(units[1].kind).toBe("single");
+    expect(units[1].indexes).toEqual([3]);
+  });
+
+  it("emits two homogeneous groups when two 3+ runs are adjacent", () => {
+    const calls = [
+      tc("read"),
+      tc("read"),
+      tc("read"),
+      tc("search"),
+      tc("search"),
+      tc("search"),
+    ];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(2);
+    expect(units[0].groupName).toBe("read");
+    expect(units[0].calls).toHaveLength(3);
+    expect(units[1].groupName).toBe("search");
+    expect(units[1].calls).toHaveLength(3);
+  });
+
+  it("coalesces singletons that wrap around homogeneous groups", () => {
+    // [a, b, read×3, c, d, e] → 2 singles (below threshold), group, mixed group of 3
+    const calls = [
+      tc("a"),
+      tc("b"),
+      tc("read"),
+      tc("read"),
+      tc("read"),
+      tc("c"),
+      tc("d"),
+      tc("e"),
+    ];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(4);
+    expect(units[0].kind).toBe("single");
+    expect(units[1].kind).toBe("single");
+    expect(units[2].kind).toBe("group");
+    expect(units[2].groupName).toBe("read");
+    expect(units[3].kind).toBe("group");
+    expect(units[3].groupName).toBe("__mixed__");
+    expect(units[3].uniqueNames).toEqual(["c", "d", "e"]);
+  });
+
+  it("preserves every call exactly once across units", () => {
+    const calls = [
+      tc("status", "s1"),
+      tc("search", "s2"),
+      tc("search", "s3"),
+      tc("read", "r1"),
+      tc("read", "r2"),
+      tc("read", "r3"),
+      tc("read", "r4"),
+      tc("manage", "m1"),
+    ];
+    const units = partitionToolCalls(calls);
+    const seenIds = units.flatMap((u) => u.calls.map((c) => c.id));
+    expect(seenIds).toEqual(["s1", "s2", "s3", "r1", "r2", "r3", "r4", "m1"]);
+    const seenIdx = units.flatMap((u) => u.indexes);
+    expect(seenIdx).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("handles a pure mixed-group scenario with more than threshold", () => {
+    // All different names, 5 total → one mixed group of 5
+    const calls = [tc("a"), tc("b"), tc("c"), tc("d"), tc("e")];
+    const units = partitionToolCalls(calls);
+    expect(units).toHaveLength(1);
+    expect(units[0].groupName).toBe("__mixed__");
+    expect(units[0].calls).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary

- Parallel tool calls now collapse into a single accordion card instead of stacking as a wall of individual cards. Runs of 3+ same-named calls become a homogeneous group (e.g. `● 10 read calls · 62ms`); runs of 3+ heterogeneous calls become a mixed group; singles and pairs keep the existing FlashCard look.
- Fix a width regression where short-content cards (like `search 0ms`) shrank to their content instead of filling the column. Root cause: `.flash-card` had `max-width:100%` but no `width:100%`, so when the surrounding flex chain imposed `min-w-0`/`overflow-hidden` the default cross-axis stretch collapsed.
- Show `<1ms` instead of `0ms` for sub-millisecond durations that round to zero. A real `ms: 0` from the engine error path still renders as `0ms`.
- Cleanup pass (QA follow-ups, same PR):
  - `RenderUnit` is a proper discriminated union (`single | homogeneous | mixed`); the `"__mixed__"` sentinel is gone, along with the non-null assertions it required.
  - `FlashCardGroup` dropped its `displayDetail` prop; the caller (`MessageList`) now gates with a single `displayDetail !== "quiet"` check at the one call site.
  - Extracted shared `useCopyable` hook and `ToolResultPanel` component so `FlashCard` and `GroupedRow` no longer duplicate copy/result-panel logic (`density: "card" | "row"` drives the style variations).
  - `aria-expanded` on every expand button (improves on the pre-existing pattern).
  - Removed dead `e.stopPropagation()` on the copy buttons (they're siblings of the expand buttons, not nested).

The accordion is collapsed by default; the summary dot still pulses while any call is running so aggregate progress remains visible.

## Before / After

Before: ten parallel reads produced ten cards ≈ 600px of scroll. After: one accordion card ≈ 44px, expandable to mini-rows with click-to-expand result JSON per row.

## Test plan

- [x] `bun test` in `web/` — 61/61 pass (23 new tests across `partitionToolCalls` including a regression guard that a tool literally named `mixed` still groups correctly, plus `formatDuration` and `stripServerPrefix`)
- [x] `bunx tsc --noEmit` in `web/` — clean
- [x] `bun run format:check` — clean
- [x] `bun run build` in `web/` — clean
- [ ] Manual: verify grouping kicks in for a 10-read batch, single/pair batches still render as FlashCards, mixed heading lists unique tool names, collapsed cards pulse while running
- [ ] Manual: verify a standalone short-content card (e.g. a fast `search`) now fills the column width

## Notes

- Ships behind no flag — straightforward replacement in the existing `verbose` display path. `ToolCallIndicator` (balanced mode) is untouched.
- Grouping threshold is `GROUP_THRESHOLD = 3` in `web/src/lib/tool-grouping.ts` and can be tuned later.