### PR TITLE
Fix unclickable code-block copy/download buttons in chat (#81)

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -16,7 +16,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.1.0",
         "shadcn": "^4.1.0",
-        "streamdown": "^2.5.0",
+        "streamdown": "~2.5.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
       },

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.0",
     "shadcn": "^4.1.0",
-    "streamdown": "^2.5.0",
+    "streamdown": "~2.5.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/web/src/components/ToolAccordion.tsx
+++ b/web/src/components/ToolAccordion.tsx
@@ -235,7 +235,7 @@ function CopyButton({ content }: { content: string }) {
       type="button"
       onClick={onClick}
       className="tool-accordion__copy"
-      aria-label="Copy to clipboard"
+      aria-label={state === "failed" ? "Copy failed" : "Copy to clipboard"}
     >
       {state === "copied" ? (
         <>

--- a/web/test/MessageList.copy.test.tsx
+++ b/web/test/MessageList.copy.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import type { ChatMessage } from "../src/hooks/useChat.ts";
+import { MessageList } from "../src/components/MessageList.tsx";
+
+/**
+ * Locks in the message-level copy button's success and failure feedback.
+ * Issue #81 was about Streamdown's per-block buttons (fixed via CSS), but
+ * the same PR added try/catch + AlertCircle feedback to the custom copy
+ * button — easy to silently regress if someone ever drops the await or
+ * the failure-state branch. This test fails noisily if either happens.
+ */
+
+const assistantMsg: ChatMessage = {
+	role: "assistant",
+	content: "hello world",
+};
+
+let originalClipboard: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+	originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+});
+
+afterEach(() => {
+	if (originalClipboard) {
+		Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+	} else {
+		// happy-dom's navigator may not have clipboard by default; remove what we set
+		// biome-ignore lint/performance/noDelete: cleanup of test mock
+		delete (globalThis.navigator as { clipboard?: unknown }).clipboard;
+	}
+});
+
+function findCopyButton(container: HTMLElement): HTMLButtonElement {
+	const btns = container.getElementsByTagName("button");
+	for (const b of Array.from(btns)) {
+		const label = b.getAttribute("aria-label");
+		if (label === "Copy message" || label === "Copy failed") return b as HTMLButtonElement;
+	}
+	throw new Error("CopyButton not found");
+}
+
+function hasIcon(container: HTMLElement, className: string): boolean {
+	const svgs = container.getElementsByTagName("svg");
+	for (const svg of Array.from(svgs)) {
+		if ((svg.getAttribute("class") ?? "").split(/\s+/).includes(className)) return true;
+	}
+	return false;
+}
+
+function setClipboard(impl: { writeText: (text: string) => Promise<void> } | null) {
+	Object.defineProperty(globalThis.navigator, "clipboard", {
+		value: impl,
+		configurable: true,
+		writable: true,
+	});
+}
+
+describe("MessageList CopyButton feedback", () => {
+	it("shows the success state after a successful copy", async () => {
+		let captured = "";
+		setClipboard({
+			writeText: async (text: string) => {
+				captured = text;
+			},
+		});
+
+		const { container } = render(
+			<MessageList
+				messages={[assistantMsg]}
+				isStreaming={false}
+				streamingState="idle"
+				displayDetail="balanced"
+			/>,
+		);
+
+		const btn = findCopyButton(container);
+		await act(async () => {
+			fireEvent.click(btn);
+		});
+
+		expect(captured).toBe("hello world");
+		// Success path renders the Check icon (lucide-react adds class "lucide-check").
+		await waitFor(() => {
+			expect(hasIcon(container, "lucide-check")).toBe(true);
+		});
+	});
+
+	it("shows the failure state when writeText rejects", async () => {
+		setClipboard({
+			writeText: async () => {
+				throw new Error("denied");
+			},
+		});
+
+		const { container } = render(
+			<MessageList
+				messages={[assistantMsg]}
+				isStreaming={false}
+				streamingState="idle"
+				displayDetail="balanced"
+			/>,
+		);
+
+		const btn = findCopyButton(container);
+		await act(async () => {
+			fireEvent.click(btn);
+		});
+
+		await waitFor(() => {
+			// Failure path renders the AlertCircle icon and updates aria-label.
+			expect(hasIcon(container, "lucide-circle-alert")).toBe(true);
+			expect(btn.getAttribute("aria-label")).toBe("Copy failed");
+		});
+	});
+
+	it("shows the failure state when the Clipboard API is unavailable", async () => {
+		setClipboard(null);
+
+		const { container } = render(
+			<MessageList
+				messages={[assistantMsg]}
+				isStreaming={false}
+				streamingState="idle"
+				displayDetail="balanced"
+			/>,
+		);
+
+		const btn = findCopyButton(container);
+		await act(async () => {
+			fireEvent.click(btn);
+		});
+
+		await waitFor(() => {
+			expect(hasIcon(container, "lucide-circle-alert")).toBe(true);
+			expect(btn.getAttribute("aria-label")).toBe("Copy failed");
+		});
+	});
+});

--- a/web/test/ToolAccordion.copy.test.tsx
+++ b/web/test/ToolAccordion.copy.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import type { ToolCallDisplay } from "../src/hooks/useChat.ts";
+import { ToolAccordion } from "../src/components/ToolAccordion.tsx";
+
+/**
+ * Locks in the tool-result CopyButton's success and failure feedback.
+ * The accordion section's CopyButton is shown for any tool call that has
+ * resultText/errorText. Ensures we surface a "Copy failed" state when the
+ * Clipboard API write rejects, instead of the previous fire-and-forget.
+ */
+
+function callWithResult(text: string): ToolCallDisplay {
+	return {
+		id: "t1",
+		name: "search",
+		status: "done",
+		ok: true,
+		ms: 50,
+		result: {
+			content: [{ type: "text", text }],
+			isError: false,
+		},
+	};
+}
+
+let originalClipboard: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+	originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+});
+
+afterEach(() => {
+	if (originalClipboard) {
+		Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+	} else {
+		// biome-ignore lint/performance/noDelete: cleanup of test mock
+		delete (globalThis.navigator as { clipboard?: unknown }).clipboard;
+	}
+});
+
+function setClipboard(impl: { writeText: (text: string) => Promise<void> } | null) {
+	Object.defineProperty(globalThis.navigator, "clipboard", {
+		value: impl,
+		configurable: true,
+		writable: true,
+	});
+}
+
+function findCopyButton(container: HTMLElement): HTMLButtonElement {
+	const btns = container.getElementsByTagName("button");
+	for (const b of Array.from(btns)) {
+		const cls = b.getAttribute("class") ?? "";
+		if (cls.split(/\s+/).includes("tool-accordion__copy")) return b as HTMLButtonElement;
+	}
+	throw new Error("CopyButton not found");
+}
+
+function findHeadToggle(container: HTMLElement): HTMLButtonElement {
+	const btns = container.getElementsByTagName("button");
+	for (const b of Array.from(btns)) {
+		const cls = b.getAttribute("class") ?? "";
+		if (cls.split(/\s+/).includes("tool-accordion__head")) return b as HTMLButtonElement;
+	}
+	throw new Error("Head toggle not found");
+}
+
+function buttonText(btn: HTMLElement): string {
+	return (btn.textContent ?? "").trim().toLowerCase();
+}
+
+function renderExpandedAccordion(text: string) {
+	const result = render(
+		<ToolAccordion calls={[callWithResult(text)]} displayDetail="balanced" />,
+	);
+	// Expand the accordion head so the result Section + CopyButton mount.
+	fireEvent.click(findHeadToggle(result.container));
+	return result;
+}
+
+describe("ToolAccordion CopyButton feedback", () => {
+	it("shows the success state after a successful copy", async () => {
+		let captured = "";
+		setClipboard({
+			writeText: async (t: string) => {
+				captured = t;
+			},
+		});
+
+		const { container } = renderExpandedAccordion("the result");
+
+		const btn = findCopyButton(container);
+		await act(async () => {
+			fireEvent.click(btn);
+		});
+
+		expect(captured).toBe("the result");
+		await waitFor(() => {
+			expect(buttonText(btn)).toContain("copied");
+		});
+	});
+
+	it("shows the failure state when writeText rejects", async () => {
+		setClipboard({
+			writeText: () => Promise.reject(new Error("denied")),
+		});
+
+		const { container } = renderExpandedAccordion("the result");
+
+		const btn = findCopyButton(container);
+		await act(async () => {
+			fireEvent.click(btn);
+		});
+
+		await waitFor(() => {
+			expect(buttonText(btn)).toContain("failed");
+			expect(btn.getAttribute("aria-label")).toBe("Copy failed");
+		});
+	});
+
+	it("shows the failure state when the Clipboard API is unavailable", async () => {
+		setClipboard(null);
+
+		const { container } = renderExpandedAccordion("the result");
+
+		const btn = findCopyButton(container);
+		await act(async () => {
+			fireEvent.click(btn);
+		});
+
+		await waitFor(() => {
+			expect(buttonText(btn)).toContain("failed");
+			expect(btn.getAttribute("aria-label")).toBe("Copy failed");
+		});
+	});
+});


