### PR TITLE
Honor X-Forwarded-Proto in MCP OAuth resource URLs

### DIFF
--- a/src/api/routes/mcp.ts
+++ b/src/api/routes/mcp.ts
@@ -21,7 +21,12 @@ import { type AppContext, type AuthEnv, apiError } from "../types.ts";
  */
 function mcpWwwAuthenticate(req: Request): string {
   const url = new URL(req.url);
-  const origin = `${url.protocol}//${url.host}`;
+  // Honor X-Forwarded-Proto from the ALB (which rewrites it based on the
+  // actual client→ALB connection). Host comes from the Host header via
+  // url.host; we deliberately do NOT honor X-Forwarded-Host.
+  const proto =
+    req.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() ?? url.protocol.replace(/:$/, "");
+  const origin = `${proto}://${url.host}`;
   return [
     'Bearer error="unauthorized"',
     'error_description="Authorization required"',

--- a/src/api/routes/well-known.ts
+++ b/src/api/routes/well-known.ts
@@ -77,8 +77,24 @@ function getAuthkitDomain(ctx: AppContext): string | null {
   return null;
 }
 
-/** Derive the resource origin from the incoming request URL. */
+/**
+ * Derive the resource origin from the incoming request.
+ *
+ * Honors `X-Forwarded-Proto` so the advertised resource matches the
+ * public scheme used by the client, not the internal HTTP connection
+ * seen by the pod behind a TLS-terminating proxy (ALB, Caddy, etc.).
+ * Without this, `resource` is `http://` and OAuth resource validation
+ * fails in clients that connect via `https://`.
+ *
+ * Host comes from `req.url.host` (the Host header), which ALB/Caddy
+ * forward verbatim from the client. We deliberately do NOT honor
+ * `X-Forwarded-Host`: AWS ALB rewrites `X-Forwarded-Proto` based on
+ * the actual client connection, but nothing similarly sanitizes
+ * `X-Forwarded-Host` in our proxy chain, and we don't need it.
+ */
 function deriveResourceOrigin(req: Request): string {
   const url = new URL(req.url);
-  return `${url.protocol}//${url.host}`;
+  const proto =
+    req.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() ?? url.protocol.replace(/:$/, "");
+  return `${proto}://${url.host}`;
 }

--- a/test/unit/api/mcp-oauth.test.ts
+++ b/test/unit/api/mcp-oauth.test.ts
@@ -99,6 +99,27 @@ describe("MCP OAuth WWW-Authenticate header", () => {
     );
   });
 
+  it("honors X-Forwarded-Proto when behind a TLS-terminating proxy", async () => {
+    const app = createApp({ authkitDomain: "myapp" });
+    // Simulates ALB → pod: pod sees HTTP, but ALB sets X-Forwarded-Proto: https
+    // The Host header stays as the public host (ALB forwards it verbatim).
+    const res = await app.request("http://hq.example.com/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Forwarded-Proto": "https",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+
+    expect(res.status).toBe(401);
+
+    const wwwAuth = res.headers.get("WWW-Authenticate");
+    expect(wwwAuth).toContain(
+      'resource_metadata="https://hq.example.com/.well-known/oauth-protected-resource"',
+    );
+  });
+
   it("does not include WWW-Authenticate when AuthKit is not configured", async () => {
     const app = createApp({});
     const res = await app.request("/mcp", {

--- a/test/unit/api/well-known-routes.test.ts
+++ b/test/unit/api/well-known-routes.test.ts
@@ -68,6 +68,19 @@ describe("GET /.well-known/oauth-protected-resource", () => {
     const body = await res.json();
     expect(body.error).toBe("MCP OAuth not configured");
   });
+
+  it("honors X-Forwarded-Proto when behind a TLS-terminating proxy", async () => {
+    const app = createApp("myapp");
+    // Simulates ALB → pod: pod sees HTTP, but ALB sets X-Forwarded-Proto: https.
+    const res = await app.request(
+      "http://hq.example.com/.well-known/oauth-protected-resource",
+      { headers: { "X-Forwarded-Proto": "https" } },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.resource).toBe("https://hq.example.com");
+  });
 });
 
 // ── Authorization Server Metadata proxy ──────────────────────────


### PR DESCRIPTION
## Summary

- `/.well-known/oauth-protected-resource` and the `WWW-Authenticate: resource_metadata=...` URL on `/mcp` now honor `X-Forwarded-Proto`, so deployments behind a TLS-terminating proxy (AWS ALB, Caddy) advertise `https://` instead of the pod's internal `http://` scheme.
- Without this, MCP clients (Claude Code, etc.) reject the discovery response with *"Protected resource http://... does not match expected https://..."* even though OAuth is otherwise configured correctly.
- Added unit coverage in `well-known-routes.test.ts` and `mcp-oauth.test.ts`.

## Security

- Only `X-Forwarded-Proto` is trusted. AWS ALB rewrites this header based on the actual client→ALB connection scheme, so it can't be spoofed past the ALB in our production topology.
- `X-Forwarded-Host` is deliberately NOT trusted — nothing in our proxy chain sanitizes it, and `url.host` from the forwarded Host header is already correct.
- Spoofed values in the fallback path only affect the response to the spoofing client (no cache, no pivot to other users). The MCP SDK also validates `resource` against the URL it connected to.

## Test plan

- [ ] `bun test test/unit/api/well-known-routes.test.ts test/unit/api/mcp-oauth.test.ts` — passes locally
- [ ] `bun run verify` — full CI parity
- [ ] After deploy: `curl https://hq.platform.nimblebrain.ai/.well-known/oauth-protected-resource` returns `"resource": "https://..."` (not `http://`)
- [ ] Claude Code `/mcp add` against `https://hq.platform.nimblebrain.ai/mcp` completes OAuth without the protocol-mismatch error