### PR TITLE
Polish release pipeline: image labels + Node 24 action bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           aws-region: us-east-1
       - uses: aws-actions/amazon-ecr-login@v2
         id: ecr
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3.13-slim AS base
 
+LABEL org.opencontainers.image.title="NimbleBrain"
+LABEL org.opencontainers.image.description="Self-hosted platform for MCP Apps and agent automations"
+LABEL org.opencontainers.image.source="https://github.com/NimbleBrainInc/nimblebrain"
+LABEL org.opencontainers.image.url="https://nimblebrain.ai"
+LABEL org.opencontainers.image.vendor="NimbleBrain"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 # Bun runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl unzip nodejs npm \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,6 +10,14 @@ ENV VITE_TURNSTILE_SITE_KEY=$VITE_TURNSTILE_SITE_KEY
 RUN npm run build
 
 FROM caddy:2-alpine
+
+LABEL org.opencontainers.image.title="NimbleBrain Web"
+LABEL org.opencontainers.image.description="Web UI for the NimbleBrain self-hosted platform (Caddy + React SPA)"
+LABEL org.opencontainers.image.source="https://github.com/NimbleBrainInc/nimblebrain"
+LABEL org.opencontainers.image.url="https://nimblebrain.ai"
+LABEL org.opencontainers.image.vendor="NimbleBrain"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 COPY --from=build /app/dist /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 


### PR DESCRIPTION
## Summary

Two small, related cleanups against the release pipeline.

### 1. OCI image labels

The GHCR package page for `nimblebrain-web` was displaying Caddy's description (*"a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"*) because it inherited labels from the `caddy:2-alpine` base image. Add explicit `org.opencontainers.image.*` labels (title, description, source, url, vendor, licenses) to both Dockerfiles.

The `org.opencontainers.image.source` label also enables the official repo ↔ package link in the GitHub UI on next release.

### 2. Bump actions off Node 20

GitHub is force-migrating Node 20 actions to Node 24 on 2026-06-02 (removed entirely 2026-09-16). Two actions we use are still on Node 20:

- `docker/login-action` v3 → v4 (release.yml, GHCR login) — this one threw a deprecation warning during the `v0.4.0-beta.1` run
- `actions/setup-python` v5 → v6 (ci.yml, smoke job) — not yet warning, but same category

Both are pure runtime bumps — no config/API changes for our usage.

Everything else we use is already current: `actions/checkout@v6`, `oven-sh/setup-bun@v2`, `aws-actions/amazon-ecr-login@v2`, `aws-actions/configure-aws-credentials@v6`, `softprops/action-gh-release@v3`.

## Test plan

- [ ] Merge, then cut `v0.4.0-beta.2`.
- [ ] Confirm the GHCR package descriptions for `nimblebrain` and `nimblebrain-web` now show the NimbleBrain copy (not Caddy's).
- [ ] Confirm both packages show a linked source repo.
- [ ] Confirm the release workflow no longer emits the Node 20 deprecation warning.
- [ ] Confirm CI's smoke job (post-merge to main) doesn't emit one either.