### PR DESCRIPTION
Fixes #81.

## Summary

- Override Streamdown's `position: sticky` + `pointer-events-none` wrapper on code-block action buttons with `position: absolute`, so clicks reach the buttons in nested scroll containers. This is the documented workaround for upstream [vercel/streamdown#494](https://github.com/vercel/streamdown/issues/494) — Streamdown's own `navigator.clipboard.writeText()` call is fine; hit-testing on the sticky wrapper was eating every click.
- Add real error handling to the message-level `CopyButton` in `MessageList.tsx` and the tool-result `CopyButton` in `ToolAccordion.tsx`. Both were calling `navigator.clipboard.writeText()` fire-and-forget, so any failure was invisible to the user. They now await the write and surface an AlertCircle "failed" state on error.

## Root cause

The issue's Secure-Context / clipboard-API theories are red herrings — I reproduced Streamdown's buttons in isolation on `localhost` and they work correctly, and `localhost` is a Secure Context. The actual failure is CSS layering: Streamdown renders code-block actions as

```html
<div class="pointer-events-none sticky top-2 -mt-10">
  <div class="pointer-events-auto">[buttons]</div>
</div>
```

In a layout with 2+ nested scroll containers (the chat panel has one), hit-testing on the inner `pointer-events-auto` div fails and clicks register on the outer `<div data-streamdown="code-block">`. DevTools "Select element" on the button area picks the wrapper, not the button, confirming the interception.

## Trade-off

With `position: absolute`, the action buttons no longer follow the viewport when you scroll past long code blocks — they stay pinned to the top of the block. For chat prose that's a fine trade, and upstream considers this the standard workaround.

## Test plan

- [ ] Start a conversation, ask for a long code block, hover over it, click Copy — paste confirms the code was copied.
- [ ] Same flow for Download — file downloads with correct extension.
- [ ] Hover over a message, click the message-level copy button — paste confirms full-message copy, and the icon briefly shows Check.
- [ ] Temporarily block clipboard (e.g., DevTools `navigator.clipboard = undefined`), click either custom copy button — icon shows AlertCircle "failed" state instead of silently doing nothing.
- [ ] `bun run verify` passes.