### PR TITLE
Fix payload-too-large on context-doc uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- **Context-doc uploads >1 MB no longer 413.** The HTTP body-size cap was a single global `bodyLimit(1_048_576)` — orders of magnitude below the `files.maxTotalSize` and `files.maxFileSize` the ingest pipeline already enforces — so any file >1 MB was rejected at the middleware before reaching ingest. Body-limit is now per-route: JSON endpoints stay at 1 MB, `/v1/chat/stream` multipart uploads defer to `runtime.getFilesConfig().maxTotalSize` (default 100 MB, per-file 25 MB still enforced authoritatively by `ingestFiles()`). 413 responses now include structured `{ limit, received, contentType }` so the web client shows "Upload is N MB — limit is M MB" instead of a generic toast.
 - **`features`, `maxHistoryMessages`, `maxToolResultSize`, and `files` are now loaded from `nimblebrain.json`.** These fields were accepted by the JSON schema and declared on `RuntimeConfig`, but `cli/config.ts` silently dropped them — so setting `features.mcpServer: false` or `maxHistoryMessages: 100` in a config file had no effect unless passed programmatically to `Runtime.start()`.
 - Config schema now lists `userManagement` and `workspaceManagement` under `features` (previously only in code; setting them produced a spurious "unknown key" warning).
 - `InlineSource.execute()` now validates input against the tool's declared `inputSchema` before dispatching. Closes the bug class where malformed tool calls via `/mcp` leaked Node-internal errors (`fs.readFile(undefined)`, `Buffer.from(undefined)`) as tool results.

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import { WorkspaceResolutionError } from "./auth-middleware.ts";
-import { bodyLimit } from "./middleware/body-limit.ts";
 import { corsMiddleware } from "./middleware/cors.ts";
 import { securityHeaders } from "./middleware/security-headers.ts";
 import { authRoutes } from "./routes/auth.ts";
