### PR TITLE
Fix clipped Daily Cost chart tooltip on Usage settings

### DIFF
--- a/web/src/components/charts/CostChart.tsx
+++ b/web/src/components/charts/CostChart.tsx
@@ -80,6 +80,15 @@ export function CostChart({ data }: CostChartProps) {
     { key: "input", field: "input" },
   ];
 
+  // Tooltip anchor: center normally, but snap to the closer edge near the
+  // chart boundaries so the popover never spills past the card (the parent
+  // card uses overflow-visible so the tooltip isn't clipped).
+  const tooltipCenterPct =
+    hoveredIndex !== null
+      ? ((paddingLeft + gap + hoveredIndex * (barWidth + gap) + barWidth / 2) / width) * 100
+      : 0;
+  const tooltipTranslateX = tooltipCenterPct < 15 ? "0%" : tooltipCenterPct > 85 ? "-100%" : "-50%";
+
   return (
     <div className="relative">
       <svg
@@ -176,11 +185,11 @@ export function CostChart({ data }: CostChartProps) {
       {/* Tooltip */}
       {hoveredIndex !== null && data[hoveredIndex] && (
         <div
-          className="absolute bg-popover border border-border rounded-md shadow-md px-3 py-2 text-xs pointer-events-none z-10"
+          className="absolute bg-popover border border-border rounded-md shadow-md px-3 py-2 text-xs pointer-events-none z-20"
           style={{
-            left: `${((paddingLeft + gap + hoveredIndex * (barWidth + gap) + barWidth / 2) / width) * 100}%`,
+            left: `${tooltipCenterPct}%`,
             top: 0,
-            transform: "translate(-50%, 0)",
+            transform: `translate(${tooltipTranslateX}, 0)`,
             minWidth: 140,
           }}
         >

--- a/web/src/pages/settings/UsageTab.tsx
+++ b/web/src/pages/settings/UsageTab.tsx
@@ -274,7 +274,7 @@ export function UsageTab() {
 
       {/* Daily cost chart */}
       {hasActivity && (
-        <Card>
+        <Card className="overflow-visible">
           <CardHeader>
             <CardTitle>Daily Cost</CardTitle>
           </CardHeader>


### PR DESCRIPTION
## Summary
- Daily Cost bar chart tooltip on `/settings/usage` was clipped at the card edge and appeared to sit behind the next card.
- Root cause: base `Card` styles in `web/src/components/ui/card.tsx` include `overflow-hidden`, which clips the absolutely-positioned tooltip once it extends past the card bounds.
- Fix: pass `className="overflow-visible"` on just the Daily Cost card so its tooltip can overflow.

## Test plan
- [ ] Open `/settings/usage` and hover each bar in the Daily Cost chart — full tooltip (including 'Total' and calls line) renders on top, not clipped by the card below.
- [ ] Confirm other Cards (Stats, By Model, Daily Breakdown) render unchanged.