### PR TITLE
Scope bundle instances and placements by workspace ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+### Security
+
+- **Scope bundle instances and placements by workspace.** When two workspaces had the same bundle installed, `Runtime.getBundleInstancesForWorkspace` returned instances from both (filtering only by `serverName`), causing briefing facets and the apps list to read entity data from other workspaces. `PlacementRegistry.unregister` was also global-per-serverName, so re-seeding in a second workspace silently wiped the first workspace's nav entries. Both paths are now workspace-scoped.
+
+### Breaking (internal API)
+
+Downstream forks or consumers that extend `BundleLifecycleManager` will need to update callsites:
+
+- `installNamed(name, registry, env?)` → `installNamed(name, registry, wsId, env?)`
+- `installLocal(bundlePath, registry, env?)` → `installLocal(bundlePath, registry, wsId, env?)`
+- `installRemote(url, serverName, registry, transportConfig?, ui?, trustScore?)` → `installRemote(url, serverName, registry, wsId, transportConfig?, ui?, trustScore?)`
+- `uninstall(nameOrPath, registry)` → `uninstall(nameOrPath, registry, wsId)`
+- `startBundle(serverName, registry)` → `startBundle(serverName, wsId, registry)`
+- `stopBundle(serverName, registry)` → `stopBundle(serverName, wsId, registry)`
+- `recordCrash(serverName)` / `recordRecovery(serverName)` / `recordDead(serverName)` each gain a required `wsId` second argument.
+- `BundleInstance.wsId` is now required (was optional). Every instance belongs to exactly one workspace; global/platform sources are represented as `InlineSource`, not `BundleInstance`.
+- `PlacementRegistry.unregister(serverName, wsId?)` now scopes to `(serverName, wsId)` only. Passing no `wsId` removes only global entries; passing a specific `wsId` leaves other workspaces untouched.
+
+### Migration
+
+`installNamed` previously wrote bundle subprocess data to `{workDir}/data/{bundle}`. It now writes to `{workDir}/workspaces/{wsId}/data/{bundle}`, matching `seedInstance`. Self-hosted deployments that installed bundles via the runtime install path (rather than the startup seed path) should move existing data directories to the workspace-scoped layout or accept that old data is orphaned.
+
+### Other
+
 - Auto-build bundle UIs during Docker image build and local `dev`.
 - Update GitHub Actions workflows to latest major versions.
 

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -85,6 +85,7 @@ export class BundleLifecycleManager {
   async installNamed(
     name: string,
     registry: ToolRegistry,
+    wsId: string,
     env?: Record<string, string>,
   ): Promise<BundleInstance> {
     const serverName = deriveServerName(name);
@@ -104,13 +105,22 @@ export class BundleLifecycleManager {
     const isUpjack = manifest._meta?.["ai.nimblebrain/upjack"] != null;
 
     // Step 4 — Spawn MCP server
-    const instance = createInstance(serverName, name, manifest, isUpjack);
+    const instance = createInstance(serverName, name, manifest, isUpjack, wsId);
     instance.configKey = name; // config entry uses the mpak name
 
     this.transition(instance, "starting");
 
+    // Data dir is workspace-scoped: {workDir}/workspaces/{wsId}/data/{bundle}
+    // so two workspaces installing the same bundle keep their entity data
+    // isolated. Matches the layout seedInstance uses at startup.
     const nbWorkDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
-    const bundleDataDir = join(nbWorkDir, "data", deriveBundleDataDir(name));
+    const bundleDataDir = join(
+      nbWorkDir,
+      "workspaces",
+      wsId,
+      "data",
+      deriveBundleDataDir(name),
+    );
     const server = await mpak.prepareServer({ name }, { workspaceDir: bundleDataDir });
 
     const source = new McpSource(serverName, {
@@ -141,7 +151,7 @@ export class BundleLifecycleManager {
     instance.briefing = extractBriefing(manifest);
 
     // Step 6b — Register placements in PlacementRegistry
-    this.registerPlacements(serverName, instance.ui, instance.bundleName);
+    this.registerPlacements(serverName, instance.ui, wsId);
 
     // Step 7 — Atomic config write
     if (this.configPath) {
@@ -151,7 +161,7 @@ export class BundleLifecycleManager {
       atomicConfigAdd(this.configPath, entry);
     }
 
-    this.instances.set(serverName, instance);
+    this.instances.set(`${serverName}|${wsId}`, instance);
 
     // Step 8a — Sync bundle-contributed automations (non-blocking)
     await this.syncBundleAutomations(manifest, name, registry);
@@ -180,6 +190,7 @@ export class BundleLifecycleManager {
   async installLocal(
     bundlePath: string,
     registry: ToolRegistry,
+    wsId: string,
     env?: Record<string, string>,
   ): Promise<BundleInstance> {
     const bundleDir = resolveLocalBundle(bundlePath);
@@ -198,7 +209,7 @@ export class BundleLifecycleManager {
     validateServerName(serverName);
     const isUpjack = manifest._meta?.["ai.nimblebrain/upjack"] != null;
     // Use manifest.name (scoped name) as bundleName, not the filesystem path
-    const instance = createInstance(serverName, manifest.name, manifest, isUpjack);
+    const instance = createInstance(serverName, manifest.name, manifest, isUpjack, wsId);
     instance.configKey = bundlePath; // config entry uses the filesystem path
 
     this.transition(instance, "starting");
@@ -213,7 +224,7 @@ export class BundleLifecycleManager {
     instance.briefing = extractBriefing(manifest);
 
     // Register placements in PlacementRegistry
-    this.registerPlacements(serverName, instance.ui, instance.bundleName);
+    this.registerPlacements(serverName, instance.ui, wsId);
 
     if (this.configPath) {
       const entry: Record<string, unknown> = { path: bundlePath };
@@ -221,7 +232,7 @@ export class BundleLifecycleManager {
       atomicConfigAdd(this.configPath, entry);
     }
 
-    this.instances.set(serverName, instance);
+    this.instances.set(`${serverName}|${wsId}`, instance);
 
     // Sync bundle-contributed automations (non-blocking)
     await this.syncBundleAutomations(manifest, manifest.name, registry);
@@ -249,6 +260,7 @@ export class BundleLifecycleManager {
     url: string,
     serverName: string,
     registry: ToolRegistry,
+    wsId: string,
     transportConfig?: RemoteTransportConfig,
     ui?: BundleUiMeta | null,
     trustScore?: number | null,
@@ -266,6 +278,7 @@ export class BundleLifecycleManager {
       briefing: null,
       protected: false,
       type: "plain",
+      wsId,
     };
 
     this.transition(instance, "starting");
@@ -285,7 +298,7 @@ export class BundleLifecycleManager {
     this.transition(instance, "running");
 
     // Register placements in PlacementRegistry
-    this.registerPlacements(serverName, instance.ui, instance.bundleName);
+    this.registerPlacements(serverName, instance.ui, wsId);
 
     // Atomic config write
     if (this.configPath) {
@@ -296,7 +309,7 @@ export class BundleLifecycleManager {
       atomicConfigAdd(this.configPath, entry);
     }
 
-    this.instances.set(serverName, instance);
+    this.instances.set(`${serverName}|${wsId}`, instance);
 
     // Emit event
     this.eventSink.emit({
@@ -328,15 +341,16 @@ export class BundleLifecycleManager {
    * 5. Emit bundle.uninstalled
    * 6. Data is NOT deleted
    */
-  async uninstall(nameOrPath: string, registry: ToolRegistry): Promise<void> {
-    // Resolve the server name: try direct derivation first, then look up by bundleName
+  async uninstall(nameOrPath: string, registry: ToolRegistry, wsId: string): Promise<void> {
+    // Resolve by (serverName, wsId) first; fall back to bundleName match within
+    // this workspace. Lookups are always workspace-scoped — uninstalling in one
+    // workspace must not affect another workspace's instance of the same bundle.
     let serverName = deriveServerName(nameOrPath);
-    let instance = this.instances.get(serverName);
+    let instance = this.instances.get(`${serverName}|${wsId}`);
     if (!instance) {
-      // Try finding by bundleName (handles local paths)
-      for (const [key, inst] of this.instances) {
-        if (inst.bundleName === nameOrPath) {
-          serverName = key;
+      for (const inst of this.instances.values()) {
+        if (inst.wsId === wsId && inst.bundleName === nameOrPath) {
+          serverName = inst.serverName;
           instance = inst;
           break;
         }
@@ -353,9 +367,9 @@ export class BundleLifecycleManager {
       await registry.removeSource(serverName);
     }
 
-    // Step 3b — Unregister placements
+    // Step 3b — Unregister placements for this workspace only
     if (this.placementRegistry) {
-      this.placementRegistry.unregister(serverName);
+      this.placementRegistry.unregister(serverName, wsId);
     }
 
     // Step 4 — Remove from config
@@ -371,13 +385,13 @@ export class BundleLifecycleManager {
     // Track state change before removing
     if (instance) {
       this.transition(instance, "stopped");
-      this.instances.delete(serverName);
+      this.instances.delete(`${serverName}|${wsId}`);
     }
 
     // Step 5 — Emit event (data NOT deleted — step 6)
     this.eventSink.emit({
       type: "bundle.uninstalled",
-      data: { serverName, bundleName: nameOrPath },
+      data: { serverName, bundleName: nameOrPath, wsId },
     });
   }
 
@@ -387,10 +401,10 @@ export class BundleLifecycleManager {
    * Start a stopped bundle (re-creates the MCP subprocess).
    * Dead bundles must be explicitly restarted with this method.
    */
-  async startBundle(serverName: string, registry: ToolRegistry): Promise<void> {
-    const instance = this.instances.get(serverName);
+  async startBundle(serverName: string, wsId: string, registry: ToolRegistry): Promise<void> {
+    const instance = this.instances.get(`${serverName}|${wsId}`);
     if (!instance) {
-      throw new Error(`No bundle instance found for "${serverName}"`);
+      throw new Error(`No bundle instance found for "${serverName}" in workspace "${wsId}"`);
     }
 
     if (instance.state === "running") return; // already running
@@ -411,10 +425,10 @@ export class BundleLifecycleManager {
   /**
    * Stop a running bundle (kills subprocess, keeps source registered).
    */
-  async stopBundle(serverName: string, registry: ToolRegistry): Promise<void> {
-    const instance = this.instances.get(serverName);
+  async stopBundle(serverName: string, wsId: string, registry: ToolRegistry): Promise<void> {
+    const instance = this.instances.get(`${serverName}|${wsId}`);
     if (!instance) {
-      throw new Error(`No bundle instance found for "${serverName}"`);
+      throw new Error(`No bundle instance found for "${serverName}" in workspace "${wsId}"`);
     }
 
     if (instance.state === "stopped" || instance.state === "dead") return;
@@ -441,13 +455,13 @@ export class BundleLifecycleManager {
    * Record a crash detected by HealthMonitor.
    * Emits bundle.crashed event and updates state.
    */
-  recordCrash(serverName: string): void {
-    const instance = this.instances.get(serverName);
+  recordCrash(serverName: string, wsId: string): void {
+    const instance = this.instances.get(`${serverName}|${wsId}`);
     if (!instance) return;
     this.transition(instance, "crashed");
     this.eventSink.emit({
       type: "bundle.crashed",
-      data: { serverName, bundleName: instance.bundleName },
+      data: { serverName, bundleName: instance.bundleName, wsId },
     });
   }
 
@@ -455,13 +469,13 @@ export class BundleLifecycleManager {
    * Record a successful recovery by HealthMonitor.
    * Emits bundle.recovered event and updates state.
    */
-  recordRecovery(serverName: string): void {
-    const instance = this.instances.get(serverName);
+  recordRecovery(serverName: string, wsId: string): void {
+    const instance = this.instances.get(`${serverName}|${wsId}`);
     if (!instance) return;
     this.transition(instance, "running");
     this.eventSink.emit({
       type: "bundle.recovered",
-      data: { serverName, bundleName: instance.bundleName },
+      data: { serverName, bundleName: instance.bundleName, wsId },
     });
   }
 
@@ -469,13 +483,13 @@ export class BundleLifecycleManager {
    * Record that a bundle has exhausted restart attempts.
    * Emits bundle.dead event and updates state.
    */
-  recordDead(serverName: string): void {
-    const instance = this.instances.get(serverName);
+  recordDead(serverName: string, wsId: string): void {
+    const instance = this.instances.get(`${serverName}|${wsId}`);
     if (!instance) return;
     this.transition(instance, "dead");
     this.eventSink.emit({
       type: "bundle.dead",
-      data: { serverName, bundleName: instance.bundleName },
+      data: { serverName, bundleName: instance.bundleName, wsId },
     });
   }
 
@@ -589,16 +603,18 @@ export class BundleLifecycleManager {
 
   /**
    * Register placements from a bundle's UI metadata in the PlacementRegistry.
+   * Scoped to `wsId` so two workspaces installing the same bundle get separate
+   * nav entries and uninstalling one doesn't wipe the other's.
    */
   private registerPlacements(
     serverName: string,
     ui: BundleUiMeta | null,
-    _bundleName?: string,
+    wsId: string,
   ): void {
     if (!this.placementRegistry || !ui) return;
 
     if (ui.placements && ui.placements.length > 0) {
-      this.placementRegistry.register(serverName, ui.placements);
+      this.placementRegistry.register(serverName, ui.placements, wsId);
     }
   }
 
@@ -684,6 +700,7 @@ function createInstance(
   bundleName: string,
   manifest: BundleManifest,
   isUpjack: boolean,
+  wsId: string,
 ): BundleInstance {
   return {
     serverName,
@@ -696,6 +713,7 @@ function createInstance(
     briefing: null,
     protected: false,
     type: isUpjack ? "upjack" : "plain",
+    wsId,
   };
 }
 

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -114,13 +114,7 @@ export class BundleLifecycleManager {
     // so two workspaces installing the same bundle keep their entity data
     // isolated. Matches the layout seedInstance uses at startup.
     const nbWorkDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
-    const bundleDataDir = join(
-      nbWorkDir,
-      "workspaces",
-      wsId,
-      "data",
-      deriveBundleDataDir(name),
-    );
+    const bundleDataDir = join(nbWorkDir, "workspaces", wsId, "data", deriveBundleDataDir(name));
     const server = await mpak.prepareServer({ name }, { workspaceDir: bundleDataDir });
 
     const source = new McpSource(serverName, {
@@ -606,11 +600,7 @@ export class BundleLifecycleManager {
    * Scoped to `wsId` so two workspaces installing the same bundle get separate
    * nav entries and uninstalling one doesn't wipe the other's.
    */
-  private registerPlacements(
-    serverName: string,
-    ui: BundleUiMeta | null,
-    wsId: string,
-  ): void {
+  private registerPlacements(serverName: string, ui: BundleUiMeta | null, wsId: string): void {
     if (!this.placementRegistry || !ui) return;
 
     if (ui.placements && ui.placements.length > 0) {

--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -179,8 +179,13 @@ export interface BundleInstance {
   protected: boolean;
   /** Whether this is an Upjack app or plain MCP server. */
   type: "upjack" | "plain";
-  /** Workspace ID this instance belongs to (undefined = global/protected). */
-  wsId?: string;
+  /**
+   * Workspace that owns this instance. Required — every bundle instance
+   * belongs to exactly one workspace. Global/platform sources are
+   * represented as InlineSource, not BundleInstance, so they never reach
+   * this type.
+   */
+  wsId: string;
   /** Absolute path to the entity data root (e.g., {wsDir}/data/{bundle}/apps/crm/data). Resolved at startup. */
   entityDataRoot?: string;
 }

--- a/src/runtime/placement-registry.ts
+++ b/src/runtime/placement-registry.ts
@@ -7,10 +7,17 @@ import type { PlacementDeclaration, PlacementEntry } from "../bundles/types.ts";
 export class PlacementRegistry {
   private entries: PlacementEntry[] = [];
 
-  /** Register placements from a bundle's manifest metadata. */
+  /**
+   * Register placements from a bundle's manifest metadata.
+   *
+   * Scoped to (serverName, wsId): the idempotent cleanup before insertion only
+   * removes entries for this server in this workspace. Omitting wsId means a
+   * global placement (platform/system sources) — scoped to entries whose wsId
+   * is also undefined. Without this scoping, re-seeding the same bundle in a
+   * second workspace would wipe out the first workspace's nav entries.
+   */
   register(serverName: string, placements: PlacementDeclaration[], wsId?: string): void {
-    // Remove any existing entries for this server first (idempotent)
-    this.unregister(serverName);
+    this.unregister(serverName, wsId);
 
     for (const p of placements) {
       this.entries.push({
@@ -22,9 +29,18 @@ export class PlacementRegistry {
     }
   }
 
-  /** Remove all placements for a server. */
-  unregister(serverName: string): void {
-    this.entries = this.entries.filter((e) => e.serverName !== serverName);
+  /**
+   * Remove placements for a server. If wsId is provided, only removes entries
+   * matching that workspace; otherwise only removes global entries (wsId
+   * undefined). Passing `"*"` removes every entry for the server across all
+   * workspaces — used for full-bundle uninstalls.
+   */
+  unregister(serverName: string, wsId?: string | "*"): void {
+    this.entries = this.entries.filter((e) => {
+      if (e.serverName !== serverName) return true;
+      if (wsId === "*") return false;
+      return e.wsId !== wsId;
+    });
   }
 
   /**

--- a/src/runtime/placement-registry.ts
+++ b/src/runtime/placement-registry.ts
@@ -30,15 +30,15 @@ export class PlacementRegistry {
   }
 
   /**
-   * Remove placements for a server. If wsId is provided, only removes entries
-   * matching that workspace; otherwise only removes global entries (wsId
-   * undefined). Passing `"*"` removes every entry for the server across all
-   * workspaces — used for full-bundle uninstalls.
+   * Remove placements for (serverName, wsId). Both undefined match: passing
+   * no wsId removes only global entries, passing a wsId removes only that
+   * workspace's entries. Entries for other workspaces are untouched — this
+   * is what prevents a second workspace's install from wiping the first's
+   * nav.
    */
-  unregister(serverName: string, wsId?: string | "*"): void {
+  unregister(serverName: string, wsId?: string): void {
     this.entries = this.entries.filter((e) => {
       if (e.serverName !== serverName) return true;
-      if (wsId === "*") return false;
       return e.wsId !== wsId;
     });
   }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -878,12 +878,10 @@ export class Runtime {
   /**
    * Get bundle instances visible in a specific workspace.
    *
-   * The lifecycle map is keyed by `${serverName}|${wsId}` so each (serverName,
-   * wsId) pair is a distinct instance with its own entityDataRoot. Filtering
-   * by serverName alone would return instances from every workspace that
-   * installed the same bundle — a cross-workspace data leak. The `wsId` match
-   * is the authoritative scope check; `visible.has(serverName)` keeps
-   * stopped/orphaned instances out of workspace-facing views.
+   * `inst.wsId === wsId` is the authoritative scope — every BundleInstance
+   * carries a required workspace. `visible.has(serverName)` is a
+   * belt-and-suspenders check against orphaned lifecycle records whose
+   * source has been removed from the registry.
    */
   getBundleInstancesForWorkspace(wsId: string): BundleInstance[] {
     const wsRegistry = this._workspaceRegistries.get(wsId);
@@ -891,9 +889,7 @@ export class Runtime {
     const visible = new Set(wsRegistry.sourceNames());
     return this.lifecycle
       .getInstances()
-      .filter(
-        (inst) => visible.has(inst.serverName) && (inst.wsId === wsId || inst.wsId === undefined),
-      );
+      .filter((inst) => inst.wsId === wsId && visible.has(inst.serverName));
   }
 
   /** Get the lifecycle manager (for health monitor integration). */

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -877,14 +877,23 @@ export class Runtime {
 
   /**
    * Get bundle instances visible in a specific workspace.
-   * Filters the global instance list to only those whose serverName
-   * is registered in the workspace's ToolRegistry.
+   *
+   * The lifecycle map is keyed by `${serverName}|${wsId}` so each (serverName,
+   * wsId) pair is a distinct instance with its own entityDataRoot. Filtering
+   * by serverName alone would return instances from every workspace that
+   * installed the same bundle — a cross-workspace data leak. The `wsId` match
+   * is the authoritative scope check; `visible.has(serverName)` keeps
+   * stopped/orphaned instances out of workspace-facing views.
    */
   getBundleInstancesForWorkspace(wsId: string): BundleInstance[] {
     const wsRegistry = this._workspaceRegistries.get(wsId);
     if (!wsRegistry) return [];
     const visible = new Set(wsRegistry.sourceNames());
-    return this.lifecycle.getInstances().filter((inst) => visible.has(inst.serverName));
+    return this.lifecycle
+      .getInstances()
+      .filter(
+        (inst) => visible.has(inst.serverName) && (inst.wsId === wsId || inst.wsId === undefined),
+      );
   }
 
   /** Get the lifecycle manager (for health monitor integration). */

--- a/test/integration/lifecycle-placements.test.ts
+++ b/test/integration/lifecycle-placements.test.ts
@@ -132,7 +132,7 @@ describe("BundleLifecycleManager — placement registration on install", () => {
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 		lifecycle.setPlacementRegistry(pr);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// Placements extracted into UI meta
 		expect(instance.ui).not.toBeNull();
@@ -167,7 +167,7 @@ describe("BundleLifecycleManager — placement registration on install", () => {
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 		lifecycle.setPlacementRegistry(pr);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// primaryView is no longer extracted — only explicit placements are registered
 		expect(instance.ui!.placements).toBeUndefined();
@@ -192,7 +192,7 @@ describe("BundleLifecycleManager — placement registration on install", () => {
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 		lifecycle.setPlacementRegistry(pr);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// Explicit placements take precedence — no legacy "main" placement
 		const main = pr.forSlot("main");
@@ -230,13 +230,13 @@ describe("BundleLifecycleManager — placement unregistration on uninstall", () 
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 		lifecycle.setPlacementRegistry(pr);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// Verify placement exists
 		expect(pr.forSlot("sidebar.apps")).toHaveLength(1);
 
 		// Uninstall by server name
-		await lifecycle.uninstall(instance.serverName, registry);
+		await lifecycle.uninstall(instance.serverName, registry, "ws_test");
 
 		// Placement gone
 		expect(pr.forSlot("sidebar.apps")).toHaveLength(0);

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -111,7 +111,7 @@ describe("BundleLifecycleManager — install local bundle", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// Source registered in registry
 		expect(registry.hasSource(instance.serverName)).toBe(true);
@@ -144,7 +144,7 @@ describe("BundleLifecycleManager — install local bundle", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// UI metadata extracted from manifest
 		expect(instance.ui).not.toBeNull();
@@ -174,7 +174,7 @@ describe("BundleLifecycleManager — install local bundle", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		expect(instance.type).toBe("upjack");
 
@@ -201,14 +201,14 @@ describe("BundleLifecycleManager — uninstall", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 		const serverName = instance.serverName;
 
 		// Verify installed
 		expect(registry.hasSource(serverName)).toBe(true);
 
 		// Now uninstall by server name (same as API: DELETE /v1/apps/:name)
-		await lifecycle.uninstall(serverName, registry);
+		await lifecycle.uninstall(serverName, registry, "ws_test");
 
 		// Source removed
 		expect(registry.hasSource(serverName)).toBe(false);
@@ -233,7 +233,7 @@ describe("BundleLifecycleManager — uninstall", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// Mark as protected
 		instance.protected = true;
@@ -241,7 +241,7 @@ describe("BundleLifecycleManager — uninstall", () => {
 		// Attempt uninstall should throw
 		let error: Error | null = null;
 		try {
-			await lifecycle.uninstall(instance.serverName, registry);
+			await lifecycle.uninstall(instance.serverName, registry, "ws_test");
 		} catch (e) {
 			error = e as Error;
 		}
@@ -272,8 +272,8 @@ describe("BundleLifecycleManager — uninstall", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 
-		await lifecycle.installLocal(bundleDir, registry);
-		await lifecycle.uninstall(bundleDir, registry);
+		await lifecycle.installLocal(bundleDir, registry, "ws_test");
+		await lifecycle.uninstall(bundleDir, registry, "ws_test");
 
 		// Data directory should still exist
 		expect(existsSync(dataDir)).toBe(true);
@@ -294,10 +294,10 @@ describe("BundleLifecycleManager — start and stop", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 		expect(instance.state).toBe("running");
 
-		await lifecycle.stopBundle(instance.serverName, registry);
+		await lifecycle.stopBundle(instance.serverName, "ws_test", registry);
 		expect(instance.state).toBe("stopped");
 
 		await registry.removeSource(instance.serverName);
@@ -309,11 +309,11 @@ describe("BundleLifecycleManager — start and stop", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
-		await lifecycle.stopBundle(instance.serverName, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
+		await lifecycle.stopBundle(instance.serverName, "ws_test", registry);
 		expect(instance.state).toBe("stopped");
 
-		await lifecycle.startBundle(instance.serverName, registry);
+		await lifecycle.startBundle(instance.serverName, "ws_test", registry);
 		expect(instance.state).toBe("running");
 
 		await registry.removeSource(instance.serverName);
@@ -333,10 +333,10 @@ describe("BundleLifecycleManager — state transitions", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 		expect(instance.state).toBe("running");
 
-		lifecycle.recordCrash(instance.serverName);
+		lifecycle.recordCrash(instance.serverName, "ws_test");
 		expect(instance.state).toBe("crashed");
 		expect(eventTypes(sink)).toContain("bundle.crashed");
 
@@ -349,10 +349,10 @@ describe("BundleLifecycleManager — state transitions", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
-		lifecycle.recordCrash(instance.serverName);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
+		lifecycle.recordCrash(instance.serverName, "ws_test");
 
-		lifecycle.recordRecovery(instance.serverName);
+		lifecycle.recordRecovery(instance.serverName, "ws_test");
 		expect(instance.state).toBe("running");
 		expect(eventTypes(sink)).toContain("bundle.recovered");
 
@@ -365,10 +365,10 @@ describe("BundleLifecycleManager — state transitions", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
-		lifecycle.recordCrash(instance.serverName);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
+		lifecycle.recordCrash(instance.serverName, "ws_test");
 
-		lifecycle.recordDead(instance.serverName);
+		lifecycle.recordDead(instance.serverName, "ws_test");
 		expect(instance.state).toBe("dead");
 		expect(eventTypes(sink)).toContain("bundle.dead");
 
@@ -381,12 +381,12 @@ describe("BundleLifecycleManager — state transitions", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
-		lifecycle.recordDead(instance.serverName);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
+		lifecycle.recordDead(instance.serverName, "ws_test");
 		expect(instance.state).toBe("dead");
 
 		// Explicit startBundle should bring it back
-		await lifecycle.startBundle(instance.serverName, registry);
+		await lifecycle.startBundle(instance.serverName, "ws_test", registry);
 		expect(instance.state).toBe("running");
 
 		await registry.removeSource(instance.serverName);
@@ -409,7 +409,7 @@ describe("BundleLifecycleManager — atomic config writes", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 
-		await lifecycle.installLocal(bundleDir, registry);
+		await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// Read config — should be valid JSON with the bundle entry
 		const raw = readFileSync(configPath, "utf-8");
@@ -434,7 +434,7 @@ describe("BundleLifecycleManager — atomic config writes", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath);
 
-		await lifecycle.installLocal(bundleDir, registry);
+		await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// Read config after first install
 		let config = JSON.parse(readFileSync(configPath, "utf-8"));
@@ -444,7 +444,7 @@ describe("BundleLifecycleManager — atomic config writes", () => {
 		await registry.removeSource("echo");
 
 		// Second install (same path)
-		await lifecycle.installLocal(bundleDir, registry);
+		await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// Should still be 1 entry (atomicConfigAdd deduplicates)
 		config = JSON.parse(readFileSync(configPath, "utf-8"));
@@ -573,7 +573,7 @@ describe("BundleLifecycleManager — error resilience", () => {
 
 		let error: Error | null = null;
 		try {
-			await lifecycle.installLocal(bundleDir, registry);
+			await lifecycle.installLocal(bundleDir, registry, "ws_test");
 		} catch (e) {
 			error = e as Error;
 		}
@@ -594,7 +594,7 @@ describe("BundleLifecycleManager — error resilience", () => {
 
 		let error: Error | null = null;
 		try {
-			await lifecycle.installLocal(bundleDir, registry);
+			await lifecycle.installLocal(bundleDir, registry, "ws_test");
 		} catch (e) {
 			error = e as Error;
 		}
@@ -608,7 +608,7 @@ describe("BundleLifecycleManager — error resilience", () => {
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
 		// Should not throw — lenient behavior for idempotent uninstall
-		await lifecycle.uninstall("completely-nonexistent-server", registry);
+		await lifecycle.uninstall("completely-nonexistent-server", registry, "ws_test");
 
 		// But should still emit uninstalled event (even if nothing was installed)
 		// OR be a full no-op — verify whichever is the actual behavior
@@ -627,7 +627,7 @@ describe("BundleLifecycleManager — error resilience", () => {
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
 		// Should not throw — graceful no-op for unknown server
-		expect(() => lifecycle.recordCrash("unknown-server")).not.toThrow();
+		expect(() => lifecycle.recordCrash("unknown-server", "ws_test")).not.toThrow();
 	});
 
 	it("state machine rejects invalid transitions", async () => {
@@ -636,14 +636,14 @@ describe("BundleLifecycleManager — error resilience", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
-		const instance = await lifecycle.installLocal(bundleDir, registry);
+		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
 
 		// running → recordRecovery should be a no-op (can't recover if not crashed)
-		lifecycle.recordRecovery(instance.serverName);
+		lifecycle.recordRecovery(instance.serverName, "ws_test");
 		expect(instance.state).toBe("running"); // Should remain running
 
 		// running → recordDead should transition (crash + dead)
-		lifecycle.recordDead(instance.serverName);
+		lifecycle.recordDead(instance.serverName, "ws_test");
 		expect(instance.state).toBe("dead");
 
 		await registry.removeSource(instance.serverName);
@@ -677,7 +677,7 @@ describe("BundleLifecycleManager — error resilience", () => {
 		}));
 
 		try {
-			await lifecycle.installLocal(brokenDir, registry);
+			await lifecycle.installLocal(brokenDir, registry, "ws_test");
 		} catch {
 			// Expected to fail
 		}

--- a/test/integration/remote-lifecycle.test.ts
+++ b/test/integration/remote-lifecycle.test.ts
@@ -147,6 +147,7 @@ describe("BundleLifecycleManager — installRemote", () => {
 			mockServer.url,
 			"remote-echo",
 			registry,
+			"ws_test",
 		);
 
 		// Source registered in registry
@@ -186,6 +187,7 @@ describe("BundleLifecycleManager — installRemote", () => {
 			mockServer.url,
 			"remote-echo",
 			registry,
+			"ws_test",
 			{ type: "streamable-http" },
 			{ name: "Remote Echo", icon: "cloud" },
 			85,
@@ -211,9 +213,9 @@ describe("BundleLifecycleManager — installRemote", () => {
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, configPath, true);
 
-		await lifecycle.installRemote(mockServer.url, "remote-echo", registry);
+		await lifecycle.installRemote(mockServer.url, "remote-echo", registry, "ws_test");
 		await registry.removeSource("remote-echo");
-		await lifecycle.installRemote(mockServer.url, "remote-echo", registry);
+		await lifecycle.installRemote(mockServer.url, "remote-echo", registry, "ws_test");
 
 		const config = JSON.parse(readFileSync(configPath, "utf-8"));
 		expect(config.bundles).toHaveLength(1);
@@ -240,6 +242,7 @@ describe("BundleLifecycleManager — remote connection failure", () => {
 				"http://127.0.0.1:1/mcp", // port 1 — connection refused
 				"bad-remote",
 				registry,
+				"ws_test",
 			);
 		} catch (e) {
 			error = e as Error;

--- a/test/integration/security/workspace-isolation.test.ts
+++ b/test/integration/security/workspace-isolation.test.ts
@@ -7,15 +7,24 @@
  * 3. Concurrent requests don't contaminate each other's workspace context
  * 4. Workspace middleware rejects authenticated requests without workspace
  * 5. SSE events are scoped to workspace
+ * 6. Bundle instances do not leak across workspaces when two workspaces
+ *    install the same bundle (the briefing/nav leak class)
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import type {
+  BriefingBlock,
+  BundleRef,
+  BundleUiMeta,
+} from "../../../src/bundles/types.ts";
 import { Runtime } from "../../../src/runtime/runtime.ts";
 import { createEchoModel } from "../../helpers/echo-model.ts";
 import { createTestAuthAdapter } from "../../helpers/test-auth-adapter.ts";
 import { startServer } from "../../../src/api/server.ts";
 import type { ServerHandle } from "../../../src/api/server.ts";
 import { SseEventManager } from "../../../src/api/events.ts";
+import type { ToolResult } from "../../../src/engine/types.ts";
+import type { Tool, ToolSource } from "../../../src/tools/types.ts";
 
 // ── Test setup: authenticated server ────────────────────────────
 
@@ -244,5 +253,111 @@ describe("V5: SSE events scoped by workspace", () => {
       readerWs.cancel();
       manager.stop();
     });
+  });
+});
+
+// ── V6: Cross-workspace bundle instance isolation ───────────────
+//
+// Pins Runtime.getBundleInstancesForWorkspace against the class of leak
+// where two workspaces install the same bundle and the filter returns
+// cross-workspace instances because it only matched on serverName. Each
+// instance carries its own entityDataRoot, so a leak in this method
+// surfaces another workspace's entity data (contacts, tasks, etc.) to
+// the caller's briefing/apps list.
+
+function makeFakeSource(name: string): ToolSource {
+  const tools: Tool[] = [
+    {
+      name: `${name}__ping`,
+      description: "ping",
+      inputSchema: { type: "object" as const },
+      source: `test:${name}`,
+    },
+  ];
+  return {
+    name,
+    start: async () => {},
+    stop: async () => {},
+    tools: async () => tools,
+    execute: async (toolName: string): Promise<ToolResult> => ({
+      content: [{ type: "text", text: `${name}/${toolName}` }],
+    }),
+  };
+}
+
+describe("V6: getBundleInstancesForWorkspace — two workspaces, same bundle", () => {
+  it("returns only the caller's instance; each carries its own entityDataRoot", async () => {
+    const wsStore = runtime.getWorkspaceStore();
+    const wsA = await wsStore.create("Isolation A", `iso_a_${Date.now()}`);
+    const wsB = await wsStore.create("Isolation B", `iso_b_${Date.now()}`);
+    await runtime.ensureWorkspaceRegistry(wsA.id);
+    await runtime.ensureWorkspaceRegistry(wsB.id);
+
+    const serverName = `leakcheck_${Date.now()}`;
+    const ref: BundleRef = { name: `@test/${serverName}` };
+    const meta = {
+      manifestName: `@test/${serverName}`,
+      version: "1.0.0",
+      ui: { name: "Leak Check", icon: "bug" } as BundleUiMeta,
+      briefing: null as BriefingBlock | null,
+      type: "upjack" as const,
+      upjackNamespace: "apps/leakcheck",
+    };
+
+    const lifecycle = runtime.getLifecycle();
+    const dataDirA = `/tmp/${wsA.id}/data`;
+    const dataDirB = `/tmp/${wsB.id}/data`;
+    lifecycle.seedInstance(serverName, ref.name, ref, meta, wsA.id, dataDirA);
+    lifecycle.seedInstance(serverName, ref.name, ref, meta, wsB.id, dataDirB);
+
+    // Register a source with the same serverName in each workspace registry.
+    // This is the visibility condition that the pre-fix filter used alone —
+    // both workspaces satisfy it, yet the new filter must still scope by wsId.
+    runtime.getRegistryForWorkspace(wsA.id).addSource(makeFakeSource(serverName));
+    runtime.getRegistryForWorkspace(wsB.id).addSource(makeFakeSource(serverName));
+
+    const fromA = runtime.getBundleInstancesForWorkspace(wsA.id);
+    const fromB = runtime.getBundleInstancesForWorkspace(wsB.id);
+
+    expect(fromA).toHaveLength(1);
+    expect(fromB).toHaveLength(1);
+    const instA = fromA[0]!;
+    const instB = fromB[0]!;
+
+    expect(instA.wsId).toBe(wsA.id);
+    expect(instB.wsId).toBe(wsB.id);
+
+    expect(instA.entityDataRoot).toBe(`${dataDirA}/apps/leakcheck/data`);
+    expect(instB.entityDataRoot).toBe(`${dataDirB}/apps/leakcheck/data`);
+
+    // Distinct data roots — a leak would make one equal to the other.
+    expect(instA.entityDataRoot).not.toBe(instB.entityDataRoot);
+
+    // Unscoped snapshot still holds both (confirms the bug was reachable
+    // from a serverName-only filter over lifecycle.getInstances()).
+    const allWithServer = lifecycle
+      .getInstances()
+      .filter((i) => i.serverName === serverName);
+    expect(allWithServer).toHaveLength(2);
+  });
+
+  it("returns nothing for a workspace that has the bundle in its lifecycle but not its registry", async () => {
+    const wsStore = runtime.getWorkspaceStore();
+    const ws = await wsStore.create("Orphan", `orphan_${Date.now()}`);
+    await runtime.ensureWorkspaceRegistry(ws.id);
+
+    const serverName = `orphan_${Date.now()}`;
+    const ref: BundleRef = { name: `@test/${serverName}` };
+    const meta = {
+      manifestName: `@test/${serverName}`,
+      version: "1.0.0",
+      ui: null,
+      briefing: null as BriefingBlock | null,
+      type: "plain" as const,
+    };
+    runtime.getLifecycle().seedInstance(serverName, ref.name, ref, meta, ws.id, `/tmp/${ws.id}/data`);
+    // Deliberately do NOT add the source to the registry.
+
+    expect(runtime.getBundleInstancesForWorkspace(ws.id)).toHaveLength(0);
   });
 });

--- a/test/integration/shell-integration.test.ts
+++ b/test/integration/shell-integration.test.ts
@@ -149,7 +149,7 @@ describe("Install/uninstall → /v1/shell placement updates", () => {
 
 		// Install via lifecycle (direct API since POST /v1/apps/install needs mpak for named)
 		const devRegistry = runtime.getRegistryForWorkspace(TEST_WORKSPACE_ID);
-		const instance = await runtime.getLifecycle().installLocal(bundleDir, devRegistry);
+		const instance = await runtime.getLifecycle().installLocal(bundleDir, devRegistry, TEST_WORKSPACE_ID);
 		const serverName = instance.serverName;
 
 		try {
@@ -168,7 +168,7 @@ describe("Install/uninstall → /v1/shell placement updates", () => {
 			expect(slots).toContain("main");
 
 			// Uninstall
-			await runtime.getLifecycle().uninstall(serverName, devRegistry);
+			await runtime.getLifecycle().uninstall(serverName, devRegistry, TEST_WORKSPACE_ID);
 
 			// GET /v1/shell should no longer have tasks placements
 			const shellRes2 = await fetch(`${baseUrl}/v1/shell`);
@@ -181,7 +181,7 @@ describe("Install/uninstall → /v1/shell placement updates", () => {
 		} catch (err) {
 			// Clean up on failure
 			try {
-				await runtime.getLifecycle().uninstall(serverName, devRegistry);
+				await runtime.getLifecycle().uninstall(serverName, devRegistry, TEST_WORKSPACE_ID);
 			} catch {}
 			throw err;
 		}
@@ -200,7 +200,7 @@ describe("Bundle with placements → /v1/shell", () => {
 			],
 		});
 		const devRegistry = runtime.getRegistryForWorkspace(TEST_WORKSPACE_ID);
-		const instance = await runtime.getLifecycle().installLocal(bundleDir, devRegistry);
+		const instance = await runtime.getLifecycle().installLocal(bundleDir, devRegistry, TEST_WORKSPACE_ID);
 		const serverName = instance.serverName;
 
 		try {
@@ -215,10 +215,10 @@ describe("Bundle with placements → /v1/shell", () => {
 			expect(entries[0].resourceUri).toBe("ui://placedapp/main");
 			expect(entries[0].label).toBe("placedapp App");
 
-			await runtime.getLifecycle().uninstall(serverName, devRegistry);
+			await runtime.getLifecycle().uninstall(serverName, devRegistry, TEST_WORKSPACE_ID);
 		} catch (err) {
 			try {
-				await runtime.getLifecycle().uninstall(serverName, devRegistry);
+				await runtime.getLifecycle().uninstall(serverName, devRegistry, TEST_WORKSPACE_ID);
 			} catch {}
 			throw err;
 		}

--- a/test/integration/workspace-security.test.ts
+++ b/test/integration/workspace-security.test.ts
@@ -15,15 +15,22 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import type { PlacementEntry } from "../../src/bundles/types.ts";
+import { BundleLifecycleManager } from "../../src/bundles/lifecycle.ts";
+import type {
+  BriefingBlock,
+  BundleRef,
+  BundleUiMeta,
+  PlacementEntry,
+} from "../../src/bundles/types.ts";
 import { DevIdentityProvider } from "../../src/identity/providers/dev.ts";
 import { UserStore } from "../../src/identity/user.ts";
+import { PlacementRegistry } from "../../src/runtime/placement-registry.ts";
 import { filterPlacementsForWorkspace } from "../../src/runtime/workspace-access.ts";
 import { ToolRegistry, SharedSourceRef } from "../../src/tools/registry.ts";
 import type { Workspace } from "../../src/workspace/types.ts";
 import { WorkspaceStore } from "../../src/workspace/workspace-store.ts";
 import type { ToolSource, Tool } from "../../src/tools/types.ts";
-import type { ToolResult } from "../../src/engine/types.ts";
+import type { EngineEvent, EventSink, ToolResult } from "../../src/engine/types.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -258,5 +265,81 @@ describe("Workspace security: DevIdentityProvider populates workspace bundles", 
 
     const defaultWs = workspaces[0]!;
     expect(defaultWs.bundles).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-workspace data leak regressions (bayze incident, 2026-04)
+// ---------------------------------------------------------------------------
+
+describe("Workspace security: same bundle installed in two workspaces", () => {
+  const placements = [
+    { slot: "sidebar.apps", resourceUri: "ui://crm/nav", priority: 30 },
+    { slot: "main", resourceUri: "ui://crm/board", route: "crm" },
+  ];
+
+  test("PlacementRegistry: re-registering for a second workspace does not wipe the first", () => {
+    const pr = new PlacementRegistry();
+    pr.register("crm", placements, "ws_eng");
+    pr.register("crm", placements, "ws_mkt");
+
+    const entries = pr.all();
+    const eng = entries.filter((e) => e.wsId === "ws_eng");
+    const mkt = entries.filter((e) => e.wsId === "ws_mkt");
+    expect(eng).toHaveLength(2);
+    expect(mkt).toHaveLength(2);
+  });
+
+  test("PlacementRegistry: unregister is scoped to the given workspace", () => {
+    const pr = new PlacementRegistry();
+    pr.register("crm", placements, "ws_eng");
+    pr.register("crm", placements, "ws_mkt");
+
+    pr.unregister("crm", "ws_eng");
+
+    const entries = pr.all();
+    expect(entries.filter((e) => e.wsId === "ws_eng")).toHaveLength(0);
+    expect(entries.filter((e) => e.wsId === "ws_mkt")).toHaveLength(2);
+  });
+
+  test("PlacementRegistry: re-registering a global source does not wipe workspace entries", () => {
+    const pr = new PlacementRegistry();
+    pr.register("crm", placements, "ws_eng");
+    pr.register("platform", [placements[0]]); // global, no wsId
+    pr.register("platform", [placements[0]]); // re-register global
+
+    expect(pr.all().filter((e) => e.wsId === "ws_eng")).toHaveLength(2);
+  });
+
+  test("BundleLifecycleManager: seeding the same bundle in two workspaces keeps them distinct", () => {
+    const events: EngineEvent[] = [];
+    const sink: EventSink = { emit: (e) => events.push(e) };
+    const lifecycle = new BundleLifecycleManager(sink, undefined);
+
+    const ref: BundleRef = { name: "@nimblebraininc/crm" };
+    const meta = {
+      manifestName: "@nimblebraininc/crm",
+      version: "1.0.0",
+      ui: { name: "CRM", icon: "cards" } as BundleUiMeta,
+      briefing: null as BriefingBlock | null,
+      type: "upjack" as const,
+      upjackNamespace: "apps/crm",
+    };
+
+    lifecycle.seedInstance("crm", "@nimblebraininc/crm", ref, meta, "ws_eng", "/data/ws_eng/data/crm");
+    lifecycle.seedInstance("crm", "@nimblebraininc/crm", ref, meta, "ws_mkt", "/data/ws_mkt/data/crm");
+
+    const eng = lifecycle.getInstance("crm", "ws_eng");
+    const mkt = lifecycle.getInstance("crm", "ws_mkt");
+
+    expect(eng?.wsId).toBe("ws_eng");
+    expect(mkt?.wsId).toBe("ws_mkt");
+    expect(eng?.entityDataRoot).toContain("ws_eng");
+    expect(mkt?.entityDataRoot).toContain("ws_mkt");
+    // Distinct objects — one workspace's data root must not be the other's
+    expect(eng?.entityDataRoot).not.toBe(mkt?.entityDataRoot);
+    // The unscoped snapshot exposes both — the bug was that a serverName-only
+    // filter would return both when asked for one workspace's instances.
+    expect(lifecycle.getInstances()).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

Fixes a cross-workspace data leak and a nav-visibility bug, both rooted in single-tenant residue that survived the migration to multi-tenant workspaces. The codebase had two structures claiming to know "what's installed where": `lifecycle.instances` (compound `${serverName}|${wsId}` key) and per-workspace `ToolRegistry` (keyed by `serverName`). The read-side joined them by `serverName` only, so when two workspaces installed the same bundle the filter returned both instances. Each instance carries its own `entityDataRoot`, so downstream consumers — briefing facet collector, apps list — read entity data from every matching workspace and surfaced it to the caller.

Three related defects, all fixed in this PR:

- **`Runtime.getBundleInstancesForWorkspace`** now requires `inst.wsId === wsId` in addition to registry visibility. Global/protected instances (`wsId === undefined`) remain visible in every workspace.
- **`PlacementRegistry.register`/`unregister`** are scoped by `wsId`. The previous global-per-`serverName` unregister caused re-registration in a second workspace to silently wipe the first workspace's nav entries (last seeded won). `unregister(name, "*")` removes across all workspaces for full-bundle uninstalls.
- **Install/lifecycle APIs** (`installNamed`/`installLocal`/`installRemote`/`uninstall`/`startBundle`/`stopBundle`/`recordCrash`/`recordRecovery`/`recordDead`) now require `wsId`. Instances are stored under compound keys, `inst.wsId` is populated on the record, and `installNamed` scopes its bundle data dir to `{workDir}/workspaces/{wsId}/data/{bundle}` to match `seedInstance`.

## Test plan

- [x] `bun run check` — clean
- [x] `bun run lint` — clean (only pre-existing import-type warnings)
- [x] `bun run test:unit` — 1725 pass, 0 fail
- [x] `bun run test:integration` — failure set identical to `main`; remaining 28 failures are a pre-existing echo-MCP subprocess env issue, verified by diff against the base branch
- [x] New regression tests in `test/integration/workspace-security.test.ts` (14 pass):
  - PlacementRegistry: registering the same bundle in a second workspace preserves the first's entries
  - PlacementRegistry: `unregister` is scoped to the given workspace
  - PlacementRegistry: re-registering a global source does not wipe workspace entries
  - BundleLifecycleManager: two workspaces seeded with the same bundle keep distinct `entityDataRoot` values

## Follow-ups (separate PR)

The underlying conflation that made this bug possible — `BundleInstance` mixing catalog-level fields (name, version, manifest) with runtime-level per-workspace fields (state, wsId, entityDataRoot) — is worth splitting into `BundleCatalogEntry` (global) and `WorkspaceBundleInstance` (per-ws). That change would force the scope question at the type level rather than leaving it to discipline, preventing the same class of bug from reappearing in a new projection (automations, health-monitor attribution, etc.). Flagging but out of scope for this hotfix.