### PR TITLE
Bump runtime DEFAULT_MODEL fallback to claude-sonnet-4-6

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -68,7 +68,7 @@ import type { ChatRequest, ChatResult, ModelSlots, RuntimeConfig, TurnUsage } fr
 import { createWorkspaceRegistry, startWorkspaceBundles } from "./workspace-runtime.ts";
 
 const DEFAULT_WORK_DIR = join(homedir(), ".nimblebrain");
-const DEFAULT_MODEL = "claude-sonnet-4-5-20250929";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 import {
   DEFAULT_MAX_INPUT_TOKENS,


### PR DESCRIPTION
## Summary

- Change `DEFAULT_MODEL` in `src/runtime/runtime.ts` from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6`.
- Anthropic is retiring the 1M context beta (`context-1m-2025-08-07`) on Sonnet 4 and Sonnet 4.5 on **2026-04-30**. After that date, requests over 200k tokens on those models will error.
- Our runtime defaults `maxInputTokens` to 500k, so any request that falls through to `DEFAULT_MODEL` (when a tenant or caller doesn't specify one) could exceed the post-retirement 200k ceiling.
- Sonnet 4.6 is the drop-in successor: same price, 1M context is GA, no beta header required.

All production/staging tenants in `deployments/nimblebrain` already set `defaultModel` to `claude-sonnet-4-6` or `claude-opus-4-7` explicitly, so this only affects callers that fall through to the hard-coded fallback. Out of an abundance of caution, bump it so that stale configs and new code paths land on a GA 1M-context model.

## Test plan

- [ ] `bun test` passes
- [ ] Type check clean
- [ ] Smoke test: start runtime without an explicit `defaultModel` and confirm the fallback resolves to `claude-sonnet-4-6`