### PR TITLE
Fix Settings layout on wide viewports and zero-fill empty days

### DIFF
--- a/src/conversation/usage-aggregator.ts
+++ b/src/conversation/usage-aggregator.ts
@@ -318,5 +318,29 @@ export async function aggregateUsage(
     }))
     .sort((a, b) => a.key.localeCompare(b.key));
 
+  // For day grouping over a bounded period, zero-fill missing days so the
+  // chart and table show the full window rather than only days with activity.
+  // Skipped for `all` — the range can span years and noise outweighs signal.
+  if (groupBy === "day" && period !== "all") {
+    const byKey = new Map(breakdown.map((e) => [e.key, e]));
+    const filled: BreakdownEntry[] = [];
+    const cursor = new Date(`${range.from}T00:00:00Z`);
+    const end = new Date(`${range.to}T00:00:00Z`);
+    while (cursor <= end) {
+      const key = cursor.toISOString().slice(0, 10);
+      filled.push(
+        byKey.get(key) ?? {
+          key,
+          tokens: createTokenBreakdown(),
+          cost: createCostBreakdown(),
+          llmCalls: 0,
+          conversations: 0,
+        },
+      );
+      cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+    return { period: range, totals, models, breakdown: filled };
+  }
+
   return { period: range, totals, models, breakdown };
 }

--- a/web/src/components/charts/CostChart.tsx
+++ b/web/src/components/charts/CostChart.tsx
@@ -178,7 +178,7 @@ export function CostChart({ data }: CostChartProps) {
         <div
           className="absolute bg-popover border border-border rounded-md shadow-md px-3 py-2 text-xs pointer-events-none z-10"
           style={{
-            left: `${paddingLeft + gap + hoveredIndex * (barWidth + gap) + barWidth / 2}px`,
+            left: `${((paddingLeft + gap + hoveredIndex * (barWidth + gap) + barWidth / 2) / width) * 100}%`,
             top: 0,
             transform: "translate(-50%, 0)",
             minWidth: 140,

--- a/web/src/pages/settings/AboutTab.tsx
+++ b/web/src/pages/settings/AboutTab.tsx
@@ -85,7 +85,7 @@ export function AboutTab() {
   }, [fetchApps]);
 
   return (
-    <div className="flex flex-col gap-6 max-w-2xl">
+    <div className="flex flex-col gap-6 max-w-3xl mx-auto">
       {/* Platform info */}
       <Card>
         <CardHeader>

--- a/web/src/pages/settings/ModelTab.tsx
+++ b/web/src/pages/settings/ModelTab.tsx
@@ -141,7 +141,7 @@ export function ModelTab() {
   }
 
   return (
-    <div className="max-w-xl">
+    <div className="max-w-xl mx-auto">
       <Card>
         <CardHeader>
           <CardTitle>Model Configuration</CardTitle>

--- a/web/src/pages/settings/ProfileTab.tsx
+++ b/web/src/pages/settings/ProfileTab.tsx
@@ -101,7 +101,7 @@ export function ProfileTab() {
   const { activeWorkspace } = useWorkspaceContext();
 
   return (
-    <div className="max-w-xl space-y-6">
+    <div className="max-w-xl mx-auto space-y-6">
       <Card>
         <CardHeader>
           <CardTitle>Profile</CardTitle>

--- a/web/src/pages/settings/UsageTab.tsx
+++ b/web/src/pages/settings/UsageTab.tsx
@@ -179,9 +179,10 @@ export function UsageTab() {
 
   const { tokens, cost } = report.totals;
   const totalTokens = tokens.input + tokens.output + tokens.cacheRead;
+  const hasActivity = report.totals.llmCalls > 0;
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className="max-w-5xl mx-auto space-y-6">
       {/* Period selector */}
       <div className="max-w-xs">
         <select
@@ -272,7 +273,7 @@ export function UsageTab() {
       </div>
 
       {/* Daily cost chart */}
-      {report.breakdown.length > 0 && (
+      {hasActivity && (
         <Card>
           <CardHeader>
             <CardTitle>Daily Cost</CardTitle>
@@ -322,7 +323,7 @@ export function UsageTab() {
           <CardTitle>Daily Breakdown</CardTitle>
         </CardHeader>
         <CardContent>
-          {report.breakdown.length === 0 ? (
+          {!hasActivity ? (
             <p className="text-sm text-muted-foreground">No usage data for this period.</p>
           ) : (
             <Table>

--- a/web/src/pages/settings/UsersTab.tsx
+++ b/web/src/pages/settings/UsersTab.tsx
@@ -189,7 +189,7 @@ export function UsersTab() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="max-w-5xl mx-auto space-y-6">
       {/* Header + Create toggle */}
       <div className="flex items-center justify-between">
         <div>

--- a/web/src/pages/settings/WorkspacesTab.tsx
+++ b/web/src/pages/settings/WorkspacesTab.tsx
@@ -169,7 +169,7 @@ export function WorkspacesTab() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="max-w-5xl mx-auto space-y-6">
       {/* Header + Create toggle */}
       <div className="flex items-center justify-between">
         <div>


### PR DESCRIPTION
## Summary
- Usage aggregator now zero-fills missing days for `day`/`week`/`month` periods so the chart and breakdown table show the full selected window, not just days with activity. `all` is skipped to avoid years of empty rows.
- Settings tabs (Profile, Model, Usage, About, Users, Workspaces) were either confined to the left of wide viewports or stretched edge-to-edge. All now use consistent `max-w-* mx-auto` wrappers sized to their content (forms narrow, dashboards/tables wider).
- Usage page: `max-w-3xl` → `max-w-5xl mx-auto` for the dashboard feel. Empty-state guards switched from `breakdown.length` to `totals.llmCalls` since breakdown is now always non-empty for bounded periods.
- Fixed a latent bug in CostChart where the tooltip was positioned in px against the 700px viewBox while the SVG scaled with the container — switched to percentage-based positioning so it tracks the scaled chart at any width.

## Test plan
- [ ] Usage → "This month" shows all days in the range, including days with no activity
- [ ] Usage → "Last 7 days" shows 8 days (inclusive range)
- [ ] Usage → "All time" still shows only days with data (no years of zeros)
- [ ] Usage → empty workspace shows friendly "No usage data" message (not a table of zeros)
- [ ] On a wide viewport (≥1600px), all Settings tabs are horizontally centered in the content area
- [ ] CostChart tooltip aligns with the hovered bar at various viewport widths
- [ ] `bun run test:unit` passes