### PR TITLE
Sync model catalog to add Claude Opus 4.7

### DIFF
--- a/src/model/catalog-data.json
+++ b/src/model/catalog-data.json
@@ -132,32 +132,6 @@
         "knowledgeCutoff": "2024-10-31",
         "releaseDate": "2025-02-19"
       },
-      "claude-3-7-sonnet-latest": {
-        "id": "claude-3-7-sonnet-latest",
-        "name": "Claude Sonnet 3.7 (latest)",
-        "family": "claude-sonnet",
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cacheRead": 0.3,
-          "cacheWrite": 3.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-10-31",
-        "releaseDate": "2025-02-19"
-      },
       "claude-3-haiku-20240307": {
         "id": "claude-3-haiku-20240307",
         "name": "Claude Haiku 3",
@@ -467,8 +441,34 @@
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-05",
+        "knowledgeCutoff": "2025-05-31",
         "releaseDate": "2026-02-05"
+      },
+      "claude-opus-4-7": {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "family": "claude-opus",
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "limits": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2026-01-31",
+        "releaseDate": "2026-04-16"
       },
       "claude-sonnet-4-0": {
         "id": "claude-sonnet-4-0",
@@ -597,8 +597,1151 @@
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-08",
+        "knowledgeCutoff": "2025-08-31",
         "releaseDate": "2026-02-17"
+      }
+    }
+  },
+  "openai": {
+    "name": "OpenAI",
+    "models": {
+      "gpt-3.5-turbo": {
+        "id": "gpt-3.5-turbo",
+        "name": "GPT-3.5-turbo",
+        "family": "gpt",
+        "cost": {
+          "input": 0.5,
+          "output": 1.5,
+          "cacheRead": 1.25
+        },
+        "limits": {
+          "context": 16385,
+          "output": 4096
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2021-09-01",
+        "releaseDate": "2023-03-01"
+      },
+      "gpt-4": {
+        "id": "gpt-4",
+        "name": "GPT-4",
+        "family": "gpt",
+        "cost": {
+          "input": 30,
+          "output": 60
+        },
+        "limits": {
+          "context": 8192,
+          "output": 8192
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-11",
+        "releaseDate": "2023-11-06"
+      },
+      "gpt-4-turbo": {
+        "id": "gpt-4-turbo",
+        "name": "GPT-4 Turbo",
+        "family": "gpt",
+        "cost": {
+          "input": 10,
+          "output": 30
+        },
+        "limits": {
+          "context": 128000,
+          "output": 4096
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-12",
+        "releaseDate": "2023-11-06"
+      },
+      "gpt-4.1": {
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "family": "gpt",
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cacheRead": 0.5
+        },
+        "limits": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-04",
+        "releaseDate": "2025-04-14"
+      },
+      "gpt-4.1-mini": {
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "family": "gpt-mini",
+        "cost": {
+          "input": 0.4,
+          "output": 1.6,
+          "cacheRead": 0.1
+        },
+        "limits": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-04",
+        "releaseDate": "2025-04-14"
+      },
+      "gpt-4.1-nano": {
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "family": "gpt-nano",
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cacheRead": 0.03
+        },
+        "limits": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-04",
+        "releaseDate": "2025-04-14"
+      },
+      "gpt-4o": {
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "family": "gpt",
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cacheRead": 1.25
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-05-13"
+      },
+      "gpt-4o-2024-05-13": {
+        "id": "gpt-4o-2024-05-13",
+        "name": "GPT-4o (2024-05-13)",
+        "family": "gpt",
+        "cost": {
+          "input": 5,
+          "output": 15
+        },
+        "limits": {
+          "context": 128000,
+          "output": 4096
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-05-13"
+      },
+      "gpt-4o-2024-08-06": {
+        "id": "gpt-4o-2024-08-06",
+        "name": "GPT-4o (2024-08-06)",
+        "family": "gpt",
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cacheRead": 1.25
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-08-06"
+      },
+      "gpt-4o-2024-11-20": {
+        "id": "gpt-4o-2024-11-20",
+        "name": "GPT-4o (2024-11-20)",
+        "family": "gpt",
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cacheRead": 1.25
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-11-20"
+      },
+      "gpt-4o-mini": {
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "family": "gpt-mini",
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cacheRead": 0.08
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-07-18"
+      },
+      "gpt-5": {
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "family": "gpt",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-08-07"
+      },
+      "gpt-5-chat-latest": {
+        "id": "gpt-5-chat-latest",
+        "name": "GPT-5 Chat (latest)",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-08-07"
+      },
+      "gpt-5-codex": {
+        "id": "gpt-5-codex",
+        "name": "GPT-5-Codex",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-09-15"
+      },
+      "gpt-5-mini": {
+        "id": "gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "family": "gpt-mini",
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cacheRead": 0.025
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05-30",
+        "releaseDate": "2025-08-07"
+      },
+      "gpt-5-nano": {
+        "id": "gpt-5-nano",
+        "name": "GPT-5 Nano",
+        "family": "gpt-nano",
+        "cost": {
+          "input": 0.05,
+          "output": 0.4,
+          "cacheRead": 0.005
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05-30",
+        "releaseDate": "2025-08-07"
+      },
+      "gpt-5-pro": {
+        "id": "gpt-5-pro",
+        "name": "GPT-5 Pro",
+        "family": "gpt-pro",
+        "cost": {
+          "input": 15,
+          "output": 120
+        },
+        "limits": {
+          "context": 400000,
+          "output": 272000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-10-06"
+      },
+      "gpt-5.1": {
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "family": "gpt",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.13
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.1-chat-latest": {
+        "id": "gpt-5.1-chat-latest",
+        "name": "GPT-5.1 Chat",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.1-codex": {
+        "id": "gpt-5.1-codex",
+        "name": "GPT-5.1 Codex",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.1-codex-max": {
+        "id": "gpt-5.1-codex-max",
+        "name": "GPT-5.1 Codex Max",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.1-codex-mini": {
+        "id": "gpt-5.1-codex-mini",
+        "name": "GPT-5.1 Codex mini",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cacheRead": 0.025
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.2": {
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "family": "gpt",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2025-12-11"
+      },
+      "gpt-5.2-chat-latest": {
+        "id": "gpt-5.2-chat-latest",
+        "name": "GPT-5.2 Chat",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2025-12-11"
+      },
+      "gpt-5.2-codex": {
+        "id": "gpt-5.2-codex",
+        "name": "GPT-5.2 Codex",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2025-12-11"
+      },
+      "gpt-5.2-pro": {
+        "id": "gpt-5.2-pro",
+        "name": "GPT-5.2 Pro",
+        "family": "gpt-pro",
+        "cost": {
+          "input": 21,
+          "output": 168
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2025-12-11"
+      },
+      "gpt-5.3-chat-latest": {
+        "id": "gpt-5.3-chat-latest",
+        "name": "GPT-5.3 Chat (latest)",
+        "family": "gpt",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-03"
+      },
+      "gpt-5.3-codex": {
+        "id": "gpt-5.3-codex",
+        "name": "GPT-5.3 Codex",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-02-05"
+      },
+      "gpt-5.3-codex-spark": {
+        "id": "gpt-5.3-codex-spark",
+        "name": "GPT-5.3 Codex Spark",
+        "family": "gpt-codex-spark",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 128000,
+          "output": 32000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-02-05"
+      },
+      "gpt-5.4": {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "family": "gpt",
+        "cost": {
+          "input": 2.5,
+          "output": 15,
+          "cacheRead": 0.25
+        },
+        "limits": {
+          "context": 1050000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-05"
+      },
+      "gpt-5.4-mini": {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "family": "gpt-mini",
+        "cost": {
+          "input": 0.75,
+          "output": 4.5,
+          "cacheRead": 0.075
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-17"
+      },
+      "gpt-5.4-nano": {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "family": "gpt-nano",
+        "cost": {
+          "input": 0.2,
+          "output": 1.25,
+          "cacheRead": 0.02
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-17"
+      },
+      "gpt-5.4-pro": {
+        "id": "gpt-5.4-pro",
+        "name": "GPT-5.4 Pro",
+        "family": "gpt-pro",
+        "cost": {
+          "input": 30,
+          "output": 180
+        },
+        "limits": {
+          "context": 1050000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-05"
+      },
+      "o1": {
+        "id": "o1",
+        "name": "o1",
+        "family": "o",
+        "cost": {
+          "input": 15,
+          "output": 60,
+          "cacheRead": 7.5
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-12-05"
+      },
+      "o1-mini": {
+        "id": "o1-mini",
+        "name": "o1-mini",
+        "family": "o-mini",
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cacheRead": 0.55
+        },
+        "limits": {
+          "context": 128000,
+          "output": 65536
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-09-12"
+      },
+      "o1-preview": {
+        "id": "o1-preview",
+        "name": "o1-preview",
+        "family": "o",
+        "cost": {
+          "input": 15,
+          "output": 60,
+          "cacheRead": 7.5
+        },
+        "limits": {
+          "context": 128000,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-09-12"
+      },
+      "o1-pro": {
+        "id": "o1-pro",
+        "name": "o1-pro",
+        "family": "o-pro",
+        "cost": {
+          "input": 150,
+          "output": 600
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2025-03-19"
+      },
+      "o3": {
+        "id": "o3",
+        "name": "o3",
+        "family": "o",
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cacheRead": 0.5
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2025-04-16"
+      },
+      "o3-deep-research": {
+        "id": "o3-deep-research",
+        "name": "o3-deep-research",
+        "family": "o",
+        "cost": {
+          "input": 10,
+          "output": 40,
+          "cacheRead": 2.5
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2024-06-26"
+      },
+      "o3-mini": {
+        "id": "o3-mini",
+        "name": "o3-mini",
+        "family": "o-mini",
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cacheRead": 0.55
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2024-12-20"
+      },
+      "o3-pro": {
+        "id": "o3-pro",
+        "name": "o3-pro",
+        "family": "o-pro",
+        "cost": {
+          "input": 20,
+          "output": 80
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2025-06-10"
+      },
+      "o4-mini": {
+        "id": "o4-mini",
+        "name": "o4-mini",
+        "family": "o-mini",
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cacheRead": 0.28
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2025-04-16"
+      },
+      "o4-mini-deep-research": {
+        "id": "o4-mini-deep-research",
+        "name": "o4-mini-deep-research",
+        "family": "o-mini",
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cacheRead": 0.5
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2024-06-26"
+      },
+      "text-embedding-3-large": {
+        "id": "text-embedding-3-large",
+        "name": "text-embedding-3-large",
+        "family": "text-embedding",
+        "cost": {
+          "input": 0.13,
+          "output": 0
+        },
+        "limits": {
+          "context": 8191,
+          "output": 3072
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-01",
+        "releaseDate": "2024-01-25"
+      },
+      "text-embedding-3-small": {
+        "id": "text-embedding-3-small",
+        "name": "text-embedding-3-small",
+        "family": "text-embedding",
+        "cost": {
+          "input": 0.02,
+          "output": 0
+        },
+        "limits": {
+          "context": 8191,
+          "output": 1536
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-01",
+        "releaseDate": "2024-01-25"
+      },
+      "text-embedding-ada-002": {
+        "id": "text-embedding-ada-002",
+        "name": "text-embedding-ada-002",
+        "family": "text-embedding",
+        "cost": {
+          "input": 0.1,
+          "output": 0
+        },
+        "limits": {
+          "context": 8192,
+          "output": 1536
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2022-12",
+        "releaseDate": "2022-12-15"
       }
     }
   },
@@ -985,7 +2128,7 @@
         "cost": {
           "input": 1.25,
           "output": 10,
-          "cacheRead": 0.31
+          "cacheRead": 0.125
         },
         "limits": {
           "context": 1048576,
@@ -1348,1149 +2491,6 @@
         },
         "knowledgeCutoff": "2025-01",
         "releaseDate": "2025-06-17"
-      }
-    }
-  },
-  "openai": {
-    "name": "OpenAI",
-    "models": {
-      "codex-mini-latest": {
-        "id": "codex-mini-latest",
-        "name": "Codex Mini",
-        "family": "gpt-codex-mini",
-        "cost": {
-          "input": 1.5,
-          "output": 6,
-          "cacheRead": 0.375
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2025-05-16"
-      },
-      "gpt-3.5-turbo": {
-        "id": "gpt-3.5-turbo",
-        "name": "GPT-3.5-turbo",
-        "family": "gpt",
-        "cost": {
-          "input": 0.5,
-          "output": 1.5,
-          "cacheRead": 1.25
-        },
-        "limits": {
-          "context": 16385,
-          "output": 4096
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": false,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2021-09-01",
-        "releaseDate": "2023-03-01"
-      },
-      "gpt-4": {
-        "id": "gpt-4",
-        "name": "GPT-4",
-        "family": "gpt",
-        "cost": {
-          "input": 30,
-          "output": 60
-        },
-        "limits": {
-          "context": 8192,
-          "output": 8192
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-11",
-        "releaseDate": "2023-11-06"
-      },
-      "gpt-4-turbo": {
-        "id": "gpt-4-turbo",
-        "name": "GPT-4 Turbo",
-        "family": "gpt",
-        "cost": {
-          "input": 10,
-          "output": 30
-        },
-        "limits": {
-          "context": 128000,
-          "output": 4096
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-12",
-        "releaseDate": "2023-11-06"
-      },
-      "gpt-4.1": {
-        "id": "gpt-4.1",
-        "name": "GPT-4.1",
-        "family": "gpt",
-        "cost": {
-          "input": 2,
-          "output": 8,
-          "cacheRead": 0.5
-        },
-        "limits": {
-          "context": 1047576,
-          "output": 32768
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2025-04-14"
-      },
-      "gpt-4.1-mini": {
-        "id": "gpt-4.1-mini",
-        "name": "GPT-4.1 mini",
-        "family": "gpt-mini",
-        "cost": {
-          "input": 0.4,
-          "output": 1.6,
-          "cacheRead": 0.1
-        },
-        "limits": {
-          "context": 1047576,
-          "output": 32768
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2025-04-14"
-      },
-      "gpt-4.1-nano": {
-        "id": "gpt-4.1-nano",
-        "name": "GPT-4.1 nano",
-        "family": "gpt-nano",
-        "cost": {
-          "input": 0.1,
-          "output": 0.4,
-          "cacheRead": 0.03
-        },
-        "limits": {
-          "context": 1047576,
-          "output": 32768
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2025-04-14"
-      },
-      "gpt-4o": {
-        "id": "gpt-4o",
-        "name": "GPT-4o",
-        "family": "gpt",
-        "cost": {
-          "input": 2.5,
-          "output": 10,
-          "cacheRead": 1.25
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-05-13"
-      },
-      "gpt-4o-2024-05-13": {
-        "id": "gpt-4o-2024-05-13",
-        "name": "GPT-4o (2024-05-13)",
-        "family": "gpt",
-        "cost": {
-          "input": 5,
-          "output": 15
-        },
-        "limits": {
-          "context": 128000,
-          "output": 4096
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-05-13"
-      },
-      "gpt-4o-2024-08-06": {
-        "id": "gpt-4o-2024-08-06",
-        "name": "GPT-4o (2024-08-06)",
-        "family": "gpt",
-        "cost": {
-          "input": 2.5,
-          "output": 10,
-          "cacheRead": 1.25
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-08-06"
-      },
-      "gpt-4o-2024-11-20": {
-        "id": "gpt-4o-2024-11-20",
-        "name": "GPT-4o (2024-11-20)",
-        "family": "gpt",
-        "cost": {
-          "input": 2.5,
-          "output": 10,
-          "cacheRead": 1.25
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-11-20"
-      },
-      "gpt-4o-mini": {
-        "id": "gpt-4o-mini",
-        "name": "GPT-4o mini",
-        "family": "gpt-mini",
-        "cost": {
-          "input": 0.15,
-          "output": 0.6,
-          "cacheRead": 0.08
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-07-18"
-      },
-      "gpt-5": {
-        "id": "gpt-5",
-        "name": "GPT-5",
-        "family": "gpt",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-08-07"
-      },
-      "gpt-5-chat-latest": {
-        "id": "gpt-5-chat-latest",
-        "name": "GPT-5 Chat (latest)",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.25,
-          "output": 10
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-08-07"
-      },
-      "gpt-5-codex": {
-        "id": "gpt-5-codex",
-        "name": "GPT-5-Codex",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-09-15"
-      },
-      "gpt-5-mini": {
-        "id": "gpt-5-mini",
-        "name": "GPT-5 Mini",
-        "family": "gpt-mini",
-        "cost": {
-          "input": 0.25,
-          "output": 2,
-          "cacheRead": 0.025
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05-30",
-        "releaseDate": "2025-08-07"
-      },
-      "gpt-5-nano": {
-        "id": "gpt-5-nano",
-        "name": "GPT-5 Nano",
-        "family": "gpt-nano",
-        "cost": {
-          "input": 0.05,
-          "output": 0.4,
-          "cacheRead": 0.005
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05-30",
-        "releaseDate": "2025-08-07"
-      },
-      "gpt-5-pro": {
-        "id": "gpt-5-pro",
-        "name": "GPT-5 Pro",
-        "family": "gpt-pro",
-        "cost": {
-          "input": 15,
-          "output": 120
-        },
-        "limits": {
-          "context": 400000,
-          "output": 272000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-10-06"
-      },
-      "gpt-5.1": {
-        "id": "gpt-5.1",
-        "name": "GPT-5.1",
-        "family": "gpt",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.13
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
-      },
-      "gpt-5.1-chat-latest": {
-        "id": "gpt-5.1-chat-latest",
-        "name": "GPT-5.1 Chat",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
-      },
-      "gpt-5.1-codex": {
-        "id": "gpt-5.1-codex",
-        "name": "GPT-5.1 Codex",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
-      },
-      "gpt-5.1-codex-max": {
-        "id": "gpt-5.1-codex-max",
-        "name": "GPT-5.1 Codex Max",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
-      },
-      "gpt-5.1-codex-mini": {
-        "id": "gpt-5.1-codex-mini",
-        "name": "GPT-5.1 Codex mini",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 0.25,
-          "output": 2,
-          "cacheRead": 0.025
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
-      },
-      "gpt-5.2": {
-        "id": "gpt-5.2",
-        "name": "GPT-5.2",
-        "family": "gpt",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2025-12-11"
-      },
-      "gpt-5.2-chat-latest": {
-        "id": "gpt-5.2-chat-latest",
-        "name": "GPT-5.2 Chat",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2025-12-11"
-      },
-      "gpt-5.2-codex": {
-        "id": "gpt-5.2-codex",
-        "name": "GPT-5.2 Codex",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2025-12-11"
-      },
-      "gpt-5.2-pro": {
-        "id": "gpt-5.2-pro",
-        "name": "GPT-5.2 Pro",
-        "family": "gpt-pro",
-        "cost": {
-          "input": 21,
-          "output": 168
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2025-12-11"
-      },
-      "gpt-5.3-codex": {
-        "id": "gpt-5.3-codex",
-        "name": "GPT-5.3 Codex",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-02-05"
-      },
-      "gpt-5.3-codex-spark": {
-        "id": "gpt-5.3-codex-spark",
-        "name": "GPT-5.3 Codex Spark",
-        "family": "gpt-codex-spark",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 128000,
-          "output": 32000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-02-05"
-      },
-      "gpt-5.4": {
-        "id": "gpt-5.4",
-        "name": "GPT-5.4",
-        "family": "gpt",
-        "cost": {
-          "input": 2.5,
-          "output": 15,
-          "cacheRead": 0.25
-        },
-        "limits": {
-          "context": 1050000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-03-05"
-      },
-      "gpt-5.4-mini": {
-        "id": "gpt-5.4-mini",
-        "name": "GPT-5.4 mini",
-        "family": "gpt-mini",
-        "cost": {
-          "input": 0.75,
-          "output": 4.5,
-          "cacheRead": 0.075
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-03-17"
-      },
-      "gpt-5.4-nano": {
-        "id": "gpt-5.4-nano",
-        "name": "GPT-5.4 nano",
-        "family": "gpt-nano",
-        "cost": {
-          "input": 0.2,
-          "output": 1.25,
-          "cacheRead": 0.02
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-03-17"
-      },
-      "gpt-5.4-pro": {
-        "id": "gpt-5.4-pro",
-        "name": "GPT-5.4 Pro",
-        "family": "gpt-pro",
-        "cost": {
-          "input": 30,
-          "output": 180
-        },
-        "limits": {
-          "context": 1050000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-03-05"
-      },
-      "o1": {
-        "id": "o1",
-        "name": "o1",
-        "family": "o",
-        "cost": {
-          "input": 15,
-          "output": 60,
-          "cacheRead": 7.5
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-12-05"
-      },
-      "o1-mini": {
-        "id": "o1-mini",
-        "name": "o1-mini",
-        "family": "o-mini",
-        "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cacheRead": 0.55
-        },
-        "limits": {
-          "context": 128000,
-          "output": 65536
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": true,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-09-12"
-      },
-      "o1-preview": {
-        "id": "o1-preview",
-        "name": "o1-preview",
-        "family": "o",
-        "cost": {
-          "input": 15,
-          "output": 60,
-          "cacheRead": 7.5
-        },
-        "limits": {
-          "context": 128000,
-          "output": 32768
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": true,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-09-12"
-      },
-      "o1-pro": {
-        "id": "o1-pro",
-        "name": "o1-pro",
-        "family": "o-pro",
-        "cost": {
-          "input": 150,
-          "output": 600
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2025-03-19"
-      },
-      "o3": {
-        "id": "o3",
-        "name": "o3",
-        "family": "o",
-        "cost": {
-          "input": 2,
-          "output": 8,
-          "cacheRead": 0.5
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2025-04-16"
-      },
-      "o3-deep-research": {
-        "id": "o3-deep-research",
-        "name": "o3-deep-research",
-        "family": "o",
-        "cost": {
-          "input": 10,
-          "output": 40,
-          "cacheRead": 2.5
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2024-06-26"
-      },
-      "o3-mini": {
-        "id": "o3-mini",
-        "name": "o3-mini",
-        "family": "o-mini",
-        "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cacheRead": 0.55
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2024-12-20"
-      },
-      "o3-pro": {
-        "id": "o3-pro",
-        "name": "o3-pro",
-        "family": "o-pro",
-        "cost": {
-          "input": 20,
-          "output": 80
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2025-06-10"
-      },
-      "o4-mini": {
-        "id": "o4-mini",
-        "name": "o4-mini",
-        "family": "o-mini",
-        "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cacheRead": 0.28
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2025-04-16"
-      },
-      "o4-mini-deep-research": {
-        "id": "o4-mini-deep-research",
-        "name": "o4-mini-deep-research",
-        "family": "o-mini",
-        "cost": {
-          "input": 2,
-          "output": 8,
-          "cacheRead": 0.5
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2024-06-26"
-      },
-      "text-embedding-3-large": {
-        "id": "text-embedding-3-large",
-        "name": "text-embedding-3-large",
-        "family": "text-embedding",
-        "cost": {
-          "input": 0.13,
-          "output": 0
-        },
-        "limits": {
-          "context": 8191,
-          "output": 3072
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": false,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-01",
-        "releaseDate": "2024-01-25"
-      },
-      "text-embedding-3-small": {
-        "id": "text-embedding-3-small",
-        "name": "text-embedding-3-small",
-        "family": "text-embedding",
-        "cost": {
-          "input": 0.02,
-          "output": 0
-        },
-        "limits": {
-          "context": 8191,
-          "output": 1536
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": false,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-01",
-        "releaseDate": "2024-01-25"
-      },
-      "text-embedding-ada-002": {
-        "id": "text-embedding-ada-002",
-        "name": "text-embedding-ada-002",
-        "family": "text-embedding",
-        "cost": {
-          "input": 0.1,
-          "output": 0
-        },
-        "limits": {
-          "context": 8192,
-          "output": 1536
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": false,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2022-12",
-        "releaseDate": "2022-12-15"
       }
     }
   }

--- a/src/model/catalog-data.json
+++ b/src/model/catalog-data.json
@@ -2,188 +2,6 @@
   "anthropic": {
     "name": "Anthropic",
     "models": {
-      "claude-opus-4-5-20251101": {
-        "id": "claude-opus-4-5-20251101",
-        "name": "Claude Opus 4.5",
-        "family": "claude-opus",
-        "cost": {
-          "input": 5,
-          "output": 25,
-          "cacheRead": 0.5,
-          "cacheWrite": 6.25
-        },
-        "limits": {
-          "context": 200000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-03-31",
-        "releaseDate": "2025-11-01"
-      },
-      "claude-opus-4-20250514": {
-        "id": "claude-opus-4-20250514",
-        "name": "Claude Opus 4",
-        "family": "claude-opus",
-        "cost": {
-          "input": 15,
-          "output": 75,
-          "cacheRead": 1.5,
-          "cacheWrite": 18.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 32000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-03-31",
-        "releaseDate": "2025-05-22"
-      },
-      "claude-opus-4-5": {
-        "id": "claude-opus-4-5",
-        "name": "Claude Opus 4.5 (latest)",
-        "family": "claude-opus",
-        "cost": {
-          "input": 5,
-          "output": 25,
-          "cacheRead": 0.5,
-          "cacheWrite": 6.25
-        },
-        "limits": {
-          "context": 200000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-03-31",
-        "releaseDate": "2025-11-24"
-      },
-      "claude-3-7-sonnet-20250219": {
-        "id": "claude-3-7-sonnet-20250219",
-        "name": "Claude Sonnet 3.7",
-        "family": "claude-sonnet",
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cacheRead": 0.3,
-          "cacheWrite": 3.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-10-31",
-        "releaseDate": "2025-02-19"
-      },
-      "claude-opus-4-6": {
-        "id": "claude-opus-4-6",
-        "name": "Claude Opus 4.6",
-        "family": "claude-opus",
-        "cost": {
-          "input": 5,
-          "output": 25,
-          "cacheRead": 0.5,
-          "cacheWrite": 6.25
-        },
-        "limits": {
-          "context": 1000000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-05",
-        "releaseDate": "2026-02-05"
-      },
-      "claude-sonnet-4-5-20250929": {
-        "id": "claude-sonnet-4-5-20250929",
-        "name": "Claude Sonnet 4.5",
-        "family": "claude-sonnet",
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cacheRead": 0.3,
-          "cacheWrite": 3.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-07-31",
-        "releaseDate": "2025-09-29"
-      },
-      "claude-sonnet-4-6": {
-        "id": "claude-sonnet-4-6",
-        "name": "Claude Sonnet 4.6",
-        "family": "claude-sonnet",
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cacheRead": 0.3,
-          "cacheWrite": 3.75
-        },
-        "limits": {
-          "context": 1000000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08",
-        "releaseDate": "2026-02-17"
-      },
       "claude-3-5-haiku-20241022": {
         "id": "claude-3-5-haiku-20241022",
         "name": "Claude Haiku 3.5",
@@ -209,136 +27,6 @@
         },
         "knowledgeCutoff": "2024-07-31",
         "releaseDate": "2024-10-22"
-      },
-      "claude-sonnet-4-0": {
-        "id": "claude-sonnet-4-0",
-        "name": "Claude Sonnet 4 (latest)",
-        "family": "claude-sonnet",
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cacheRead": 0.3,
-          "cacheWrite": 3.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-03-31",
-        "releaseDate": "2025-05-22"
-      },
-      "claude-3-haiku-20240307": {
-        "id": "claude-3-haiku-20240307",
-        "name": "Claude Haiku 3",
-        "family": "claude-haiku",
-        "cost": {
-          "input": 0.25,
-          "output": 1.25,
-          "cacheRead": 0.03,
-          "cacheWrite": 0.3
-        },
-        "limits": {
-          "context": 200000,
-          "output": 4096
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-08-31",
-        "releaseDate": "2024-03-13"
-      },
-      "claude-sonnet-4-20250514": {
-        "id": "claude-sonnet-4-20250514",
-        "name": "Claude Sonnet 4",
-        "family": "claude-sonnet",
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cacheRead": 0.3,
-          "cacheWrite": 3.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-03-31",
-        "releaseDate": "2025-05-22"
-      },
-      "claude-opus-4-1": {
-        "id": "claude-opus-4-1",
-        "name": "Claude Opus 4.1 (latest)",
-        "family": "claude-opus",
-        "cost": {
-          "input": 15,
-          "output": 75,
-          "cacheRead": 1.5,
-          "cacheWrite": 18.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 32000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-03-31",
-        "releaseDate": "2025-08-05"
-      },
-      "claude-3-opus-20240229": {
-        "id": "claude-3-opus-20240229",
-        "name": "Claude Opus 3",
-        "family": "claude-opus",
-        "cost": {
-          "input": 15,
-          "output": 75,
-          "cacheRead": 1.5,
-          "cacheWrite": 18.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 4096
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-08-31",
-        "releaseDate": "2024-02-29"
       },
       "claude-3-5-haiku-latest": {
         "id": "claude-3-5-haiku-latest",
@@ -392,87 +80,35 @@
         "knowledgeCutoff": "2024-04-30",
         "releaseDate": "2024-06-20"
       },
-      "claude-opus-4-1-20250805": {
-        "id": "claude-opus-4-1-20250805",
-        "name": "Claude Opus 4.1",
-        "family": "claude-opus",
+      "claude-3-5-sonnet-20241022": {
+        "id": "claude-3-5-sonnet-20241022",
+        "name": "Claude Sonnet 3.5 v2",
+        "family": "claude-sonnet",
         "cost": {
-          "input": 15,
-          "output": 75,
-          "cacheRead": 1.5,
-          "cacheWrite": 18.75
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
         },
         "limits": {
           "context": 200000,
-          "output": 32000
+          "output": 8192
         },
         "capabilities": {
           "toolCall": true,
-          "reasoning": true,
+          "reasoning": false,
           "attachment": true
         },
         "modalities": {
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-03-31",
-        "releaseDate": "2025-08-05"
+        "knowledgeCutoff": "2024-04-30",
+        "releaseDate": "2024-10-22"
       },
-      "claude-opus-4-0": {
-        "id": "claude-opus-4-0",
-        "name": "Claude Opus 4 (latest)",
-        "family": "claude-opus",
-        "cost": {
-          "input": 15,
-          "output": 75,
-          "cacheRead": 1.5,
-          "cacheWrite": 18.75
-        },
-        "limits": {
-          "context": 200000,
-          "output": 32000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-03-31",
-        "releaseDate": "2025-05-22"
-      },
-      "claude-haiku-4-5-20251001": {
-        "id": "claude-haiku-4-5-20251001",
-        "name": "Claude Haiku 4.5",
-        "family": "claude-haiku",
-        "cost": {
-          "input": 1,
-          "output": 5,
-          "cacheRead": 0.1,
-          "cacheWrite": 1.25
-        },
-        "limits": {
-          "context": 200000,
-          "output": 64000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-02-28",
-        "releaseDate": "2025-10-15"
-      },
-      "claude-sonnet-4-5": {
-        "id": "claude-sonnet-4-5",
-        "name": "Claude Sonnet 4.5 (latest)",
+      "claude-3-7-sonnet-20250219": {
+        "id": "claude-3-7-sonnet-20250219",
+        "name": "Claude Sonnet 3.7",
         "family": "claude-sonnet",
         "cost": {
           "input": 3,
@@ -493,8 +129,8 @@
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-07-31",
-        "releaseDate": "2025-09-29"
+        "knowledgeCutoff": "2024-10-31",
+        "releaseDate": "2025-02-19"
       },
       "claude-3-7-sonnet-latest": {
         "id": "claude-3-7-sonnet-latest",
@@ -522,31 +158,57 @@
         "knowledgeCutoff": "2024-10-31",
         "releaseDate": "2025-02-19"
       },
-      "claude-haiku-4-5": {
-        "id": "claude-haiku-4-5",
-        "name": "Claude Haiku 4.5 (latest)",
+      "claude-3-haiku-20240307": {
+        "id": "claude-3-haiku-20240307",
+        "name": "Claude Haiku 3",
         "family": "claude-haiku",
         "cost": {
-          "input": 1,
-          "output": 5,
-          "cacheRead": 0.1,
-          "cacheWrite": 1.25
+          "input": 0.25,
+          "output": 1.25,
+          "cacheRead": 0.03,
+          "cacheWrite": 0.3
         },
         "limits": {
           "context": 200000,
-          "output": 64000
+          "output": 4096
         },
         "capabilities": {
           "toolCall": true,
-          "reasoning": true,
+          "reasoning": false,
           "attachment": true
         },
         "modalities": {
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-02-28",
-        "releaseDate": "2025-10-15"
+        "knowledgeCutoff": "2023-08-31",
+        "releaseDate": "2024-03-13"
+      },
+      "claude-3-opus-20240229": {
+        "id": "claude-3-opus-20240229",
+        "name": "Claude Opus 3",
+        "family": "claude-opus",
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cacheRead": 1.5,
+          "cacheWrite": 18.75
+        },
+        "limits": {
+          "context": 200000,
+          "output": 4096
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-08-31",
+        "releaseDate": "2024-02-29"
       },
       "claude-3-sonnet-20240229": {
         "id": "claude-3-sonnet-20240229",
@@ -574,49 +236,19 @@
         "knowledgeCutoff": "2023-08-31",
         "releaseDate": "2024-03-04"
       },
-      "claude-3-5-sonnet-20241022": {
-        "id": "claude-3-5-sonnet-20241022",
-        "name": "Claude Sonnet 3.5 v2",
-        "family": "claude-sonnet",
+      "claude-haiku-4-5": {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "family": "claude-haiku",
         "cost": {
-          "input": 3,
-          "output": 15,
-          "cacheRead": 0.3,
-          "cacheWrite": 3.75
+          "input": 1,
+          "output": 5,
+          "cacheRead": 0.1,
+          "cacheWrite": 1.25
         },
         "limits": {
           "context": 200000,
-          "output": 8192
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04-30",
-        "releaseDate": "2024-10-22"
-      }
-    }
-  },
-  "openai": {
-    "name": "OpenAI",
-    "models": {
-      "gpt-5.2-codex": {
-        "id": "gpt-5.2-codex",
-        "name": "GPT-5.2 Codex",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
+          "output": 64000
         },
         "capabilities": {
           "toolCall": true,
@@ -627,20 +259,22 @@
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2025-12-11"
+        "knowledgeCutoff": "2025-02-28",
+        "releaseDate": "2025-10-15"
       },
-      "o1-pro": {
-        "id": "o1-pro",
-        "name": "o1-pro",
-        "family": "o-pro",
+      "claude-haiku-4-5-20251001": {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "family": "claude-haiku",
         "cost": {
-          "input": 150,
-          "output": 600
+          "input": 1,
+          "output": 5,
+          "cacheRead": 0.1,
+          "cacheWrite": 1.25
         },
         "limits": {
           "context": 200000,
-          "output": 100000
+          "output": 64000
         },
         "capabilities": {
           "toolCall": true,
@@ -648,319 +282,24 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2025-03-19"
+        "knowledgeCutoff": "2025-02-28",
+        "releaseDate": "2025-10-15"
       },
-      "text-embedding-3-large": {
-        "id": "text-embedding-3-large",
-        "name": "text-embedding-3-large",
-        "family": "text-embedding",
-        "cost": {
-          "input": 0.13,
-          "output": 0
-        },
-        "limits": {
-          "context": 8191,
-          "output": 3072
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": false,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-01",
-        "releaseDate": "2024-01-25"
-      },
-      "gpt-5.1-codex-mini": {
-        "id": "gpt-5.1-codex-mini",
-        "name": "GPT-5.1 Codex mini",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 0.25,
-          "output": 2,
-          "cacheRead": 0.025
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
-      },
-      "gpt-5.4-pro": {
-        "id": "gpt-5.4-pro",
-        "name": "GPT-5.4 Pro",
-        "family": "gpt-pro",
-        "cost": {
-          "input": 30,
-          "output": 180
-        },
-        "limits": {
-          "context": 1050000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-03-05"
-      },
-      "o3-mini": {
-        "id": "o3-mini",
-        "name": "o3-mini",
-        "family": "o-mini",
-        "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cacheRead": 0.55
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2024-12-20"
-      },
-      "gpt-5.4-mini": {
-        "id": "gpt-5.4-mini",
-        "name": "GPT-5.4 mini",
-        "family": "gpt-mini",
-        "cost": {
-          "input": 0.75,
-          "output": 4.5,
-          "cacheRead": 0.075
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-03-17"
-      },
-      "gpt-5-pro": {
-        "id": "gpt-5-pro",
-        "name": "GPT-5 Pro",
-        "family": "gpt-pro",
+      "claude-opus-4-0": {
+        "id": "claude-opus-4-0",
+        "name": "Claude Opus 4 (latest)",
+        "family": "claude-opus",
         "cost": {
           "input": 15,
-          "output": 120
+          "output": 75,
+          "cacheRead": 1.5,
+          "cacheWrite": 18.75
         },
         "limits": {
-          "context": 400000,
-          "output": 272000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-10-06"
-      },
-      "gpt-5.2-chat-latest": {
-        "id": "gpt-5.2-chat-latest",
-        "name": "GPT-5.2 Chat",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2025-12-11"
-      },
-      "gpt-5": {
-        "id": "gpt-5",
-        "name": "GPT-5",
-        "family": "gpt",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-08-07"
-      },
-      "gpt-4-turbo": {
-        "id": "gpt-4-turbo",
-        "name": "GPT-4 Turbo",
-        "family": "gpt",
-        "cost": {
-          "input": 10,
-          "output": 30
-        },
-        "limits": {
-          "context": 128000,
-          "output": 4096
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-12",
-        "releaseDate": "2023-11-06"
-      },
-      "gpt-4o": {
-        "id": "gpt-4o",
-        "name": "GPT-4o",
-        "family": "gpt",
-        "cost": {
-          "input": 2.5,
-          "output": 10,
-          "cacheRead": 1.25
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-05-13"
-      },
-      "gpt-5.3-codex": {
-        "id": "gpt-5.3-codex",
-        "name": "GPT-5.3 Codex",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-02-05"
-      },
-      "gpt-5-mini": {
-        "id": "gpt-5-mini",
-        "name": "GPT-5 Mini",
-        "family": "gpt-mini",
-        "cost": {
-          "input": 0.25,
-          "output": 2,
-          "cacheRead": 0.025
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05-30",
-        "releaseDate": "2025-08-07"
-      },
-      "gpt-5.3-codex-spark": {
-        "id": "gpt-5.3-codex-spark",
-        "name": "GPT-5.3 Codex Spark",
-        "family": "gpt-codex-spark",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 128000,
+          "context": 200000,
           "output": 32000
         },
         "capabilities": {
@@ -972,46 +311,22 @@
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-02-05"
+        "knowledgeCutoff": "2025-03-31",
+        "releaseDate": "2025-05-22"
       },
-      "gpt-4o-mini": {
-        "id": "gpt-4o-mini",
-        "name": "GPT-4o mini",
-        "family": "gpt-mini",
+      "claude-opus-4-1": {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1 (latest)",
+        "family": "claude-opus",
         "cost": {
-          "input": 0.15,
-          "output": 0.6,
-          "cacheRead": 0.08
+          "input": 15,
+          "output": 75,
+          "cacheRead": 1.5,
+          "cacheWrite": 18.75
         },
         "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-07-18"
-      },
-      "gpt-5.1-codex-max": {
-        "id": "gpt-5.1-codex-max",
-        "name": "GPT-5.1 Codex Max",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
+          "context": 200000,
+          "output": 32000
         },
         "capabilities": {
           "toolCall": true,
@@ -1019,49 +334,25 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
+        "knowledgeCutoff": "2025-03-31",
+        "releaseDate": "2025-08-05"
       },
-      "gpt-4.1": {
-        "id": "gpt-4.1",
-        "name": "GPT-4.1",
-        "family": "gpt",
+      "claude-opus-4-1-20250805": {
+        "id": "claude-opus-4-1-20250805",
+        "name": "Claude Opus 4.1",
+        "family": "claude-opus",
         "cost": {
-          "input": 2,
-          "output": 8,
-          "cacheRead": 0.5
+          "input": 15,
+          "output": 75,
+          "cacheRead": 1.5,
+          "cacheWrite": 18.75
         },
         "limits": {
-          "context": 1047576,
-          "output": 32768
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2025-04-14"
-      },
-      "gpt-5.1-chat-latest": {
-        "id": "gpt-5.1-chat-latest",
-        "name": "GPT-5.1 Chat",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
+          "context": 200000,
+          "output": 32000
         },
         "capabilities": {
           "toolCall": true,
@@ -1069,48 +360,102 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
+        "knowledgeCutoff": "2025-03-31",
+        "releaseDate": "2025-08-05"
       },
-      "gpt-3.5-turbo": {
-        "id": "gpt-3.5-turbo",
-        "name": "GPT-3.5-turbo",
-        "family": "gpt",
+      "claude-opus-4-20250514": {
+        "id": "claude-opus-4-20250514",
+        "name": "Claude Opus 4",
+        "family": "claude-opus",
         "cost": {
-          "input": 0.5,
-          "output": 1.5,
-          "cacheRead": 1.25
+          "input": 15,
+          "output": 75,
+          "cacheRead": 1.5,
+          "cacheWrite": 18.75
         },
         "limits": {
-          "context": 16385,
-          "output": 4096
+          "context": 200000,
+          "output": 32000
         },
         "capabilities": {
-          "toolCall": false,
-          "reasoning": false,
-          "attachment": false
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
         },
         "modalities": {
-          "input": ["text"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2021-09-01",
-        "releaseDate": "2023-03-01"
+        "knowledgeCutoff": "2025-03-31",
+        "releaseDate": "2025-05-22"
       },
-      "gpt-5.4": {
-        "id": "gpt-5.4",
-        "name": "GPT-5.4",
-        "family": "gpt",
+      "claude-opus-4-5": {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "family": "claude-opus",
         "cost": {
-          "input": 2.5,
-          "output": 15,
-          "cacheRead": 0.25
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
         },
         "limits": {
-          "context": 1050000,
+          "context": 200000,
+          "output": 64000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-03-31",
+        "releaseDate": "2025-11-24"
+      },
+      "claude-opus-4-5-20251101": {
+        "id": "claude-opus-4-5-20251101",
+        "name": "Claude Opus 4.5",
+        "family": "claude-opus",
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "limits": {
+          "context": 200000,
+          "output": 64000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-03-31",
+        "releaseDate": "2025-11-01"
+      },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "limits": {
+          "context": 1000000,
           "output": 128000
         },
         "capabilities": {
@@ -1122,21 +467,22 @@
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-03-05"
+        "knowledgeCutoff": "2025-05",
+        "releaseDate": "2026-02-05"
       },
-      "o1": {
-        "id": "o1",
-        "name": "o1",
-        "family": "o",
+      "claude-sonnet-4-0": {
+        "id": "claude-sonnet-4-0",
+        "name": "Claude Sonnet 4 (latest)",
+        "family": "claude-sonnet",
         "cost": {
-          "input": 15,
-          "output": 60,
-          "cacheRead": 7.5
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
         },
         "limits": {
           "context": 200000,
-          "output": 100000
+          "output": 64000
         },
         "capabilities": {
           "toolCall": true,
@@ -1144,24 +490,25 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-12-05"
+        "knowledgeCutoff": "2025-03-31",
+        "releaseDate": "2025-05-22"
       },
-      "codex-mini-latest": {
-        "id": "codex-mini-latest",
-        "name": "Codex Mini",
-        "family": "gpt-codex-mini",
+      "claude-sonnet-4-20250514": {
+        "id": "claude-sonnet-4-20250514",
+        "name": "Claude Sonnet 4",
+        "family": "claude-sonnet",
         "cost": {
-          "input": 1.5,
-          "output": 6,
-          "cacheRead": 0.375
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
         },
         "limits": {
           "context": 200000,
-          "output": 100000
+          "output": 64000
         },
         "capabilities": {
           "toolCall": true,
@@ -1169,24 +516,25 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2025-05-16"
+        "knowledgeCutoff": "2025-03-31",
+        "releaseDate": "2025-05-22"
       },
-      "o3": {
-        "id": "o3",
-        "name": "o3",
-        "family": "o",
+      "claude-sonnet-4-5": {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "family": "claude-sonnet",
         "cost": {
-          "input": 2,
-          "output": 8,
-          "cacheRead": 0.5
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
         },
         "limits": {
           "context": 200000,
-          "output": 100000
+          "output": 64000
         },
         "capabilities": {
           "toolCall": true,
@@ -1194,24 +542,25 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2025-04-16"
+        "knowledgeCutoff": "2025-07-31",
+        "releaseDate": "2025-09-29"
       },
-      "gpt-5.4-nano": {
-        "id": "gpt-5.4-nano",
-        "name": "GPT-5.4 nano",
-        "family": "gpt-nano",
+      "claude-sonnet-4-5-20250929": {
+        "id": "claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4.5",
+        "family": "claude-sonnet",
         "cost": {
-          "input": 0.2,
-          "output": 1.25,
-          "cacheRead": 0.02
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
         },
         "limits": {
-          "context": 400000,
-          "output": 128000
+          "context": 200000,
+          "output": 64000
         },
         "capabilities": {
           "toolCall": true,
@@ -1219,46 +568,54 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2026-03-17"
+        "knowledgeCutoff": "2025-07-31",
+        "releaseDate": "2025-09-29"
       },
-      "gpt-4o-2024-05-13": {
-        "id": "gpt-4o-2024-05-13",
-        "name": "GPT-4o (2024-05-13)",
-        "family": "gpt",
+      "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "family": "claude-sonnet",
         "cost": {
-          "input": 5,
-          "output": 15
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
         },
         "limits": {
-          "context": 128000,
-          "output": 4096
+          "context": 1000000,
+          "output": 64000
         },
         "capabilities": {
           "toolCall": true,
-          "reasoning": false,
+          "reasoning": true,
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-05-13"
-      },
-      "gpt-4": {
-        "id": "gpt-4",
-        "name": "GPT-4",
-        "family": "gpt",
+        "knowledgeCutoff": "2025-08",
+        "releaseDate": "2026-02-17"
+      }
+    }
+  },
+  "google": {
+    "name": "Google",
+    "models": {
+      "gemini-1.5-flash": {
+        "id": "gemini-1.5-flash",
+        "name": "Gemini 1.5 Flash",
+        "family": "gemini-flash",
         "cost": {
-          "input": 30,
-          "output": 60
+          "input": 0.075,
+          "output": 0.3,
+          "cacheRead": 0.01875
         },
         "limits": {
-          "context": 8192,
+          "context": 1000000,
           "output": 8192
         },
         "capabilities": {
@@ -1267,246 +624,24 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-11",
-        "releaseDate": "2023-11-06"
-      },
-      "gpt-4o-2024-11-20": {
-        "id": "gpt-4o-2024-11-20",
-        "name": "GPT-4o (2024-11-20)",
-        "family": "gpt",
-        "cost": {
-          "input": 2.5,
-          "output": 10,
-          "cacheRead": 1.25
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-11-20"
-      },
-      "text-embedding-ada-002": {
-        "id": "text-embedding-ada-002",
-        "name": "text-embedding-ada-002",
-        "family": "text-embedding",
-        "cost": {
-          "input": 0.1,
-          "output": 0
-        },
-        "limits": {
-          "context": 8192,
-          "output": 1536
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": false,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2022-12",
-        "releaseDate": "2022-12-15"
-      },
-      "gpt-5.2": {
-        "id": "gpt-5.2",
-        "name": "GPT-5.2",
-        "family": "gpt",
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cacheRead": 0.175
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2025-12-11"
-      },
-      "o4-mini-deep-research": {
-        "id": "o4-mini-deep-research",
-        "name": "o4-mini-deep-research",
-        "family": "o-mini",
-        "cost": {
-          "input": 2,
-          "output": 8,
-          "cacheRead": 0.5
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2024-06-26"
-      },
-      "gpt-5.1": {
-        "id": "gpt-5.1",
-        "name": "GPT-5.1",
-        "family": "gpt",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.13
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
-      },
-      "gpt-4.1-mini": {
-        "id": "gpt-4.1-mini",
-        "name": "GPT-4.1 mini",
-        "family": "gpt-mini",
-        "cost": {
-          "input": 0.4,
-          "output": 1.6,
-          "cacheRead": 0.1
-        },
-        "limits": {
-          "context": 1047576,
-          "output": 32768
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "audio", "video"],
           "output": ["text"]
         },
         "knowledgeCutoff": "2024-04",
-        "releaseDate": "2025-04-14"
+        "releaseDate": "2024-05-14"
       },
-      "gpt-5-chat-latest": {
-        "id": "gpt-5-chat-latest",
-        "name": "GPT-5 Chat (latest)",
-        "family": "gpt-codex",
+      "gemini-1.5-flash-8b": {
+        "id": "gemini-1.5-flash-8b",
+        "name": "Gemini 1.5 Flash-8B",
+        "family": "gemini-flash",
         "cost": {
-          "input": 1.25,
-          "output": 10
+          "input": 0.0375,
+          "output": 0.15,
+          "cacheRead": 0.01
         },
         "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-08-07"
-      },
-      "gpt-5-nano": {
-        "id": "gpt-5-nano",
-        "name": "GPT-5 Nano",
-        "family": "gpt-nano",
-        "cost": {
-          "input": 0.05,
-          "output": 0.4,
-          "cacheRead": 0.005
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05-30",
-        "releaseDate": "2025-08-07"
-      },
-      "o3-pro": {
-        "id": "o3-pro",
-        "name": "o3-pro",
-        "family": "o-pro",
-        "cost": {
-          "input": 20,
-          "output": 80
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2025-06-10"
-      },
-      "gpt-4o-2024-08-06": {
-        "id": "gpt-4o-2024-08-06",
-        "name": "GPT-4o (2024-08-06)",
-        "family": "gpt",
-        "cost": {
-          "input": 2.5,
-          "output": 10,
-          "cacheRead": 1.25
-        },
-        "limits": {
-          "context": 128000,
-          "output": 16384
+          "context": 1000000,
+          "output": 8192
         },
         "capabilities": {
           "toolCall": true,
@@ -1514,222 +649,173 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-08-06"
-      },
-      "gpt-4.1-nano": {
-        "id": "gpt-4.1-nano",
-        "name": "GPT-4.1 nano",
-        "family": "gpt-nano",
-        "cost": {
-          "input": 0.1,
-          "output": 0.4,
-          "cacheRead": 0.03
-        },
-        "limits": {
-          "context": 1047576,
-          "output": 32768
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "audio", "video"],
           "output": ["text"]
         },
         "knowledgeCutoff": "2024-04",
-        "releaseDate": "2025-04-14"
+        "releaseDate": "2024-10-03"
       },
-      "o1-preview": {
-        "id": "o1-preview",
-        "name": "o1-preview",
-        "family": "o",
+      "gemini-1.5-pro": {
+        "id": "gemini-1.5-pro",
+        "name": "Gemini 1.5 Pro",
+        "family": "gemini-pro",
         "cost": {
-          "input": 15,
-          "output": 60,
-          "cacheRead": 7.5
+          "input": 1.25,
+          "output": 5,
+          "cacheRead": 0.3125
         },
         "limits": {
-          "context": 128000,
-          "output": 32768
+          "context": 1000000,
+          "output": 8192
         },
         "capabilities": {
-          "toolCall": false,
-          "reasoning": true,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-09-12"
-      },
-      "text-embedding-3-small": {
-        "id": "text-embedding-3-small",
-        "name": "text-embedding-3-small",
-        "family": "text-embedding",
-        "cost": {
-          "input": 0.02,
-          "output": 0
-        },
-        "limits": {
-          "context": 8191,
-          "output": 1536
-        },
-        "capabilities": {
-          "toolCall": false,
+          "toolCall": true,
           "reasoning": false,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-01",
-        "releaseDate": "2024-01-25"
-      },
-      "gpt-5-codex": {
-        "id": "gpt-5-codex",
-        "name": "GPT-5-Codex",
-        "family": "gpt-codex",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
-        },
-        "limits": {
-          "context": 400000,
-          "output": 128000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-09-15"
-      },
-      "o4-mini": {
-        "id": "o4-mini",
-        "name": "o4-mini",
-        "family": "o-mini",
-        "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cacheRead": 0.28
-        },
-        "limits": {
-          "context": 200000,
-          "output": 100000
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "audio", "video"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2025-04-16"
+        "knowledgeCutoff": "2024-04",
+        "releaseDate": "2024-02-15"
       },
-      "o3-deep-research": {
-        "id": "o3-deep-research",
-        "name": "o3-deep-research",
-        "family": "o",
+      "gemini-2.0-flash": {
+        "id": "gemini-2.0-flash",
+        "name": "Gemini 2.0 Flash",
+        "family": "gemini-flash",
         "cost": {
-          "input": 10,
-          "output": 40,
-          "cacheRead": 2.5
+          "input": 0.1,
+          "output": 0.4,
+          "cacheRead": 0.025
         },
         "limits": {
-          "context": 200000,
-          "output": 100000
+          "context": 1048576,
+          "output": 8192
         },
         "capabilities": {
           "toolCall": true,
-          "reasoning": true,
+          "reasoning": false,
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "audio", "video", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2024-05",
-        "releaseDate": "2024-06-26"
+        "knowledgeCutoff": "2024-06",
+        "releaseDate": "2024-12-11"
       },
-      "gpt-5.1-codex": {
-        "id": "gpt-5.1-codex",
-        "name": "GPT-5.1 Codex",
-        "family": "gpt-codex",
+      "gemini-2.0-flash-lite": {
+        "id": "gemini-2.0-flash-lite",
+        "name": "Gemini 2.0 Flash Lite",
+        "family": "gemini-flash-lite",
         "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.125
+          "input": 0.075,
+          "output": 0.3
         },
         "limits": {
-          "context": 400000,
-          "output": 128000
+          "context": 1048576,
+          "output": 8192
         },
         "capabilities": {
           "toolCall": true,
-          "reasoning": true,
+          "reasoning": false,
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "audio", "video", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2024-09-30",
-        "releaseDate": "2025-11-13"
+        "knowledgeCutoff": "2024-06",
+        "releaseDate": "2024-12-11"
       },
-      "o1-mini": {
-        "id": "o1-mini",
-        "name": "o1-mini",
-        "family": "o-mini",
+      "gemini-2.5-flash": {
+        "id": "gemini-2.5-flash",
+        "name": "Gemini 2.5 Flash",
+        "family": "gemini-flash",
         "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cacheRead": 0.55
+          "input": 0.3,
+          "output": 2.5,
+          "cacheRead": 0.075
         },
         "limits": {
-          "context": 128000,
+          "context": 1048576,
           "output": 65536
         },
         "capabilities": {
-          "toolCall": false,
+          "toolCall": true,
           "reasoning": true,
-          "attachment": false
+          "attachment": true
         },
         "modalities": {
-          "input": ["text"],
+          "input": ["text", "image", "audio", "video", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2023-09",
-        "releaseDate": "2024-09-12"
+        "knowledgeCutoff": "2025-01",
+        "releaseDate": "2025-03-20"
       },
-      "gpt-5.2-pro": {
-        "id": "gpt-5.2-pro",
-        "name": "GPT-5.2 Pro",
-        "family": "gpt-pro",
+      "gemini-2.5-flash-image": {
+        "id": "gemini-2.5-flash-image",
+        "name": "Gemini 2.5 Flash Image",
+        "family": "gemini-flash",
         "cost": {
-          "input": 21,
-          "output": 168
+          "input": 0.3,
+          "output": 30,
+          "cacheRead": 0.075
         },
         "limits": {
-          "context": 400000,
-          "output": 128000
+          "context": 32768,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text", "image"]
+        },
+        "knowledgeCutoff": "2025-06",
+        "releaseDate": "2025-08-26"
+      },
+      "gemini-2.5-flash-image-preview": {
+        "id": "gemini-2.5-flash-image-preview",
+        "name": "Gemini 2.5 Flash Image (Preview)",
+        "family": "gemini-flash",
+        "cost": {
+          "input": 0.3,
+          "output": 30,
+          "cacheRead": 0.075
+        },
+        "limits": {
+          "context": 32768,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text", "image"]
+        },
+        "knowledgeCutoff": "2025-06",
+        "releaseDate": "2025-08-26"
+      },
+      "gemini-2.5-flash-lite": {
+        "id": "gemini-2.5-flash-lite",
+        "name": "Gemini 2.5 Flash Lite",
+        "family": "gemini-flash-lite",
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cacheRead": 0.025
+        },
+        "limits": {
+          "context": 1048576,
+          "output": 65536
         },
         "capabilities": {
           "toolCall": true,
@@ -1737,20 +823,15 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "audio", "video", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-08-31",
-        "releaseDate": "2025-12-11"
-      }
-    }
-  },
-  "google": {
-    "name": "Google",
-    "models": {
-      "gemini-2.5-flash-lite": {
-        "id": "gemini-2.5-flash-lite",
-        "name": "Gemini 2.5 Flash Lite",
+        "knowledgeCutoff": "2025-01",
+        "releaseDate": "2025-06-17"
+      },
+      "gemini-2.5-flash-lite-preview-06-17": {
+        "id": "gemini-2.5-flash-lite-preview-06-17",
+        "name": "Gemini 2.5 Flash Lite Preview 06-17",
         "family": "gemini-flash-lite",
         "cost": {
           "input": 0.1,
@@ -1823,31 +904,6 @@
         "knowledgeCutoff": "2025-01",
         "releaseDate": "2025-04-17"
       },
-      "gemini-3.1-pro-preview": {
-        "id": "gemini-3.1-pro-preview",
-        "name": "Gemini 3.1 Pro Preview",
-        "family": "gemini-pro",
-        "cost": {
-          "input": 2,
-          "output": 12,
-          "cacheRead": 0.2
-        },
-        "limits": {
-          "context": 1048576,
-          "output": 65536
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "video", "audio", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-01",
-        "releaseDate": "2026-02-19"
-      },
       "gemini-2.5-flash-preview-05-20": {
         "id": "gemini-2.5-flash-preview-05-20",
         "name": "Gemini 2.5 Flash Preview 05-20",
@@ -1873,18 +929,18 @@
         "knowledgeCutoff": "2025-01",
         "releaseDate": "2025-05-20"
       },
-      "gemini-3-pro-preview": {
-        "id": "gemini-3-pro-preview",
-        "name": "Gemini 3 Pro Preview",
-        "family": "gemini-pro",
+      "gemini-2.5-flash-preview-09-2025": {
+        "id": "gemini-2.5-flash-preview-09-2025",
+        "name": "Gemini 2.5 Flash Preview 09-25",
+        "family": "gemini-flash",
         "cost": {
-          "input": 2,
-          "output": 12,
-          "cacheRead": 0.2
+          "input": 0.3,
+          "output": 2.5,
+          "cacheRead": 0.075
         },
         "limits": {
-          "context": 1000000,
-          "output": 64000
+          "context": 1048576,
+          "output": 65536
         },
         "capabilities": {
           "toolCall": true,
@@ -1892,15 +948,39 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image", "video", "audio", "pdf"],
+          "input": ["text", "image", "audio", "video", "pdf"],
           "output": ["text"]
         },
         "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-11-18"
+        "releaseDate": "2025-09-25"
       },
-      "gemini-2.5-pro-preview-06-05": {
-        "id": "gemini-2.5-pro-preview-06-05",
-        "name": "Gemini 2.5 Pro Preview 06-05",
+      "gemini-2.5-flash-preview-tts": {
+        "id": "gemini-2.5-flash-preview-tts",
+        "name": "Gemini 2.5 Flash Preview TTS",
+        "family": "gemini-flash",
+        "cost": {
+          "input": 0.5,
+          "output": 10
+        },
+        "limits": {
+          "context": 8000,
+          "output": 16000
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["audio"]
+        },
+        "knowledgeCutoff": "2025-01",
+        "releaseDate": "2025-05-01"
+      },
+      "gemini-2.5-pro": {
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
         "family": "gemini-pro",
         "cost": {
           "input": 1.25,
@@ -1921,7 +1001,7 @@
           "output": ["text"]
         },
         "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-06-05"
+        "releaseDate": "2025-03-20"
       },
       "gemini-2.5-pro-preview-05-06": {
         "id": "gemini-2.5-pro-preview-05-06",
@@ -1948,79 +1028,30 @@
         "knowledgeCutoff": "2025-01",
         "releaseDate": "2025-05-06"
       },
-      "gemini-2.0-flash-lite": {
-        "id": "gemini-2.0-flash-lite",
-        "name": "Gemini 2.0 Flash Lite",
-        "family": "gemini-flash-lite",
+      "gemini-2.5-pro-preview-06-05": {
+        "id": "gemini-2.5-pro-preview-06-05",
+        "name": "Gemini 2.5 Pro Preview 06-05",
+        "family": "gemini-pro",
         "cost": {
-          "input": 0.075,
-          "output": 0.3
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.31
         },
         "limits": {
           "context": 1048576,
-          "output": 8192
+          "output": 65536
         },
         "capabilities": {
           "toolCall": true,
-          "reasoning": false,
+          "reasoning": true,
           "attachment": true
         },
         "modalities": {
           "input": ["text", "image", "audio", "video", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2024-06",
-        "releaseDate": "2024-12-11"
-      },
-      "gemini-1.5-flash-8b": {
-        "id": "gemini-1.5-flash-8b",
-        "name": "Gemini 1.5 Flash-8B",
-        "family": "gemini-flash",
-        "cost": {
-          "input": 0.0375,
-          "output": 0.15,
-          "cacheRead": 0.01
-        },
-        "limits": {
-          "context": 1000000,
-          "output": 8192
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "audio", "video"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2024-10-03"
-      },
-      "gemini-1.5-flash": {
-        "id": "gemini-1.5-flash",
-        "name": "Gemini 1.5 Flash",
-        "family": "gemini-flash",
-        "cost": {
-          "input": 0.075,
-          "output": 0.3,
-          "cacheRead": 0.01875
-        },
-        "limits": {
-          "context": 1000000,
-          "output": 8192
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "audio", "video"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2024-05-14"
+        "knowledgeCutoff": "2025-01",
+        "releaseDate": "2025-06-05"
       },
       "gemini-2.5-pro-preview-tts": {
         "id": "gemini-2.5-pro-preview-tts",
@@ -2071,59 +1102,9 @@
         "knowledgeCutoff": "2025-01",
         "releaseDate": "2025-12-17"
       },
-      "gemini-2.5-pro": {
-        "id": "gemini-2.5-pro",
-        "name": "Gemini 2.5 Pro",
-        "family": "gemini-pro",
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cacheRead": 0.31
-        },
-        "limits": {
-          "context": 1048576,
-          "output": 65536
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "audio", "video", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-03-20"
-      },
-      "gemini-2.5-flash": {
-        "id": "gemini-2.5-flash",
-        "name": "Gemini 2.5 Flash",
-        "family": "gemini-flash",
-        "cost": {
-          "input": 0.3,
-          "output": 2.5,
-          "cacheRead": 0.075
-        },
-        "limits": {
-          "context": 1048576,
-          "output": 65536
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "audio", "video", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-03-20"
-      },
-      "gemini-3.1-pro-preview-customtools": {
-        "id": "gemini-3.1-pro-preview-customtools",
-        "name": "Gemini 3.1 Pro Preview Custom Tools",
+      "gemini-3-pro-preview": {
+        "id": "gemini-3-pro-preview",
+        "name": "Gemini 3 Pro Preview",
         "family": "gemini-pro",
         "cost": {
           "input": 2,
@@ -2131,8 +1112,8 @@
           "cacheRead": 0.2
         },
         "limits": {
-          "context": 1048576,
-          "output": 65536
+          "context": 1000000,
+          "output": 64000
         },
         "capabilities": {
           "toolCall": true,
@@ -2144,131 +1125,31 @@
           "output": ["text"]
         },
         "knowledgeCutoff": "2025-01",
-        "releaseDate": "2026-02-19"
+        "releaseDate": "2025-11-18"
       },
-      "gemini-2.5-flash-preview-09-2025": {
-        "id": "gemini-2.5-flash-preview-09-2025",
-        "name": "Gemini 2.5 Flash Preview 09-25",
+      "gemini-3.1-flash-image-preview": {
+        "id": "gemini-3.1-flash-image-preview",
+        "name": "Gemini 3.1 Flash Image (Preview)",
         "family": "gemini-flash",
         "cost": {
-          "input": 0.3,
-          "output": 2.5,
-          "cacheRead": 0.075
+          "input": 0.25,
+          "output": 60
         },
         "limits": {
-          "context": 1048576,
-          "output": 65536
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "audio", "video", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-09-25"
-      },
-      "gemini-2.0-flash": {
-        "id": "gemini-2.0-flash",
-        "name": "Gemini 2.0 Flash",
-        "family": "gemini-flash",
-        "cost": {
-          "input": 0.1,
-          "output": 0.4,
-          "cacheRead": 0.025
-        },
-        "limits": {
-          "context": 1048576,
-          "output": 8192
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "audio", "video", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-06",
-        "releaseDate": "2024-12-11"
-      },
-      "gemini-1.5-pro": {
-        "id": "gemini-1.5-pro",
-        "name": "Gemini 1.5 Pro",
-        "family": "gemini-pro",
-        "cost": {
-          "input": 1.25,
-          "output": 5,
-          "cacheRead": 0.3125
-        },
-        "limits": {
-          "context": 1000000,
-          "output": 8192
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": false,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "audio", "video"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2024-04",
-        "releaseDate": "2024-02-15"
-      },
-      "gemini-2.5-flash-lite-preview-06-17": {
-        "id": "gemini-2.5-flash-lite-preview-06-17",
-        "name": "Gemini 2.5 Flash Lite Preview 06-17",
-        "family": "gemini-flash-lite",
-        "cost": {
-          "input": 0.1,
-          "output": 0.4,
-          "cacheRead": 0.025
-        },
-        "limits": {
-          "context": 1048576,
-          "output": 65536
-        },
-        "capabilities": {
-          "toolCall": true,
-          "reasoning": true,
-          "attachment": true
-        },
-        "modalities": {
-          "input": ["text", "image", "audio", "video", "pdf"],
-          "output": ["text"]
-        },
-        "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-06-17"
-      },
-      "gemini-2.5-flash-preview-tts": {
-        "id": "gemini-2.5-flash-preview-tts",
-        "name": "Gemini 2.5 Flash Preview TTS",
-        "family": "gemini-flash",
-        "cost": {
-          "input": 0.5,
-          "output": 10
-        },
-        "limits": {
-          "context": 8000,
-          "output": 16000
+          "context": 131072,
+          "output": 32768
         },
         "capabilities": {
           "toolCall": false,
-          "reasoning": false,
-          "attachment": false
+          "reasoning": true,
+          "attachment": true
         },
         "modalities": {
-          "input": ["text"],
-          "output": ["audio"]
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
         },
         "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-05-01"
+        "releaseDate": "2026-02-26"
       },
       "gemini-3.1-flash-lite-preview": {
         "id": "gemini-3.1-flash-lite-preview",
@@ -2296,14 +1177,14 @@
         "knowledgeCutoff": "2025-01",
         "releaseDate": "2026-03-03"
       },
-      "gemini-flash-lite-latest": {
-        "id": "gemini-flash-lite-latest",
-        "name": "Gemini Flash-Lite Latest",
-        "family": "gemini-flash-lite",
+      "gemini-3.1-pro-preview": {
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "family": "gemini-pro",
         "cost": {
-          "input": 0.1,
-          "output": 0.4,
-          "cacheRead": 0.025
+          "input": 2,
+          "output": 12,
+          "cacheRead": 0.2
         },
         "limits": {
           "context": 1048576,
@@ -2315,60 +1196,60 @@
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image", "audio", "video", "pdf"],
+          "input": ["text", "image", "video", "audio", "pdf"],
           "output": ["text"]
         },
         "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-09-25"
+        "releaseDate": "2026-02-19"
       },
-      "gemini-3.1-flash-image-preview": {
-        "id": "gemini-3.1-flash-image-preview",
-        "name": "Gemini 3.1 Flash Image (Preview)",
-        "family": "gemini-flash",
+      "gemini-3.1-pro-preview-customtools": {
+        "id": "gemini-3.1-pro-preview-customtools",
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "family": "gemini-pro",
         "cost": {
-          "input": 0.25,
-          "output": 60
+          "input": 2,
+          "output": 12,
+          "cacheRead": 0.2
         },
         "limits": {
-          "context": 131072,
-          "output": 32768
+          "context": 1048576,
+          "output": 65536
         },
         "capabilities": {
-          "toolCall": false,
+          "toolCall": true,
           "reasoning": true,
           "attachment": true
         },
         "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text", "image"]
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
         },
         "knowledgeCutoff": "2025-01",
-        "releaseDate": "2026-02-26"
+        "releaseDate": "2026-02-19"
       },
-      "gemini-2.5-flash-image": {
-        "id": "gemini-2.5-flash-image",
-        "name": "Gemini 2.5 Flash Image",
-        "family": "gemini-flash",
+      "gemini-embedding-001": {
+        "id": "gemini-embedding-001",
+        "name": "Gemini Embedding 001",
+        "family": "gemini",
         "cost": {
-          "input": 0.3,
-          "output": 30,
-          "cacheRead": 0.075
+          "input": 0.15,
+          "output": 0
         },
         "limits": {
-          "context": 32768,
-          "output": 32768
+          "context": 2048,
+          "output": 3072
         },
         "capabilities": {
           "toolCall": false,
-          "reasoning": true,
-          "attachment": true
+          "reasoning": false,
+          "attachment": false
         },
         "modalities": {
-          "input": ["text", "image"],
-          "output": ["text", "image"]
+          "input": ["text"],
+          "output": ["text"]
         },
-        "knowledgeCutoff": "2025-06",
-        "releaseDate": "2025-08-26"
+        "knowledgeCutoff": "2025-05",
+        "releaseDate": "2025-05-20"
       },
       "gemini-flash-latest": {
         "id": "gemini-flash-latest",
@@ -2395,53 +1276,30 @@
         "knowledgeCutoff": "2025-01",
         "releaseDate": "2025-09-25"
       },
-      "gemini-live-2.5-flash-preview-native-audio": {
-        "id": "gemini-live-2.5-flash-preview-native-audio",
-        "name": "Gemini Live 2.5 Flash Preview Native Audio",
-        "family": "gemini-flash",
+      "gemini-flash-lite-latest": {
+        "id": "gemini-flash-lite-latest",
+        "name": "Gemini Flash-Lite Latest",
+        "family": "gemini-flash-lite",
         "cost": {
-          "input": 0.5,
-          "output": 2
+          "input": 0.1,
+          "output": 0.4,
+          "cacheRead": 0.025
         },
         "limits": {
-          "context": 131072,
+          "context": 1048576,
           "output": 65536
         },
         "capabilities": {
           "toolCall": true,
           "reasoning": true,
-          "attachment": false
+          "attachment": true
         },
         "modalities": {
-          "input": ["text", "audio", "video"],
-          "output": ["text", "audio"]
-        },
-        "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-06-17"
-      },
-      "gemini-embedding-001": {
-        "id": "gemini-embedding-001",
-        "name": "Gemini Embedding 001",
-        "family": "gemini",
-        "cost": {
-          "input": 0.15,
-          "output": 0
-        },
-        "limits": {
-          "context": 2048,
-          "output": 3072
-        },
-        "capabilities": {
-          "toolCall": false,
-          "reasoning": false,
-          "attachment": false
-        },
-        "modalities": {
-          "input": ["text"],
+          "input": ["text", "image", "audio", "video", "pdf"],
           "output": ["text"]
         },
-        "knowledgeCutoff": "2025-05",
-        "releaseDate": "2025-05-20"
+        "knowledgeCutoff": "2025-01",
+        "releaseDate": "2025-09-25"
       },
       "gemini-live-2.5-flash": {
         "id": "gemini-live-2.5-flash",
@@ -2467,18 +1325,368 @@
         "knowledgeCutoff": "2025-01",
         "releaseDate": "2025-09-01"
       },
-      "gemini-2.5-flash-image-preview": {
-        "id": "gemini-2.5-flash-image-preview",
-        "name": "Gemini 2.5 Flash Image (Preview)",
+      "gemini-live-2.5-flash-preview-native-audio": {
+        "id": "gemini-live-2.5-flash-preview-native-audio",
+        "name": "Gemini Live 2.5 Flash Preview Native Audio",
         "family": "gemini-flash",
         "cost": {
-          "input": 0.3,
-          "output": 30,
-          "cacheRead": 0.075
+          "input": 0.5,
+          "output": 2
         },
         "limits": {
-          "context": 32768,
+          "context": 131072,
+          "output": 65536
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text", "audio", "video"],
+          "output": ["text", "audio"]
+        },
+        "knowledgeCutoff": "2025-01",
+        "releaseDate": "2025-06-17"
+      }
+    }
+  },
+  "openai": {
+    "name": "OpenAI",
+    "models": {
+      "codex-mini-latest": {
+        "id": "codex-mini-latest",
+        "name": "Codex Mini",
+        "family": "gpt-codex-mini",
+        "cost": {
+          "input": 1.5,
+          "output": 6,
+          "cacheRead": 0.375
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-04",
+        "releaseDate": "2025-05-16"
+      },
+      "gpt-3.5-turbo": {
+        "id": "gpt-3.5-turbo",
+        "name": "GPT-3.5-turbo",
+        "family": "gpt",
+        "cost": {
+          "input": 0.5,
+          "output": 1.5,
+          "cacheRead": 1.25
+        },
+        "limits": {
+          "context": 16385,
+          "output": 4096
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2021-09-01",
+        "releaseDate": "2023-03-01"
+      },
+      "gpt-4": {
+        "id": "gpt-4",
+        "name": "GPT-4",
+        "family": "gpt",
+        "cost": {
+          "input": 30,
+          "output": 60
+        },
+        "limits": {
+          "context": 8192,
+          "output": 8192
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-11",
+        "releaseDate": "2023-11-06"
+      },
+      "gpt-4-turbo": {
+        "id": "gpt-4-turbo",
+        "name": "GPT-4 Turbo",
+        "family": "gpt",
+        "cost": {
+          "input": 10,
+          "output": 30
+        },
+        "limits": {
+          "context": 128000,
+          "output": 4096
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-12",
+        "releaseDate": "2023-11-06"
+      },
+      "gpt-4.1": {
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "family": "gpt",
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cacheRead": 0.5
+        },
+        "limits": {
+          "context": 1047576,
           "output": 32768
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-04",
+        "releaseDate": "2025-04-14"
+      },
+      "gpt-4.1-mini": {
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "family": "gpt-mini",
+        "cost": {
+          "input": 0.4,
+          "output": 1.6,
+          "cacheRead": 0.1
+        },
+        "limits": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-04",
+        "releaseDate": "2025-04-14"
+      },
+      "gpt-4.1-nano": {
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "family": "gpt-nano",
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cacheRead": 0.03
+        },
+        "limits": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-04",
+        "releaseDate": "2025-04-14"
+      },
+      "gpt-4o": {
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "family": "gpt",
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cacheRead": 1.25
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-05-13"
+      },
+      "gpt-4o-2024-05-13": {
+        "id": "gpt-4o-2024-05-13",
+        "name": "GPT-4o (2024-05-13)",
+        "family": "gpt",
+        "cost": {
+          "input": 5,
+          "output": 15
+        },
+        "limits": {
+          "context": 128000,
+          "output": 4096
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-05-13"
+      },
+      "gpt-4o-2024-08-06": {
+        "id": "gpt-4o-2024-08-06",
+        "name": "GPT-4o (2024-08-06)",
+        "family": "gpt",
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cacheRead": 1.25
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-08-06"
+      },
+      "gpt-4o-2024-11-20": {
+        "id": "gpt-4o-2024-11-20",
+        "name": "GPT-4o (2024-11-20)",
+        "family": "gpt",
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cacheRead": 1.25
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-11-20"
+      },
+      "gpt-4o-mini": {
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "family": "gpt-mini",
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cacheRead": 0.08
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": false,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-07-18"
+      },
+      "gpt-5": {
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "family": "gpt",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-08-07"
+      },
+      "gpt-5-chat-latest": {
+        "id": "gpt-5-chat-latest",
+        "name": "GPT-5 Chat (latest)",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
         },
         "capabilities": {
           "toolCall": false,
@@ -2487,10 +1695,802 @@
         },
         "modalities": {
           "input": ["text", "image"],
-          "output": ["text", "image"]
+          "output": ["text"]
         },
-        "knowledgeCutoff": "2025-06",
-        "releaseDate": "2025-08-26"
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-08-07"
+      },
+      "gpt-5-codex": {
+        "id": "gpt-5-codex",
+        "name": "GPT-5-Codex",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-09-15"
+      },
+      "gpt-5-mini": {
+        "id": "gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "family": "gpt-mini",
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cacheRead": 0.025
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05-30",
+        "releaseDate": "2025-08-07"
+      },
+      "gpt-5-nano": {
+        "id": "gpt-5-nano",
+        "name": "GPT-5 Nano",
+        "family": "gpt-nano",
+        "cost": {
+          "input": 0.05,
+          "output": 0.4,
+          "cacheRead": 0.005
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05-30",
+        "releaseDate": "2025-08-07"
+      },
+      "gpt-5-pro": {
+        "id": "gpt-5-pro",
+        "name": "GPT-5 Pro",
+        "family": "gpt-pro",
+        "cost": {
+          "input": 15,
+          "output": 120
+        },
+        "limits": {
+          "context": 400000,
+          "output": 272000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-10-06"
+      },
+      "gpt-5.1": {
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "family": "gpt",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.13
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.1-chat-latest": {
+        "id": "gpt-5.1-chat-latest",
+        "name": "GPT-5.1 Chat",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.1-codex": {
+        "id": "gpt-5.1-codex",
+        "name": "GPT-5.1 Codex",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.1-codex-max": {
+        "id": "gpt-5.1-codex-max",
+        "name": "GPT-5.1 Codex Max",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cacheRead": 0.125
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.1-codex-mini": {
+        "id": "gpt-5.1-codex-mini",
+        "name": "GPT-5.1 Codex mini",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cacheRead": 0.025
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-09-30",
+        "releaseDate": "2025-11-13"
+      },
+      "gpt-5.2": {
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "family": "gpt",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2025-12-11"
+      },
+      "gpt-5.2-chat-latest": {
+        "id": "gpt-5.2-chat-latest",
+        "name": "GPT-5.2 Chat",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 128000,
+          "output": 16384
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2025-12-11"
+      },
+      "gpt-5.2-codex": {
+        "id": "gpt-5.2-codex",
+        "name": "GPT-5.2 Codex",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2025-12-11"
+      },
+      "gpt-5.2-pro": {
+        "id": "gpt-5.2-pro",
+        "name": "GPT-5.2 Pro",
+        "family": "gpt-pro",
+        "cost": {
+          "input": 21,
+          "output": 168
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2025-12-11"
+      },
+      "gpt-5.3-codex": {
+        "id": "gpt-5.3-codex",
+        "name": "GPT-5.3 Codex",
+        "family": "gpt-codex",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-02-05"
+      },
+      "gpt-5.3-codex-spark": {
+        "id": "gpt-5.3-codex-spark",
+        "name": "GPT-5.3 Codex Spark",
+        "family": "gpt-codex-spark",
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175
+        },
+        "limits": {
+          "context": 128000,
+          "output": 32000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-02-05"
+      },
+      "gpt-5.4": {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "family": "gpt",
+        "cost": {
+          "input": 2.5,
+          "output": 15,
+          "cacheRead": 0.25
+        },
+        "limits": {
+          "context": 1050000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-05"
+      },
+      "gpt-5.4-mini": {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "family": "gpt-mini",
+        "cost": {
+          "input": 0.75,
+          "output": 4.5,
+          "cacheRead": 0.075
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-17"
+      },
+      "gpt-5.4-nano": {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "family": "gpt-nano",
+        "cost": {
+          "input": 0.2,
+          "output": 1.25,
+          "cacheRead": 0.02
+        },
+        "limits": {
+          "context": 400000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-17"
+      },
+      "gpt-5.4-pro": {
+        "id": "gpt-5.4-pro",
+        "name": "GPT-5.4 Pro",
+        "family": "gpt-pro",
+        "cost": {
+          "input": 30,
+          "output": 180
+        },
+        "limits": {
+          "context": 1050000,
+          "output": 128000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2025-08-31",
+        "releaseDate": "2026-03-05"
+      },
+      "o1": {
+        "id": "o1",
+        "name": "o1",
+        "family": "o",
+        "cost": {
+          "input": 15,
+          "output": 60,
+          "cacheRead": 7.5
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-12-05"
+      },
+      "o1-mini": {
+        "id": "o1-mini",
+        "name": "o1-mini",
+        "family": "o-mini",
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cacheRead": 0.55
+        },
+        "limits": {
+          "context": 128000,
+          "output": 65536
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-09-12"
+      },
+      "o1-preview": {
+        "id": "o1-preview",
+        "name": "o1-preview",
+        "family": "o",
+        "cost": {
+          "input": 15,
+          "output": 60,
+          "cacheRead": 7.5
+        },
+        "limits": {
+          "context": 128000,
+          "output": 32768
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2024-09-12"
+      },
+      "o1-pro": {
+        "id": "o1-pro",
+        "name": "o1-pro",
+        "family": "o-pro",
+        "cost": {
+          "input": 150,
+          "output": 600
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2023-09",
+        "releaseDate": "2025-03-19"
+      },
+      "o3": {
+        "id": "o3",
+        "name": "o3",
+        "family": "o",
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cacheRead": 0.5
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2025-04-16"
+      },
+      "o3-deep-research": {
+        "id": "o3-deep-research",
+        "name": "o3-deep-research",
+        "family": "o",
+        "cost": {
+          "input": 10,
+          "output": 40,
+          "cacheRead": 2.5
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2024-06-26"
+      },
+      "o3-mini": {
+        "id": "o3-mini",
+        "name": "o3-mini",
+        "family": "o-mini",
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cacheRead": 0.55
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2024-12-20"
+      },
+      "o3-pro": {
+        "id": "o3-pro",
+        "name": "o3-pro",
+        "family": "o-pro",
+        "cost": {
+          "input": 20,
+          "output": 80
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2025-06-10"
+      },
+      "o4-mini": {
+        "id": "o4-mini",
+        "name": "o4-mini",
+        "family": "o-mini",
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cacheRead": 0.28
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2025-04-16"
+      },
+      "o4-mini-deep-research": {
+        "id": "o4-mini-deep-research",
+        "name": "o4-mini-deep-research",
+        "family": "o-mini",
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cacheRead": 0.5
+        },
+        "limits": {
+          "context": 200000,
+          "output": 100000
+        },
+        "capabilities": {
+          "toolCall": true,
+          "reasoning": true,
+          "attachment": true
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-05",
+        "releaseDate": "2024-06-26"
+      },
+      "text-embedding-3-large": {
+        "id": "text-embedding-3-large",
+        "name": "text-embedding-3-large",
+        "family": "text-embedding",
+        "cost": {
+          "input": 0.13,
+          "output": 0
+        },
+        "limits": {
+          "context": 8191,
+          "output": 3072
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-01",
+        "releaseDate": "2024-01-25"
+      },
+      "text-embedding-3-small": {
+        "id": "text-embedding-3-small",
+        "name": "text-embedding-3-small",
+        "family": "text-embedding",
+        "cost": {
+          "input": 0.02,
+          "output": 0
+        },
+        "limits": {
+          "context": 8191,
+          "output": 1536
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2024-01",
+        "releaseDate": "2024-01-25"
+      },
+      "text-embedding-ada-002": {
+        "id": "text-embedding-ada-002",
+        "name": "text-embedding-ada-002",
+        "family": "text-embedding",
+        "cost": {
+          "input": 0.1,
+          "output": 0
+        },
+        "limits": {
+          "context": 8192,
+          "output": 1536
+        },
+        "capabilities": {
+          "toolCall": false,
+          "reasoning": false,
+          "attachment": false
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "knowledgeCutoff": "2022-12",
+        "releaseDate": "2022-12-15"
       }
     }
   }

--- a/src/model/sync-models.ts
+++ b/src/model/sync-models.ts
@@ -99,7 +99,9 @@ async function main() {
 
     const models: Record<string, CatalogModel> = {};
 
-    for (const [modelId, raw] of Object.entries(provider.models)) {
+    // Sort by model ID for stable, review-friendly diffs across sync runs.
+    const entries = Object.entries(provider.models).sort(([a], [b]) => a.localeCompare(b));
+    for (const [modelId, raw] of entries) {
       // Skip models with no cost data (embeddings, etc. without pricing)
       if (!raw.cost?.input && !raw.cost?.output) continue;
 


### PR DESCRIPTION
## Summary

Adds `claude-opus-4-7` to the model catalog via a two-step approach to keep the diff reviewable.

### Commit 1 — Sort sync-models output (zero content change)

`sync-models.ts` previously iterated `Object.entries(provider.models)` without sorting. models.dev returns entries in non-deterministic order, so every sync run reshuffled the file — producing thousand-line diffs dominated by reordering noise. Fixed by sorting by model ID, and re-sorting the existing catalog in place.

Verified semantically identical to prior main:
```
diff <(git show main:src/model/catalog-data.json | jq --sort-keys .) \
     <(git show HEAD~1:src/model/catalog-data.json | jq --sort-keys .)
# (no output)
```

### Commit 2 — Content refresh

Structural diff is **147 lines of real change**; the 1000+ line textual diff is git's line-based algorithm reacting to single-entry JSON insertions/removals. To see only the semantic delta:

```bash
diff <(git show HEAD~1:src/model/catalog-data.json | jq -S .) \
     <(jq -S . src/model/catalog-data.json)
```

**Real changes:**

| Provider | Added | Removed |
|----------|-------|---------|
| anthropic | `claude-opus-4-7` — $5/$25 per 1M, 1M ctx, 128K out, full tool/reasoning/attachment | `claude-3-7-sonnet-latest` (tombstoned upstream) |
| openai | `gpt-5.3-chat-latest` | `codex-mini-latest` |
| google | — | — |

Plus incidental upstream enrichments (some `knowledgeCutoff` strings gained day precision, a handful of `reasoning` flags reclassified).

## Why

Enables cost estimation (`estimateCost()`) and model-picker metadata for Opus 4.7. Runtime already resolves any valid Anthropic model ID via the AI SDK — the catalog is what powers pricing and capability display.

Paired with NimbleBrainInc/deployments#1 which wires Opus 4.7 into the HQ tenant's reasoning slot.

## Test plan

- [x] `bun run test:unit` — 1835/1835 pass
- [x] `bun run check` — clean
- [x] `bun run format:check` — clean
- [ ] Post-merge: confirm HQ deploy picks up the new image so delegate/reasoning calls cost-account correctly