### PR TITLE
Guard web PostHog init against concurrent callers

### DIFF
--- a/web/src/telemetry.ts
+++ b/web/src/telemetry.ts
@@ -7,7 +7,12 @@ const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY ?? "";
 let initialized = false;
 
 export function initTelemetry(installId?: string): void {
-  if (!installId || !POSTHOG_KEY) return;
+  if (initialized || !installId || !POSTHOG_KEY) return;
+
+  // Flip the guard before posthog.init to prevent concurrent callers
+  // (e.g. React StrictMode double-invoking effects) from racing into a
+  // second init, which PostHog logs as "already initialized".
+  initialized = true;
 
   posthog.init(POSTHOG_KEY, {
     api_host: "https://us.i.posthog.com",
@@ -19,7 +24,6 @@ export function initTelemetry(installId?: string): void {
   });
 
   posthog.register({ installId });
-  initialized = true;
 }
 
 export function captureEvent(name: string, properties?: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary
- The \`initTelemetry\` effect in \`web/src/App.tsx\` fires twice in dev because React StrictMode double-invokes effects. Both \`callTool\` promises resolved and both reached \`posthog.init()\` before the \`initialized\` flag was set, producing the console warning: \`[PostHog.js] You have already initialized PostHog! Re-initializing is a no-op\`.
- Flip the guard at the top of \`initTelemetry\` and set \`initialized = true\` **before** calling \`posthog.init\` so any concurrent second call returns early.

## Test plan
- [ ] Load the web client with \`VITE_POSTHOG_KEY\` set in dev — verify the PostHog warning no longer appears in the browser console
- [ ] Confirm \`window.posthog\` is still initialized exactly once and subsequent \`captureEvent\` / \`capturePageView\` calls continue to work
- [ ] \`bun run verify\` passes in CI