### PR TITLE
Keep SSE chat stream alive with 20s heartbeat

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -17,7 +17,7 @@ import { InlineSource } from "../tools/inline-source.ts";
 import { validateToolInput } from "../tools/validate-input.ts";
 import type { ConversationEventManager } from "./conversation-events.ts";
 import type { SseEventManager } from "./events.ts";
-import { type SseHeartbeat, startSseHeartbeat } from "./sse-heartbeat.ts";
+import { startSseHeartbeat } from "./sse-heartbeat.ts";
 import { apiError } from "./types.ts";
 
 const pkgPath = resolve(import.meta.dirname ?? __dirname, "../../package.json");
@@ -29,7 +29,7 @@ const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
  * `deployments/agent-platform/*`) while staying quiet enough to be
  * invisible to the user.
  */
-export const HEARTBEAT_INTERVAL_MS = 20_000;
+const HEARTBEAT_INTERVAL_MS = 20_000;
 
 /** Handle POST /v1/chat — synchronous chat request. */
 export async function handleChat(
@@ -89,11 +89,14 @@ export async function handleChatStream(
 
   const sink = new CallbackEventSink();
   let markClosed: () => void;
-  let heartbeat: SseHeartbeat = { stop: () => {} };
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       const encoder = new TextEncoder();
       let closed = false;
+      // Keep the TCP connection alive during slow tool calls (Typst
+      // compile, MCP task-augmented research) — ALB idle-timeout kills
+      // silent streams. Must be created before `markClosed` captures it.
+      const heartbeat = startSseHeartbeat(controller, HEARTBEAT_INTERVAL_MS);
       markClosed = () => {
         closed = true;
         heartbeat.stop();
@@ -102,10 +105,6 @@ export async function handleChatStream(
         if (closed) return;
         controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
       };
-      // Keep the TCP connection alive during slow tool calls (Typst
-      // compile, MCP task-augmented research) — ALB idle-timeout kills
-      // silent streams.
-      heartbeat = startSseHeartbeat(controller, HEARTBEAT_INTERVAL_MS);
       const finish = () => {
         if (closed) return;
         closed = true;

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -17,10 +17,19 @@ import { InlineSource } from "../tools/inline-source.ts";
 import { validateToolInput } from "../tools/validate-input.ts";
 import type { ConversationEventManager } from "./conversation-events.ts";
 import type { SseEventManager } from "./events.ts";
+import { type SseHeartbeat, startSseHeartbeat } from "./sse-heartbeat.ts";
 import { apiError } from "./types.ts";
 
 const pkgPath = resolve(import.meta.dirname ?? __dirname, "../../package.json");
 const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
+
+/**
+ * Interval between SSE comment heartbeats on /v1/chat/stream. Chosen to sit
+ * safely below AWS ALB idle-timeout (60s default, raised to 900s in
+ * `deployments/agent-platform/*`) while staying quiet enough to be
+ * invisible to the user.
+ */
+export const HEARTBEAT_INTERVAL_MS = 20_000;
 
 /** Handle POST /v1/chat — synchronous chat request. */
 export async function handleChat(
@@ -80,20 +89,27 @@ export async function handleChatStream(
 
   const sink = new CallbackEventSink();
   let markClosed: () => void;
+  let heartbeat: SseHeartbeat = { stop: () => {} };
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       const encoder = new TextEncoder();
       let closed = false;
       markClosed = () => {
         closed = true;
+        heartbeat.stop();
       };
       const send = (event: string, data: unknown) => {
         if (closed) return;
         controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
       };
+      // Keep the TCP connection alive during slow tool calls (Typst
+      // compile, MCP task-augmented research) — ALB idle-timeout kills
+      // silent streams.
+      heartbeat = startSseHeartbeat(controller, HEARTBEAT_INTERVAL_MS);
       const finish = () => {
         if (closed) return;
         closed = true;
+        heartbeat.stop();
         unsubscribe();
         controller.close();
       };

--- a/src/api/sse-heartbeat.ts
+++ b/src/api/sse-heartbeat.ts
@@ -1,10 +1,17 @@
 /**
- * SSE keepalive helper.
+ * SSE keepalive helper for request-scoped streams.
  *
  * Emits `: ping\n\n` comment frames on an SSE stream's controller at a
  * fixed interval so AWS ALB (and anything else enforcing TCP idle
  * timeouts) doesn't drop long-running streams during silent engine
  * periods. SSE comment lines are ignored by the client per spec.
+ *
+ * Not to be confused with `SseEventManager`/`ConversationEventManager`'s
+ * `heartbeat` broadcast: those emit a named `heartbeat` SSE *event* at
+ * 30s to every subscriber on a shared workspace/conversation channel.
+ * This helper emits comment frames at 20s on a single request-scoped
+ * stream (currently only `/v1/chat/stream`). Same word, different
+ * paradigm.
  */
 
 const encoder = new TextEncoder();

--- a/src/api/sse-heartbeat.ts
+++ b/src/api/sse-heartbeat.ts
@@ -1,0 +1,43 @@
+/**
+ * SSE keepalive helper.
+ *
+ * Emits `: ping\n\n` comment frames on an SSE stream's controller at a
+ * fixed interval so AWS ALB (and anything else enforcing TCP idle
+ * timeouts) doesn't drop long-running streams during silent engine
+ * periods. SSE comment lines are ignored by the client per spec.
+ */
+
+const encoder = new TextEncoder();
+const PING_FRAME = encoder.encode(": ping\n\n");
+
+export interface SseHeartbeat {
+  /** Cancel the heartbeat. Idempotent. */
+  stop(): void;
+}
+
+/**
+ * Start a heartbeat on `controller`, firing every `intervalMs`.
+ * Returns a handle with `stop()` to cancel. Enqueue failures (e.g.
+ * controller already closed) are swallowed — callers own controller
+ * lifecycle.
+ */
+export function startSseHeartbeat(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  intervalMs: number,
+): SseHeartbeat {
+  const timer = setInterval(() => {
+    try {
+      controller.enqueue(PING_FRAME);
+    } catch {
+      // Controller already closed; the timer will be cleared by stop().
+    }
+  }, intervalMs);
+  let stopped = false;
+  return {
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}

--- a/test/unit/api/sse-heartbeat.test.ts
+++ b/test/unit/api/sse-heartbeat.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { startSseHeartbeat } from "../../../src/api/sse-heartbeat.ts";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Build a real ReadableStream + controller so we can observe enqueues
+ * exactly the way the chat handler would. Reading the stream drains
+ * frames so we can assert on them.
+ */
+function makeStreamPair(): {
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  read: () => Promise<string>;
+} {
+  let controllerRef!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controllerRef = c;
+    },
+  });
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const read = async (): Promise<string> => {
+    let out = "";
+    while (true) {
+      const raced = await Promise.race<ReadableStreamReadResult<Uint8Array> | "idle">([
+        reader.read(),
+        sleep(5).then(() => "idle" as const),
+      ]);
+      if (raced === "idle") return out;
+      if (raced.done) return out;
+      out += decoder.decode(raced.value);
+    }
+  };
+  return { controller: controllerRef, read };
+}
+
+describe("startSseHeartbeat", () => {
+  test("emits a SSE comment frame on each tick", async () => {
+    const { controller, read } = makeStreamPair();
+    const heartbeat = startSseHeartbeat(controller, 15);
+    await sleep(50); // Allow ~3 ticks.
+    heartbeat.stop();
+    controller.close();
+    const out = await read();
+    const pings = out.match(/: ping\n\n/g) ?? [];
+    expect(pings.length).toBeGreaterThanOrEqual(2);
+    expect(pings.length).toBeLessThanOrEqual(5);
+  });
+
+  test("stop() cancels further ticks", async () => {
+    const { controller, read } = makeStreamPair();
+    const heartbeat = startSseHeartbeat(controller, 10);
+    await sleep(25);
+    heartbeat.stop();
+    const before = (await read()).match(/: ping\n\n/g)?.length ?? 0;
+    await sleep(40); // No further pings should arrive.
+    controller.close();
+    const after = ((await read()).match(/: ping\n\n/g)?.length ?? 0) + before;
+    // Reader was drained in `before`; `after` counts ADDITIONAL pings only.
+    // Anything remaining is still just `before`. `after - before` must be 0.
+    expect(after - before).toBe(0);
+  });
+
+  test("stop() is idempotent", async () => {
+    const { controller, read } = makeStreamPair();
+    const heartbeat = startSseHeartbeat(controller, 20);
+    heartbeat.stop();
+    heartbeat.stop(); // must not throw
+    controller.close();
+    await read();
+  });
+
+  test("swallows enqueue errors after the controller is closed", async () => {
+    const { controller } = makeStreamPair();
+    const heartbeat = startSseHeartbeat(controller, 10);
+    controller.close();
+    // Next tick tries to enqueue into a closed controller — must not throw.
+    await sleep(30);
+    heartbeat.stop();
+  });
+});

--- a/test/unit/api/sse-heartbeat.test.ts
+++ b/test/unit/api/sse-heartbeat.test.ts
@@ -53,13 +53,13 @@ describe("startSseHeartbeat", () => {
     const heartbeat = startSseHeartbeat(controller, 10);
     await sleep(25);
     heartbeat.stop();
-    const before = (await read()).match(/: ping\n\n/g)?.length ?? 0;
-    await sleep(40); // No further pings should arrive.
+    // Drain anything enqueued before stop(), then verify no more arrive.
+    const drainedBeforeStop = (await read()).match(/: ping\n\n/g)?.length ?? 0;
+    expect(drainedBeforeStop).toBeGreaterThanOrEqual(1);
+    await sleep(40);
     controller.close();
-    const after = ((await read()).match(/: ping\n\n/g)?.length ?? 0) + before;
-    // Reader was drained in `before`; `after` counts ADDITIONAL pings only.
-    // Anything remaining is still just `before`. `after - before` must be 0.
-    expect(after - before).toBe(0);
+    const drainedAfterStop = (await read()).match(/: ping\n\n/g)?.length ?? 0;
+    expect(drainedAfterStop).toBe(0);
   });
 
   test("stop() is idempotent", async () => {


### PR DESCRIPTION
## Summary
Fixes the red \"network error\" toast during long agent turns. Backend runs complete — the LB just silently killed the idle SSE connection. `/v1/chat/stream` now emits a 20s heartbeat (SSE comment) so ALB never sees it as idle.

## Why
\`/v1/chat/stream\` only emits frames on engine events. A multi-minute tool call (Typst compile, MCP task-augmented research, long delegate) leaves the SSE pipe idle → ALB's 60s default kills the TCP connection → browser shows a red toast even though conversation events persist cleanly. \`/v1/events\` and \`/v1/conversations/:id/events\` already heartbeat via their event managers; this handler was the only unprotected site.

## Changes
- \`src/api/sse-heartbeat.ts\` — new reusable helper. \`startSseHeartbeat(controller, intervalMs)\` returns a handle with \`stop()\`; enqueues \`: ping\\n\\n\` per tick; swallows enqueue errors after close.
- \`src/api/handlers.ts\` — wires the heartbeat into \`handleChatStream\`'s \`ReadableStream.start()\`; stops it in \`finish()\` and \`cancel()\`.
- Interval: 20s (3× safety below 60s default ALB idle, 45× below the 900s we'll set via deploy-config).

## Scope
This is **Change 1 of 3** from the spec. The other two are:
- **Change 2** (infra): ALB idle-timeout annotation in \`deployments/agent-platform/*/base-values.yaml\`. Separate PR on the deployments submodule, stage → prod rollout.
- **Change 3** (client): soft \"Reconnecting…\" + switch to \`/v1/conversations/:id/events\` on transport error. Proposed as a separate follow-up PR — defense-in-depth for the tail case where Changes 1+2 fail. Not urgent once 1+2 ship.

## Test plan
- [x] \`bun run verify\` — unit (new: 4 heartbeat cases covering tick emission, stop idempotence, after-close enqueue) + integration + smoke all green.
- [ ] Staging: run a >60s tool call (Typst compile / research), confirm no red toast and the stream stays open with periodic 6-byte frames in DevTools Network tab.

## Deferred
- Integration test for \`handleChatStream\` wiring — the wiring is 2 lines over a unit-tested helper; the real integration case needs either multi-second waits or env-var plumbing. Can add if QA requests.