### PR TITLE
Fix race in TestAuthAdapter concurrent provisioning

### DIFF
--- a/test/helpers/test-auth-adapter.ts
+++ b/test/helpers/test-auth-adapter.ts
@@ -27,7 +27,7 @@ export const TEST_IDENTITY: UserIdentity = {
 };
 
 export class TestAuthAdapter implements IdentityProvider {
-  private initialized = false;
+  private initPromise?: Promise<void>;
 
   readonly capabilities: ProviderCapabilities = {
     authCodeFlow: false,
@@ -73,8 +73,19 @@ export class TestAuthAdapter implements IdentityProvider {
     return false;
   }
 
-  private async ensureDefaults(): Promise<void> {
-    if (this.initialized || !this.userStore || !this.workspaceStore) return;
+  private ensureDefaults(): Promise<void> {
+    // Single-flight: concurrent requests share one in-flight promise so we
+    // don't double-provision the user/workspace. Without this, parallel
+    // authenticated requests all race past the init check and multiple
+    // addMember() calls collide on MemberConflictError.
+    if (!this.initPromise) {
+      this.initPromise = this.doEnsureDefaults();
+    }
+    return this.initPromise;
+  }
+
+  private async doEnsureDefaults(): Promise<void> {
+    if (!this.userStore || !this.workspaceStore) return;
 
     const existingUser = await this.userStore.get(TEST_IDENTITY.id);
     if (!existingUser) {
@@ -108,8 +119,6 @@ export class TestAuthAdapter implements IdentityProvider {
         await this.workspaceStore.addMember(ws.id, TEST_IDENTITY.id, "admin");
       }
     }
-
-    this.initialized = true;
   }
 }
 


### PR DESCRIPTION
## Summary
- `TestAuthAdapter.ensureDefaults()` guarded first-auth provisioning with a boolean flag set only *after* the async work finished, so 10 concurrent authenticated requests would all pass the init check and all race on `workspaceStore.addMember(ws_test, usr_test, …)`. The first wins, the rest throw `MemberConflictError`, which bubbles up as `500 Internal Server Error` and makes `test/integration/api-integration.test.ts:198` intermittently fail (seen on `main` after the #70 merge).
- Switch to the single-flight pattern: cache the in-flight `Promise` so concurrent callers await the same work. Test-helper-only change; no production code affected.

## Test plan
- [x] Reproduced the failure locally — 3 of 8 unfixed runs failed with `Received: undefined` for one of the 10 concurrent messages
- [x] Confirmed the 500 response body came from `MemberConflictError: User "usr_test" is already a member of workspace "ws_test"`
- [x] 20/20 clean runs of `bun test test/integration/api-integration.test.ts` after the fix
- [x] `bun run verify` green (unit + integration + smoke)