### PR TITLE
Show engine errors inline on the message

### DIFF
--- a/web/src/components/AppWithChat.tsx
+++ b/web/src/components/AppWithChat.tsx
@@ -321,6 +321,7 @@ export function AppWithChat({ placement, onNavigate }: AppWithChatProps) {
           onFullscreen={handleFullscreen}
           onBack={isMobile ? handleBack : undefined}
           isFullscreen={isFullscreen}
+          onRetry={chat.retryLastMessage}
         />
       </div>
     </div>

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -14,6 +14,7 @@ export function Chat() {
     sendMessage,
     newConversation,
     loadConversation,
+    retryLastMessage,
   } = useChatContext();
 
   useEffect(() => {
@@ -48,6 +49,7 @@ export function Chat() {
       sendMessage={handleSendMessage}
       newConversation={handleNewConversation}
       compact={false}
+      onRetry={retryLastMessage}
     />
   );
 }

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -19,6 +19,8 @@ export interface ChatPanelProps {
   onBack?: () => void;
   isFullscreen?: boolean;
   displayDetail?: DisplayDetail;
+  /** Called when the user clicks "Try again" on an errored message. */
+  onRetry?: () => void;
 }
 
 export interface ChatPanelRef {
@@ -38,6 +40,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
     onBack,
     isFullscreen = false,
     displayDetail: displayDetailProp,
+    onRetry,
   },
   ref,
 ) {
@@ -215,6 +218,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
         compact={compact}
         currentUserId={currentUserId}
         participantMap={participantMap}
+        onRetry={onRetry}
       />
 
       <div ref={inputWrapperRef} className={compact ? "px-4" : "max-w-4xl w-full mx-auto px-8"}>

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Check, ChevronDown, Copy, Zap } from "lucide-react";
+import { AlertCircle, Check, ChevronDown, Copy, RotateCcw, Zap } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Streamdown } from "streamdown";
 import type { ChatMessage, StreamingState } from "../hooks/useChat";
@@ -82,6 +82,8 @@ interface MessageListProps {
   currentUserId?: string;
   /** Map of userId → display name for participant labels. */
   participantMap?: Map<string, string>;
+  /** Called when the user clicks "Try again" on an errored message. */
+  onRetry?: () => void;
 }
 
 const BOTTOM_THRESHOLD = 50;
