### PR TITLE
Publish workspace via host context; home briefing reacts to switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Claude Code internal config (developer tooling, not part of OSS repo)
 .claude
 .environments/collateral-test/
+
+# git worktrees (local dev only — never commit worktree checkouts)
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,11 @@ bun run format             # Biome auto-format (writes)
 
 cd web && bun install      # Web client dependencies (separate package.json)
 cd web && bun run build    # Web production build → web/dist/
+
+bun run build:bundles      # Rebuild every src/bundles/*/ui (vite single-file)
 ```
+
+**`bun run dev` does NOT rebuild bundles.** The API serves each bundle from its pre-built `src/bundles/<name>/ui/dist/index.html`. After editing any file under `src/bundles/*/ui/src/`, run `bun run build:bundles` and restart the dev server (the API reads dist on iframe mount; it doesn't watch the file). Forgetting this means the iframe loads stale code while your changes look "live" in the source tree — a high-confusion failure mode.
 
 **Before opening a PR, run `bun run verify`.** It is the single command that mirrors CI, enforced by construction: `.github/workflows/ci.yml` invokes only `verify:*` subscripts (plus `test:integration` and `smoke`) — no inline check steps. To add or change a check, edit the matching subscript in `package.json`; CI picks it up automatically. If CI ever catches something `verify` didn't, the fix is to update the subscript, not the checklist. Tool-level parity is the gate; discipline-level rules are not.
 

--- a/src/bundles/home/ui/bun.lock
+++ b/src/bundles/home/ui/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@nimblebraininc/home-ui",
       "dependencies": {
-        "@nimblebrain/synapse": "^0.4.0",
+        "@nimblebrain/synapse": "^0.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
@@ -126,7 +126,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@nimblebrain/synapse": ["@nimblebrain/synapse@0.4.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-7VLuwPhAgp7n7Ok9IVRs/qtK64KTl7RAPMWR2IGmiyjXW/552vwuMrAgDkksuPrIiZECalXSx08Zaks/+SRsxg=="],
+    "@nimblebrain/synapse": ["@nimblebrain/synapse@0.6.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-r5jVc63+c9Y7GsNK7QwOzHhZ1pkPwCzBeVG8X/lPQ8oquMD8WFeYNPLwo7WT6P6giZ3s55GolHib3Xj5Rgm3xA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/src/bundles/home/ui/package.json
+++ b/src/bundles/home/ui/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nimblebrain/synapse": "^0.4.0",
+    "@nimblebrain/synapse": "^0.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/bundles/home/ui/src/App.tsx
+++ b/src/bundles/home/ui/src/App.tsx
@@ -183,7 +183,9 @@ function Dashboard() {
   // The host publishes the active workspace as `hostContext.workspace` on
   // every workspace switch. Keying the briefing fetch on `workspace.id`
   // refetches the (workspace-scoped) briefing without remounting this iframe.
-  const { workspace } = useHostContext<{ workspace?: { id: string } }>();
+  // Narrow to both id and name even though only id drives refetch — keeps
+  // future briefing copy ("Switched to Acme") cheap to wire up.
+  const { workspace } = useHostContext<{ workspace?: { id: string; name: string } }>();
   const workspaceId = workspace?.id;
   const [briefing, setBriefing] = useState<BriefingOutput | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -212,12 +214,18 @@ function Dashboard() {
     }
   }, []);
 
-  // Reload on mount and whenever the active workspace changes. The host
-  // bridge sends `host-context-changed` with the new workspace id; the
-  // SDK exposes it via `useHostContext`. `loadBriefing` is stable so it
-  // isn't a dep — `workspaceId` is the only meaningful trigger.
+  // Reload whenever the active workspace lands or changes. The host bridge
+  // sends `host-context-changed` with the new workspace id; the SDK exposes
+  // it via `useHostContext`. `loadBriefing` is stable so it isn't a dep —
+  // `workspaceId` is the only meaningful trigger.
+  //
+  // Skip the first render where `workspaceId` is undefined: the
+  // `useHostContext` value lands on the next render after the handshake
+  // resolves. Without the guard we'd fire one wasted briefing fetch in the
+  // handshake-window, then immediately fire again with the real id.
   // biome-ignore lint/correctness/useExhaustiveDependencies: workspaceId is the refetch trigger; loadBriefing is stable
   useEffect(() => {
+    if (!workspaceId) return;
     loadBriefing();
   }, [workspaceId]);
 

--- a/src/bundles/home/ui/src/App.tsx
+++ b/src/bundles/home/ui/src/App.tsx
@@ -1,4 +1,9 @@
-import { SynapseProvider, useDataSync, useSynapse } from "@nimblebrain/synapse/react";
+import {
+  SynapseProvider,
+  useDataSync,
+  useHostContext,
+  useSynapse,
+} from "@nimblebrain/synapse/react";
 import { useCallback, useEffect, useState } from "react";
 
 /* ---------- types ---------- */
