### PR TITLE
refactor(config): drop NB_CONFIG_* convention, use SDK-declared env aliases

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@ai-sdk/openai": "^3.0.48",
         "@modelcontextprotocol/ext-apps": "^1.3.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@nimblebrain/mpak-sdk": "0.3.0",
+        "@nimblebrain/mpak-sdk": "0.4.0",
         "@nimblebrain/synapse": "^0.4.0",
         "@workos-inc/node": "^8.12.1",
         "ai": "^6.0.138",
@@ -84,7 +84,7 @@
 
     "@nimblebrain/mpak-schemas": ["@nimblebrain/mpak-schemas@0.2.0", "", { "dependencies": { "zod": "^4.1.12" } }, "sha512-hGE6RV0krHrQr0wF2zi+0/DwzLwxDago4hyEZbUPbKlfmC2ZFT0hIrT60xcEVEAg3jRZewJX4FaCkvbIMVMStw=="],
 
-    "@nimblebrain/mpak-sdk": ["@nimblebrain/mpak-sdk@0.3.0", "", { "dependencies": { "@nimblebrain/mpak-schemas": "0.2.0", "zod": "^4.3.6" } }, "sha512-jAW46HaPEKtFtWT8ToB6NHMwWCfU9fF1NyPUDk2TwcFlw4a7onv8kAOexBMLXbpGpW2NASd2yktlx8ANA0EGdg=="],
+    "@nimblebrain/mpak-sdk": ["@nimblebrain/mpak-sdk@0.4.0", "", { "dependencies": { "@nimblebrain/mpak-schemas": "0.2.0", "zod": "^4.3.6" } }, "sha512-/DIOjaktfR5rUheCyLR188xcnC+krmz0lws4umvzWoT2fkHb4RTEeGtiqaQJD9gzRjtvxoDucWLJY1gbilnjMg=="],
 
     "@nimblebrain/synapse": ["@nimblebrain/synapse@0.4.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-7VLuwPhAgp7n7Ok9IVRs/qtK64KTl7RAPMWR2IGmiyjXW/552vwuMrAgDkksuPrIiZECalXSx08Zaks/+SRsxg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@ai-sdk/openai": "^3.0.48",
         "@modelcontextprotocol/ext-apps": "^1.3.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@nimblebrain/mpak-sdk": "0.4.0",
+        "@nimblebrain/mpak-sdk": "0.4.1",
         "@nimblebrain/synapse": "^0.4.0",
         "@workos-inc/node": "^8.12.1",
         "ai": "^6.0.138",
@@ -84,7 +84,7 @@
 
     "@nimblebrain/mpak-schemas": ["@nimblebrain/mpak-schemas@0.2.0", "", { "dependencies": { "zod": "^4.1.12" } }, "sha512-hGE6RV0krHrQr0wF2zi+0/DwzLwxDago4hyEZbUPbKlfmC2ZFT0hIrT60xcEVEAg3jRZewJX4FaCkvbIMVMStw=="],
 
-    "@nimblebrain/mpak-sdk": ["@nimblebrain/mpak-sdk@0.4.0", "", { "dependencies": { "@nimblebrain/mpak-schemas": "0.2.0", "zod": "^4.3.6" } }, "sha512-/DIOjaktfR5rUheCyLR188xcnC+krmz0lws4umvzWoT2fkHb4RTEeGtiqaQJD9gzRjtvxoDucWLJY1gbilnjMg=="],
+    "@nimblebrain/mpak-sdk": ["@nimblebrain/mpak-sdk@0.4.1", "", { "dependencies": { "@nimblebrain/mpak-schemas": "0.2.0", "zod": "^4.3.6" } }, "sha512-fXYwAuxkM6jktMnWaezg6vQCW8Xw8IPtiKS7v+ZZQtpyO6mY3gC1CL2keWdCiVbqdNIfT7725nMRixyXlaQhpA=="],
 
     "@nimblebrain/synapse": ["@nimblebrain/synapse@0.4.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-7VLuwPhAgp7n7Ok9IVRs/qtK64KTl7RAPMWR2IGmiyjXW/552vwuMrAgDkksuPrIiZECalXSx08Zaks/+SRsxg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@ai-sdk/openai": "^3.0.48",
         "@modelcontextprotocol/ext-apps": "^1.3.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@nimblebrain/mpak-sdk": "0.4.1",
+        "@nimblebrain/mpak-sdk": "0.5.0",
         "@nimblebrain/synapse": "^0.4.0",
         "@workos-inc/node": "^8.12.1",
         "ai": "^6.0.138",
@@ -84,7 +84,7 @@
 
     "@nimblebrain/mpak-schemas": ["@nimblebrain/mpak-schemas@0.2.0", "", { "dependencies": { "zod": "^4.1.12" } }, "sha512-hGE6RV0krHrQr0wF2zi+0/DwzLwxDago4hyEZbUPbKlfmC2ZFT0hIrT60xcEVEAg3jRZewJX4FaCkvbIMVMStw=="],
 
-    "@nimblebrain/mpak-sdk": ["@nimblebrain/mpak-sdk@0.4.1", "", { "dependencies": { "@nimblebrain/mpak-schemas": "0.2.0", "zod": "^4.3.6" } }, "sha512-fXYwAuxkM6jktMnWaezg6vQCW8Xw8IPtiKS7v+ZZQtpyO6mY3gC1CL2keWdCiVbqdNIfT7725nMRixyXlaQhpA=="],
+    "@nimblebrain/mpak-sdk": ["@nimblebrain/mpak-sdk@0.5.0", "", { "dependencies": { "@nimblebrain/mpak-schemas": "0.2.0", "zod": "^4.3.6" } }, "sha512-5/licnb5dEMwovrOLxWTZZNCCPCp63TSw++u6khQe4nWfdqf1ZsRsMzRLhuwZDK9/XHZ+qr/40q4lF3FWlp4lQ=="],
 
     "@nimblebrain/synapse": ["@nimblebrain/synapse@0.4.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-7VLuwPhAgp7n7Ok9IVRs/qtK64KTl7RAPMWR2IGmiyjXW/552vwuMrAgDkksuPrIiZECalXSx08Zaks/+SRsxg=="],
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@ai-sdk/openai": "^3.0.48",
     "@modelcontextprotocol/ext-apps": "^1.3.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@nimblebrain/mpak-sdk": "0.3.0",
+    "@nimblebrain/mpak-sdk": "0.4.0",
     "@nimblebrain/synapse": "^0.4.0",
     "@workos-inc/node": "^8.12.1",
     "ai": "^6.0.138",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@ai-sdk/openai": "^3.0.48",
     "@modelcontextprotocol/ext-apps": "^1.3.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@nimblebrain/mpak-sdk": "0.4.1",
+    "@nimblebrain/mpak-sdk": "0.5.0",
     "@nimblebrain/synapse": "^0.4.0",
     "@workos-inc/node": "^8.12.1",
     "ai": "^6.0.138",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@ai-sdk/openai": "^3.0.48",
     "@modelcontextprotocol/ext-apps": "^1.3.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@nimblebrain/mpak-sdk": "0.4.0",
+    "@nimblebrain/mpak-sdk": "0.4.1",
     "@nimblebrain/synapse": "^0.4.0",
     "@workos-inc/node": "^8.12.1",
     "ai": "^6.0.138",

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -164,7 +164,10 @@ export async function startBundleSource(
         { workspaceDir: bundleDataDir, userConfig },
       );
     } catch (err) {
-      throw friendlyMpakConfigError(err, opts.wsId);
+      // Pass the manifest so the error message names the specific env
+      // var(s) the user can export — the onboarding UX depends on
+      // users not needing to open the manifest to find that out.
+      throw friendlyMpakConfigError(err, opts.wsId, cachedManifest);
     }
 
     source = new McpSource(

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -164,10 +164,10 @@ export async function startBundleSource(
         { workspaceDir: bundleDataDir, userConfig },
       );
     } catch (err) {
-      // Pass the manifest so the error message names the specific env
-      // var(s) the user can export — the onboarding UX depends on
-      // users not needing to open the manifest to find that out.
-      throw friendlyMpakConfigError(err, opts.wsId, cachedManifest);
+      // MpakConfigError (0.5.0+) carries envAliases per missing field,
+      // so friendlyMpakConfigError can name `export ANTHROPIC_API_KEY`
+      // hints without us threading the manifest through.
+      throw friendlyMpakConfigError(err, opts.wsId);
     }
 
     source = new McpSource(

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -2,7 +2,11 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { log } from "../cli/log.ts";
-import { resolveUserConfig, type UserConfigFieldDef } from "../config/workspace-credentials.ts";
+import {
+  friendlyMpakConfigError,
+  resolveUserConfig,
+  type UserConfigFieldDef,
+} from "../config/workspace-credentials.ts";
 import type { EventSink } from "../engine/types.ts";
 import { McpSource } from "../tools/mcp-source.ts";
 import type { ToolRegistry } from "../tools/registry.ts";
@@ -139,10 +143,13 @@ export async function startBundleSource(
       manifest = cachedManifest;
     }
 
-    // Resolve user_config values from the workspace credential store (tier 1),
-    // process env (tier 2), and manifest defaults (tier 3). This is how named
-    // bundles get their credentials at startup — `BundleRef.env` layers on top
-    // afterwards for non-sensitive overrides, unchanged.
+    // Read host-side credentials from the workspace credential store. The
+    // mpak SDK does the rest of the resolution chain: manifest-declared
+    // mcp_config.env aliases (so a bundle with
+    // `"NEWSAPI_API_KEY": "${user_config.api_key}"` is satisfied by a host
+    // NEWSAPI_API_KEY export) and manifest defaults. Any still-missing
+    // required field surfaces as MpakConfigError, which we translate to
+    // the familiar `nb config set -w <wsId>` hint.
     const userConfig = await resolveUserConfig({
       bundleName: ref.name,
       userConfigSchema: cachedManifest?.user_config,
@@ -150,10 +157,15 @@ export async function startBundleSource(
       workDir: nbWorkDir,
     });
 
-    const server = await mpak.prepareServer(
-      { name: ref.name },
-      { workspaceDir: bundleDataDir, userConfig },
-    );
+    let server: Awaited<ReturnType<typeof mpak.prepareServer>>;
+    try {
+      server = await mpak.prepareServer(
+        { name: ref.name },
+        { workspaceDir: bundleDataDir, userConfig },
+      );
+    } catch (err) {
+      throw friendlyMpakConfigError(err, opts.wsId);
+    }
 
     source = new McpSource(
       sourceName,

--- a/src/config/workspace-credentials.ts
+++ b/src/config/workspace-credentials.ts
@@ -1,5 +1,6 @@
 import { chmod, mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { MpakConfigError } from "@nimblebrain/mpak-sdk";
 import { WORKSPACE_ID_RE } from "../workspace/workspace-store.ts";
 import type { ConfirmationGate } from "./privilege.ts";
 
@@ -447,29 +448,20 @@ export async function resolveUserConfig(
  * error, so `catch` blocks can forward non-credential failures untouched.
  */
 export function friendlyMpakConfigError(err: unknown, wsId: string): Error {
-  // Duck-typed check so we don't force a hard dependency on the SDK's
-  // exported class here — the shape is stable (bundleName + missingFields).
-  if (
-    !err ||
-    typeof err !== "object" ||
-    !("code" in err) ||
-    (err as { code: unknown }).code !== "CONFIG_MISSING"
-  ) {
+  if (!(err instanceof MpakConfigError)) {
     return err instanceof Error ? err : new Error(String(err));
   }
-  const e = err as unknown as {
-    message?: string;
-    packageName?: string;
-    missingFields?: Array<{ key: string; title?: string }>;
-  };
-  const bundle = e.packageName ?? "<bundle>";
-  const fields = e.missingFields ?? [];
-  if (fields.length === 0) return new Error(e.message ?? String(err));
+  // `err` is narrowed to MpakConfigError — no duck-typing needed.
+  const bundle = err.packageName;
+  const fields = err.missingFields;
+  if (fields.length === 0) return new Error(err.message);
 
   const hints = fields
     .map((f) => `  nb config set ${bundle} ${f.key}=<value> -w ${wsId}`)
     .join("\n");
-  const labels = fields.map((f) => `"${f.title ?? f.key}"`).join(", ");
+  // MpakConfigError types `title` as required string, but an empty value
+  // is useless for user-facing output — fall back to the raw key.
+  const labels = fields.map((f) => `"${f.title?.length ? f.title : f.key}"`).join(", ");
   return new Error(
     `Missing required config ${labels} for ${bundle}.\n` +
       `Run one of:\n${hints}\n` +

--- a/src/config/workspace-credentials.ts
+++ b/src/config/workspace-credentials.ts
@@ -440,14 +440,58 @@ export async function resolveUserConfig(
 }
 
 /**
+ * Minimal manifest shape used by `friendlyMpakConfigError` to suggest the
+ * specific env var(s) a user can export to satisfy each missing field.
+ * Kept narrow on purpose — callers hand in the cached manifest they
+ * already have in scope; we only need `server.mcp_config.env`.
+ */
+export interface EnvAliasSource {
+  server?: { mcp_config?: { env?: Record<string, unknown> } };
+}
+
+/**
+ * Given a manifest and a user_config field name, list the host env var
+ * names that would satisfy it via the SDK's reverse-lookup tier.
+ *
+ * Mirrors the SDK's `buildEnvAliasMap` logic (same regex, same "whole
+ * template substitution only" constraint) so the hint in our error
+ * message matches what the SDK would actually honor.
+ */
+function envAliasesForField(
+  manifest: EnvAliasSource | null | undefined,
+  fieldName: string,
+): string[] {
+  const entries = manifest?.server?.mcp_config?.env;
+  if (!entries) return [];
+  // Keep in sync with `[^}]+` in mpak-sdk — see mpak/pull/83.
+  const wholeSubstitution = /^\$\{user_config\.([^}]+)\}$/;
+  const aliases: string[] = [];
+  for (const [envVar, template] of Object.entries(entries)) {
+    if (typeof template !== "string") continue;
+    const match = wholeSubstitution.exec(template);
+    if (match?.[1] === fieldName) aliases.push(envVar);
+  }
+  return aliases;
+}
+
+/**
  * Translate an `MpakConfigError` from the mpak SDK into NimbleBrain's
  * copy-pastable `nb config set -w <wsId>` hint. Callers use this at every
  * site that calls `mpak.prepareServer` after host-side credential resolution.
  *
+ * When a `manifest` is provided, the message additionally names the
+ * specific env var(s) each missing field can be satisfied by (via the
+ * SDK's reverse-lookup tier), so users don't have to inspect the
+ * manifest to find them. When omitted, falls back to a generic hint.
+ *
  * Returns the input error unchanged when it is not a credential-missing
  * error, so `catch` blocks can forward non-credential failures untouched.
  */
-export function friendlyMpakConfigError(err: unknown, wsId: string): Error {
+export function friendlyMpakConfigError(
+  err: unknown,
+  wsId: string,
+  manifest?: EnvAliasSource | null,
+): Error {
   if (!(err instanceof MpakConfigError)) {
     return err instanceof Error ? err : new Error(String(err));
   }
@@ -456,15 +500,24 @@ export function friendlyMpakConfigError(err: unknown, wsId: string): Error {
   const fields = err.missingFields;
   if (fields.length === 0) return new Error(err.message);
 
-  const hints = fields
-    .map((f) => `  nb config set ${bundle} ${f.key}=<value> -w ${wsId}`)
-    .join("\n");
+  // Per-field hint: one `nb config set` line plus, when we can find
+  // them, the specific env vars the bundle declared as aliases. This is
+  // almost always the onboarding-error path; naming the concrete env
+  // var ("export ANTHROPIC_API_KEY") beats pointing at a file format
+  // they haven't read.
+  const hintLines: string[] = [];
+  for (const f of fields) {
+    hintLines.push(`  nb config set ${bundle} ${f.key}=<value> -w ${wsId}`);
+    const aliases = envAliasesForField(manifest, f.key);
+    for (const envVar of aliases) {
+      hintLines.push(`  export ${envVar}=<value>  # satisfies "${f.key}"`);
+    }
+  }
+
   // MpakConfigError types `title` as required string, but an empty value
   // is useless for user-facing output — fall back to the raw key.
   const labels = fields.map((f) => `"${f.title?.length ? f.title : f.key}"`).join(", ");
   return new Error(
-    `Missing required config ${labels} for ${bundle}.\n` +
-      `Run one of:\n${hints}\n` +
-      `Or export the env var declared in the bundle's mcp_config.env.`,
+    `Missing required config ${labels} for ${bundle}.\nRun one of:\n${hintLines.join("\n")}`,
   );
 }

--- a/src/config/workspace-credentials.ts
+++ b/src/config/workspace-credentials.ts
@@ -329,69 +329,6 @@ export async function clearAllWorkspaceCredentials(
 
 // ── Tier resolver ─────────────────────────────────────────────────
 
-/**
- * Strip a trailing `inc` (case-insensitive) from a scope segment.
- *
- * Rationale: the GitHub org `nimblebraininc` exists only because `nimblebrain`
- * was taken on GitHub. The brand — and therefore the env var convention — is
- * `nimblebrain`. Stripping the suffix keeps the env var name aligned with the
- * public brand instead of a GitHub artifact.
- *
- * Collision caveat: the rule applies to ALL scopes, not just `nimblebraininc`.
- * A future scope like `@fooinc` would collide with `@foo` under this mapping.
- * Acceptable today because the NimbleBrain-published bundle ecosystem doesn't
- * have scopes ending in `inc` other than ours; if that ever changes we
- * should either promote this to an explicit alias map or warn at resolve
- * time when a collision is detected.
- */
-function normalizeScope(scope: string): string {
-  return scope.replace(/inc$/i, "");
-}
-
-/**
- * Compute the process environment variable name for a bundle field.
- *
- * Convention: `NB_CONFIG_{SCOPE}_{NAME}_{FIELD}` — uppercase, with hyphens
- * replaced by underscores. The scope segment is included to prevent collisions
- * between same-named bundles from different scopes.
- *
- * Scope normalization: a trailing `inc` on the scope is stripped (see
- * `normalizeScope`). If the scope collapses to an empty string (e.g. a bare
- * `@inc/foo`), the env var falls back to the unscoped form.
- *
- * Examples:
- *   `@nimblebraininc/newsapi` + `api_key` → `NB_CONFIG_NIMBLEBRAIN_NEWSAPI_API_KEY`
- *   `@foo/bar`                + `field`   → `NB_CONFIG_FOO_BAR_FIELD`
- *   `bundleName`              + `field`   → `NB_CONFIG_BUNDLENAME_FIELD`
- *   `my-bundle`               + `api-key` → `NB_CONFIG_MY_BUNDLE_API_KEY`
- */
-export function envVarName(bundleName: string, fieldName: string): string {
-  const normalize = (s: string): string => s.replace(/-/g, "_").toUpperCase();
-
-  // Strip leading `@` and split into [scope, name] if scoped.
-  const stripped = bundleName.replace(/^@/, "");
-  const slashIdx = stripped.indexOf("/");
-
-  const fieldPart = normalize(fieldName);
-
-  if (slashIdx === -1) {
-    // Unscoped: NB_CONFIG_{NAME}_{FIELD}
-    return `NB_CONFIG_${normalize(stripped)}_${fieldPart}`;
-  }
-
-  const rawScope = stripped.slice(0, slashIdx);
-  const name = stripped.slice(slashIdx + 1);
-  const scope = normalizeScope(rawScope);
-
-  // Edge case: scope normalizes to empty (e.g. bare `inc`) — fall back to
-  // unscoped form rather than emitting a double-underscore.
-  if (scope === "") {
-    return `NB_CONFIG_${normalize(name)}_${fieldPart}`;
-  }
-
-  return `NB_CONFIG_${normalize(scope)}_${normalize(name)}_${fieldPart}`;
-}
-
 /** Field descriptor from a bundle's `user_config` manifest section. */
 export interface UserConfigFieldDef {
   type: string;
@@ -416,43 +353,43 @@ export interface ResolveUserConfigOpts {
   wsId: string;
   /** Root work directory (e.g. `~/.nimblebrain`). */
   workDir: string;
-  /** Interactive gate used to prompt for missing values (TUI-only). */
+  /** Interactive gate used to prompt for values (TUI `configure` flow only). */
   gate?: ConfirmationGate;
   /**
-   * If `true`, prompt for every field even when a stored value exists.
+   * If `true`, prompt for every field via the gate and persist responses to
+   * the workspace store. Used by the `nb__manage_app configure` TUI action.
    * No effect when `gate?.supportsInteraction` is false.
    */
   forcePrompt?: boolean;
 }
 
 /**
- * Resolve all `user_config` field values for a bundle in a workspace.
+ * Resolve `user_config` field values for a bundle from the workspace
+ * credential store.
  *
- * Resolution hierarchy (first match wins, per field):
- *   1. Workspace credential store — `getWorkspaceCredentials(wsId, bundleName, workDir)`
- *   2. Process environment        — `process.env[envVarName(bundleName, field)]`
- *   3. Manifest default           — `field.default`
+ * This is the host-side half of a two-stage resolution. It returns a
+ * **partial** map of whatever it found (or prompted for); the mpak SDK
+ * then tries its own tiers — manifest-declared `mcp_config.env` aliases
+ * and manifest defaults — and throws `MpakConfigError` if anything
+ * required is still unresolved. Callers catch that at the SDK boundary
+ * and translate to a `nb config set -w <wsId>` hint.
  *
- * `~/.mpak/config.json` is intentionally NOT consulted. NimbleBrain neither
- * reads nor writes the global mpak config; users with values there must re-set
- * them via `nb config set -w <wsId>`.
+ * Behavior:
  *
- * If a field is still missing after all tiers:
- *   - If `gate?.supportsInteraction` is true, prompt via
- *     `gate.promptConfigValue(...)`. A returned value is persisted to the
- *     workspace credential store (tier 1) and included in the result.
- *   - Else if `field.required !== false` (required or unspecified), throw a
- *     descriptive error with a copy-pastable `nb config set -w <wsId>` hint.
- *   - Otherwise (optional), the field is silently omitted from the result.
+ *   - Default mode: read each field from `getWorkspaceCredentials`.
+ *     Include any non-empty string values in the result. Absent/empty
+ *     values fall through silently — the SDK decides whether that's an
+ *     error based on `required` and its own tiers.
  *
- * When `forcePrompt` is true AND the gate supports interaction, the resolver
- * skips steps 1–3 entirely and prompts for every field. This is how
- * `nb config set` re-prompts are implemented.
+ *   - `forcePrompt` + interactive gate: used by the TUI configure flow.
+ *     Prompt every field via `gate.promptConfigValue`. Persist each
+ *     returned value to the workspace store. Skipped responses are
+ *     omitted — the SDK's missing-required check fires if appropriate.
  *
  * `null`/`undefined`/empty `userConfigSchema` short-circuits to `{}`.
  *
- * The returned map contains only resolved values as strings — callers pass it
- * directly to the mpak SDK's `prepareServer({ userConfig })` option.
+ * `~/.mpak/config.json` is intentionally not consulted here or anywhere
+ * else in NimbleBrain — the workspace store is our persistence surface.
  */
 export async function resolveUserConfig(
   opts: ResolveUserConfigOpts,
@@ -463,52 +400,16 @@ export async function resolveUserConfig(
   const fieldNames = Object.keys(userConfigSchema);
   if (fieldNames.length === 0) return {};
 
-  // Tier 1 is read once per bundle (it's a single file).
-  const stored = (await getWorkspaceCredentials(wsId, bundleName, workDir)) ?? {};
-
   const interactive = gate?.supportsInteraction === true;
-  const resolved: Record<string, string> = {};
 
-  for (const key of fieldNames) {
-    const field = userConfigSchema[key];
-    if (!field) continue;
-
-    let value: string | undefined;
-
-    if (forcePrompt && interactive) {
-      // Skip tiers 1–3; go straight to prompt.
-    } else {
-      // Tier 1: workspace credential store.
-      const storedValue = stored[key];
-      if (typeof storedValue === "string" && storedValue.length > 0) {
-        value = storedValue;
-      }
-
-      // Tier 2: process environment.
-      if (value === undefined) {
-        const envValue = process.env[envVarName(bundleName, key)];
-        if (typeof envValue === "string" && envValue.length > 0) {
-          value = envValue;
-        }
-      }
-
-      // Tier 3: manifest default.
-      // MCPB manifests restrict user_config types to primitives (string, number,
-      // boolean, directory, file), so String() is safe. An object/array default
-      // would stringify to "[object Object]" or a comma-joined form — if that
-      // ever happens it reflects a malformed manifest upstream, not a bug here.
-      if (value === undefined && field.default !== undefined && field.default !== null) {
-        value = String(field.default);
-      }
-    }
-
-    if (value !== undefined) {
-      resolved[key] = value;
-      continue;
-    }
-
-    // Still missing. Try interactive prompt if available.
-    if (interactive && gate) {
+  // TUI configure flow: prompt every field, persist, return whatever the
+  // user provided. Skipped prompts don't get persisted and don't end up in
+  // the result — the SDK's required-field check catches that downstream.
+  if (forcePrompt && interactive && gate) {
+    const resolved: Record<string, string> = {};
+    for (const key of fieldNames) {
+      const field = userConfigSchema[key];
+      if (!field) continue;
       const prompted = await gate.promptConfigValue({
         key,
         title: field.title,
@@ -519,22 +420,59 @@ export async function resolveUserConfig(
       if (typeof prompted === "string" && prompted.length > 0) {
         await saveWorkspaceCredential(wsId, bundleName, key, prompted, workDir);
         resolved[key] = prompted;
-        continue;
       }
     }
-
-    // No value, no prompt (or prompt returned nothing).
-    const isRequired = field.required !== false;
-    if (isRequired) {
-      const label = field.title ?? key;
-      // Never include values or defaults in the error — only field names.
-      throw new Error(
-        `Missing required config "${label}" for ${bundleName}.\n` +
-          `Run: nb config set ${bundleName} ${key}=<value> -w ${wsId}`,
-      );
-    }
-    // Optional field with no value — skip.
+    return resolved;
   }
 
+  // Default: read workspace store, return non-empty string values. The SDK
+  // handles mcp_config.env aliases, manifest defaults, and required-field
+  // validation from here. See `mpak-sdk`'s `gatherUserConfig` for the rest
+  // of the resolution chain.
+  const stored = (await getWorkspaceCredentials(wsId, bundleName, workDir)) ?? {};
+  const resolved: Record<string, string> = {};
+  for (const key of fieldNames) {
+    const v = stored[key];
+    if (typeof v === "string" && v.length > 0) resolved[key] = v;
+  }
   return resolved;
+}
+
+/**
+ * Translate an `MpakConfigError` from the mpak SDK into NimbleBrain's
+ * copy-pastable `nb config set -w <wsId>` hint. Callers use this at every
+ * site that calls `mpak.prepareServer` after host-side credential resolution.
+ *
+ * Returns the input error unchanged when it is not a credential-missing
+ * error, so `catch` blocks can forward non-credential failures untouched.
+ */
+export function friendlyMpakConfigError(err: unknown, wsId: string): Error {
+  // Duck-typed check so we don't force a hard dependency on the SDK's
+  // exported class here — the shape is stable (bundleName + missingFields).
+  if (
+    !err ||
+    typeof err !== "object" ||
+    !("code" in err) ||
+    (err as { code: unknown }).code !== "CONFIG_MISSING"
+  ) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+  const e = err as unknown as {
+    message?: string;
+    packageName?: string;
+    missingFields?: Array<{ key: string; title?: string }>;
+  };
+  const bundle = e.packageName ?? "<bundle>";
+  const fields = e.missingFields ?? [];
+  if (fields.length === 0) return new Error(e.message ?? String(err));
+
+  const hints = fields
+    .map((f) => `  nb config set ${bundle} ${f.key}=<value> -w ${wsId}`)
+    .join("\n");
+  const labels = fields.map((f) => `"${f.title ?? f.key}"`).join(", ");
+  return new Error(
+    `Missing required config ${labels} for ${bundle}.\n` +
+      `Run one of:\n${hints}\n` +
+      `Or export the env var declared in the bundle's mcp_config.env.`,
+  );
 }

--- a/src/config/workspace-credentials.ts
+++ b/src/config/workspace-credentials.ts
@@ -440,76 +440,34 @@ export async function resolveUserConfig(
 }
 
 /**
- * Minimal manifest shape used by `friendlyMpakConfigError` to suggest the
- * specific env var(s) a user can export to satisfy each missing field.
- * Kept narrow on purpose — callers hand in the cached manifest they
- * already have in scope; we only need `server.mcp_config.env`.
- */
-export interface EnvAliasSource {
-  server?: { mcp_config?: { env?: Record<string, unknown> } };
-}
-
-/**
- * Given a manifest and a user_config field name, list the host env var
- * names that would satisfy it via the SDK's reverse-lookup tier.
- *
- * Mirrors the SDK's `buildEnvAliasMap` logic (same regex, same "whole
- * template substitution only" constraint) so the hint in our error
- * message matches what the SDK would actually honor.
- */
-function envAliasesForField(
-  manifest: EnvAliasSource | null | undefined,
-  fieldName: string,
-): string[] {
-  const entries = manifest?.server?.mcp_config?.env;
-  if (!entries) return [];
-  // Keep in sync with `[^}]+` in mpak-sdk — see mpak/pull/83.
-  const wholeSubstitution = /^\$\{user_config\.([^}]+)\}$/;
-  const aliases: string[] = [];
-  for (const [envVar, template] of Object.entries(entries)) {
-    if (typeof template !== "string") continue;
-    const match = wholeSubstitution.exec(template);
-    if (match?.[1] === fieldName) aliases.push(envVar);
-  }
-  return aliases;
-}
-
-/**
  * Translate an `MpakConfigError` from the mpak SDK into NimbleBrain's
  * copy-pastable `nb config set -w <wsId>` hint. Callers use this at every
  * site that calls `mpak.prepareServer` after host-side credential resolution.
  *
- * When a `manifest` is provided, the message additionally names the
- * specific env var(s) each missing field can be satisfied by (via the
- * SDK's reverse-lookup tier), so users don't have to inspect the
- * manifest to find them. When omitted, falls back to a generic hint.
+ * Each missing field's message includes the specific env var(s) the
+ * bundle declared as satisfying it in `mcp_config.env` — read directly
+ * from `MpakConfigError.missingFields[i].envAliases` (0.5.0+). Users
+ * see the actual export line they can run, not a pointer at a file they
+ * may not know how to inspect.
  *
  * Returns the input error unchanged when it is not a credential-missing
  * error, so `catch` blocks can forward non-credential failures untouched.
  */
-export function friendlyMpakConfigError(
-  err: unknown,
-  wsId: string,
-  manifest?: EnvAliasSource | null,
-): Error {
+export function friendlyMpakConfigError(err: unknown, wsId: string): Error {
   if (!(err instanceof MpakConfigError)) {
     return err instanceof Error ? err : new Error(String(err));
   }
-  // `err` is narrowed to MpakConfigError — no duck-typing needed.
   const bundle = err.packageName;
   const fields = err.missingFields;
   if (fields.length === 0) return new Error(err.message);
 
-  // Per-field hint: one `nb config set` line plus, when we can find
-  // them, the specific env vars the bundle declared as aliases. This is
-  // almost always the onboarding-error path; naming the concrete env
-  // var ("export ANTHROPIC_API_KEY") beats pointing at a file format
-  // they haven't read.
+  // Per-field hint: one `nb config set` line, plus one `export VAR=...`
+  // line per declared env alias. The alias list is derived by the SDK
+  // and attached to each missing field — we don't re-derive it.
   const hintLines: string[] = [];
   for (const f of fields) {
     hintLines.push(`  nb config set ${bundle} ${f.key}=<value> -w ${wsId}`);
-    const aliases = envAliasesForField(manifest, f.key);
-    for (const envVar of aliases) {
+    for (const envVar of f.envAliases) {
       hintLines.push(`  export ${envVar}=<value>  # satisfies "${f.key}"`);
     }
   }

--- a/test/integration/startup-credentials.test.ts
+++ b/test/integration/startup-credentials.test.ts
@@ -1,19 +1,22 @@
 /**
  * Integration tests for the credential-resolution wiring in the bundle
- * startup path. Covers task 005 — `resolveUserConfig` must run BEFORE
- * `mpak.prepareServer()` validates `user_config`.
+ * startup path. `startBundleSource` reads the workspace credential store
+ * and hands whatever it finds to `mpak.prepareServer({ userConfig })`;
+ * the SDK then tries the bundle's declared `mcp_config.env` aliases
+ * and manifest defaults before throwing `MpakConfigError`. The host
+ * translates that to a `nb config set -w <wsId>` hint.
  *
- * These tests seed the mpak bundle cache on disk with a hand-authored manifest
- * that declares a `user_config` field. `startBundleSource` is then invoked
- * against a named bundle and we assert on the outcome:
+ * These tests seed the mpak bundle cache on disk with a hand-authored
+ * manifest and exercise three paths:
  *
- *   - Happy path: credentials in the workspace credential store → bundle starts.
- *   - Env path:   credentials in the `NB_CONFIG_*` env var → bundle starts.
- *   - Failure:    no credentials anywhere → throws with an actionable hint.
+ *   - Store path:  credentials in the workspace credential store → bundle starts.
+ *   - Env path:    credentials in the env var declared by the bundle's
+ *                  own mcp_config.env mapping → bundle starts.
+ *   - Failure:     no credentials anywhere → throws a friendly
+ *                  MpakConfigError with the nb config set hint.
  *
- * The bundle itself is a minimal CommonJS MCP server that exposes a single tool
- * and reads the credential from its process env (mirroring how a real bundle's
- * `mcp_config.env` substitutes `${user_config.*}`).
+ * The bundle itself is a minimal CommonJS MCP server that exposes a single
+ * tool and echoes the credential env var the manifest declares.
  */
 
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
@@ -22,7 +25,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NoopEventSink } from "../../src/adapters/noop-events.ts";
 import { startBundleSource } from "../../src/bundles/startup.ts";
-import { envVarName, saveWorkspaceCredential } from "../../src/config/workspace-credentials.ts";
+import { saveWorkspaceCredential } from "../../src/config/workspace-credentials.ts";
 import { ToolRegistry } from "../../src/tools/registry.ts";
 
 const BUNDLE_NAME = "@nbtest/creds-bundle";
@@ -153,19 +156,18 @@ describe("startBundleSource — credential resolution", () => {
     prevMpakHome = process.env.MPAK_HOME;
     process.env.MPAK_HOME = layout.mpakHome;
 
-    // Clear any leaking env override from a previous test.
-    const name = envVarName(BUNDLE_NAME, "api_key");
-    prevEnvVal = process.env[name];
-    delete process.env[name];
+    // Clear any leaked copy of the bundle-declared env var from a prior
+    // test — the SDK's reverse-lookup tier reads this at resolve time.
+    prevEnvVal = process.env[BUNDLE_ENV_VAR];
+    delete process.env[BUNDLE_ENV_VAR];
   });
 
   // Restore env after each test so one case can't contaminate the next.
   function restoreEnv(): void {
     if (prevMpakHome === undefined) delete process.env.MPAK_HOME;
     else process.env.MPAK_HOME = prevMpakHome;
-    const name = envVarName(BUNDLE_NAME, "api_key");
-    if (prevEnvVal === undefined) delete process.env[name];
-    else process.env[name] = prevEnvVal;
+    if (prevEnvVal === undefined) delete process.env[BUNDLE_ENV_VAR];
+    else process.env[BUNDLE_ENV_VAR] = prevEnvVal;
   }
 
   test(
@@ -209,11 +211,15 @@ describe("startBundleSource — credential resolution", () => {
   );
 
   test(
-    "env path — NB_CONFIG_* env var satisfies user_config, bundle starts",
+    "env path — bundle-declared env var (mcp_config.env) satisfies user_config",
     async () => {
       try {
-        const envName = envVarName(BUNDLE_NAME, "api_key");
-        process.env[envName] = "sk-env-456";
+        // The bundle's manifest declares
+        //   `"NBTEST_API_KEY": "${user_config.api_key}"`
+        // which the SDK reads in reverse: if the host has NBTEST_API_KEY
+        // set, the api_key field is satisfied. No NB_CONFIG_* prefix, no
+        // host convention — just the bundle's own mapping.
+        process.env[BUNDLE_ENV_VAR] = "sk-env-456";
 
         const registry = new ToolRegistry();
         const result = await startBundleSource(

--- a/test/unit/workspace-credentials.test.ts
+++ b/test/unit/workspace-credentials.test.ts
@@ -8,7 +8,7 @@ import {
   clearAllWorkspaceCredentials,
   clearWorkspaceCredential,
   credentialPath,
-  envVarName,
+  friendlyMpakConfigError,
   getWorkspaceCredentials,
   resolveUserConfig,
   saveWorkspaceCredential,
@@ -424,98 +424,38 @@ describe("concurrent save/clear on the same bundle", () => {
   });
 });
 
-// ── envVarName ────────────────────────────────────────────────────
-
-describe("envVarName", () => {
-  test("scoped with trailing `inc`: @nimblebraininc/newsapi + api_key → NB_CONFIG_NIMBLEBRAIN_NEWSAPI_API_KEY", () => {
-    expect(envVarName("@nimblebraininc/newsapi", "api_key")).toBe(
-      "NB_CONFIG_NIMBLEBRAIN_NEWSAPI_API_KEY",
-    );
-  });
-
-  test("scoped without `inc`: @foo/bar + field → NB_CONFIG_FOO_BAR_FIELD", () => {
-    expect(envVarName("@foo/bar", "field")).toBe("NB_CONFIG_FOO_BAR_FIELD");
-  });
-
-  test("unscoped: bundleName + field → NB_CONFIG_BUNDLENAME_FIELD", () => {
-    expect(envVarName("bundleName", "field")).toBe("NB_CONFIG_BUNDLENAME_FIELD");
-  });
-
-  test("hyphens in name and field become underscores", () => {
-    expect(envVarName("my-bundle", "api-key")).toBe("NB_CONFIG_MY_BUNDLE_API_KEY");
-    expect(envVarName("@acme/cool-tool", "my-field")).toBe("NB_CONFIG_ACME_COOL_TOOL_MY_FIELD");
-  });
-
-  test("edge case: scope of exactly `inc` collapses to empty → falls back to unscoped form", () => {
-    expect(envVarName("@inc/foo", "bar")).toBe("NB_CONFIG_FOO_BAR");
-  });
-
-  test("edge case: scope `INC` (uppercase) is also stripped case-insensitively", () => {
-    expect(envVarName("@INC/foo", "bar")).toBe("NB_CONFIG_FOO_BAR");
-  });
-
-  test("scope that contains `inc` but does not end with it is preserved", () => {
-    // `incremental` does not end with `inc` — no, wait, it does. Use a real counter-example.
-    expect(envVarName("@inco/foo", "bar")).toBe("NB_CONFIG_INCO_FOO_BAR");
-  });
-});
-
 // ── resolveUserConfig ─────────────────────────────────────────────
+//
+// The resolver is intentionally narrow: read the workspace credential
+// store and (in TUI `configure` mode) prompt via the gate, persisting
+// responses. Everything else — mcp_config.env reverse lookup, manifest
+// defaults, required-field validation — lives in the mpak SDK. These
+// tests cover the host-side contract only.
 
-/**
- * Minimal in-memory mock of `ConfirmationGate` for testing the interactive
- * branch of `resolveUserConfig`. Tracks calls so assertions can verify the
- * resolver actually prompted (and with what field info).
- */
-function mockGate(opts: {
-  responses?: Record<string, string | null>;
-  supportsInteraction?: boolean;
-} = {}): ConfirmationGate & { calls: ConfigField[] } {
+function mockGate(
+  opts: {
+    supportsInteraction?: boolean;
+    responses?: Record<string, string>;
+  } = {},
+): ConfirmationGate & { calls: ConfigField[] } {
   const calls: ConfigField[] = [];
   return {
     supportsInteraction: opts.supportsInteraction ?? true,
-    async confirm(): Promise<boolean> {
-      return true;
-    },
-    async promptConfigValue(field: ConfigField): Promise<string | null> {
+    confirm: async () => true,
+    promptConfigValue: async (field) => {
       calls.push(field);
-      const answer = opts.responses?.[field.key];
-      return answer === undefined ? null : answer;
+      return opts.responses?.[field.key] ?? null;
     },
     calls,
-  };
-}
-
-/**
- * Helper to snapshot process.env, mutate it, and restore afterwards.
- * Tests that touch env must always use this to stay hermetic.
- */
-function withEnv(keys: string[]) {
-  const snapshot: Record<string, string | undefined> = {};
-  for (const k of keys) snapshot[k] = process.env[k];
-  return {
-    set(k: string, v: string): void {
-      process.env[k] = v;
-    },
-    unset(k: string): void {
-      delete process.env[k];
-    },
-    restore(): void {
-      for (const k of keys) {
-        const v = snapshot[k];
-        if (v === undefined) delete process.env[k];
-        else process.env[k] = v;
-      }
-    },
-  };
+  } as ConfirmationGate & { calls: ConfigField[] };
 }
 
 describe("resolveUserConfig", () => {
   const SCHEMA: Record<string, UserConfigFieldDef> = {
-    api_key: { type: "string", required: true, sensitive: true },
+    api_key: { type: "string", required: true, sensitive: true, title: "API Key" },
   };
 
-  test("returns {} when schema is null", async () => {
+  test("null schema → {}", async () => {
     const result = await resolveUserConfig({
       bundleName: BUNDLE,
       userConfigSchema: null,
@@ -525,7 +465,7 @@ describe("resolveUserConfig", () => {
     expect(result).toEqual({});
   });
 
-  test("returns {} when schema is undefined", async () => {
+  test("undefined schema → {}", async () => {
     const result = await resolveUserConfig({
       bundleName: BUNDLE,
       userConfigSchema: undefined,
@@ -535,7 +475,7 @@ describe("resolveUserConfig", () => {
     expect(result).toEqual({});
   });
 
-  test("returns {} when schema is an empty object", async () => {
+  test("empty schema → {}", async () => {
     const result = await resolveUserConfig({
       bundleName: BUNDLE,
       userConfigSchema: {},
@@ -545,128 +485,32 @@ describe("resolveUserConfig", () => {
     expect(result).toEqual({});
   });
 
-  // ── Tier priority ──────────────────────────────────────────────
+  test("workspace store: returns stored values", async () => {
+    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "sk-from-store", workDir);
 
-  test("tier 1: workspace credential store beats process env", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.set(envKey, "from-env");
-      await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "from-store", workDir);
-
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: SCHEMA,
-        wsId: WS_A,
-        workDir,
-      });
-      expect(result).toEqual({ api_key: "from-store" });
-    } finally {
-      env.restore();
-    }
+    const result = await resolveUserConfig({
+      bundleName: BUNDLE,
+      userConfigSchema: SCHEMA,
+      wsId: WS_A,
+      workDir,
+    });
+    expect(result).toEqual({ api_key: "sk-from-store" });
   });
 
-  test("tier 2: process env beats manifest default", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.set(envKey, "from-env");
-      const schema: Record<string, UserConfigFieldDef> = {
-        api_key: { type: "string", default: "from-default" },
-      };
-
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: schema,
-        wsId: WS_A,
-        workDir,
-      });
-      expect(result).toEqual({ api_key: "from-env" });
-    } finally {
-      env.restore();
-    }
+  test("no stored value + no gate → returns partial map (does NOT throw)", async () => {
+    // The SDK is now responsible for required-field validation. The
+    // resolver returns whatever it found and lets the SDK surface
+    // MpakConfigError if appropriate.
+    const result = await resolveUserConfig({
+      bundleName: BUNDLE,
+      userConfigSchema: SCHEMA,
+      wsId: WS_A,
+      workDir,
+    });
+    expect(result).toEqual({});
   });
 
-  test("tier 3: manifest default used when nothing else provides", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-      const schema: Record<string, UserConfigFieldDef> = {
-        api_key: { type: "string", default: "from-default" },
-      };
-
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: schema,
-        wsId: WS_A,
-        workDir,
-      });
-      expect(result).toEqual({ api_key: "from-default" });
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("manifest default is coerced to string (numbers, booleans)", async () => {
-    const envKey1 = envVarName(BUNDLE, "max_items");
-    const envKey2 = envVarName(BUNDLE, "enabled");
-    const env = withEnv([envKey1, envKey2]);
-    try {
-      env.unset(envKey1);
-      env.unset(envKey2);
-      const schema: Record<string, UserConfigFieldDef> = {
-        max_items: { type: "number", default: 42 },
-        enabled: { type: "boolean", default: true },
-      };
-
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: schema,
-        wsId: WS_A,
-        workDir,
-      });
-      expect(result).toEqual({ max_items: "42", enabled: "true" });
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("mixed: field A from workspace, B from env, C from default", async () => {
-    const envKeyB = envVarName(BUNDLE, "field_b");
-    const envKeyA = envVarName(BUNDLE, "field_a");
-    const envKeyC = envVarName(BUNDLE, "field_c");
-    const env = withEnv([envKeyA, envKeyB, envKeyC]);
-    try {
-      env.unset(envKeyA);
-      env.set(envKeyB, "from-env-b");
-      env.unset(envKeyC);
-
-      await saveWorkspaceCredential(WS_A, BUNDLE, "field_a", "from-store-a", workDir);
-
-      const schema: Record<string, UserConfigFieldDef> = {
-        field_a: { type: "string" },
-        field_b: { type: "string" },
-        field_c: { type: "string", default: "from-default-c" },
-      };
-
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: schema,
-        wsId: WS_A,
-        workDir,
-      });
-      expect(result).toEqual({
-        field_a: "from-store-a",
-        field_b: "from-env-b",
-        field_c: "from-default-c",
-      });
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("workspace isolation: two workspaces resolve different values for same bundle", async () => {
+  test("workspace isolation: two workspaces have independent stores", async () => {
     await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "sk-alpha", workDir);
     await saveWorkspaceCredential(WS_B, BUNDLE, "api_key", "sk-beta", workDir);
 
@@ -682,222 +526,56 @@ describe("resolveUserConfig", () => {
       wsId: WS_B,
       workDir,
     });
+
     expect(a).toEqual({ api_key: "sk-alpha" });
     expect(b).toEqual({ api_key: "sk-beta" });
   });
 
-  // ── Required / optional ────────────────────────────────────────
+  test("empty string in workspace store is treated as absent (not returned)", async () => {
+    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "", workDir);
 
-  test("missing required field (no gate) throws with -w <wsId> hint", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-
-      await expect(
-        resolveUserConfig({
-          bundleName: BUNDLE,
-          userConfigSchema: SCHEMA,
-          wsId: WS_A,
-          workDir,
-        }),
-      ).rejects.toThrow(/nb config set .*-w ws_alpha/);
-    } finally {
-      env.restore();
-    }
+    const result = await resolveUserConfig({
+      bundleName: BUNDLE,
+      userConfigSchema: SCHEMA,
+      wsId: WS_A,
+      workDir,
+    });
+    expect(result).toEqual({});
   });
 
-  test("error message includes bundle name and field key, but not stored values", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-
-      let thrown: Error | undefined;
-      try {
-        await resolveUserConfig({
-          bundleName: BUNDLE,
-          userConfigSchema: SCHEMA,
-          wsId: WS_A,
-          workDir,
-        });
-      } catch (err) {
-        thrown = err as Error;
-      }
-      expect(thrown).toBeDefined();
-      expect(thrown?.message).toContain(BUNDLE);
-      expect(thrown?.message).toContain("api_key");
-      // no value should be in the message (the stored value, if any, is sk-)
-      expect(thrown?.message).not.toContain("sk-");
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("missing required with non-interactive gate throws with -w <wsId> hint", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-      const gate = mockGate({ supportsInteraction: false });
-
-      await expect(
-        resolveUserConfig({
-          bundleName: BUNDLE,
-          userConfigSchema: SCHEMA,
-          wsId: WS_A,
-          workDir,
-          gate,
-        }),
-      ).rejects.toThrow(/-w ws_alpha/);
-      expect(gate.calls).toHaveLength(0);
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("error message prefers field.title over field key when available", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-      const schema: Record<string, UserConfigFieldDef> = {
-        api_key: { type: "string", required: true, title: "API Key" },
-      };
-
-      await expect(
-        resolveUserConfig({
-          bundleName: BUNDLE,
-          userConfigSchema: schema,
-          wsId: WS_A,
-          workDir,
-        }),
-      ).rejects.toThrow(/"API Key"/);
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("missing optional field (required: false) is silently omitted", async () => {
-    const envKey = envVarName(BUNDLE, "opt_field");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-      const schema: Record<string, UserConfigFieldDef> = {
-        opt_field: { type: "string", required: false },
-      };
-
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: schema,
-        wsId: WS_A,
-        workDir,
-      });
-      expect(result).toEqual({});
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("field without explicit `required` defaults to required (throws when missing)", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-      const schema: Record<string, UserConfigFieldDef> = {
-        api_key: { type: "string" }, // no `required` field
-      };
-
-      await expect(
-        resolveUserConfig({
-          bundleName: BUNDLE,
-          userConfigSchema: schema,
-          wsId: WS_A,
-          workDir,
-        }),
-      ).rejects.toThrow(/Missing required/);
-    } finally {
-      env.restore();
-    }
-  });
-
-  // ── Interactive prompting ──────────────────────────────────────
-
-  test("interactive gate: prompts for missing field, saves result to workspace store", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-
-      const gate = mockGate({ responses: { api_key: "prompted-value" } });
-
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: SCHEMA,
-        wsId: WS_A,
-        workDir,
-        gate,
-      });
-      expect(result).toEqual({ api_key: "prompted-value" });
-      expect(gate.calls).toHaveLength(1);
-      expect(gate.calls[0]).toMatchObject({ key: "api_key", sensitive: true, required: true });
-
-      // Value should now be on disk.
-      const stored = await getWorkspaceCredentials(WS_A, BUNDLE, workDir);
-      expect(stored).toEqual({ api_key: "prompted-value" });
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("interactive gate: prompt returning null on required field throws", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-      const gate = mockGate({ responses: { api_key: null } });
-
-      await expect(
-        resolveUserConfig({
-          bundleName: BUNDLE,
-          userConfigSchema: SCHEMA,
-          wsId: WS_A,
-          workDir,
-          gate,
-        }),
-      ).rejects.toThrow(/Missing required/);
-      expect(gate.calls).toHaveLength(1);
-    } finally {
-      env.restore();
-    }
-  });
-
-  test("interactive gate: prompt returning null on optional field silently omits it", async () => {
+  test("multi-field: returns only fields with non-empty stored values", async () => {
     const schema: Record<string, UserConfigFieldDef> = {
-      opt_field: { type: "string", required: false },
+      api_key: { type: "string", required: true },
+      workspace_id: { type: "string", required: false },
+      region: { type: "string", required: false },
     };
-    const envKey = envVarName(BUNDLE, "opt_field");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-      const gate = mockGate({ responses: { opt_field: null } });
+    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "sk-xxx", workDir);
+    await saveWorkspaceCredential(WS_A, BUNDLE, "region", "us-west", workDir);
+    // workspace_id intentionally not set
 
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: schema,
-        wsId: WS_A,
-        workDir,
-        gate,
-      });
-      expect(result).toEqual({});
-    } finally {
-      env.restore();
-    }
+    const result = await resolveUserConfig({
+      bundleName: BUNDLE,
+      userConfigSchema: schema,
+      wsId: WS_A,
+      workDir,
+    });
+    expect(result).toEqual({ api_key: "sk-xxx", region: "us-west" });
   });
+});
 
-  test("forcePrompt: re-prompts even when a stored value already exists", async () => {
-    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "stored-old", workDir);
-    const gate = mockGate({ responses: { api_key: "prompted-new" } });
+describe("resolveUserConfig — forcePrompt (TUI configure flow)", () => {
+  const SCHEMA: Record<string, UserConfigFieldDef> = {
+    api_key: {
+      type: "string",
+      required: true,
+      sensitive: true,
+      title: "API Key",
+      description: "Your API key",
+    },
+  };
+
+  test("prompts, persists to workspace store, returns prompted value", async () => {
+    const gate = mockGate({ responses: { api_key: "sk-prompted" } });
 
     const result = await resolveUserConfig({
       bundleName: BUNDLE,
@@ -907,142 +585,153 @@ describe("resolveUserConfig", () => {
       gate,
       forcePrompt: true,
     });
-    expect(result).toEqual({ api_key: "prompted-new" });
-    expect(gate.calls).toHaveLength(1);
 
-    // Stored value should be overwritten.
+    expect(result).toEqual({ api_key: "sk-prompted" });
+    expect(gate.calls).toHaveLength(1);
+    expect(gate.calls[0]).toMatchObject({
+      key: "api_key",
+      title: "API Key",
+      description: "Your API key",
+      sensitive: true,
+      required: true,
+    });
+
+    // Prompted value landed in the workspace credential store.
     const stored = await getWorkspaceCredentials(WS_A, BUNDLE, workDir);
-    expect(stored).toEqual({ api_key: "prompted-new" });
+    expect(stored).toEqual({ api_key: "sk-prompted" });
   });
 
-  test("forcePrompt without an interactive gate is a no-op (uses stored value)", async () => {
-    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "stored", workDir);
+  test("overwrites existing stored value when user provides new one", async () => {
+    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "sk-old", workDir);
+    const gate = mockGate({ responses: { api_key: "sk-new" } });
 
     const result = await resolveUserConfig({
       bundleName: BUNDLE,
       userConfigSchema: SCHEMA,
       wsId: WS_A,
       workDir,
+      gate,
       forcePrompt: true,
-      // no gate
     });
-    expect(result).toEqual({ api_key: "stored" });
+
+    expect(result).toEqual({ api_key: "sk-new" });
+    const stored = await getWorkspaceCredentials(WS_A, BUNDLE, workDir);
+    expect(stored).toEqual({ api_key: "sk-new" });
   });
 
-  test("interactive gate passes title/description/sensitive to promptConfigValue", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.unset(envKey);
-      const schema: Record<string, UserConfigFieldDef> = {
-        api_key: {
-          type: "string",
-          title: "API Key",
-          description: "Your NewsAPI key",
-          sensitive: true,
-          required: true,
-        },
-      };
-      const gate = mockGate({ responses: { api_key: "prompted" } });
+  test("skipped prompt (returns null) → field omitted, not persisted", async () => {
+    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "sk-old", workDir);
+    const gate = mockGate({ responses: {} }); // returns null for all keys
 
-      await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: schema,
-        wsId: WS_A,
-        workDir,
-        gate,
-      });
-      expect(gate.calls[0]).toEqual({
-        key: "api_key",
-        title: "API Key",
-        description: "Your NewsAPI key",
-        sensitive: true,
-        required: true,
-      });
-    } finally {
-      env.restore();
-    }
+    const result = await resolveUserConfig({
+      bundleName: BUNDLE,
+      userConfigSchema: SCHEMA,
+      wsId: WS_A,
+      workDir,
+      gate,
+      forcePrompt: true,
+    });
+
+    // Field is omitted from the result (user declined to provide).
+    expect(result).toEqual({});
+    // Existing stored value is preserved — we only persist what the user
+    // actively entered.
+    const stored = await getWorkspaceCredentials(WS_A, BUNDLE, workDir);
+    expect(stored).toEqual({ api_key: "sk-old" });
   });
 
-  // ── Empty-string semantics ─────────────────────────────────────
-  //
-  // Empty strings in the workspace store or process env are treated as
-  // "absent" and fall through to the next tier. Almost always reflects
-  // an accidentally-cleared credential, so falling through is friendlier
-  // than propagating `""` as a real value. Note this is intentionally
-  // opposite to how the mpak SDK's userConfig override treats empties
-  // (where `""` is a deliberate choice by the caller). Keep these tests
-  // locked in — a future refactor shouldn't quietly flip the semantics.
+  test("forcePrompt without interactive gate → reads store as normal", async () => {
+    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "sk-from-store", workDir);
 
-  test("empty string in workspace store falls through to process env", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.set(envKey, "from-env");
-      await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "", workDir);
-
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: SCHEMA,
-        wsId: WS_A,
-        workDir,
-      });
-      expect(result).toEqual({ api_key: "from-env" });
-    } finally {
-      env.restore();
-    }
+    const result = await resolveUserConfig({
+      bundleName: BUNDLE,
+      userConfigSchema: SCHEMA,
+      wsId: WS_A,
+      workDir,
+      // no gate provided
+      forcePrompt: true,
+    });
+    expect(result).toEqual({ api_key: "sk-from-store" });
   });
 
-  test("empty string in process env falls through to manifest default", async () => {
-    const envKey = envVarName(BUNDLE, "api_key");
-    const env = withEnv([envKey]);
-    try {
-      env.set(envKey, "");
-      const schema: Record<string, UserConfigFieldDef> = {
-        api_key: { type: "string", default: "from-default", required: true },
-      };
+  test("forcePrompt with gate.supportsInteraction=false → reads store as normal", async () => {
+    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "sk-from-store", workDir);
+    const gate = mockGate({ supportsInteraction: false });
 
-      const result = await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: schema,
-        wsId: WS_A,
-        workDir,
-      });
-      expect(result).toEqual({ api_key: "from-default" });
-    } finally {
-      env.restore();
-    }
+    const result = await resolveUserConfig({
+      bundleName: BUNDLE,
+      userConfigSchema: SCHEMA,
+      wsId: WS_A,
+      workDir,
+      gate,
+      forcePrompt: true,
+    });
+    expect(result).toEqual({ api_key: "sk-from-store" });
+    expect(gate.calls).toHaveLength(0);
+  });
+});
+
+describe("friendlyMpakConfigError", () => {
+  test("translates MpakConfigError-shaped objects into nb config set hints", () => {
+    // Duck-typed shape — matches what the mpak SDK throws.
+    const mpakError = Object.assign(
+      new Error("Missing required config for @scope/bundle: API Key"),
+      {
+        code: "CONFIG_MISSING",
+        packageName: "@scope/bundle",
+        missingFields: [
+          { key: "api_key", title: "API Key", sensitive: true },
+          { key: "workspace_id", title: "Workspace ID", sensitive: false },
+        ],
+      },
+    );
+
+    const translated = friendlyMpakConfigError(mpakError, WS_A);
+    expect(translated).toBeInstanceOf(Error);
+    expect(translated.message).toContain('"API Key"');
+    expect(translated.message).toContain('"Workspace ID"');
+    expect(translated.message).toContain("@scope/bundle");
+    expect(translated.message).toContain(
+      `nb config set @scope/bundle api_key=<value> -w ${WS_A}`,
+    );
+    expect(translated.message).toContain(
+      `nb config set @scope/bundle workspace_id=<value> -w ${WS_A}`,
+    );
+    // References the bundle-declared env-var alternative so users know that
+    // path exists too.
+    expect(translated.message).toContain("mcp_config.env");
   });
 
-  // ── forcePrompt + null response ────────────────────────────────
+  test("uses field.key when title is missing", () => {
+    const mpakError = Object.assign(new Error("..."), {
+      code: "CONFIG_MISSING",
+      packageName: "@scope/bundle",
+      missingFields: [{ key: "raw_key", sensitive: false }],
+    });
 
-  test("forcePrompt + gate returns null for required field throws actionable error", async () => {
-    // forcePrompt skips tiers 1-3 even if values exist; if the gate then
-    // refuses to provide a value for a required field, we should still
-    // throw the same "Missing required" error as the non-interactive path.
-    await saveWorkspaceCredential(WS_A, BUNDLE, "api_key", "stored", workDir);
-    const gate = mockGate({ responses: {} }); // returns null for unknown keys
+    const translated = friendlyMpakConfigError(mpakError, WS_A);
+    expect(translated.message).toContain('"raw_key"');
+  });
 
-    let thrown: Error | undefined;
-    try {
-      await resolveUserConfig({
-        bundleName: BUNDLE,
-        userConfigSchema: SCHEMA,
-        wsId: WS_A,
-        workDir,
-        gate,
-        forcePrompt: true,
-      });
-    } catch (err) {
-      thrown = err as Error;
-    }
+  test("passes through non-CONFIG_MISSING errors unchanged", () => {
+    const other = new Error("something else broke");
+    const translated = friendlyMpakConfigError(other, WS_A);
+    expect(translated).toBe(other);
+  });
 
-    expect(thrown).toBeDefined();
-    expect(thrown?.message).toMatch(/api_key|API key/i);
-    expect(thrown?.message).toMatch(/nb config set/);
-    expect(thrown?.message).toContain(WS_A);
-    // Stored value must not leak into the error message.
-    expect(thrown?.message).not.toContain("stored");
-    expect(gate.calls).toHaveLength(1);
+  test("wraps non-Error thrown values", () => {
+    const translated = friendlyMpakConfigError("string thrown", WS_A);
+    expect(translated).toBeInstanceOf(Error);
+    expect(translated.message).toBe("string thrown");
+  });
+
+  test("CONFIG_MISSING with empty missingFields falls back to the original message", () => {
+    const mpakError = Object.assign(new Error("raw mpak msg"), {
+      code: "CONFIG_MISSING",
+      packageName: "@scope/bundle",
+      missingFields: [],
+    });
+    const translated = friendlyMpakConfigError(mpakError, WS_A);
+    expect(translated.message).toBe("raw mpak msg");
   });
 });

--- a/test/unit/workspace-credentials.test.ts
+++ b/test/unit/workspace-credentials.test.ts
@@ -673,10 +673,12 @@ describe("resolveUserConfig — forcePrompt (TUI configure flow)", () => {
 });
 
 describe("friendlyMpakConfigError", () => {
-  test("translates MpakConfigError into nb config set hints (no manifest → generic)", () => {
+  test("translates MpakConfigError into nb config set hints", () => {
+    // No envAliases declared on these fields → only the `nb config set`
+    // lines appear, no `export` suggestions.
     const mpakError = new MpakConfigError("@scope/bundle", [
-      { key: "api_key", title: "API Key", sensitive: true },
-      { key: "workspace_id", title: "Workspace ID", sensitive: false },
+      { key: "api_key", title: "API Key", sensitive: true, envAliases: [] },
+      { key: "workspace_id", title: "Workspace ID", sensitive: false, envAliases: [] },
     ]);
 
     const translated = friendlyMpakConfigError(mpakError, WS_A);
@@ -690,79 +692,60 @@ describe("friendlyMpakConfigError", () => {
     expect(translated.message).toContain(
       `nb config set @scope/bundle workspace_id=<value> -w ${WS_A}`,
     );
-    // With no manifest, nothing suggests an export.
     expect(translated.message).not.toContain("export ");
   });
 
-  test("names concrete env vars when a manifest is provided", () => {
+  test("names concrete env vars when the SDK attaches envAliases", () => {
     // A bundle that maps api_key to both ANTHROPIC_API_KEY and CLAUDE_API_KEY
-    // should surface both options. The user's onboarding question ("what do
-    // I export?") should be answered right in the error message.
+    // surfaces both options. The user's onboarding question ("what do I
+    // export?") is answered right in the error message. The SDK already
+    // derived and attached this list — we don't re-derive from the manifest.
     const mpakError = new MpakConfigError("@scope/bundle", [
-      { key: "api_key", title: "API Key", sensitive: true },
-    ]);
-    const manifest = {
-      server: {
-        mcp_config: {
-          env: {
-            ANTHROPIC_API_KEY: "${user_config.api_key}",
-            CLAUDE_API_KEY: "${user_config.api_key}",
-            LOG_LEVEL: "info", // literal, not a substitution — must be ignored
-            PREFIXED: "prefix-${user_config.api_key}", // not whole-value — must be ignored
-          },
-        },
+      {
+        key: "api_key",
+        title: "API Key",
+        sensitive: true,
+        envAliases: ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"],
       },
-    };
+    ]);
 
-    const translated = friendlyMpakConfigError(mpakError, WS_A, manifest);
+    const translated = friendlyMpakConfigError(mpakError, WS_A);
     expect(translated.message).toContain(
       `nb config set @scope/bundle api_key=<value> -w ${WS_A}`,
     );
     expect(translated.message).toContain('export ANTHROPIC_API_KEY=<value>');
     expect(translated.message).toContain('export CLAUDE_API_KEY=<value>');
-    // Literals and partial substitutions must not be suggested as aliases
-    // — they would not actually satisfy the field via the SDK's reverse tier.
-    expect(translated.message).not.toContain("LOG_LEVEL");
-    expect(translated.message).not.toContain("PREFIXED");
   });
 
-  test("manifest provided but field has no env alias → only the nb config set line appears", () => {
+  test("mixed fields: some with aliases, some without", () => {
     const mpakError = new MpakConfigError("@scope/bundle", [
-      { key: "secret_only", title: "Secret Only", sensitive: true },
-    ]);
-    const manifest = {
-      // Declared mapping for a DIFFERENT field — should not be suggested
-      // for `secret_only`.
-      server: {
-        mcp_config: { env: { OTHER_KEY: "${user_config.other_field}" } },
+      {
+        key: "api_key",
+        title: "API Key",
+        sensitive: true,
+        envAliases: ["ANTHROPIC_API_KEY"],
       },
-    };
-    const translated = friendlyMpakConfigError(mpakError, WS_A, manifest);
+      {
+        key: "secret_only",
+        title: "Secret Only",
+        sensitive: true,
+        envAliases: [],
+      },
+    ]);
+
+    const translated = friendlyMpakConfigError(mpakError, WS_A);
+    // api_key has an export hint.
+    expect(translated.message).toContain('export ANTHROPIC_API_KEY=<value>  # satisfies "api_key"');
+    // secret_only gets only its nb config set line.
     expect(translated.message).toContain(
       `nb config set @scope/bundle secret_only=<value> -w ${WS_A}`,
     );
-    expect(translated.message).not.toContain("export ");
-    expect(translated.message).not.toContain("OTHER_KEY");
-  });
-
-  test("null/undefined manifest behaves as no manifest", () => {
-    const mpakError = new MpakConfigError("@scope/bundle", [
-      { key: "api_key", title: "API Key", sensitive: true },
-    ]);
-    const withNull = friendlyMpakConfigError(mpakError, WS_A, null);
-    const withUndef = friendlyMpakConfigError(mpakError, WS_A, undefined);
-    const withoutArg = friendlyMpakConfigError(mpakError, WS_A);
-    // All three should produce the same output — degenerate cases don't
-    // diverge.
-    expect(withNull.message).toBe(withoutArg.message);
-    expect(withUndef.message).toBe(withoutArg.message);
+    expect(translated.message).not.toContain('satisfies "secret_only"');
   });
 
   test("uses field.key when title is empty", () => {
-    // MpakConfigError's `title` is required in the type but can be an empty
-    // string — make sure we fall through to the raw key in that case.
     const mpakError = new MpakConfigError("@scope/bundle", [
-      { key: "raw_key", title: "", sensitive: false },
+      { key: "raw_key", title: "", sensitive: false, envAliases: [] },
     ]);
     const translated = friendlyMpakConfigError(mpakError, WS_A);
     expect(translated.message).toContain('"raw_key"');
@@ -775,13 +758,10 @@ describe("friendlyMpakConfigError", () => {
   });
 
   test("passes through duck-typed look-alikes (only real MpakConfigError translates)", () => {
-    // Before switching to instanceof we accepted any object with the right
-    // shape. Now only real SDK errors translate — a look-alike is treated
-    // as a plain error and forwarded verbatim.
     const fakeError = Object.assign(new Error("I'm not really one"), {
       code: "CONFIG_MISSING",
       packageName: "@fake/bundle",
-      missingFields: [{ key: "x", title: "X", sensitive: false }],
+      missingFields: [{ key: "x", title: "X", sensitive: false, envAliases: [] }],
     });
     const translated = friendlyMpakConfigError(fakeError, WS_A);
     expect(translated).toBe(fakeError);
@@ -796,8 +776,6 @@ describe("friendlyMpakConfigError", () => {
   test("MpakConfigError with empty missingFields falls back to the original message", () => {
     const mpakError = new MpakConfigError("@scope/bundle", []);
     const translated = friendlyMpakConfigError(mpakError, WS_A);
-    // The SDK's message format is what the caller sees when there's nothing
-    // specific to surface.
     expect(translated.message).toBe(mpakError.message);
   });
 });

--- a/test/unit/workspace-credentials.test.ts
+++ b/test/unit/workspace-credentials.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { MpakConfigError } from "@nimblebrain/mpak-sdk";
 import type { ConfigField, ConfirmationGate } from "../../src/config/privilege.ts";
 import {
   bundleSlug,
@@ -672,19 +673,11 @@ describe("resolveUserConfig — forcePrompt (TUI configure flow)", () => {
 });
 
 describe("friendlyMpakConfigError", () => {
-  test("translates MpakConfigError-shaped objects into nb config set hints", () => {
-    // Duck-typed shape — matches what the mpak SDK throws.
-    const mpakError = Object.assign(
-      new Error("Missing required config for @scope/bundle: API Key"),
-      {
-        code: "CONFIG_MISSING",
-        packageName: "@scope/bundle",
-        missingFields: [
-          { key: "api_key", title: "API Key", sensitive: true },
-          { key: "workspace_id", title: "Workspace ID", sensitive: false },
-        ],
-      },
-    );
+  test("translates MpakConfigError into nb config set hints", () => {
+    const mpakError = new MpakConfigError("@scope/bundle", [
+      { key: "api_key", title: "API Key", sensitive: true },
+      { key: "workspace_id", title: "Workspace ID", sensitive: false },
+    ]);
 
     const translated = friendlyMpakConfigError(mpakError, WS_A);
     expect(translated).toBeInstanceOf(Error);
@@ -702,21 +695,33 @@ describe("friendlyMpakConfigError", () => {
     expect(translated.message).toContain("mcp_config.env");
   });
 
-  test("uses field.key when title is missing", () => {
-    const mpakError = Object.assign(new Error("..."), {
-      code: "CONFIG_MISSING",
-      packageName: "@scope/bundle",
-      missingFields: [{ key: "raw_key", sensitive: false }],
-    });
-
+  test("uses field.key when title is empty", () => {
+    // MpakConfigError's `title` is required in the type but can be an empty
+    // string — make sure we fall through to the raw key in that case.
+    const mpakError = new MpakConfigError("@scope/bundle", [
+      { key: "raw_key", title: "", sensitive: false },
+    ]);
     const translated = friendlyMpakConfigError(mpakError, WS_A);
     expect(translated.message).toContain('"raw_key"');
   });
 
-  test("passes through non-CONFIG_MISSING errors unchanged", () => {
+  test("passes through non-MpakConfigError Error instances unchanged", () => {
     const other = new Error("something else broke");
     const translated = friendlyMpakConfigError(other, WS_A);
     expect(translated).toBe(other);
+  });
+
+  test("passes through duck-typed look-alikes (only real MpakConfigError translates)", () => {
+    // Before switching to instanceof we accepted any object with the right
+    // shape. Now only real SDK errors translate — a look-alike is treated
+    // as a plain error and forwarded verbatim.
+    const fakeError = Object.assign(new Error("I'm not really one"), {
+      code: "CONFIG_MISSING",
+      packageName: "@fake/bundle",
+      missingFields: [{ key: "x", title: "X", sensitive: false }],
+    });
+    const translated = friendlyMpakConfigError(fakeError, WS_A);
+    expect(translated).toBe(fakeError);
   });
 
   test("wraps non-Error thrown values", () => {
@@ -725,13 +730,11 @@ describe("friendlyMpakConfigError", () => {
     expect(translated.message).toBe("string thrown");
   });
 
-  test("CONFIG_MISSING with empty missingFields falls back to the original message", () => {
-    const mpakError = Object.assign(new Error("raw mpak msg"), {
-      code: "CONFIG_MISSING",
-      packageName: "@scope/bundle",
-      missingFields: [],
-    });
+  test("MpakConfigError with empty missingFields falls back to the original message", () => {
+    const mpakError = new MpakConfigError("@scope/bundle", []);
     const translated = friendlyMpakConfigError(mpakError, WS_A);
-    expect(translated.message).toBe("raw mpak msg");
+    // The SDK's message format is what the caller sees when there's nothing
+    // specific to surface.
+    expect(translated.message).toBe(mpakError.message);
   });
 });

--- a/test/unit/workspace-credentials.test.ts
+++ b/test/unit/workspace-credentials.test.ts
@@ -673,7 +673,7 @@ describe("resolveUserConfig — forcePrompt (TUI configure flow)", () => {
 });
 
 describe("friendlyMpakConfigError", () => {
-  test("translates MpakConfigError into nb config set hints", () => {
+  test("translates MpakConfigError into nb config set hints (no manifest → generic)", () => {
     const mpakError = new MpakConfigError("@scope/bundle", [
       { key: "api_key", title: "API Key", sensitive: true },
       { key: "workspace_id", title: "Workspace ID", sensitive: false },
@@ -690,9 +690,72 @@ describe("friendlyMpakConfigError", () => {
     expect(translated.message).toContain(
       `nb config set @scope/bundle workspace_id=<value> -w ${WS_A}`,
     );
-    // References the bundle-declared env-var alternative so users know that
-    // path exists too.
-    expect(translated.message).toContain("mcp_config.env");
+    // With no manifest, nothing suggests an export.
+    expect(translated.message).not.toContain("export ");
+  });
+
+  test("names concrete env vars when a manifest is provided", () => {
+    // A bundle that maps api_key to both ANTHROPIC_API_KEY and CLAUDE_API_KEY
+    // should surface both options. The user's onboarding question ("what do
+    // I export?") should be answered right in the error message.
+    const mpakError = new MpakConfigError("@scope/bundle", [
+      { key: "api_key", title: "API Key", sensitive: true },
+    ]);
+    const manifest = {
+      server: {
+        mcp_config: {
+          env: {
+            ANTHROPIC_API_KEY: "${user_config.api_key}",
+            CLAUDE_API_KEY: "${user_config.api_key}",
+            LOG_LEVEL: "info", // literal, not a substitution — must be ignored
+            PREFIXED: "prefix-${user_config.api_key}", // not whole-value — must be ignored
+          },
+        },
+      },
+    };
+
+    const translated = friendlyMpakConfigError(mpakError, WS_A, manifest);
+    expect(translated.message).toContain(
+      `nb config set @scope/bundle api_key=<value> -w ${WS_A}`,
+    );
+    expect(translated.message).toContain('export ANTHROPIC_API_KEY=<value>');
+    expect(translated.message).toContain('export CLAUDE_API_KEY=<value>');
+    // Literals and partial substitutions must not be suggested as aliases
+    // — they would not actually satisfy the field via the SDK's reverse tier.
+    expect(translated.message).not.toContain("LOG_LEVEL");
+    expect(translated.message).not.toContain("PREFIXED");
+  });
+
+  test("manifest provided but field has no env alias → only the nb config set line appears", () => {
+    const mpakError = new MpakConfigError("@scope/bundle", [
+      { key: "secret_only", title: "Secret Only", sensitive: true },
+    ]);
+    const manifest = {
+      // Declared mapping for a DIFFERENT field — should not be suggested
+      // for `secret_only`.
+      server: {
+        mcp_config: { env: { OTHER_KEY: "${user_config.other_field}" } },
+      },
+    };
+    const translated = friendlyMpakConfigError(mpakError, WS_A, manifest);
+    expect(translated.message).toContain(
+      `nb config set @scope/bundle secret_only=<value> -w ${WS_A}`,
+    );
+    expect(translated.message).not.toContain("export ");
+    expect(translated.message).not.toContain("OTHER_KEY");
+  });
+
+  test("null/undefined manifest behaves as no manifest", () => {
+    const mpakError = new MpakConfigError("@scope/bundle", [
+      { key: "api_key", title: "API Key", sensitive: true },
+    ]);
+    const withNull = friendlyMpakConfigError(mpakError, WS_A, null);
+    const withUndef = friendlyMpakConfigError(mpakError, WS_A, undefined);
+    const withoutArg = friendlyMpakConfigError(mpakError, WS_A);
+    // All three should produce the same output — degenerate cases don't
+    // diverge.
+    expect(withNull.message).toBe(withoutArg.message);
+    expect(withUndef.message).toBe(withoutArg.message);
   });
 
   test("uses field.key when title is empty", () => {


### PR DESCRIPTION
## Summary

Removes NimbleBrain's host-specific \`NB_CONFIG_{SCOPE}_{NAME}_{FIELD}\` env-var convention. The mpak SDK (0.4.0, from mpak#82) now does the resolution itself by reading each bundle's canonical \`mcp_config.env\` declaration in reverse: a bundle that maps \`\"NEWSAPI_API_KEY\": \"\${user_config.api_key}\"\` is satisfied by a host \`NEWSAPI_API_KEY\` export. No host convention, no special-case \`inc\`-stripping, no duplicate source of truth.

## End-to-end behavior

**Before:**
\`\`\`bash
export NB_CONFIG_NIMBLEBRAIN_NEWSAPI_API_KEY=sk-xxx    # ugly, host-specific
bun run dev   # newsapi starts
\`\`\`

**After:**
\`\`\`bash
export NEWSAPI_API_KEY=sk-xxx                          # matches the bundle's declared mapping
bun run dev   # newsapi starts
\`\`\`

Same pattern works for any bundle that declares canonical env vars — \`ANTHROPIC_API_KEY\`, \`OPENAI_API_KEY\`, \`GITHUB_TOKEN\`, etc. No renaming required.

## Architectural shift

Host-side resolution shrinks to two concerns:
1. Read the workspace credential store.
2. In the TUI configure flow, prompt via gate + persist responses.

Everything else — \`mcp_config.env\` reverse lookup, manifest defaults, required-field validation — lives in the SDK's \`gatherUserConfig\`. The result is:

- **Every mpak host benefits uniformly.** The convention is in one place.
- **Bundle manifest is the single source of truth.** It already had to declare the field-to-env mapping for spawn time; the SDK just uses it both ways.
- **No special-case scope stripping.** The \`inc\`-stripping rule that was a warning sign of wrong design is gone.

## Changes

- Bump \`@nimblebrain/mpak-sdk\` 0.3.0 → 0.4.0
- Delete \`envVarName()\` and \`normalizeScope()\`
- Remove the process-env tier from \`resolveUserConfig\`
- \`resolveUserConfig\` returns a partial map (no throw on missing required) — the SDK owns that contract
- Add \`friendlyMpakConfigError()\` helper: translates SDK's \`MpakConfigError\` into the \`nb config set -w <wsId>\` hint
- \`startBundleSource\` catches \`MpakConfigError\` via the helper so user-facing messages stay the same
- Net diff: +332 / -687

## Test plan

- [x] \`workspace-credentials.test.ts\` rewritten for the simplified contract. 61 tests covering the primitives (slug, paths, CRUD, permissions, concurrent writes), the new \`resolveUserConfig\` shape, and \`friendlyMpakConfigError\` translation.
- [x] \`integration/startup-credentials.test.ts\` "env path" test now uses the bundle-declared \`NBTEST_API_KEY\` directly.
- [x] \`bun run test:unit\` — 1832 pass, 0 fail.
- [x] \`bun run test:integration\` — 351 pass, 0 fail.
- [x] \`bun run check\` clean.
- [x] \`bun run lint\` clean (1 pre-existing \`url-validator.ts\` warning).
- [x] \`bun run format:check\` clean.

## Manual verification

\`\`\`bash
# With newsapi bundle declaring:
#   \"NEWSAPI_API_KEY\": \"\${user_config.api_key}\"
export NEWSAPI_API_KEY=sk-xxx
bun run dev
# → newsapi starts, no NB_CONFIG_* needed, no nb config set required
\`\`\`

Closes the ergonomics gap raised in the post-merge critique of #42.