@@ -179,6 +181,7 @@ export function MessageList({
   compact = false,
   currentUserId,
   participantMap,
+  onRetry,
 }: MessageListProps) {
   const { scrollRef, bottomRef, isAtBottom, scrollToBottom } = useSmartScroll(messages);
 
@@ -403,6 +406,35 @@ export function MessageList({
                             ? "I reached my step limit for this turn. Send another message and I'll pick up where I left off."
                             : `Run ended: ${msg.stopReason}`}
                         </span>
+                      </div>
+                    )}
+                    {/* Inline error notice */}
+                    {msg.error && (
+                      <div className="px-3 py-2.5 rounded-md bg-destructive/8 border border-destructive/20 text-sm">
+                        <div className="flex items-center gap-2">
+                          <AlertCircle className="w-4 h-4 shrink-0 text-destructive" />
+                          <span className="flex-1 text-foreground">
+                            Something went wrong. You can try again or continue the conversation.
+                          </span>
+                        {onRetry && (
+                          <button
+                            type="button"
+                            onClick={onRetry}
+                            className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md border border-border bg-card hover:bg-muted text-foreground transition-colors shrink-0"
+                          >
+                            <RotateCcw className="w-3 h-3" />
+                            Try again
+                          </button>
+                        )}
+                        </div>
+                        <details className="mt-1.5 ml-6">
+                          <summary className="text-xs text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors">
+                            Details
+                          </summary>
+                          <p className="text-xs text-muted-foreground mt-1 font-mono break-all">
+                            {msg.error}
+                          </p>
+                        </details>
                       </div>
                     )}
                     {/* Inline app views are rendered within their tool block above */}

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -416,16 +416,16 @@ export function MessageList({
                           <span className="flex-1 text-foreground">
                             Something went wrong. You can try again or continue the conversation.
                           </span>
-                        {onRetry && (
-                          <button
-                            type="button"
-                            onClick={onRetry}
-                            className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md border border-border bg-card hover:bg-muted text-foreground transition-colors shrink-0"
-                          >
-                            <RotateCcw className="w-3 h-3" />
-                            Try again
-                          </button>
-                        )}
+                          {onRetry && (
+                            <button
+                              type="button"
+                              onClick={onRetry}
+                              className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md border border-border bg-card hover:bg-muted text-foreground transition-colors shrink-0"
+                            >
+                              <RotateCcw className="w-3 h-3" />
+                              Try again
+                            </button>
+                          )}
                         </div>
                         <details className="mt-1.5 ml-6">
                           <summary className="text-xs text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors">

--- a/web/src/context/ChatContext.tsx
+++ b/web/src/context/ChatContext.tsx
@@ -59,6 +59,16 @@ export function ChatProvider({
 }: ChatProviderProps) {
   const chat = useChat(initialConversationId, currentUserId);
 
+  // Dev helper: window.__nb.simulateError("some error message")
+  useEffect(() => {
+    const w = window as unknown as Record<string, Record<string, unknown>>;
+    if (!w.__nb) w.__nb = {};
+    w.__nb.simulateError = chat.simulateError;
+    return () => {
+      if (w.__nb) delete w.__nb.simulateError;
+    };
+  }, [chat.simulateError]);
+
   // -- Config state (stable) --
   const [selectedModel, setSelectedModelState] = useState<string | null>(() =>
     localStorage.getItem("nb:selectedModel"),

--- a/web/src/context/ChatContext.tsx
+++ b/web/src/context/ChatContext.tsx
@@ -61,11 +61,14 @@ export function ChatProvider({
 
   // Dev helper: window.__nb.simulateError("some error message")
   useEffect(() => {
-    const w = window as unknown as Record<string, Record<string, unknown>>;
-    if (!w.__nb) w.__nb = {};
-    w.__nb.simulateError = chat.simulateError;
+    if (!import.meta.env.DEV) return;
+    if (!window.__nb) window.__nb = {};
+    window.__nb.simulateError = chat.simulateError;
     return () => {
-      if (w.__nb) delete w.__nb.simulateError;
+      if (window.__nb) {
+        delete window.__nb.simulateError;
+        if (Object.keys(window.__nb).length === 0) delete window.__nb;
+      }
     };
   }, [chat.simulateError]);
 

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiClientError, callTool, streamChat, streamChatMultipart } from "../api/client";
 import { formatSendError } from "../api/format-error";
 import { captureEvent } from "../telemetry";
@@ -103,6 +103,8 @@ export interface ChatMessage {
   userId?: string;
   files?: MessageFileAttachment[];
   stopReason?: string;
+  /** Set when the engine errors mid-stream — renders inline on the message. */
+  error?: string;
   usage?: {
     inputTokens: number;
     outputTokens: number;
@@ -138,6 +140,10 @@ export interface UseChatReturn {
   injectRemoteUserMessage: (userId: string, displayName: string, content: string) => void;
   /** Process a streaming event from a remote participant's assistant response. */
   processRemoteStreamEvent: (type: string, data: unknown) => void;
+  /** Retry the last failed message (removes errored pair and re-sends). */
+  retryLastMessage: () => void;
+  /** Inject a synthetic error for demoing the error UX (dev only). */
+  simulateError: (message: string) => void;
 }
 
 /** Deep-copy blocks for immutable state updates. */
@@ -407,7 +413,19 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             case "error": {
               const evt = data as StreamErrorEvent;
               setStreamingState(null);
-              setError(evt.message);
+              // Stamp the error on the last assistant message so it renders
+              // inline — not as a disconnected banner at the top.
+              setMessages((prev) => {
+                const updated = [...prev];
+                const last = updated[updated.length - 1];
+                if (last?.role === "assistant") {
+                  updated[updated.length - 1] = { ...last, error: evt.message };
+                } else {
+                  // No assistant message to attach to — fall back to banner
+                  setError(evt.message);
+                }
+                return updated;
+              });
               break;
             }
           }
@@ -433,6 +451,16 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
           });
         }
         const msg = formatSendError(err);
+        // Stamp on the last assistant message if one exists
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          if (last?.role === "assistant") {
+            const updated = [...prev];
+            updated[updated.length - 1] = { ...last, error: msg };
+            return updated;
+          }
+          return prev;
+        });
         setError(msg);
       } finally {
         setIsStreaming(false);
@@ -647,6 +675,54 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
     [flushToMessage],
   );
 
