### PR TITLE
Publish release images to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  packages: write
 
 jobs:
   # Each step below runs a `bun run verify:*` subscript; package.json is the
@@ -33,7 +34,7 @@ jobs:
         run: bun run test:integration
 
   build-and-push:
-    name: Build & Push to ECR
+    name: Build & Push
     needs: verify
     runs-on: ubuntu-latest
     steps:
@@ -44,6 +45,11 @@ jobs:
           aws-region: us-east-1
       - uses: aws-actions/amazon-ecr-login@v2
         id: ecr
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -56,27 +62,40 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
-      # We deliberately do NOT tag `:latest`. ECR repositories have immutable
+      # ECR tags deliberately exclude `:latest` — repositories have immutable
       # tags enabled, so `latest` can't be reused across releases. Deploys pin
-      # to the version tag or short sha.
+      # to the version tag or short sha. GHCR is public and follows the
+      # standard convention of moving `:latest` forward on each release.
       - name: Build and push platform image
         run: |
           docker build --platform linux/amd64 \
             --build-arg BUILD_SHA=${{ steps.tags.outputs.sha }} \
             -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.version }} \
             -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.sha }} \
+            -t ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.version }} \
+            -t ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.sha }} \
+            -t ghcr.io/nimblebraininc/nimblebrain:latest \
             -f Dockerfile .
           docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.version }}
           docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.sha }}
+          docker push ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.version }}
+          docker push ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.sha }}
+          docker push ghcr.io/nimblebraininc/nimblebrain:latest
 
       - name: Build and push web image
         run: |
           docker build --platform linux/amd64 \
             -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.version }} \
             -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.sha }} \
+            -t ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.version }} \
+            -t ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.sha }} \
+            -t ghcr.io/nimblebraininc/nimblebrain-web:latest \
             -f web/Dockerfile web/
           docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.version }}
           docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.sha }}
+          docker push ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.version }}
+          docker push ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.sha }}
+          docker push ghcr.io/nimblebraininc/nimblebrain-web:latest
 
   github-release:
     name: GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,8 @@ jobs:
 
       # ECR tags deliberately exclude `:latest` — repositories have immutable
       # tags enabled, so `latest` can't be reused across releases. Deploys pin
-      # to the version tag or short sha. GHCR is public and follows the
-      # standard convention of moving `:latest` forward on each release.
+      # to the version tag or short sha. GHCR gets `:latest` too, but only
+      # for stable releases (see the gated steps below).
       - name: Build and push platform image
         run: |
           docker build --platform linux/amd64 \
@@ -74,13 +74,11 @@ jobs:
             -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.sha }} \
             -t ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.version }} \
             -t ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.sha }} \
-            -t ghcr.io/nimblebraininc/nimblebrain:latest \
             -f Dockerfile .
           docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.version }}
           docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.sha }}
           docker push ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.version }}
           docker push ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.sha }}
-          docker push ghcr.io/nimblebraininc/nimblebrain:latest
 
       - name: Build and push web image
         run: |
@@ -89,12 +87,27 @@ jobs:
             -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.sha }} \
             -t ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.version }} \
             -t ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.sha }} \
-            -t ghcr.io/nimblebraininc/nimblebrain-web:latest \
             -f web/Dockerfile web/
           docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.version }}
           docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.sha }}
           docker push ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.version }}
           docker push ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.sha }}
+
+      # Stable-release-only. SemVer pre-release tags always contain a hyphen
+      # (v0.4.0-beta.1, v1.0.0-rc.1); GA tags don't. Gating on the hyphen
+      # keeps `:latest` pointing at the most recent GA release.
+      - name: Promote platform image to :latest (stable releases only)
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: |
+          docker tag ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.version }} \
+                     ghcr.io/nimblebraininc/nimblebrain:latest
+          docker push ghcr.io/nimblebraininc/nimblebrain:latest
+
+      - name: Promote web image to :latest (stable releases only)
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: |
+          docker tag ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.version }} \
+                     ghcr.io/nimblebraininc/nimblebrain-web:latest
           docker push ghcr.io/nimblebraininc/nimblebrain-web:latest
 
   github-release:
@@ -109,3 +122,4 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ Images are published to GHCR on every release:
 - `ghcr.io/nimblebraininc/nimblebrain` — runtime (Bun + Python 3.13 + Node 22 + mpak)
 - `ghcr.io/nimblebraininc/nimblebrain-web` — Caddy serving the SPA, proxying `/v1/*` to the platform
 