@@ -175,6 +180,11 @@ function SectionGroup({
 
 function Dashboard() {
   const synapse = useSynapse();
+  // The host publishes the active workspace as `hostContext.workspace` on
+  // every workspace switch. Keying the briefing fetch on `workspace.id`
+  // refetches the (workspace-scoped) briefing without remounting this iframe.
+  const { workspace } = useHostContext<{ workspace?: { id: string } }>();
+  const workspaceId = workspace?.id;
   const [briefing, setBriefing] = useState<BriefingOutput | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -202,10 +212,14 @@ function Dashboard() {
     }
   }, []);
 
-  // Load once on mount
+  // Reload on mount and whenever the active workspace changes. The host
+  // bridge sends `host-context-changed` with the new workspace id; the
+  // SDK exposes it via `useHostContext`. `loadBriefing` is stable so it
+  // isn't a dep — `workspaceId` is the only meaningful trigger.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: workspaceId is the refetch trigger; loadBriefing is stable
   useEffect(() => {
     loadBriefing();
-  }, [loadBriefing]);
+  }, [workspaceId]);
 
   // Show refresh banner on data changes
   useDataSync(() => {

--- a/test/unit/bridge-extensions.test.ts
+++ b/test/unit/bridge-extensions.test.ts
@@ -538,3 +538,131 @@ describe("Bridge — unknown message types", () => {
     handle.destroy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// ui/initialize hostContext extensions
+// ---------------------------------------------------------------------------
+
+describe("Bridge — ui/initialize hostContext extensions", () => {
+  /** Find the response posted in reply to a `ui/initialize` request. */
+  function findInitResponse(posted: unknown[]) {
+    return posted.find(
+      (m) =>
+        m &&
+        typeof m === "object" &&
+        (m as Record<string, unknown>).id === "init-1" &&
+        typeof (m as Record<string, unknown>).result === "object",
+    ) as { result: { hostContext: Record<string, unknown> } } | undefined;
+  }
+
+  it("merges getHostExtensions() into hostContext alongside spec fields", () => {
+    const { iframe, posted } = makeFakeIframe();
+    const handle = createBridge(iframe, "test-app", {
+      getHostExtensions: () => ({ workspace: { id: "ws_a", name: "Alpha" } }),
+    });
+
+    simulatePostMessage(iframe, {
+      jsonrpc: "2.0",
+      id: "init-1",
+      method: "ui/initialize",
+      params: { protocolVersion: "2026-01-26", appInfo: { name: "x", version: "1" } },
+    });
+
+    const response = findInitResponse(posted);
+    expect(response?.result.hostContext).toMatchObject({
+      workspace: { id: "ws_a", name: "Alpha" },
+      theme: expect.anything(),
+      styles: expect.anything(),
+    });
+    handle.destroy();
+  });
+
+  it("invokes getHostExtensions() exactly once per ui/initialize", () => {
+    const { iframe } = makeFakeIframe();
+    let calls = 0;
+    const handle = createBridge(iframe, "test-app", {
+      getHostExtensions: () => {
+        calls++;
+        return { workspace: { id: "ws_a", name: "Alpha" } };
+      },
+    });
+
+    simulatePostMessage(iframe, {
+      jsonrpc: "2.0",
+      id: "init-1",
+      method: "ui/initialize",
+      params: { protocolVersion: "2026-01-26", appInfo: { name: "x", version: "1" } },
+    });
+
+    expect(calls).toBe(1);
+    handle.destroy();
+  });
+
+  it("spec fields (theme, styles) win over same-named extension keys", () => {
+    const { iframe, posted } = makeFakeIframe();
+    const handle = createBridge(iframe, "test-app", {
+      getHostExtensions: () => ({
+        // Adversarial caller tries to override a spec field — bridge must ignore.
+        theme: "WRONG",
+        styles: { variables: { "--evil": "true" } },
+        workspace: { id: "ws_a", name: "Alpha" },
+      }),
+    });
+
+    simulatePostMessage(iframe, {
+      jsonrpc: "2.0",
+      id: "init-1",
+      method: "ui/initialize",
+      params: { protocolVersion: "2026-01-26", appInfo: { name: "x", version: "1" } },
+    });
+
+    const response = findInitResponse(posted);
+    const ctx = response?.result.hostContext as Record<string, unknown>;
+    expect(ctx.theme).not.toBe("WRONG");
+    expect((ctx.styles as Record<string, unknown>).variables).not.toMatchObject({ "--evil": "true" });
+    expect(ctx.workspace).toEqual({ id: "ws_a", name: "Alpha" });
+    handle.destroy();
+  });
+
+  it("missing getHostExtensions yields a hostContext with no extensions", () => {
+    const { iframe, posted } = makeFakeIframe();
+    const handle = createBridge(iframe, "test-app");
+
+    simulatePostMessage(iframe, {
+      jsonrpc: "2.0",
+      id: "init-1",
+      method: "ui/initialize",
+      params: { protocolVersion: "2026-01-26", appInfo: { name: "x", version: "1" } },
+    });
+
+    const response = findInitResponse(posted);
+    const ctx = response?.result.hostContext as Record<string, unknown>;
+    expect(ctx).toMatchObject({ theme: expect.anything(), styles: expect.anything() });
+    expect(ctx.workspace).toBeUndefined();
+    handle.destroy();
+  });
+
+  it("a throwing getHostExtensions does not drop the ui/initialize response", () => {
+    const { iframe, posted } = makeFakeIframe();
+    const handle = createBridge(iframe, "test-app", {
+      getHostExtensions: () => {
+        throw new Error("boom");
+      },
+    });
+
+    simulatePostMessage(iframe, {
+      jsonrpc: "2.0",
+      id: "init-1",
+      method: "ui/initialize",
+      params: { protocolVersion: "2026-01-26", appInfo: { name: "x", version: "1" } },
+    });
+
+    const response = findInitResponse(posted);
+    expect(response).toBeDefined();
+    const ctx = response?.result.hostContext as Record<string, unknown>;
+    // Spec fields still present; extensions silently dropped on throw.
+    expect(ctx).toMatchObject({ theme: expect.anything(), styles: expect.anything() });
+    expect(ctx.workspace).toBeUndefined();
+    handle.destroy();
+  });
+});

--- a/web/src/bridge/bridge.ts
+++ b/web/src/bridge/bridge.ts
@@ -163,7 +163,22 @@ export function createBridge(
       // Spec-standardized fields (theme, styles) take precedence over any
       // same-named keys returned by `getHostExtensions()`, so callers can
       // safely return arbitrary extension keys without colliding.
-      const extensions = callbacks?.getHostExtensions?.() ?? {};
+      //
+      // Top-level extension keys (e.g. `workspace`) are spec-allowed: the
+      // ext-apps `McpUiHostContextSchema` is `.passthrough()`, so strict
+      // SDK clients (Reboot/Zod) preserve unknown keys at the hostContext
+      // root. The strict-key concern documented above applies only to
+      // `hostContext.styles.variables`, which is a typed enum of CSS
+      // custom properties — extensions there would tear down the connection.
+      //
+      // Wrapped in try/catch: a throwing callback would otherwise drop the
+      // entire `ui/initialize` response and hang the iframe at "Connecting…".
+      let extensions: Record<string, unknown> = {};
+      try {
+        extensions = callbacks?.getHostExtensions?.() ?? {};
+      } catch (err) {
+        console.error("getHostExtensions threw — proceeding with no extensions:", err);
+      }
       const response: ExtAppsInitializeResponse = {
         jsonrpc: "2.0",
         id: msg.id,

--- a/web/src/bridge/bridge.ts
+++ b/web/src/bridge/bridge.ts
@@ -160,6 +160,10 @@ export function createBridge(
       // NB extensions and out-of-spec tokens still flow through the iframe's
       // injected `<style>` block — they just don't cross the protocol.
       const extTokens = getSpecThemeTokens(extMode);
+      // Spec-standardized fields (theme, styles) take precedence over any
+      // same-named keys returned by `getHostExtensions()`, so callers can
+      // safely return arbitrary extension keys without colliding.
+      const extensions = callbacks?.getHostExtensions?.() ?? {};
       const response: ExtAppsInitializeResponse = {
         jsonrpc: "2.0",
         id: msg.id,
@@ -172,6 +176,7 @@ export function createBridge(
             logging: {},
           },
           hostContext: {
+            ...extensions,
             theme: extMode,
             styles: {
               variables: extTokens,

--- a/web/src/bridge/host-extensions.ts
+++ b/web/src/bridge/host-extensions.ts
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------
+// Host-context extension builders
+//
+// NimbleBrain-specific keys we publish into the ext-apps `hostContext` bag.
+// The bridge stays workspace-agnostic; this module owns what extensions get
+// surfaced to apps. Used by both `SlotRenderer` (placement iframes) and
+// `InlineAppView` (inline tool-result iframes) so the host-context payload
+// is consistent across mount points — apps that read
+// `useHostContext().workspace` see the same value regardless of how the
+// iframe was mounted.
+//
+// Spec-standardized fields (`theme`, `styles`) are NOT defined here. The
+// bridge merges them in itself and they always win over same-named keys
+// returned from `buildHostExtensions`, so this layer only ever owns the
+// non-spec keys.
+// ---------------------------------------------------------------------------
+
+import { getThemeTokens } from "./theme";
+
+export type WorkspaceForHostContext = { id: string; name: string } | null;
+
+/**
+ * Non-spec extension keys to merge into the `ui/initialize` hostContext
+ * response. Bridge merges these alongside theme/styles; spec fields win
+ * on key collisions.
+ */
+export function buildHostExtensions(workspace: WorkspaceForHostContext): Record<string, unknown> {
+  return workspace ? { workspace: { id: workspace.id, name: workspace.name } } : {};
+}
+
+/**
+ * Full hostContext payload for `host-context-changed` notifications. Spec
+ * fields (`theme`, `styles`) plus extensions, in one shot. Spread order
+ * means extensions are written first; spec fields override on collision.
+ */
+export function buildHostContext(
+  mode: "light" | "dark",
+  workspace: WorkspaceForHostContext,
+): Record<string, unknown> {
+  const tokens = getThemeTokens(mode);
+  return {
+    ...buildHostExtensions(workspace),
+    theme: mode,
+    styles: { variables: tokens },
+  };
+}

--- a/web/src/bridge/types.ts
+++ b/web/src/bridge/types.ts
@@ -381,4 +381,15 @@ export interface BridgeCallbacks {
   onAction?: (action: string, params: Record<string, unknown>) => void;
   /** Called when the iframe confirms handshake complete. */
   onInitialized?: () => void;
+  /**
+   * Provide NimbleBrain-specific extensions to merge into the ext-apps
+   * `hostContext` at handshake time (e.g. `{ workspace: { id, name } }`).
+   * Called once per `ui/initialize` request, so it can read live state at
+   * the moment the iframe finishes loading.
+   *
+   * The bridge stays workspace-agnostic; the caller owns what extensions to
+   * publish. Spec-standardized fields (`theme`, `styles`) are always set by
+   * the bridge and override any same-named keys returned here.
+   */
+  getHostExtensions?: () => Record<string, unknown>;
 }

--- a/web/src/components/InlineAppView.tsx
+++ b/web/src/components/InlineAppView.tsx
@@ -3,7 +3,9 @@ import { useEffect, useRef, useState } from "react";
 import { getResources, uiPathFromUri } from "../api/client";
 import type { BridgeHandle } from "../bridge/bridge";
 import { createBridge } from "../bridge/bridge";
+import { buildHostExtensions } from "../bridge/host-extensions";
 import { createAppIframe } from "../bridge/iframe";
+import { useWorkspaceContext } from "../context/WorkspaceContext";
 
 import type { ToolResultForUI } from "../hooks/useChat";
 
@@ -31,6 +33,14 @@ export function InlineAppView({ appName, resourceUri, toolResult }: InlineAppVie
   // re-renders with a new object reference (e.g., during streaming text deltas).
   const toolResultRef = useRef(toolResult);
   toolResultRef.current = toolResult;
+  // Mirror SlotRenderer: publish workspace into hostContext so apps mounted
+  // here see the same `useHostContext().workspace` value as in placements.
+  // Inline previews don't push host-context-changed (they're scoped to a
+  // single tool result, no workspace switching mid-life), so the handshake
+  // is the only delivery point.
+  const { activeWorkspace } = useWorkspaceContext();
+  const workspaceRef = useRef(activeWorkspace);
+  workspaceRef.current = activeWorkspace;
 
   const [height, setHeight] = useState(DEFAULT_HEIGHT);
   const [loading, setLoading] = useState(true);
@@ -88,6 +98,7 @@ export function InlineAppView({ appName, resourceUri, toolResult }: InlineAppVie
               bridge.sendToolResult(tr.result);
             }
           },
+          getHostExtensions: () => buildHostExtensions(workspaceRef.current),
         });
         bridgeRef.current = bridge;
 

--- a/web/src/components/SlotRenderer.tsx
+++ b/web/src/components/SlotRenderer.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef } from "react";
 import { getResources, uiPathFromUri } from "../api/client";
 import type { BridgeHandle } from "../bridge/bridge";
 import { createBridge } from "../bridge/bridge";
+import { buildHostContext, buildHostExtensions } from "../bridge/host-extensions";
 import { createAppIframe } from "../bridge/iframe";
-import { getThemeTokens } from "../bridge/theme";
 import type { UiChatContext } from "../bridge/types";
 import { useTheme } from "../context/ThemeContext";
 import { useWorkspaceContext } from "../context/WorkspaceContext";
@@ -137,32 +137,4 @@ export function SlotRenderer({
   if (filtered.length === 0) return null;
 
   return <div ref={containerRef} className={`w-full h-full ${className ?? ""}`} />;
-}
-
-// ---------------------------------------------------------------------------
-// Host-context builders
-//
-// `buildHostExtensions` populates non-spec keys for the handshake response
-// (theme/styles are bridged separately). `buildHostContext` builds the full
-// payload for `host-context-changed` notifications. Keep them in lockstep —
-// any new extension goes in both, since iframes get exactly one of these
-// shapes per bridge lifecycle (handshake) plus N updates (notifications).
-// ---------------------------------------------------------------------------
-
-function buildHostExtensions(
-  workspace: { id: string; name: string } | null,
-): Record<string, unknown> {
-  return workspace ? { workspace: { id: workspace.id, name: workspace.name } } : {};
-}
-
-function buildHostContext(
-  mode: "light" | "dark",
-  workspace: { id: string; name: string } | null,
-): Record<string, unknown> {
-  const tokens = getThemeTokens(mode);
-  return {
-    ...buildHostExtensions(workspace),
-    theme: mode,
-    styles: { variables: tokens },
-  };
 }

--- a/web/src/components/SlotRenderer.tsx
+++ b/web/src/components/SlotRenderer.tsx
@@ -6,6 +6,7 @@ import { createAppIframe } from "../bridge/iframe";
 import { getThemeTokens } from "../bridge/theme";
 import type { UiChatContext } from "../bridge/types";
 import { useTheme } from "../context/ThemeContext";
+import { useWorkspaceContext } from "../context/WorkspaceContext";
 import type { PlacementEntry } from "../types";
 
 interface SlotRendererProps {
@@ -29,9 +30,16 @@ export function SlotRenderer({
   const containerRef = useRef<HTMLDivElement>(null);
   const bridgesRef = useRef<BridgeHandle[]>([]);
   const { mode } = useTheme();
+  const { activeWorkspace } = useWorkspaceContext();
   // Keep mode in a ref so the async renderPlacements() reads the latest value
   const modeRef = useRef(mode);
   modeRef.current = mode;
+  // Refs let `getHostExtensions` read the live workspace at handshake time
+  // (which happens after the iframe loads, possibly several effect cycles
+  // after createBridge). Without the ref, the closure would capture a stale
+  // workspace from the render that mounted the iframe.
+  const workspaceRef = useRef(activeWorkspace);
+  workspaceRef.current = activeWorkspace;
 
   // Keep callbacks in refs so the iframe-mounting effect doesn't re-run
   // when callback identity changes (e.g. during chat streaming).
@@ -91,6 +99,7 @@ export function SlotRenderer({
             onChat: (...args) => onChatRef.current?.(...args),
             onNavigate: (...args) => onNavigateRef.current?.(...args),
             onPromptAction: (...args) => onPromptActionRef.current?.(...args),
+            getHostExtensions: () => buildHostExtensions(workspaceRef.current),
           });
           bridges.push(bridge);
         } catch (err) {
@@ -114,16 +123,46 @@ export function SlotRenderer({
     // biome-ignore lint/correctness/useExhaustiveDependencies: callbacks accessed via refs
   }, [placementKey]);
 
-  // Separate effect: propagate theme changes to all mounted iframes.
-  // Only depends on `mode` so theme toggles do NOT re-mount iframes.
+  // Propagate host-context changes (theme + workspace) to mounted iframes
+  // via the ext-apps `host-context-changed` notification. Iframes stay
+  // mounted; apps that observe `useHostContext()` (or `useTheme()`) re-render
+  // and refetch workspace-scoped data without losing local state.
   useEffect(() => {
-    const tokens = getThemeTokens(mode);
+    const ctx = buildHostContext(mode, activeWorkspace);
     for (const bridge of bridgesRef.current) {
-      bridge.setHostContext({ theme: mode, styles: { variables: tokens } });
+      bridge.setHostContext(ctx);
     }
-  }, [mode]);
+  }, [mode, activeWorkspace]);
 
   if (filtered.length === 0) return null;
 
   return <div ref={containerRef} className={`w-full h-full ${className ?? ""}`} />;
+}
+
+// ---------------------------------------------------------------------------
+// Host-context builders
+//
+// `buildHostExtensions` populates non-spec keys for the handshake response
+// (theme/styles are bridged separately). `buildHostContext` builds the full
+// payload for `host-context-changed` notifications. Keep them in lockstep —
+// any new extension goes in both, since iframes get exactly one of these
+// shapes per bridge lifecycle (handshake) plus N updates (notifications).
+// ---------------------------------------------------------------------------
+
+function buildHostExtensions(
+  workspace: { id: string; name: string } | null,
+): Record<string, unknown> {
+  return workspace ? { workspace: { id: workspace.id, name: workspace.name } } : {};
+}
+
+function buildHostContext(
+  mode: "light" | "dark",
+  workspace: { id: string; name: string } | null,
+): Record<string, unknown> {
+  const tokens = getThemeTokens(mode);
+  return {
+    ...buildHostExtensions(workspace),
+    theme: mode,
+    styles: { variables: tokens },
+  };
 }


### PR DESCRIPTION
## Summary

Fix: switching workspaces on the home page didn't refresh the briefing — required clicking out of home and back. Root-caused as the bridge having no mechanism to publish workspace identity to mounted iframe apps.

- Extend `BridgeCallbacks` with `getHostExtensions()` so callers can add non-spec keys (e.g. `workspace`) into the ext-apps `hostContext` bag at handshake time. Bridge stays NimbleBrain-agnostic; SlotRenderer owns the value.
- Spec fields (`theme`, `styles`) take precedence in the merge so extensions can never collide.
- `SlotRenderer` reads `useWorkspaceContext`, publishes workspace via `getHostExtensions` (handshake) and `setHostContext` (on change). **`placementKey` is unchanged — iframes stay mounted.**
- Home briefing reads `workspace.id` via `useHostContext` from the new SDK API and keys its fetch on it.

## Why this design

Theme is already plumbed through `host-context-changed` notifications; workspace wasn't. Treating workspace as just another open-record extension on `hostContext` (the spec explicitly invites this with `[key: string]: unknown`) means we don't add a new mechanism — we use the one that already exists.

Iframes stay mounted on workspace switch:
- No CSP re-parse, no JS re-startup, no DOM flash.
- Local UI state (scroll, expanded sections, modals) preserved.
- Apps that observe `useHostContext()` refetch workspace-scoped data; apps that don't simply stay on the initial workspace (same contract as theme).

The `placementKey` re-mount alternative was rejected: layering violation (SlotRenderer shouldn't know what a workspace is), nuke-and-pave per switch, and it would mask the real fix.

## Depends on

`@nimblebrain/synapse@0.6.0` — separate PR in the synapse repo: NimbleBrainInc/synapse#6. After that ships, run `cd src/bundles/home/ui && bun install` to refresh the lockfile.

## Test plan

- [x] `bun run verify:static` — clean (1 unrelated pre-existing warning)
- [x] `bun run verify:test-unit` — 1893 unit + 130 web tests pass
- [ ] Manual smoke after synapse 0.6.0 publishes: `bun run dev`, switch workspaces on home, briefing refreshes without flash; iframe DOM node identity preserved across switch