### PR TITLE
Fix Rules of Hooks violation in ProfileTab

### DIFF
--- a/web/src/pages/settings/ProfileTab.tsx
+++ b/web/src/pages/settings/ProfileTab.tsx
@@ -45,6 +45,7 @@ export function ProfileTab() {
   const session = useSession();
   const user = session?.user;
   const { applyPreference } = useTheme();
+  const { activeWorkspace } = useWorkspaceContext();
 
   const [displayName, setDisplayName] = useState(user?.displayName ?? "");
   const [timezone, setTimezone] = useState("");
@@ -97,8 +98,6 @@ export function ProfileTab() {
   if (loading) {
     return <div className="text-muted-foreground text-sm">Loading profile...</div>;
   }
-
-  const { activeWorkspace } = useWorkspaceContext();
 
   return (
     <div className="max-w-xl mx-auto space-y-6">


### PR DESCRIPTION
## Summary

`web/src/pages/settings/ProfileTab.tsx` called `useWorkspaceContext()` *after* an early-return on the `loading` flag. Hook count differed between the loading and loaded renders, so React surfaced:

> React has detected a change in the order of Hooks called by ProfileTab. This will lead to bugs and errors if not fixed.

## Fix

Move the hook call up alongside the other top-level hooks (`useSession`, `useTheme`). One-line move; no behavior change. `activeWorkspace` is still consumed by the same JSX (`<McpConnectionCard workspaceId={activeWorkspace.id} />` in the loaded view).

## Provenance

Pre-existing bug, not introduced by recent host-context work. `git blame` traces it back to commit `44a216d` (2026-04-15). Surfaced in dev console while testing PR #83 locally.

## Test plan

- [x] `bun run verify:static` clean
- [x] `bun run verify:test-unit` clean (1893 unit + 130 web tests)
- [ ] Manual: load Settings → Profile in browser, no Rules of Hooks warning in console