### PR TITLE
Prevent chat tool-call rows from overflowing the message column

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,7 @@ jobs:
 
       # We deliberately do NOT tag `:latest`. ECR repositories have immutable
       # tags enabled, so `latest` can't be reused across releases. Deploys pin
-      # to the version tag (or short sha) — see deployments/agent-platform/
-      # Makefile, which derives TAG from `git rev-parse --short HEAD`.
+      # to the version tag or short sha.
       - name: Build and push platform image
         run: |
           docker build --platform linux/amd64 \

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -298,7 +298,7 @@ export function MessageList({
                     <span className="presence-user-message italic">{displayContent}</span>
                   </div>
                 ) : (
-                  <div className="break-words min-w-0 overflow-hidden flex flex-col gap-3">
+                  <div className="w-full break-words min-w-0 overflow-hidden flex flex-col gap-3">
                     {showThinkingPlaceholder && (
                       <span className="text-xs font-mono text-muted-foreground/60 presence-thinking">
                         Thinking


### PR DESCRIPTION
## Summary
- Assistant message wrapper was sizing to its widest child because the parent flex column uses `items-start`. Tool-row summaries use `white-space: nowrap`, so their intrinsic width blew out the wrapper and the existing row-summary ellipsis never engaged.
- Added `w-full` to the wrapper so it pins to the message column width — `overflow-hidden` on the wrapper plus `text-overflow: ellipsis` on `.tool-accordion__row-summary` now take effect.

## Test plan
- [ ] Open a chat with a multi-tool-call block where at least one tool has a long first argument (e.g. a long SQL question)
- [ ] Confirm the row summary truncates with an ellipsis at the column edge instead of overflowing
- [ ] Check both full-screen chat and compact/sidebar modes
- [ ] Confirm prose and single-tool headers still render as before