### PR TITLE
Add "analyzing" streaming state to cover post-tool inference gap

### DIFF
--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -147,7 +147,8 @@ export function MessageInput({
     [addFiles],
   );
 
-  const isActive = streamingState === "thinking" || streamingState === "working";
+  const isActive =
+    streamingState === "thinking" || streamingState === "working" || streamingState === "analyzing";
   const canSend = (text.trim() || attachedFiles.length > 0) && !disabled;
 
   return (
@@ -233,7 +234,11 @@ export function MessageInput({
       <div className="flex items-center justify-center gap-3 mt-2 text-[10px] text-muted-foreground">
         {isActive && (
           <span className="text-processing font-mono font-medium">
-            {streamingState === "working" ? "Working..." : "Thinking..."}
+            {streamingState === "working"
+              ? "Working..."
+              : streamingState === "analyzing"
+                ? "Analyzing..."
+                : "Thinking..."}
           </span>
         )}
         {onNewConversation && (

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -341,6 +341,11 @@ export function MessageList({
                               <ToolAccordion
                                 calls={block.toolCalls}
                                 displayDetail={displayDetail}
+                                pending={
+                                  streamingState === "analyzing" &&
+                                  idx === messages.length - 1 &&
+                                  blockIdx === msg.blocks!.length - 1
+                                }
                               />
                               {blockWidgets.map((tc) => {
                                 const match = tc.resourceUri!.match(/^ui:\/\/[^/]+\/(.+)$/);

--- a/web/src/components/ToolAccordion.tsx
+++ b/web/src/components/ToolAccordion.tsx
@@ -28,11 +28,19 @@ import { describeBatch } from "../lib/tool-display";
 interface ToolAccordionProps {
   calls: ToolCallDisplay[];
   displayDetail: DisplayDetail;
+  /**
+   * True when this block's tools have all finished and the model is now
+   * inferring on the results (streamingState === "analyzing"). Renders an
+   * "Analyzing…" footer so the UI doesn't appear frozen between tool.done
+   * and the next text.delta / tool.start.
+   */
+  pending?: boolean;
 }
 
 export const ToolAccordion = memo(function ToolAccordion({
   calls,
   displayDetail,
+  pending = false,
 }: ToolAccordionProps) {
   // Visual statuses smooth the running→done transition so quick tools don't flash.
   const visualStatuses = useMinDisplayTime(calls);
@@ -80,6 +88,16 @@ export const ToolAccordion = memo(function ToolAccordion({
           ) : (
             batch.items.map((item) => <ToolRow key={item.id} item={item} />)
           )}
+        </div>
+      )}
+
+      {pending && (
+        <div className="tool-accordion__pending" aria-live="polite">
+          <Loader2
+            className="tool-accordion__icon tool-accordion__icon--running"
+            style={{ width: 12, height: 12 }}
+          />
+          <span>Analyzing</span>
         </div>
       )}
     </div>

--- a/web/src/components/ToolAccordion.tsx
+++ b/web/src/components/ToolAccordion.tsx
@@ -52,6 +52,9 @@ export const ToolAccordion = memo(function ToolAccordion({
   const [expanded, setExpanded] = useState(false);
   const toggle = useCallback(() => setExpanded((v) => !v), []);
 
+  // `quiet` hides the whole accordion — including the pending footer. That's
+  // intentional; in quiet mode the composer's "Analyzing..." label is the only
+  // post-tool signal, which matches how quiet mode suppresses tool surfaces.
   if (displayDetail === "quiet" || batch.items.length === 0) return null;
 
   // Narrow via element lookup rather than length comparison so this stays

--- a/web/src/components/ToolAccordion.tsx
+++ b/web/src/components/ToolAccordion.tsx
@@ -94,8 +94,13 @@ export const ToolAccordion = memo(function ToolAccordion({
         </div>
       )}
 
-      {pending && (
-        <div className="tool-accordion__pending" aria-live="polite">
+      {/* Hold the footer back until the head has actually resolved to done/error.
+          `useMinDisplayTime` keeps very fast tools visually in the running state
+          for 600ms to prevent flashing; showing "Analyzing" during that window
+          would put two spinners with conflicting copy on screen simultaneously
+          (head: "Researching · Acme", footer: "Analyzing"). */}
+      {pending && visualStatuses.every((vs) => vs.status !== "running") && (
+        <div className="tool-accordion__pending" role="status" aria-live="polite">
           <Loader2
             className="tool-accordion__icon tool-accordion__icon--running"
             style={{ width: 12, height: 12 }}

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { callTool, streamChat, streamChatMultipart } from "../api/client";
+import { ApiClientError, callTool, streamChat, streamChatMultipart } from "../api/client";
 import { captureEvent } from "../telemetry";
 import type {
   AppContext,
@@ -30,8 +30,15 @@ function triggerResourceDownload(serverName: string): void {
   setTimeout(() => document.body.removeChild(anchor), 100);
 }
 
-/** Streaming state machine: null → thinking → streaming ↔ working → null. */
-export type StreamingState = null | "thinking" | "streaming" | "working";
+/**
+ * Streaming state machine:
+ *   null → thinking → streaming ↔ working → analyzing → streaming → null
+ *
+ * `analyzing` fills the gap between the last tool.done (all tools finished)
+ * and the next text.delta / tool.start, when the model is inferring on tool
+ * results but the UI would otherwise look frozen.
+ */
+export type StreamingState = null | "thinking" | "streaming" | "working" | "analyzing";
 
 /** Typed tool result shape forwarded through the bridge. */
 export interface ToolResultForUI {
@@ -305,7 +312,6 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             }
             case "tool.done": {
               const evt = data as ToolDoneEvent;
-              setStreamingState("streaming");
               const updater = updateTool(evt);
               // Update flat ref
               toolCallsRef.current = toolCallsRef.current.map(updater);
@@ -315,6 +321,11 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
                   block.toolCalls = block.toolCalls.map(updater);
                 }
               }
+              // Hold `working` while other parallel tools are still running;
+              // only flip to `analyzing` when the last tool in the batch lands,
+              // so the indicator reflects "model is inferring on results."
+              const anyRunning = toolCallsRef.current.some((tc) => tc.status === "running");
+              setStreamingState(anyRunning ? "working" : "analyzing");
               flushToMessage();
 
               // Auto-download: when agent calls export_pdf, trigger browser download
@@ -407,8 +418,17 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
           has_app_context: !!appContext,
         });
       } catch (err) {
-        const msg = err instanceof Error ? err.message : "An unexpected error occurred";
-        setError(msg);
+        if (err instanceof ApiClientError && err.code === "run_in_progress") {
+          // Server rejected because a previous run is still in flight.
+          // Drop the optimistic user+assistant placeholders so the user can retry.
+          setMessages((prev) => prev.slice(0, -2));
+          setError(
+            "The assistant is still working on your previous message. Wait for it to finish, then try again.",
+          );
+        } else {
+          const msg = err instanceof Error ? err.message : "An unexpected error occurred";
+          setError(msg);
+        }
       } finally {
         setIsStreaming(false);
         setStreamingState(null);
@@ -545,7 +565,6 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
         }
         case "tool.done": {
           const evt = data as ToolDoneEvent;
-          setStreamingState("streaming");
           const updater = updateTool(evt);
           toolCallsRef.current = toolCallsRef.current.map(updater);
           for (const block of blocksRef.current) {
@@ -553,6 +572,8 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
               block.toolCalls = block.toolCalls.map(updater);
             }
           }
+          const anyRunning = toolCallsRef.current.some((tc) => tc.status === "running");
+          setStreamingState(anyRunning ? "working" : "analyzing");
           flushToMessage();
           break;
         }

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -32,11 +32,14 @@ function triggerResourceDownload(serverName: string): void {
 
 /**
  * Streaming state machine:
+ *
  *   null → thinking → streaming ↔ working → analyzing → streaming → null
+ *                                                    ↘ working (next tool.start)
  *
  * `analyzing` fills the gap between the last tool.done (all tools finished)
  * and the next text.delta / tool.start, when the model is inferring on tool
- * results but the UI would otherwise look frozen.
+ * results but the UI would otherwise look frozen. Any `tool.start` can
+ * re-enter `working` from a non-terminal state.
  */
 export type StreamingState = null | "thinking" | "streaming" | "working" | "analyzing";
 

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { ApiClientError, callTool, streamChat, streamChatMultipart } from "../api/client";
+import { callTool, streamChat, streamChatMultipart } from "../api/client";
 import { captureEvent } from "../telemetry";
 import type {
   AppContext,
@@ -418,17 +418,8 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
           has_app_context: !!appContext,
         });
       } catch (err) {
-        if (err instanceof ApiClientError && err.code === "run_in_progress") {
-          // Server rejected because a previous run is still in flight.
-          // Drop the optimistic user+assistant placeholders so the user can retry.
-          setMessages((prev) => prev.slice(0, -2));
-          setError(
-            "The assistant is still working on your previous message. Wait for it to finish, then try again.",
-          );
-        } else {
-          const msg = err instanceof Error ? err.message : "An unexpected error occurred";
-          setError(msg);
-        }
+        const msg = err instanceof Error ? err.message : "An unexpected error occurred";
+        setError(msg);
       } finally {
         setIsStreaming(false);
         setStreamingState(null);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -452,6 +452,32 @@
   transform: rotate(90deg);
 }
 
+/* Post-tool "Analyzing" indicator — renders below the accordion head when
+   all tools in the block have finished and the model is inferring on the
+   results. Fills the gap between tool.done and the next text.delta so the
+   UI doesn't appear frozen. */
+.tool-accordion__pending {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  padding: 2px 0;
+  font-size: 13px;
+  color: var(--processing);
+  animation: tool-accordion-reveal 180ms ease-out;
+}
+.tool-accordion__pending span::after {
+  content: "…";
+  display: inline-block;
+  animation: tool-accordion-ellipsis 1.4s steps(4, end) infinite;
+  overflow: hidden;
+  vertical-align: bottom;
+  width: 0;
+}
+@keyframes tool-accordion-ellipsis {
+  to { width: 1em; }
+}
+
 .tool-accordion__icon { flex-shrink: 0; }
 .tool-accordion__icon--ok {
   width: 6px;

--- a/web/test/MessageList.pending.test.tsx
+++ b/web/test/MessageList.pending.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { render } from "@testing-library/react";
+import type { ChatMessage, ToolCallDisplay } from "../src/hooks/useChat.ts";
+import { MessageList } from "../src/components/MessageList.tsx";
+
+function doneCall(id: string): ToolCallDisplay {
+	return { id, name: "search", status: "done", ok: true, ms: 50 };
+}
+
+function countPendingFooters(html: string): number {
+	return (html.match(/tool-accordion__pending/g) ?? []).length;
+}
+
+/**
+ * Regression guard for the pending-prop indexing in MessageList:
+ *
+ *   pending = streamingState === "analyzing"
+ *          && idx       === messages.length - 1      // latest message
+ *          && blockIdx  === msg.blocks.length - 1    // latest block in that message
+ *
+ * An off-by-one or a dropped conjunct would show the "Analyzing…" indicator
+ * on the wrong tool block (or on every tool block in the turn), which is
+ * easy to miss in manual QA.
+ */
+describe("MessageList pending indexing", () => {
+	const user: ChatMessage = {
+		role: "user",
+		content: "go",
+	};
+
+	const assistantWithTwoToolBlocks: ChatMessage = {
+		role: "assistant",
+		content: "",
+		blocks: [
+			{ type: "tool", toolCalls: [doneCall("a1")] },
+			{ type: "text", text: "thinking about that" },
+			{ type: "tool", toolCalls: [doneCall("b1")] },
+		],
+	};
+
+	it("renders the Analyzing footer only on the last tool block when analyzing", () => {
+		const { container } = render(
+			<MessageList
+				messages={[user, assistantWithTwoToolBlocks]}
+				isStreaming={true}
+				streamingState="analyzing"
+				displayDetail="balanced"
+			/>,
+		);
+		// Exactly one pending footer; no other tool block gets it.
+		expect(countPendingFooters(container.innerHTML)).toBe(1);
+	});
+
+	it("does not render any Analyzing footer when not in analyzing state", () => {
+		const { container } = render(
+			<MessageList
+				messages={[user, assistantWithTwoToolBlocks]}
+				isStreaming={true}
+				streamingState="working"
+				displayDetail="balanced"
+			/>,
+		);
+		expect(countPendingFooters(container.innerHTML)).toBe(0);
+	});
+
+	it("does not attach pending to a tool block that is NOT the last message", () => {
+		// Two assistant turns, both with tool blocks. Only the LATEST message's
+		// last block is eligible — an earlier turn's tool block must stay silent.
+		const earlierAssistant: ChatMessage = {
+			role: "assistant",
+			content: "done",
+			blocks: [{ type: "tool", toolCalls: [doneCall("x1")] }],
+		};
+		const { container } = render(
+			<MessageList
+				messages={[user, earlierAssistant, user, assistantWithTwoToolBlocks]}
+				isStreaming={true}
+				streamingState="analyzing"
+				displayDetail="balanced"
+			/>,
+		);
+		// Still exactly one pending footer even though there are two assistant
+		// turns with tool blocks — prior turn's tool block must not get it.
+		expect(countPendingFooters(container.innerHTML)).toBe(1);
+	});
+});

--- a/web/test/ToolAccordion.test.tsx
+++ b/web/test/ToolAccordion.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { render } from "@testing-library/react";
+import type { ToolCallDisplay } from "../src/hooks/useChat.ts";
+import { ToolAccordion } from "../src/components/ToolAccordion.tsx";
+
+function doneCall(id: string, name = "search"): ToolCallDisplay {
+	return {
+		id,
+		name,
+		status: "done",
+		ok: true,
+		ms: 120,
+	};
+}
+
+function hasPendingFooter(html: string): boolean {
+	return html.includes("tool-accordion__pending");
+}
+
+describe("ToolAccordion pending footer", () => {
+	it("does not render the Analyzing row when pending is false", () => {
+		const { container } = render(
+			<ToolAccordion calls={[doneCall("t1")]} displayDetail="balanced" pending={false} />,
+		);
+		expect(hasPendingFooter(container.innerHTML)).toBe(false);
+	});
+
+	it("renders the Analyzing row when pending is true", () => {
+		const { container } = render(
+			<ToolAccordion calls={[doneCall("t1")]} displayDetail="balanced" pending={true} />,
+		);
+		expect(hasPendingFooter(container.innerHTML)).toBe(true);
+		expect(container.innerHTML).toContain("Analyzing");
+	});
+
+	it("does not render the accordion at all (including pending) in quiet mode", () => {
+		const { container } = render(
+			<ToolAccordion calls={[doneCall("t1")]} displayDetail="quiet" pending={true} />,
+		);
+		// In quiet mode the whole accordion is suppressed; the composer carries the signal.
+		expect(container.innerHTML).toBe("");
+	});
+});

--- a/web/test/ToolAccordion.test.tsx
+++ b/web/test/ToolAccordion.test.tsx
@@ -13,6 +13,10 @@ function doneCall(id: string, name = "search"): ToolCallDisplay {
 	};
 }
 
+function runningCall(id: string, name = "search"): ToolCallDisplay {
+	return { id, name, status: "running" };
+}
+
 function hasPendingFooter(html: string): boolean {
 	return html.includes("tool-accordion__pending");
 }
@@ -39,5 +43,16 @@ describe("ToolAccordion pending footer", () => {
 		);
 		// In quiet mode the whole accordion is suppressed; the composer carries the signal.
 		expect(container.innerHTML).toBe("");
+	});
+
+	// Regression guard for the useMinDisplayTime overlap: while any call is
+	// still visually running (either actually running or inside the 600ms
+	// smoothing window), the pending footer must stay hidden to avoid two
+	// spinners with conflicting copy on screen simultaneously.
+	it("suppresses the Analyzing row while any call is visually running", () => {
+		const { container } = render(
+			<ToolAccordion calls={[runningCall("t1")]} displayDetail="balanced" pending={true} />,
+		);
+		expect(hasPendingFooter(container.innerHTML)).toBe(false);
 	});
 });

--- a/web/test/streamingState.test.tsx
+++ b/web/test/streamingState.test.tsx
@@ -103,7 +103,7 @@ describe("streamingState state machine", () => {
 		expect(result.current.streamingState).toBe("working");
 	});
 
-	it("transitions working → streaming on tool.done", async () => {
+	it("transitions working → analyzing on last tool.done", async () => {
 		const { result } = renderHook(() => useStreamingState(), { wrapper });
 
 		act(() => {
@@ -122,7 +122,75 @@ describe("streamingState state machine", () => {
 		act(() => {
 			capturedCallback?.("tool.done", { id: "t1", name: "search", ok: true, ms: 100 });
 		});
+		// No in-flight tools remain → model is inferring on the result.
+		expect(result.current.streamingState).toBe("analyzing");
+	});
+
+	it("holds working while parallel tools are still in flight, then analyzing", async () => {
+		const { result } = renderHook(() => useStreamingState(), { wrapper });
+
+		act(() => {
+			result.current.sendMessage("hello");
+		});
+		await act(async () => {});
+
+		act(() => {
+			capturedCallback?.("tool.start", { id: "a", name: "search" });
+			capturedCallback?.("tool.start", { id: "b", name: "fetch" });
+		});
+		expect(result.current.streamingState).toBe("working");
+
+		// First of two completes — the other is still running, so stay `working`.
+		act(() => {
+			capturedCallback?.("tool.done", { id: "a", name: "search", ok: true, ms: 10 });
+		});
+		expect(result.current.streamingState).toBe("working");
+
+		// Last one lands → flip to `analyzing`.
+		act(() => {
+			capturedCallback?.("tool.done", { id: "b", name: "fetch", ok: false, ms: 725 });
+		});
+		expect(result.current.streamingState).toBe("analyzing");
+	});
+
+	it("transitions analyzing → streaming on the next text.delta", async () => {
+		const { result } = renderHook(() => useStreamingState(), { wrapper });
+
+		act(() => {
+			result.current.sendMessage("hello");
+		});
+		await act(async () => {});
+
+		act(() => {
+			capturedCallback?.("tool.start", { id: "t1", name: "search" });
+			capturedCallback?.("tool.done", { id: "t1", name: "search", ok: true, ms: 10 });
+		});
+		expect(result.current.streamingState).toBe("analyzing");
+
+		act(() => {
+			capturedCallback?.("text.delta", { text: "Based on that…" });
+		});
 		expect(result.current.streamingState).toBe("streaming");
+	});
+
+	it("transitions analyzing → working when the model calls another tool", async () => {
+		const { result } = renderHook(() => useStreamingState(), { wrapper });
+
+		act(() => {
+			result.current.sendMessage("hello");
+		});
+		await act(async () => {});
+
+		act(() => {
+			capturedCallback?.("tool.start", { id: "t1", name: "search" });
+			capturedCallback?.("tool.done", { id: "t1", name: "search", ok: true, ms: 10 });
+		});
+		expect(result.current.streamingState).toBe("analyzing");
+
+		act(() => {
+			capturedCallback?.("tool.start", { id: "t2", name: "fetch" });
+		});
+		expect(result.current.streamingState).toBe("working");
 	});
 
 	it("transitions to null on done event", async () => {
@@ -191,7 +259,7 @@ describe("streamingState state machine", () => {
 		expect(result.current.streamingState).toBeNull();
 	});
 
-	it("full cycle: thinking → streaming → working → streaming → null", async () => {
+	it("full cycle: thinking → streaming → working → analyzing → streaming → null", async () => {
 		const { result } = renderHook(() => useStreamingState(), { wrapper });
 
 		act(() => {
@@ -213,7 +281,7 @@ describe("streamingState state machine", () => {
 		act(() => {
 			capturedCallback?.("tool.done", { id: "t1", name: "lookup", ok: true, ms: 50 });
 		});
-		expect(result.current.streamingState).toBe("streaming");
+		expect(result.current.streamingState).toBe("analyzing");
 
 		act(() => {
 			capturedCallback?.("text.delta", { text: "here you go" });


### PR DESCRIPTION
## Summary

- Adds an `analyzing` streaming state to `useChat` that fills the previously-silent gap between the last `tool.done` and the next `text.delta` / `tool.start`
- Parallel tool batches now correctly stay in `working` until the final call lands — previously, any `tool.done` in a batch flipped the state to `streaming` even while siblings were still running
- `ToolAccordion` renders an "Analyzing…" sub-row (spinning Loader2 + animated ellipsis) when it's the active block and the model is inferring post-tool; composer footer mirrors this with an "Analyzing..." label

## Why

Real-world example from `conv_8f474335077b4ca4`: `webfetch__web_fetch` returned an error at `20:20:44.645`, `files__search` had already completed at `20:20:43.921`, and the next LLM response didn't start streaming until `~20:20:46.0` — a **~1,370ms** dead window during which the user saw a red "Couldn't fetch" headline and nothing else. That's well above both the `useMinDisplayTime` smoothing threshold and human perceptual threshold, so the UI genuinely looked frozen. Failure paths expose this worst because error recovery tends to require more thinking than happy-path synthesis.

## State machine

```
null → thinking → streaming ↔ working → analyzing → streaming → null
                                     ↘ working (if the model calls another tool)
```

- `tool.done` → `analyzing` only when `toolCallsRef.current.some(tc => tc.status === "running") === false`
- `text.delta` flips `analyzing → streaming` via the existing `prev !== "streaming"` guard
- `tool.start` flips `analyzing → working` via the existing unconditional set
- `done` / `error` still flush to `null`

## Test plan

- [x] `bun run verify:static` (format, lint, tsc, check:cycles)
- [x] `bun run test:unit` — 1835 pass
- [x] `bun run test:web` — 96 pass, including new coverage in `streamingState.test.tsx`:
  - `working → analyzing` on last `tool.done` (was: `working → streaming`)
  - `working` holds while parallel tools are still in flight; flips to `analyzing` on the final `tool.done`
  - `analyzing → streaming` on the next `text.delta`
  - `analyzing → working` when the model calls another tool
  - Updated full-cycle test to include the `analyzing` phase
- [ ] Manual: replay a prompt that causes a `web_fetch` redirect failure (e.g. "Search the web for the latest Anthropic model pricing…" hitting `anthropic.com/pricing` → `claude.com/pricing` redirect) and verify the "Analyzing…" sub-row appears under the red headline for the ~1.3s window before recovery text streams in
- [ ] Manual: send a multi-tool-call prompt and verify the indicator does NOT appear until *all* parallel tools complete