### PR TITLE
Proxy /mcp through Caddy to the platform

### DIFF
--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -2,6 +2,9 @@
     handle /v1/* {
         reverse_proxy {$PLATFORM_URL}
     }
+    handle /mcp* {
+        reverse_proxy {$PLATFORM_URL}
+    }
     handle {
         root * /srv
         try_files {path} /index.html


### PR DESCRIPTION
## Summary

- The web Caddy only reverse-proxied `/v1/*` to the platform, so external MCP clients hitting `/mcp` in production (e.g. `https://hq.platform.nimblebrain.ai/mcp`) fell through to the SPA's `index.html` fallback and failed with `SDK auth failed: Failed to parse JSON`.
- The platform binds MCP at `/mcp` (`src/api/routes/mcp.ts:72`), not under `/v1/*`, so add a matching `handle /mcp*` block that reverse-proxies to `$PLATFORM_URL`.
- Localhost was unaffected because `bun run dev` hits the API directly on `:27247` with no Caddy in front.

## Test plan

- [ ] Rebuild the web image and redeploy a tenant (e.g. `hq` staging).
- [ ] `curl -i https://<tenant>.platform.nimblebrain.ai/mcp` returns JSON-RPC / MCP headers, not HTML.
- [ ] Connect an external MCP client to `/mcp` and confirm the auth handshake succeeds.
- [ ] SPA routes (e.g. `/`, `/chat`, deep links) still load `index.html`.