### PR TITLE
Accept Blob in synapse/download-file bridge payload

### DIFF
--- a/web/src/bridge/bridge.ts
+++ b/web/src/bridge/bridge.ts
@@ -545,12 +545,8 @@ async function pickFiles(accept: string, maxSize: number, multiple: boolean): Pr
 }
 
 /** Trigger a browser file download via a temporary anchor tag. */
-function triggerDownload(data: string, filename: string, mimeType: string): void {
-  const bytes = new Uint8Array(data.length);
-  for (let i = 0; i < data.length; i++) {
-    bytes[i] = data.charCodeAt(i);
-  }
-  const blob = new Blob([bytes], { type: mimeType });
+function triggerDownload(data: Blob, filename: string, mimeType: string): void {
+  const blob = data.type === mimeType ? data : new Blob([data], { type: mimeType });
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;

--- a/web/src/bridge/types.ts
+++ b/web/src/bridge/types.ts
@@ -119,7 +119,7 @@ export interface UiDownloadFileMessage {
   method: "synapse/download-file";
   id?: string;
   params: {
-    data: string;
+    data: Blob;
     filename: string;
     mimeType: string;
   };


### PR DESCRIPTION
## Summary

- The `synapse/download-file` bridge handler treated `params.data` as a string and converted it byte-by-byte with `charCodeAt` — which truncates any byte above 0xFF, so even if a real binary payload had reached the bridge (it didn't — see paired synapse PR), the resulting file would still have been corrupted.
- `triggerDownload` now accepts a Blob and hands it to the anchor download as-is. `UiDownloadFileMessage.params.data` is typed as `Blob`.
- Backwards-compatible with existing synapse clients on 0.4.x: those clients send a `string` for all `downloadFile()` calls, which never worked correctly for binary content anyway. After the paired PR ships, the wire format is uniformly `Blob`.

## ⚠️ Merge + deploy sequencing

**Merge and deploy this PR first**, then merge [NimbleBrainInc/synapse#4](https://github.com/NimbleBrainInc/synapse/pull/4). The synapse PR changes the wire format from `string` → `Blob`; a host running the old bridge against a client on the new synapse will produce empty downloads.

## Test plan

- [x] `bun run check` (TypeScript) clean
- [x] `bun run test:web` — 113/113 pass
- [x] `cd web && bun run build` — passes
- [ ] Manual (post-deploy + synapse 0.5.0 publish): in collateral-studio, click Export → receive a real PDF

## Also on this branch

Only `web/src/bridge/bridge.ts` and `web/src/bridge/types.ts`. Staged explicitly to avoid picking up unrelated in-progress work in the working tree.