+  // Pending retry text — set by retryLastMessage, consumed by an effect
+  const retryRef = useRef<string | null>(null);
+
+  const retryLastMessage = useCallback(() => {
+    // Find the last user message, stash its text, remove the failed pair
+    setMessages((prev) => {
+      for (let i = prev.length - 1; i >= 0; i--) {
+        if (prev[i].role === "user") {
+          retryRef.current = prev[i].content;
+          return prev.slice(0, i);
+        }
+      }
+      return prev;
+    });
+    // Clear error + streaming state so sendMessage's guard passes
+    setError(null);
+    setIsStreaming(false);
+    setStreamingState(null);
+  }, []);
+
+  // Effect: once isStreaming is false and there's a pending retry, fire it.
+  // This ensures React has flushed the state updates from retryLastMessage
+  // before sendMessage checks the isStreaming guard.
+  useEffect(() => {
+    if (!isStreaming && retryRef.current) {
+      const text = retryRef.current;
+      retryRef.current = null;
+      sendMessage(text);
+    }
+  }, [isStreaming, sendMessage]);
+
+  const simulateError = useCallback((message: string) => {
+    setMessages((prev) => {
+      if (prev.length === 0) return prev;
+      const updated = [...prev];
+      const last = updated[updated.length - 1];
+      if (last?.role === "assistant") {
+        updated[updated.length - 1] = { ...last, error: message };
+      } else {
+        // Append a synthetic assistant message with the error
+        updated.push({ role: "assistant", content: "", error: message });
+      }
+      return updated;
+    });
+    setStreamingState(null);
+    setIsStreaming(false);
+  }, []);
+
   return {
     messages,
     isStreaming,
@@ -659,5 +735,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
     loadConversation,
     injectRemoteUserMessage,
     processRemoteStreamEvent,
+    retryLastMessage,
+    simulateError,
   };
 }

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -449,9 +449,13 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             conversation_id: conversationId ?? null,
             has_app_context: !!appContext,
           });
+          // Banner only — nothing in this turn to mark inline
+          setError(formatSendError(err));
+          return;
         }
         const msg = formatSendError(err);
-        // Stamp on the last assistant message if one exists
+        // Stamp on the last assistant message if one exists;
+        // only fall back to banner when there's no message to attach to.
         setMessages((prev) => {
           const last = prev[prev.length - 1];
           if (last?.role === "assistant") {
@@ -459,9 +463,10 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             updated[updated.length - 1] = { ...last, error: msg };
             return updated;
           }
+          // No assistant message — fall back to banner
+          setError(msg);
           return prev;
         });
-        setError(msg);
       } finally {
         setIsStreaming(false);
         setStreamingState(null);
@@ -696,8 +701,14 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
   }, []);
 
   // Effect: once isStreaming is false and there's a pending retry, fire it.
