### PR TITLE
Sort equal-priority sidebar placements alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Changed
 
 - Bump `@nimblebrain/mpak-sdk` from `0.2.1` → `0.5.0`. Brings `prepareServer({ userConfig })`, `mcp_config.env` reverse-lookup resolver, and `envAliases` on `MpakConfigError.missingFields`.
+- **Sort equal-priority sidebar placements alphabetically by label.** Previously, placements with the same `priority` rendered in registration order, so three apps at the default priority (100) appeared in whatever order their bundles happened to start. The shell now tie-breaks by display label (case-insensitive, falling back to `route`), giving a deterministic, user-predictable order.
 
 ### Removed
 

--- a/web/src/hooks/useShell.ts
+++ b/web/src/hooks/useShell.ts
@@ -47,7 +47,12 @@ export function useShell(_token: string, workspaceId?: string, initialShell?: Sh
       if (!shell) return [];
       return shell.placements
         .filter((p) => p.slot === slot || p.slot.startsWith(`${slot}.`))
-        .sort((a, b) => a.priority - b.priority);
+        .sort((a, b) => {
+          if (a.priority !== b.priority) return a.priority - b.priority;
+          const aLabel = a.label ?? a.route ?? "";
+          const bLabel = b.label ?? b.route ?? "";
+          return aLabel.localeCompare(bLabel, undefined, { sensitivity: "base" });
+        });
     },
     [shell],
   );

--- a/web/test/useShell.test.tsx
+++ b/web/test/useShell.test.tsx
@@ -181,4 +181,34 @@ describe("useShell", () => {
     expect(sidebarItems[1].route).toBe("/a");
     expect(sidebarItems[2].route).toBe("/b");
   });
+
+  it("forSlot sorts equal-priority placements alphabetically by label", () => {
+    const shell = {
+      placements: [
+        { slot: "sidebar.apps", route: "/todo", priority: 100, label: "To-Do Board" },
+        { slot: "sidebar.apps", route: "/crm", priority: 100, label: "CRM" },
+        { slot: "sidebar.apps", route: "/collateral", priority: 100, label: "Collateral" },
+      ],
+      chatEndpoint: "/v1/chat",
+      eventsEndpoint: "/v1/events",
+    };
+
+    const { result } = renderHook(() => useShell("tok", "ws-1", shell));
+
+    const items = result.current.forSlot("sidebar");
+    expect(items.map((p) => p.label)).toEqual(["Collateral", "CRM", "To-Do Board"]);
+  });
+
+  it("forSlot falls back to route when label is missing for tie-break", () => {
+    const shell = makeShell([
+      { slot: "sidebar.apps", route: "/zebra", priority: 100 },
+      { slot: "sidebar.apps", route: "/apple", priority: 100 },
+      { slot: "sidebar.apps", route: "/mango", priority: 100 },
+    ]);
+
+    const { result } = renderHook(() => useShell("tok", "ws-1", shell));
+
+    const items = result.current.forSlot("sidebar");
+    expect(items.map((p) => p.route)).toEqual(["/apple", "/mango", "/zebra"]);
+  });
 });


### PR DESCRIPTION
## Summary

- Equal-priority sidebar placements were rendering in bundle-registration order — so three apps at the default `priority: 100` (CRM, Todo Board, Collateral) appeared in whatever order their bundles happened to start up.
- `useShell.forSlot` now tie-breaks by display label (case-insensitive `localeCompare`, falling back to `route`), giving a deterministic, user-predictable order.
- CHANGELOG entry added under Unreleased → Changed.

## Test plan

- [x] `bun test useShell` — 10/10 pass, including two new cases:
  - Three placements at priority 100 (CRM / Collateral / Todo Board) → alphabetical
  - Three placements at priority 100 with **no labels** → alphabetical by route (guards against a future change that drops the `route` fallback)
- [x] `bun run check` clean
- [x] Manually verified in local dev: shell renders Collateral → CRM → Todo Board in the "Apps" group
- [ ] Follow-up (separate PR): update `products/nimblebrain/docs/src/content/docs/apps/placements.mdx` "Priority sorting" section to document the alphabetical tie-break