-Each release is tagged with the version (`v1.2.3`), the short git SHA, and `latest`. Pin to a version tag in production. Pass `--build` to `docker compose` to build from source instead.
+Each release is tagged with the version (e.g. `v1.2.3`) and the short git SHA. Stable releases also move `:latest` forward; pre-releases (e.g. `v0.4.0-beta.1`) do not. Pin to a version tag in production. Pass `--build` to `docker compose` to build from source instead.
 
 See `Dockerfile`, `web/Dockerfile`, and `docker-compose.yml` for full config.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A self-hosted platform for [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview) and agent automations. Install an MCP bundle and you get more than tools — you get an interactive UI in the sidebar with live agent-UI data sync, and the ability to run the agent on demand or on a cron schedule. Full [ext-apps](https://apps.extensions.modelcontextprotocol.io/api/) host support on top of an agentic loop with skill-driven prompt composition and multi-agent delegation.
 
-Ships as container images. Also exposes itself as an MCP server via Streamable HTTP so external MCP clients can consume the aggregated toolset.
+Ships as container images on GHCR (`ghcr.io/nimblebraininc/nimblebrain`, `ghcr.io/nimblebraininc/nimblebrain-web`). Also exposes itself as an MCP server via Streamable HTTP so external MCP clients can consume the aggregated toolset.
 
 ## Quick Start
 
@@ -17,12 +17,15 @@ Ships as container images. Also exposes itself as an MCP server via Streamable H
 # Prerequisites: Docker
 export ANTHROPIC_API_KEY=sk-ant-...
 
-docker compose up --build
+docker compose up
+# Pulls ghcr.io/nimblebraininc/nimblebrain + nimblebrain-web
 # Web UI:  http://localhost:27246
 # API:     http://localhost:27246/v1/health
 ```
 
 Open `http://localhost:27246` in your browser. Auth is configured via `instance.json` (see Configuration).
+
+To build from source instead of pulling (e.g. when developing against local changes), run `docker compose up --build`.
 
 ### Option 2: Local development
 
@@ -498,12 +501,16 @@ src/
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 export ALLOWED_ORIGINS=http://localhost:27246  # for cookie-based auth
-docker compose up --build
+docker compose up
 # Platform: internal only (API), Web: localhost:27246 (UI)
 ```
 
-- Runtime container: Bun + Python 3.13 + Node 22 + mpak
-- Web container: Caddy serving the SPA, proxying `/v1/*` to the platform
+Images are published to GHCR on every release:
+
+- `ghcr.io/nimblebraininc/nimblebrain` — runtime (Bun + Python 3.13 + Node 22 + mpak)
+- `ghcr.io/nimblebraininc/nimblebrain-web` — Caddy serving the SPA, proxying `/v1/*` to the platform
+
+Each release is tagged with the version (`v1.2.3`), the short git SHA, and `latest`. Pin to a version tag in production. Pass `--build` to `docker compose` to build from source instead.
 
 See `Dockerfile`, `web/Dockerfile`, and `docker-compose.yml` for full config.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   platform:
-    image: nimblebrain/platform:latest
+    image: ghcr.io/nimblebraininc/nimblebrain:latest
     build: .
     restart: unless-stopped
     volumes:
@@ -14,7 +14,7 @@ services:
       - internal
 
   web:
-    image: nimblebrain/web:latest
+    image: ghcr.io/nimblebraininc/nimblebrain-web:latest
     build: web/
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

- The README advertised container images, but only private ECR was being pushed — OSS users had no way to pull. This adds GHCR as a second target so `docker compose up` (without `--build`) works out of the box.
- Release workflow now logs in to `ghcr.io` via the built-in `GITHUB_TOKEN` and pushes `ghcr.io/nimblebraininc/nimblebrain` and `ghcr.io/nimblebraininc/nimblebrain-web` alongside the existing ECR tags (version + sha + `latest` on GHCR; version + sha on ECR as before, since ECR has immutable tags enabled).
- `docker-compose.yml` points `image:` refs at the GHCR tags; `build:` stays so contributors can still run `docker compose up --build`.
- README: tagline names the GHCR images, Quick Start drops `--build` (pulls by default), Deployment documents the publish flow and tag policy.

The ECR rename (`agent-platform` → `nimblebrain`) is intentionally left as a follow-up so this PR is reviewable in isolation and doesn't touch the deploy Makefile / Helm chart.

## Post-merge step (one-time)

On the first release after this merges, GHCR will create the `nimblebrain` and `nimblebrain-web` packages as **private** by default. Flip each to public in the org package settings so anonymous `docker pull` works:

- `https://github.com/orgs/NimbleBrainInc/packages/container/nimblebrain/settings`
- `https://github.com/orgs/NimbleBrainInc/packages/container/nimblebrain-web/settings`

## Test plan

- [ ] Cut a pre-release tag (e.g. `v0.0.0-ghcr-test`) and confirm the Release workflow pushes to both ECR and GHCR.
- [ ] After flipping the GHCR packages public, run `docker pull ghcr.io/nimblebraininc/nimblebrain:latest` and `...-web:latest` anonymously.
- [ ] From a clean checkout with `ANTHROPIC_API_KEY` set, run `docker compose up` (no `--build`) and hit `http://localhost:27246`.
- [ ] `docker compose up --build` still works for contributors.