-  // This ensures React has flushed the state updates from retryLastMessage
-  // before sendMessage checks the isStreaming guard.
+  // We can't call sendMessage synchronously from retryLastMessage because
+  // sendMessage is memoized with isStreaming in its dep list — the closure
+  // still sees isStreaming=true until React re-renders with the new state.
+  // This effect fires after React flushes the state updates, at which point
+  // sendMessage has been recreated with isStreaming=false.
+  // NOTE: this depends on sendMessage's identity changing when isStreaming
+  // changes (via flushToMessage in its dep list). Do not memoize
+  // flushToMessage without verifying this still fires.
   useEffect(() => {
     if (!isStreaming && retryRef.current) {
       const text = retryRef.current;

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+export {};
+
+declare global {
+  interface Window {
+    __nb?: {
+      simulateError?: (message: string) => void;
+    };
+  }
+}

--- a/web/test/inlineError.test.tsx
+++ b/web/test/inlineError.test.tsx
@@ -1,0 +1,183 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { ChatProvider, useChatContext } from "../src/context/ChatContext.tsx";
+
+// ---------------------------------------------------------------------------
+// Mock streamChat so we can control SSE events in tests
+// ---------------------------------------------------------------------------
+
+type StreamCallback = (type: string, data: unknown) => void;
+
+let capturedCallback: StreamCallback | null = null;
+let resolveStream: (() => void) | null = null;
+let rejectStream: ((err: Error) => void) | null = null;
+
+mock.module("../src/api/client", () => ({
+	streamChat: (_req: unknown, cb: StreamCallback) => {
+		capturedCallback = cb;
+		return new Promise<void>((resolve, reject) => {
+			resolveStream = resolve;
+			rejectStream = reject;
+		});
+	},
+	getConversationHistory: mock(() =>
+		Promise.resolve({ conversationId: "c1", messages: [] }),
+	),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function wrapper({ children }: { children: ReactNode }) {
+	return <ChatProvider>{children}</ChatProvider>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("inline error UX", () => {
+	beforeEach(() => {
+		capturedCallback = null;
+		resolveStream = null;
+		rejectStream = null;
+	});
+
+	it("stream error event stamps error on last assistant message, not banner", async () => {
+		const { result } = renderHook(() => useChatContext(), { wrapper });
+
+		act(() => {
+			result.current.sendMessage("hello");
+		});
+		await act(async () => {});
+
+		// Simulate some streaming content first
+		act(() => {
+			capturedCallback?.("text.delta", { text: "Here is my response" });
+		});
+
+		// Fire SSE error event
+		act(() => {
+			capturedCallback?.("error", {
+				error: "json_parse",
+				message: "JSON Parse error: Unable to parse JSON string",
+			});
+		});
+
+		// Error should be on the last assistant message
+		const lastMsg = result.current.messages[result.current.messages.length - 1];
+		expect(lastMsg?.role).toBe("assistant");
+		expect(lastMsg?.error).toBe("JSON Parse error: Unable to parse JSON string");
+
+		// Banner error should NOT be set
+		expect(result.current.error).toBeNull();
+	});
+
+	it("simulateError is a no-op when there are no messages", () => {
+		const { result } = renderHook(() => useChatContext(), { wrapper });
+
+		expect(result.current.messages).toHaveLength(0);
+
+		act(() => {
+			result.current.simulateError("Something broke");
+		});
+
+		// No messages to stamp on — stays empty
+		expect(result.current.messages).toHaveLength(0);
+		expect(result.current.isStreaming).toBe(false);
+		expect(result.current.streamingState).toBeNull();
+	});
+
+	it("simulateError stamps on existing assistant message", async () => {
+		const { result } = renderHook(() => useChatContext(), { wrapper });
+
+		act(() => {
+			result.current.sendMessage("hello");
+		});
+		await act(async () => {});
+
+		act(() => {
+			capturedCallback?.("text.delta", { text: "response text" });
+		});
+
+		// Complete the stream so isStreaming is false
+		act(() => {
+			capturedCallback?.("done", {
+				response: "response text",
+				conversationId: "c1",
+				toolCalls: [],
+				inputTokens: 10,
+				outputTokens: 5,
+				stopReason: "complete",
+			});
+		});
+		act(() => {
+			resolveStream?.();
+		});
+		await act(async () => {});
+
+		const msgCountBefore = result.current.messages.length;
+
+		act(() => {
+			result.current.simulateError("Simulated crash");
+		});
+
+		// Should stamp on existing message, not add a new one
+		expect(result.current.messages).toHaveLength(msgCountBefore);
+		const lastMsg = result.current.messages[result.current.messages.length - 1];
+		expect(lastMsg?.role).toBe("assistant");
+		expect(lastMsg?.error).toBe("Simulated crash");
+	});
+
+	it("retryLastMessage removes failed pair and re-sends", async () => {
+		const { result } = renderHook(() => useChatContext(), { wrapper });
+
+		// Send a message
+		act(() => {
+			result.current.sendMessage("try this");
+		});
+		await act(async () => {});
+
+		// Simulate some content then error
+		act(() => {
+			capturedCallback?.("text.delta", { text: "partial" });
+		});
+		act(() => {
+			capturedCallback?.("error", {
+				error: "crash",
+				message: "Engine crashed",
+			});
+		});
+
+		// Complete the stream promise so isStreaming clears
+		act(() => {
+			resolveStream?.();
+		});
+		await act(async () => {});
+
+		// Should have user + errored assistant
+		expect(result.current.messages).toHaveLength(2);
+		expect(result.current.messages[1].error).toBe("Engine crashed");
+
+		// Reset mocks for the retry
+		capturedCallback = null;
+		resolveStream = null;
+
+		// Retry
+		act(() => {
+			result.current.retryLastMessage();
+		});
+		await act(async () => {});
+
+		// retryLastMessage removes the failed pair and triggers a new send.
+		// After retry fires, we should have a new user + assistant placeholder.
+		// The callback should be captured again from the new sendMessage call.
+		// Give it another tick for the effect to fire sendMessage
+		await act(async () => {});
+
+		// The retry effect should have fired sendMessage, creating new messages
+		expect(result.current.isStreaming).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- When the agent loop crashes mid-stream (e.g. JSON parse error), the error now appears **inline on the assistant message** instead of a disconnected red banner at the top
- Friendly one-line summary by default, with a **Details** disclosure for the raw error
- **Try again** button re-sends the last user message
- `window.__nb.simulateError("msg")` dev helper for demoing the UX without crashing anything

## Test plan

- [ ] Send a message, wait for response, run `window.__nb.simulateError("JSON Parse error: Unable to parse JSON string")` in browser console
- [ ] Verify inline error renders on the last assistant message with "Try again" button
- [ ] Click "Details" — raw error string expands
- [ ] Click "Try again" — last user message re-sends
- [ ] Verify banner still shows for non-streaming errors (e.g. conversation load failure)
- [ ] Verify no regressions: normal chat flow, stop reason notice, shared conversations