@@ -25,7 +24,6 @@ export function createApp(
   // Global CORS middleware
   app.use("*", corsMiddleware(authConfigured, allowedOrigins));
   app.use("*", securityHeaders());
-  app.use("*", bodyLimit(1_048_576)); // 1MB body size limit
 
   // Route groups — well-known endpoints first (unauthenticated, no body limit needed)
   app.route("/", wellKnownRoutes(ctx));

--- a/src/api/middleware/body-limit.ts
+++ b/src/api/middleware/body-limit.ts
@@ -17,6 +17,12 @@ export interface BodyLimitOptions {
  * Returns 413 Payload Too Large if Content-Length exceeds the applicable
  * limit. JSON payloads are bounded by `maxBytes`; multipart uploads use
  * `opts.multipart` when provided, otherwise they fall back to `maxBytes`.
+ *
+ * This is advisory: requests without `Content-Length` (e.g. chunked
+ * transfer encoding) or with malformed headers pass through untouched.
+ * The ingest pipeline in `src/files/ingest.ts` enforces per-file,
+ * total-size, and MIME rules authoritatively — middleware only stops
+ * oversized uploads before we buffer them.
  */
 export function bodyLimit(maxBytes: number, opts: BodyLimitOptions = {}) {
   return createMiddleware(async (c, next) => {

--- a/src/api/middleware/body-limit.ts
+++ b/src/api/middleware/body-limit.ts
@@ -1,20 +1,49 @@
 import { createMiddleware } from "hono/factory";
 import { apiError } from "../types.ts";
 
+export interface BodyLimitOptions {
+  /**
+   * Optional override for `multipart/*` requests. When set, uploads using
+   * `Content-Type: multipart/*` are bounded by this value rather than the
+   * base JSON `maxBytes`. The ingest pipeline enforces per-file and total
+   * caps authoritatively; this middleware only stops oversized requests
+   * before we buffer them.
+   */
+  multipart?: number;
+}
+
 /**
  * Request body size limit middleware.
- * Returns 413 Payload Too Large if Content-Length exceeds the limit.
+ * Returns 413 Payload Too Large if Content-Length exceeds the applicable
+ * limit. JSON payloads are bounded by `maxBytes`; multipart uploads use
+ * `opts.multipart` when provided, otherwise they fall back to `maxBytes`.
  */
-export function bodyLimit(maxBytes: number) {
+export function bodyLimit(maxBytes: number, opts: BodyLimitOptions = {}) {
   return createMiddleware(async (c, next) => {
     const method = c.req.method;
     if (method === "GET" || method === "HEAD" || method === "OPTIONS") {
       await next();
       return;
     }
-    const contentLength = c.req.header("content-length");
-    if (contentLength && parseInt(contentLength, 10) > maxBytes) {
-      return apiError(413, "payload_too_large", "Payload too large");
+    const contentLengthHeader = c.req.header("content-length");
+    if (!contentLengthHeader) {
+      await next();
+      return;
+    }
+    const received = Number.parseInt(contentLengthHeader, 10);
+    if (!Number.isFinite(received) || received < 0) {
+      await next();
+      return;
+    }
+    const contentType = c.req.header("content-type") ?? "";
+    const isMultipart = contentType.toLowerCase().startsWith("multipart/");
+    const limit = isMultipart && opts.multipart !== undefined ? opts.multipart : maxBytes;
+    if (received > limit) {
+      return apiError(413, "payload_too_large", "Payload too large", {
+        limit,
+        received,
+        contentType,
+      });
     }
     await next();
   });

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -6,10 +6,12 @@ import {
   handleOidcRefresh,
 } from "../handlers.ts";
 import { requireAuth } from "../middleware/auth.ts";
+import { bodyLimit } from "../middleware/body-limit.ts";
 import { type AppContext, type AuthEnv, apiError } from "../types.ts";
 
 export function authRoutes(ctx: AppContext) {
   const app = new Hono();
+  const limit = bodyLimit(1_048_576);
 
   // --- Unauthenticated ---
   app.get("/v1/auth/authorize", (_c) => {
@@ -22,7 +24,7 @@ export function authRoutes(ctx: AppContext) {
     return handleOidcCallback(c.req.raw, ctx.provider, ctx.isLocalhost, ctx.appOrigin);
   });
 
-  app.post("/v1/auth/refresh", (c) => {
+  app.post("/v1/auth/refresh", limit, (c) => {
     if (!ctx.provider) return apiError(400, "not_configured", "Auth provider not configured");
     return handleOidcRefresh(c.req.raw, ctx.provider, ctx.isLocalhost);
   });
@@ -30,7 +32,7 @@ export function authRoutes(ctx: AppContext) {
   // --- Authenticated ---
   const authed = new Hono<AuthEnv>();
   authed.use("*", requireAuth(ctx.authOptions));
-  authed.post("/v1/auth/logout", (_c) => handleLogout());
+  authed.post("/v1/auth/logout", limit, (_c) => handleLogout());
 
   app.route("/", authed);
 

--- a/src/api/routes/chat.ts
+++ b/src/api/routes/chat.ts
@@ -9,6 +9,9 @@ import type { AppContext, AppEnv } from "../types.ts";
 
 export function chatRoutes(ctx: AppContext) {
   const rl = requestRateLimit(ctx.chatLimiter);
+  // maxTotalSize is snapshot at route construction. Today filesConfig is
+  // built once from startup config + defaults and never mutated; if that
+  // invariant changes, make this limit lazy.
   const chatBodyLimit = bodyLimit(1_048_576, {
     multipart: ctx.runtime.getFilesConfig().maxTotalSize,
   });

--- a/src/api/routes/chat.ts
+++ b/src/api/routes/chat.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { handleChat, handleChatStream } from "../handlers.ts";
 import { requireAuth } from "../middleware/auth.ts";
+import { bodyLimit } from "../middleware/body-limit.ts";
 import { errorLog } from "../middleware/error-log.ts";
 import { requestRateLimit } from "../middleware/rate-limit.ts";
 import { requireWorkspace } from "../middleware/workspace.ts";
@@ -8,14 +9,17 @@ import type { AppContext, AppEnv } from "../types.ts";
 
 export function chatRoutes(ctx: AppContext) {
   const rl = requestRateLimit(ctx.chatLimiter);
+  const chatBodyLimit = bodyLimit(1_048_576, {
+    multipart: ctx.runtime.getFilesConfig().maxTotalSize,
+  });
   return new Hono<AppEnv>()
     .use("*", requireAuth(ctx.authOptions))
     .use("*", requireWorkspace(ctx.workspaceStore))
     .use("*", errorLog(ctx))
-    .post("/v1/chat", rl, (c) =>
+    .post("/v1/chat", chatBodyLimit, rl, (c) =>
       handleChat(c.req.raw, ctx.runtime, ctx.features, c.var.identity, c.var.workspaceId),
     )
-    .post("/v1/chat/stream", rl, (c) =>
+    .post("/v1/chat/stream", chatBodyLimit, rl, (c) =>
       handleChatStream(
         c.req.raw,
         ctx.runtime,

--- a/src/api/routes/mcp.ts
+++ b/src/api/routes/mcp.ts
@@ -9,6 +9,7 @@ import {
   WorkspaceResolutionError,
 } from "../auth-middleware.ts";
 import { handleMcpRequest, type McpWorkspaceContext } from "../mcp-server.ts";
+import { bodyLimit } from "../middleware/body-limit.ts";
 import { type AppContext, type AuthEnv, apiError } from "../types.ts";
 
 /**
@@ -69,7 +70,7 @@ export function mcpRoutes(ctx: AppContext) {
   const app = new Hono<AuthEnv>();
   app.use("*", requireMcpAuth(ctx.authOptions, ctx));
 
-  app.all("/mcp", async (c) => {
+  app.all("/mcp", bodyLimit(1_048_576), async (c) => {
     const features = ctx.runtime.getFeatures();
     if (!features.mcpServer) {
       return apiError(404, "not_found", "Not found");

--- a/src/api/routes/resources.ts
+++ b/src/api/routes/resources.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { handleReadResource, handleResourceProxy } from "../handlers.ts";
 import { requireAuth } from "../middleware/auth.ts";
+import { bodyLimit } from "../middleware/body-limit.ts";
 import { errorLog } from "../middleware/error-log.ts";
 import { requireWorkspace } from "../middleware/workspace.ts";
 import type { AppContext, AppEnv } from "../types.ts";
@@ -10,7 +11,7 @@ export function resourceRoutes(ctx: AppContext) {
     .use("*", requireAuth(ctx.authOptions))
     .use("*", requireWorkspace(ctx.workspaceStore))
     .use("*", errorLog(ctx))
-    .post("/v1/resources/read", (c) =>
+    .post("/v1/resources/read", bodyLimit(1_048_576), (c) =>
       handleReadResource(c.req.raw, ctx.runtime, { workspaceId: c.var.workspaceId }),
     )
     .get("/v1/apps/:name/resources/*", (c) => {

--- a/src/api/routes/tools.ts
+++ b/src/api/routes/tools.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { handleFileServe, handleShell, handleToolCall } from "../handlers.ts";
 import { requireAuth } from "../middleware/auth.ts";
+import { bodyLimit } from "../middleware/body-limit.ts";
 import { errorLog } from "../middleware/error-log.ts";
 import { requestRateLimit } from "../middleware/rate-limit.ts";
 import { requireWorkspace } from "../middleware/workspace.ts";
@@ -11,7 +12,7 @@ export function toolRoutes(ctx: AppContext) {
     .use("*", requireAuth(ctx.authOptions))
     .use("*", requireWorkspace(ctx.workspaceStore))
     .use("*", errorLog(ctx))
-    .post("/v1/tools/call", requestRateLimit(ctx.toolCallLimiter), (c) =>
+    .post("/v1/tools/call", bodyLimit(1_048_576), requestRateLimit(ctx.toolCallLimiter), (c) =>
       handleToolCall(c.req.raw, ctx.runtime, ctx.features, {
         sseManager: ctx.sseManager,
         eventSink: ctx.eventSink,

--- a/test/integration/body-limit-routes.test.ts
+++ b/test/integration/body-limit-routes.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type ServerHandle, startServer } from "../../src/api/server.ts";
+import { Runtime } from "../../src/runtime/runtime.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
+
+let runtime: Runtime;
+let handle: ServerHandle;
+let baseUrl: string;
+const testDir = join(tmpdir(), `nimblebrain-body-limit-test-${Date.now()}`);
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true });
+  runtime = await Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    logging: { disabled: true },
+    workDir: testDir,
+    files: {
+      // Lowered from the default 100 MB so the tests don't need to allocate
+      // huge buffers to prove the multipart cap is distinct from JSON.
+      maxTotalSize: 4 * 1024 * 1024,
+    },
+  });
+  await provisionTestWorkspace(runtime);
+  handle = startServer({ runtime, port: 0 });
+  baseUrl = `http://localhost:${handle.port}`;
+});
+
+afterAll(async () => {
+  handle.stop(true);
+  await runtime.shutdown();
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("per-route body limits", () => {
+  it("rejects >1MB JSON on /v1/tools/call with structured details", async () => {
+    const oversized = "x".repeat(1_100_000);
+    const res = await fetch(`${baseUrl}/v1/tools/call`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ server: "x", tool: "y", arguments: { blob: oversized } }),
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.error).toBe("payload_too_large");
+    expect(body.details?.limit).toBe(1_048_576);
+    expect(typeof body.details?.received).toBe("number");
+    expect(body.details?.received).toBeGreaterThan(1_048_576);
+    expect(body.details?.contentType).toContain("application/json");
+  });
+
+  it("rejects >1MB JSON on /v1/chat", async () => {
+    const oversized = "x".repeat(1_100_000);
+    const res = await fetch(`${baseUrl}/v1/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: oversized, workspaceId: TEST_WORKSPACE_ID }),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects multipart on /v1/chat/stream when over filesConfig.maxTotalSize", async () => {
+    // maxTotalSize was configured to 4 MB above; a 5 MB multipart body must 413.
+    const bigFile = new Blob([new Uint8Array(5 * 1024 * 1024)], {
+      type: "application/octet-stream",
+    });
+    const form = new FormData();
+    form.append("message", "test");
+    form.append("workspaceId", TEST_WORKSPACE_ID);
+    form.append("files", bigFile, "big.bin");
+    const res = await fetch(`${baseUrl}/v1/chat/stream`, { method: "POST", body: form });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.error).toBe("payload_too_large");
+    expect(body.details?.limit).toBe(4 * 1024 * 1024);
+    expect(body.details?.contentType).toContain("multipart/form-data");
+  });
+
+  it("allows in-budget multipart on /v1/chat/stream past the 1MB JSON cap", async () => {
+    // 2 MB multipart — under the 4 MB multipart budget but well over the 1 MB
+    // JSON cap. Middleware must let this through so the ingest layer (which
+    // enforces per-file/MIME rules) sees it.
+    const file = new Blob([new Uint8Array(2 * 1024 * 1024)], { type: "text/plain" });
+    const form = new FormData();
+    form.append("message", "please");
+    form.append("workspaceId", TEST_WORKSPACE_ID);
+    form.append("files", file, "notes.txt");
+    const res = await fetch(`${baseUrl}/v1/chat/stream`, { method: "POST", body: form });
+    expect(res.status).not.toBe(413);
+  });
+});

--- a/test/unit/api/body-limit.test.ts
+++ b/test/unit/api/body-limit.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { Hono } from "hono";
+import type { BodyLimitOptions } from "../../../src/api/middleware/body-limit.ts";
 import { bodyLimit } from "../../../src/api/middleware/body-limit.ts";
 
-function createTestApp(maxBytes = 1024) {
+function createTestApp(maxBytes = 1024, opts?: BodyLimitOptions) {
   const app = new Hono();
-  app.use("*", bodyLimit(maxBytes));
+  app.use("*", bodyLimit(maxBytes, opts));
   app.post("/test", (c) => c.json({ ok: true }));
   app.get("/test", (c) => c.json({ ok: true }));
   return app;
@@ -15,12 +16,27 @@ describe("bodyLimit middleware", () => {
     const app = createTestApp(1024);
     const res = await app.request("/test", {
       method: "POST",
-      headers: { "Content-Length": "2048" },
+      headers: { "Content-Length": "2048", "Content-Type": "application/json" },
     });
     expect(res.status).toBe(413);
     const body = await res.json();
     expect(body.error).toBe("payload_too_large");
     expect(body.message).toBe("Payload too large");
+  });
+
+  test("413 body includes limit, received, and contentType", async () => {
+    const app = createTestApp(1024);
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Length": "4096", "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.details).toEqual({
+      limit: 1024,
+      received: 4096,
+      contentType: "application/json",
+    });
   });
 
   test("allows request within limit", async () => {
@@ -53,5 +69,61 @@ describe("bodyLimit middleware", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
+  });
+
+  test("multipart uploads use the multipart limit, not the base limit", async () => {
+    const app = createTestApp(1024, { multipart: 10 * 1024 });
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: {
+        "Content-Length": "8192",
+        "Content-Type": "multipart/form-data; boundary=abc",
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  test("multipart uploads over the multipart limit are rejected", async () => {
+    const app = createTestApp(1024, { multipart: 4096 });
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: {
+        "Content-Length": "8192",
+        "Content-Type": "multipart/form-data; boundary=abc",
+      },
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.details?.limit).toBe(4096);
+    expect(body.details?.received).toBe(8192);
+    expect(body.details?.contentType).toContain("multipart/form-data");
+  });
+
+  test("non-multipart content-types stay bounded by the base limit even when multipart is set", async () => {
+    const app = createTestApp(1024, { multipart: 10 * 1024 });
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: {
+        "Content-Length": "2048",
+        "Content-Type": "application/json",
+      },
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.details?.limit).toBe(1024);
+  });
+
+  test("multipart matching is case-insensitive on content-type", async () => {
+    const app = createTestApp(1024, { multipart: 10 * 1024 });
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: {
+        "Content-Length": "8192",
+        "Content-Type": "MULTIPART/FORM-DATA; boundary=abc",
+      },
+    });
+    expect(res.status).toBe(200);
   });
 });

--- a/test/unit/api/body-limit.test.ts
+++ b/test/unit/api/body-limit.test.ts
@@ -126,4 +126,41 @@ describe("bodyLimit middleware", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  // Regression guard: bodyLimit must stay scoped to the route it's attached
+  // to. Mounting it via `.use("*")` on a sub-app that is itself mounted at
+  // `/` makes it leak across sibling sub-apps — that's how the multipart
+  // limit on /v1/chat/stream was silently shadowed by the 1MB JSON limit
+  // on another sub-app in an earlier iteration of this fix.
+  test("per-handler bodyLimit does not leak across sibling sub-apps", async () => {
+    const parent = new Hono();
+
+    const jsonRouter = new Hono();
+    jsonRouter.post("/json", bodyLimit(1024), (c) => c.json({ where: "json" }));
+
+    const multipartRouter = new Hono();
+    multipartRouter.post("/multipart", bodyLimit(1024, { multipart: 8 * 1024 }), (c) =>
+      c.json({ where: "multipart" }),
+    );
+
+    parent.route("/", jsonRouter);
+    parent.route("/", multipartRouter);
+
+    const bigMultipart = await parent.request("/multipart", {
+      method: "POST",
+      headers: {
+        "Content-Length": "4096",
+        "Content-Type": "multipart/form-data; boundary=abc",
+      },
+    });
+    expect(bigMultipart.status).toBe(200);
+
+    const oversizedJson = await parent.request("/json", {
+      method: "POST",
+      headers: { "Content-Length": "4096", "Content-Type": "application/json" },
+    });
+    expect(oversizedJson.status).toBe(413);
+    const body = await oversizedJson.json();
+    expect(body.details?.limit).toBe(1024);
+  });
 });

--- a/test/unit/api/body-limit.test.ts
+++ b/test/unit/api/body-limit.test.ts
@@ -60,6 +60,26 @@ describe("bodyLimit middleware", () => {
     expect(body.ok).toBe(true);
   });
 
+  test("passes through malformed Content-Length rather than crashing or 413ing", async () => {
+    const app = createTestApp(1024);
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Length": "abc", "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  test("passes through negative Content-Length rather than 413ing", async () => {
+    const app = createTestApp(1024);
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Length": "-1", "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(200);
+  });
+
   test("allows GET requests regardless of Content-Length", async () => {
     const app = createTestApp(1024);
     const res = await app.request("/test", {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -109,7 +109,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status);
+    throw new ApiClientError(body.error, body.message, res.status, body.details);
   }
 
   return res.json() as Promise<T>;
@@ -124,6 +124,7 @@ export class ApiClientError extends Error {
     public readonly code: string,
     message: string,
     public readonly status: number,
+    public readonly details?: Record<string, unknown>,
   ) {
     super(message);
     this.name = "ApiClientError";
@@ -157,7 +158,7 @@ export async function getResources(appName: string, path: string): Promise<strin
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status);
+    throw new ApiClientError(body.error, body.message, res.status, body.details);
   }
 
   return res.text();
@@ -266,7 +267,7 @@ export async function streamChat(req: ChatRequest, onEvent: ChatStreamCallback):
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status);
+    throw new ApiClientError(body.error, body.message, res.status, body.details);
   }
 
   await consumeSSEStream(res, onEvent);
@@ -316,7 +317,7 @@ export async function streamChatMultipart(
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status);
+    throw new ApiClientError(body.error, body.message, res.status, body.details);
   }
 
   await consumeSSEStream(res, onEvent);

--- a/web/src/api/format-error.test.ts
+++ b/web/src/api/format-error.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { ApiClientError } from "./client";
+import { formatSendError, humanBytes } from "./format-error";
+
+describe("humanBytes", () => {
+  test("handles NaN and negatives by falling back to raw with B suffix", () => {
+    expect(humanBytes(Number.NaN)).toBe("NaN B");
+    expect(humanBytes(-1)).toBe("-1 B");
+  });
+
+  test("bytes below 1 KB render as integer B", () => {
+    expect(humanBytes(0)).toBe("0 B");
+    expect(humanBytes(512)).toBe("512 B");
+  });
+
+  test("kilobytes render with 1 decimal and KB suffix", () => {
+    expect(humanBytes(1024)).toBe("1.0 KB");
+    expect(humanBytes(2048)).toBe("2.0 KB");
+  });
+
+  test("megabytes render with 1 decimal and MB suffix", () => {
+    expect(humanBytes(1_048_576)).toBe("1.0 MB");
+    expect(humanBytes(2_097_152)).toBe("2.0 MB");
+    expect(humanBytes(25 * 1_048_576)).toBe("25.0 MB");
+  });
+});
+
+describe("formatSendError", () => {
+  test("expands 413 responses with structured limit/received details", () => {
+    const err = new ApiClientError("payload_too_large", "Payload too large", 413, {
+      limit: 25 * 1_048_576,
+      received: 3 * 1_048_576,
+      contentType: "multipart/form-data; boundary=abc",
+    });
+    expect(formatSendError(err)).toBe("Upload is 3.0 MB — limit is 25.0 MB.");
+  });
+
+  test("falls back to server message when 413 has no structured details", () => {
+    const err = new ApiClientError("payload_too_large", "Payload too large", 413);
+    expect(formatSendError(err)).toBe("Payload too large");
+  });
+
+  test("falls back to server message when details are wrong-typed", () => {
+    const err = new ApiClientError("payload_too_large", "Payload too large", 413, {
+      limit: "25 MB",
+      received: "3 MB",
+    });
+    expect(formatSendError(err)).toBe("Payload too large");
+  });
+
+  test("non-413 ApiClientError surfaces its message unchanged", () => {
+    const err = new ApiClientError("unauthorized", "Please sign in", 401);
+    expect(formatSendError(err)).toBe("Please sign in");
+  });
+
+  test("plain Error surfaces its message", () => {
+    expect(formatSendError(new Error("network down"))).toBe("network down");
+  });
+
+  test("non-error rejection produces a generic message", () => {
+    expect(formatSendError("something weird")).toBe("An unexpected error occurred");
+    expect(formatSendError(undefined)).toBe("An unexpected error occurred");
+  });
+});

--- a/web/src/api/format-error.ts
+++ b/web/src/api/format-error.ts
@@ -1,0 +1,26 @@
+import { ApiClientError } from "./client";
+
+export function humanBytes(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return `${n} B`;
+  if (n < 1024) return `${n} B`;
+  if (n < 1_048_576) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1_048_576).toFixed(1)} MB`;
+}
+
+/**
+ * Format an error raised while sending a chat message into a user-facing
+ * string. Expands `payload_too_large` 413 responses using the structured
+ * `{ limit, received }` details so the toast reads "Upload is 3.0 MB —
+ * limit is 25.0 MB." instead of the generic server message.
+ */
+export function formatSendError(err: unknown): string {
+  if (err instanceof ApiClientError && err.code === "payload_too_large") {
+    const limit = typeof err.details?.limit === "number" ? err.details.limit : undefined;
+    const received = typeof err.details?.received === "number" ? err.details.received : undefined;
+    if (limit !== undefined && received !== undefined) {
+      return `Upload is ${humanBytes(received)} — limit is ${humanBytes(limit)}.`;
+    }
+    return err.message;
+  }
+  return err instanceof Error ? err.message : "An unexpected error occurred";
+}

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
-import { ApiClientError, callTool, streamChat, streamChatMultipart } from "../api/client";
+import { callTool, streamChat, streamChatMultipart } from "../api/client";
+import { formatSendError } from "../api/format-error";
 import { captureEvent } from "../telemetry";
 import type {
   AppContext,
@@ -28,25 +29,6 @@ function triggerResourceDownload(serverName: string): void {
   document.body.appendChild(anchor);
   anchor.click();
   setTimeout(() => document.body.removeChild(anchor), 100);
-}
-
-function humanBytes(n: number): string {
-  if (!Number.isFinite(n) || n < 0) return `${n} B`;
-  if (n < 1024) return `${n} B`;
-  if (n < 1_048_576) return `${(n / 1024).toFixed(1)} KB`;
-  return `${(n / 1_048_576).toFixed(1)} MB`;
-}
-
-function formatSendError(err: unknown): string {
-  if (err instanceof ApiClientError && err.code === "payload_too_large") {
-    const limit = typeof err.details?.limit === "number" ? err.details.limit : undefined;
-    const received = typeof err.details?.received === "number" ? err.details.received : undefined;
-    if (limit !== undefined && received !== undefined) {
-      return `Upload is ${humanBytes(received)} — limit is ${humanBytes(limit)}.`;
-    }
-    return err.message;
-  }
-  return err instanceof Error ? err.message : "An unexpected error occurred";
 }
 
 /** Streaming state machine: null → thinking → streaming ↔ working → null. */

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { callTool, streamChat, streamChatMultipart } from "../api/client";
+import { ApiClientError, callTool, streamChat, streamChatMultipart } from "../api/client";
 import { captureEvent } from "../telemetry";
 import type {
   AppContext,
@@ -28,6 +28,25 @@ function triggerResourceDownload(serverName: string): void {
   document.body.appendChild(anchor);
   anchor.click();
   setTimeout(() => document.body.removeChild(anchor), 100);
+}
+
+function humanBytes(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return `${n} B`;
+  if (n < 1024) return `${n} B`;
+  if (n < 1_048_576) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1_048_576).toFixed(1)} MB`;
+}
+
+function formatSendError(err: unknown): string {
+  if (err instanceof ApiClientError && err.code === "payload_too_large") {
+    const limit = typeof err.details?.limit === "number" ? err.details.limit : undefined;
+    const received = typeof err.details?.received === "number" ? err.details.received : undefined;
+    if (limit !== undefined && received !== undefined) {
+      return `Upload is ${humanBytes(received)} — limit is ${humanBytes(limit)}.`;
+    }
+    return err.message;
+  }
+  return err instanceof Error ? err.message : "An unexpected error occurred";
 }
 
 /** Streaming state machine: null → thinking → streaming ↔ working → null. */
@@ -407,7 +426,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
           has_app_context: !!appContext,
         });
       } catch (err) {
-        const msg = err instanceof Error ? err.message : "An unexpected error occurred";
+        const msg = formatSendError(err);
         setError(msg);
       } finally {
         setIsStreaming(false);


### PR DESCRIPTION
## Summary
- Replaces blanket 1MB bodyLimit with per-route policy; chat multipart defers to `filesConfig.maxTotalSize` (default 100MB, per-file 25MB enforced by ingest), JSON routes stay at 1MB.
- Fixes a Hono sub-app gotcha: `.use("*")` middleware in a sub-app mounted at `/` runs for every route, which is why the multipart-aware limit on `chatRoutes` was being shadowed by the first plain 1MB limit. Middleware is now attached per-handler.
- 413 responses now return structured `{ limit, received, contentType }` details so the UI can show "file X is N MB, limit is M MB" instead of a generic toast.

## Why
Single 1MB cap on `app.use("*")` 413'd any context-doc >1MB long before reaching the ingest layer, which already enforces per-file/total/MIME authoritatively. The caps were redundant and orders of magnitude apart.

## Test plan
- [x] `bun run verify` (format:check, lint, tsc, cycles, 1840 unit, 353 integration, 16 smoke)
- [x] New `test/unit/api/body-limit.test.ts` cases for multipart branch + structured details
- [x] New `test/integration/body-limit-routes.test.ts` exercises per-route limits against a live server
- [ ] Staging smoke: upload a 3MB PDF via the UI — expect success reaching ingest layer (blocked pending Bug 4 for the final landing behavior; middleware 413 is gone as of this PR)