### PR TITLE
Proxy /.well-known/* to platform for MCP OAuth discovery

### DIFF
--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -5,6 +5,9 @@
     handle /mcp* {
         reverse_proxy {$PLATFORM_URL}
     }
+    handle /.well-known/* {
+        reverse_proxy {$PLATFORM_URL}
+    }
     handle {
         root * /srv
         try_files {path} /index.html


### PR DESCRIPTION
## Summary

- MCP clients failed OAuth discovery against tenants with auth enabled (e.g. `hq.platform.nimblebrain.ai`), reporting `SDK auth failed: Failed to parse JSON`.
- The platform correctly registers `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` (`src/api/routes/well-known.ts`), but the web pod's Caddyfile only proxied `/v1/*` and `/mcp*` to the platform, so those paths fell through to `try_files` and returned the SPA's `index.html`.
- Clients hit `<!doctype html>...` during discovery, `JSON.parse` threw, auth aborted.

Fix: add a `handle /.well-known/*` block that reverse-proxies to `{\$PLATFORM_URL}`, matching the existing `/mcp*` rule.

## Test plan

- [ ] Build and push the web image, deploy to staging (`make deploy CLIENT=acme ENV=staging TAG=<sha>`).
- [ ] `curl -s https://acme.platform.preview.nimblebrain.ai/.well-known/oauth-protected-resource` returns JSON with `Content-Type: application/json` (not the SPA).
- [ ] `curl -s https://acme.platform.preview.nimblebrain.ai/.well-known/oauth-authorization-server` returns JSON.
- [ ] MCP client authentication succeeds end-to-end against a staging tenant.
- [ ] SPA routing unaffected: loading `/`, `/settings`, `/some-deep-route` still serves `index.html`.
- [ ] Deploy to production and re-verify against `hq.platform.nimblebrain.ai`.