### PR TITLE
fix: route Files-app uploads through multipart instead of tools/call JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,7 @@ These cause production bugs if violated:
 
 - `tools/call` must return `CallToolResult` as-is (never unwrap fields)
 - `POST /v1/tools/call` must NOT emit `data.changed` SSE events (causes infinite loops)
+- Picker uploads (`synapse/request-file`) MUST persist via `POST /v1/resources` (multipart); iframes receive a `FileEntry`, never bytes. Base64-in-`tools/call` arguments hits the 1 MB JSON cap and silently breaks for any binary above ~750 KB.
 - Tool errors (`isError: true`) must become JSON-RPC `error` responses
 - Bridge must guard listeners with `destroyed` flag (React StrictMode double-mounts)
 - `SlotRenderer` effect depends only on `placementKey` (callbacks via refs, not deps)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Files-app uploads no longer fail with `Payload too large`. Picker bytes now flow through `POST /v1/resources` (multipart, workspace-scoped) instead of being base64-encoded into a `tools/call` argument; `isAllowedMime` strips Content-Type parameters, fixing a latent miss in the chat ingest path too ([#93](https://github.com/NimbleBrainInc/nimblebrain/pull/93)).
 - `nb__read_resource` and `POST /v1/resources/read` resolve `ui://` resources published by platform built-ins (settings, home, automations, conversations, files, usage, nb). Previously the structural type guard couldn't distinguish two divergent `readResource` shapes and silently skipped any platform source ([#90](https://github.com/NimbleBrainInc/nimblebrain/issues/90)).
 
 ### Removed

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1244,24 +1244,33 @@ export async function handleResourceUpload(
     return apiError(400, "bad_request", "Invalid multipart form data");
   }
 
+  // Files MUST be sent under the `file` or `files` key. Other non-string
+  // entries (e.g. a Blob accidentally appended under `tags`) are ignored
+  // rather than silently treated as uploads — caller surprises in upload
+  // contracts age badly.
   const uploads: UploadedFile[] = [];
-  for (const [_key, value] of formData.entries()) {
-    if (typeof value === "string") continue;
-    const entry = value as unknown as {
-      arrayBuffer(): Promise<ArrayBuffer>;
-      name?: string;
-      type?: string;
-    };
-    if (typeof entry.arrayBuffer !== "function") continue;
-    uploads.push({
-      data: Buffer.from(await entry.arrayBuffer()),
-      filename: entry.name || "unnamed",
-      mimeType: entry.type || "application/octet-stream",
-    });
+  try {
+    for (const [key, value] of formData.entries()) {
+      if (typeof value === "string") continue;
+      if (key !== "file" && key !== "files") continue;
+      const entry = value as unknown as {
+        arrayBuffer(): Promise<ArrayBuffer>;
+        name?: string;
+        type?: string;
+      };
+      if (typeof entry.arrayBuffer !== "function") continue;
+      uploads.push({
+        data: Buffer.from(await entry.arrayBuffer()),
+        filename: entry.name || "unnamed",
+        mimeType: entry.type || "application/octet-stream",
+      });
+    }
+  } catch {
+    return apiError(400, "bad_request", "Malformed file entry in multipart body");
   }
 
   if (uploads.length === 0) {
-    return apiError(400, "bad_request", "No files in request");
+    return apiError(400, "bad_request", "No files in request (use the 'file' or 'files' field)");
   }
 
   const config = runtime.getFilesConfig();

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -4,8 +4,9 @@ import { CallbackEventSink } from "../adapters/callback-events.ts";
 import { log } from "../cli/log.ts";
 import { isToolEnabled, isToolVisibleToRole, type ResolvedFeatures } from "../config/features.ts";
 import type { EngineEvent, EventSink } from "../engine/types.ts";
-import { ingestFiles, type UploadedFile } from "../files/ingest.ts";
+import { ingestFiles, isAllowedMime, type UploadedFile } from "../files/ingest.ts";
 import { createFileStore } from "../files/store.ts";
+import type { FileEntry } from "../files/types.ts";
 import type { IdentityProvider, UserIdentity } from "../identity/provider.ts";
 import { RunInProgressError } from "../runtime/errors.ts";
 import { type RequestContext, runWithRequestContext } from "../runtime/request-context.ts";
@@ -1212,4 +1213,127 @@ function json(data: unknown, status = 200): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+/**
+ * Handle POST /v1/resources — multipart file upload to the workspace
+ * file store. Stores each uploaded file, registers it, returns the
+ * resulting FileEntry list. This is the byte-transport entry point used
+ * by the bridge's `synapse/request-file` flow so the iframe never has
+ * to base64-encode bytes into a tool-call argument.
+ *
+ * Workspace isolation comes from `workspaceId` (set by requireWorkspace
+ * from authenticated identity, never from request input) flowing into
+ * `getWorkspaceScopedDir` — bytes physically land under the workspace's
+ * own directory.
+ */
+export async function handleResourceUpload(
+  request: Request,
+  runtime: Runtime,
+  features: ResolvedFeatures,
+  workspaceId: string,
+): Promise<Response> {
+  if (!features.fileContext) {
+    return apiError(404, "not_found", "Not found");
+  }
+
+  let formData: Awaited<ReturnType<typeof request.formData>>;
+  try {
+    formData = await request.formData();
+  } catch {
+    return apiError(400, "bad_request", "Invalid multipart form data");
+  }
+
+  const uploads: UploadedFile[] = [];
+  for (const [_key, value] of formData.entries()) {
+    if (typeof value === "string") continue;
+    const entry = value as unknown as {
+      arrayBuffer(): Promise<ArrayBuffer>;
+      name?: string;
+      type?: string;
+    };
+    if (typeof entry.arrayBuffer !== "function") continue;
+    uploads.push({
+      data: Buffer.from(await entry.arrayBuffer()),
+      filename: entry.name || "unnamed",
+      mimeType: entry.type || "application/octet-stream",
+    });
+  }
+
+  if (uploads.length === 0) {
+    return apiError(400, "bad_request", "No files in request");
+  }
+
+  const config = runtime.getFilesConfig();
+  if (uploads.length > config.maxFilesPerMessage) {
+    return apiError(413, "payload_too_large", "Too many files", {
+      count: uploads.length,
+      limit: config.maxFilesPerMessage,
+    });
+  }
+  const totalSize = uploads.reduce((s, f) => s + f.data.length, 0);
+  if (totalSize > config.maxTotalSize) {
+    return apiError(413, "payload_too_large", "Total upload size exceeds limit", {
+      size: totalSize,
+      limit: config.maxTotalSize,
+    });
+  }
+
+  // Optional metadata applied to every uploaded file. The picker flow
+  // sends none of these today; they exist so future callers (agent
+  // tools, drag-drop with tag) don't need a follow-up tool call.
+  let tags: string[] = [];
+  const tagsRaw = formData.get("tags");
+  if (typeof tagsRaw === "string" && tagsRaw) {
+    try {
+      const parsed = JSON.parse(tagsRaw);
+      if (!Array.isArray(parsed) || !parsed.every((t) => typeof t === "string")) {
+        return apiError(400, "bad_request", "tags must be a JSON array of strings");
+      }
+      tags = parsed;
+    } catch {
+      return apiError(400, "bad_request", "tags must be a valid JSON array");
+    }
+  }
+  const descriptionRaw = formData.get("description");
+  const description = typeof descriptionRaw === "string" && descriptionRaw ? descriptionRaw : null;
+  const conversationIdRaw = formData.get("conversationId");
+  const conversationId =
+    typeof conversationIdRaw === "string" && conversationIdRaw ? conversationIdRaw : null;
+
+  const store = createFileStore(join(runtime.getWorkspaceScopedDir(workspaceId), "files"));
+  const entries: FileEntry[] = [];
+  const errors: string[] = [];
+
+  for (const file of uploads) {
+    if (file.data.length > config.maxFileSize) {
+      errors.push(
+        `File "${file.filename}" (${file.data.length} bytes) exceeds per-file limit of ${config.maxFileSize}`,
+      );
+      continue;
+    }
+    if (!isAllowedMime(file.mimeType)) {
+      errors.push(`File "${file.filename}" has disallowed type: ${file.mimeType}`);
+      continue;
+    }
+    const saved = await store.saveFile(file.data, file.filename, file.mimeType);
+    const entry: FileEntry = {
+      id: saved.id,
+      filename: file.filename,
+      mimeType: file.mimeType,
+      size: saved.size,
+      tags,
+      source: "app",
+      conversationId,
+      createdAt: new Date().toISOString(),
+      description,
+    };
+    await store.appendRegistry(entry);
+    entries.push(entry);
+  }
+
+  if (entries.length === 0) {
+    return apiError(400, "file_upload_error", "All uploads were rejected", { errors });
+  }
+  return json({ files: entries, ...(errors.length > 0 ? { errors } : {}) });
 }

--- a/src/api/routes/resources.ts
+++ b/src/api/routes/resources.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { handleReadResource, handleResourceProxy } from "../handlers.ts";
+import { handleReadResource, handleResourceProxy, handleResourceUpload } from "../handlers.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import { bodyLimit } from "../middleware/body-limit.ts";
 import { errorLog } from "../middleware/error-log.ts";
@@ -7,12 +7,22 @@ import { requireWorkspace } from "../middleware/workspace.ts";
 import type { AppContext, AppEnv } from "../types.ts";
 
 export function resourceRoutes(ctx: AppContext) {
+  // maxTotalSize is snapshot at route construction; mirrors chat routes
+  // (filesConfig is built once at startup and never mutated). Multipart
+  // override lets uploads use the file-config cap; the JSON cap stays
+  // small for resources/read.
+  const uploadLimit = bodyLimit(1_048_576, {
+    multipart: ctx.runtime.getFilesConfig().maxTotalSize,
+  });
   return new Hono<AppEnv>()
     .use("*", requireAuth(ctx.authOptions))
     .use("*", requireWorkspace(ctx.workspaceStore))
     .use("*", errorLog(ctx))
     .post("/v1/resources/read", bodyLimit(1_048_576), (c) =>
       handleReadResource(c.req.raw, ctx.runtime, { workspaceId: c.var.workspaceId }),
+    )
+    .post("/v1/resources", uploadLimit, (c) =>
+      handleResourceUpload(c.req.raw, ctx.runtime, ctx.features, c.var.workspaceId),
     )
     .get("/v1/apps/:name/resources/*", (c) => {
       const name = decodeURIComponent(c.req.param("name"));

--- a/src/files/extract.ts
+++ b/src/files/extract.ts
@@ -11,20 +11,24 @@ export async function extractText(
   mimeType: string,
   maxSize: number = 204_800,
 ): Promise<{ text: string; truncated: boolean } | null> {
+  // Normalize: callers may pass `text/plain;charset=utf-8` from a
+  // browser upload. Exact-Set / equality checks against the raw value
+  // silently miss otherwise.
+  const bare = mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
   try {
-    if (isTextMime(mimeType)) {
+    if (isTextMime(bare)) {
       return truncate(data.toString("utf-8"), maxSize);
     }
 
-    if (mimeType === "application/pdf") {
+    if (bare === "application/pdf") {
       return await extractPdf(data, maxSize);
     }
 
-    if (mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
+    if (bare === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
       return await extractDocx(data, maxSize);
     }
 
-    if (mimeType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") {
+    if (bare === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") {
       return extractXlsx(data, maxSize);
     }
 

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -53,20 +53,27 @@ const ALLOWED_MIMES = new Set([
   ...BINARY_TYPES,
 ]);
 
+/**
+ * Strip Content-Type parameters and case-fold so all classification
+ * predicates (allowlist + extractable + image) see the same shape.
+ * Browsers and Bun's Blob attach `;charset=…`, `;boundary=…` etc., and
+ * exact-Set lookups against the raw value silently miss otherwise.
+ */
+function normalizeMime(mimeType: string): string {
+  return mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+}
+
 export function isAllowedMime(mimeType: string): boolean {
-  // Browsers (and Bun's Blob) attach parameters like `;charset=utf-8`
-  // to the Content-Type. Match the bare type so the allowlist behaves
-  // the same regardless of upload origin.
-  const bare = mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
-  return ALLOWED_MIMES.has(bare);
+  return ALLOWED_MIMES.has(normalizeMime(mimeType));
 }
 
 function isExtractable(mimeType: string): boolean {
-  return EXTRACTABLE_TEXT.has(mimeType) || EXTRACTABLE_DOCS.has(mimeType);
+  const bare = normalizeMime(mimeType);
+  return EXTRACTABLE_TEXT.has(bare) || EXTRACTABLE_DOCS.has(bare);
 }
 
 function isImage(mimeType: string): boolean {
-  return IMAGE_TYPES.has(mimeType);
+  return IMAGE_TYPES.has(normalizeMime(mimeType));
 }
 
 function humanSize(bytes: number): string {

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -53,8 +53,12 @@ const ALLOWED_MIMES = new Set([
   ...BINARY_TYPES,
 ]);
 
-function isAllowedMime(mimeType: string): boolean {
-  return ALLOWED_MIMES.has(mimeType);
+export function isAllowedMime(mimeType: string): boolean {
+  // Browsers (and Bun's Blob) attach parameters like `;charset=utf-8`
+  // to the Content-Type. Match the bare type so the allowlist behaves
+  // the same regardless of upload origin.
+  const bare = mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  return ALLOWED_MIMES.has(bare);
 }
 
 function isExtractable(mimeType: string): boolean {

--- a/src/tools/platform-resources/files/browser.ts
+++ b/src/tools/platform-resources/files/browser.ts
@@ -964,7 +964,10 @@ export const FILES_BROWSER_HTML = `<!DOCTYPE html>
       });
     }
 
-    // Upload button — uses synapse/request-file protocol
+    // Upload button — synapse/request-file uploads via the host's
+    // POST /v1/resources directly. The picker returns persisted
+    // FileEntry records, so no follow-up create() tool call is needed
+    // — bytes never traverse the iframe-bridge-tool path.
     var uploadBtn = document.getElementById("uploadBtn");
     if (uploadBtn) {
       uploadBtn.addEventListener("click", function() {
@@ -972,26 +975,12 @@ export const FILES_BROWSER_HTML = `<!DOCTYPE html>
         _pending[reqId] = {
           resolve: function(result) {
             if (!result) return; // user cancelled
-            var files = Array.isArray(result) ? result : [result];
-            var chain = Promise.resolve();
-            files.forEach(function(f) {
-              chain = chain.then(function() {
-                return callTool("create", {
-                  filename: f.filename,
-                  base64_data: f.base64Data,
-                  mime_type: f.mimeType || "application/octet-stream",
-                  tags: []
-                });
-              });
-            });
-            chain.then(function() { loadFiles(); })
-              .catch(function(err) {
-                state.error = "Upload failed: " + (err.message || err);
-                render();
-              });
+            var entries = Array.isArray(result) ? result : [result];
+            if (entries.length === 0) return;
+            loadFiles();
           },
           reject: function(err) {
-            state.error = "File picker failed: " + (err.message || err);
+            state.error = "Upload failed: " + (err.message || err);
             render();
           }
         };

--- a/src/tools/platform-resources/files/browser.ts
+++ b/src/tools/platform-resources/files/browser.ts
@@ -975,8 +975,7 @@ export const FILES_BROWSER_HTML = `<!DOCTYPE html>
         _pending[reqId] = {
           resolve: function(result) {
             if (!result) return; // user cancelled
-            var entries = Array.isArray(result) ? result : [result];
-            if (entries.length === 0) return;
+            if (Array.isArray(result) && result.length === 0) return;
             loadFiles();
           },
           reject: function(err) {

--- a/test/integration/resource-upload.test.ts
+++ b/test/integration/resource-upload.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type ServerHandle, startServer } from "../../src/api/server.ts";
+import { Runtime } from "../../src/runtime/runtime.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
+
+let runtime: Runtime;
+let handle: ServerHandle;
+let baseUrl: string;
+const testDir = join(tmpdir(), `nimblebrain-resource-upload-test-${Date.now()}`);
+const PER_FILE_LIMIT = 256 * 1024;
+const TOTAL_LIMIT = 1 * 1024 * 1024;
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true });
+  runtime = await Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    logging: { disabled: true },
+    workDir: testDir,
+    files: {
+      maxFileSize: PER_FILE_LIMIT,
+      maxTotalSize: TOTAL_LIMIT,
+      maxFilesPerMessage: 5,
+    },
+  });
+  await provisionTestWorkspace(runtime);
+  handle = startServer({ runtime, port: 0 });
+  baseUrl = `http://localhost:${handle.port}`;
+});
+
+afterAll(async () => {
+  handle.stop(true);
+  await runtime.shutdown();
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("POST /v1/resources", () => {
+  it("stores an uploaded file and returns its FileEntry", async () => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello world"], { type: "text/plain" }), "hello.txt");
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.files).toHaveLength(1);
+    const entry = body.files[0];
+    expect(entry.id).toMatch(/^fl_[0-9a-f]{24}$/);
+    expect(entry.filename).toBe("hello.txt");
+    // Browsers may append parameters like `;charset=utf-8`; we keep the
+    // raw Content-Type as-given so we don't lie about the upload.
+    expect(entry.mimeType.split(";")[0]).toBe("text/plain");
+    expect(entry.size).toBe(11);
+
+    // Bytes physically land under the authenticated workspace's directory.
+    // This is the "isolation by composition" guarantee — the upload route
+    // never lets the caller pick a different workspace's path.
+    const wsFilesDir = join(testDir, "workspaces", TEST_WORKSPACE_ID, "files");
+    const onDisk = readdirSync(wsFilesDir);
+    expect(onDisk.some((name) => name.startsWith(`${entry.id}_`))).toBe(true);
+  });
+
+  it("accepts multiple files in a single request", async () => {
+    const form = new FormData();
+    form.append("file", new Blob(["a"], { type: "text/plain" }), "a.txt");
+    form.append("file", new Blob(["bb"], { type: "text/plain" }), "b.txt");
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.files).toHaveLength(2);
+    expect(body.files.map((f: { filename: string }) => f.filename).sort()).toEqual([
+      "a.txt",
+      "b.txt",
+    ]);
+  });
+
+  it("rejects an over-per-file-cap upload with structured details", async () => {
+    const big = new Blob([new Uint8Array(PER_FILE_LIMIT + 1)], { type: "text/plain" });
+    const form = new FormData();
+    form.append("file", big, "too-big.txt");
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    // Per-file enforcement happens after middleware: middleware passes
+    // (single file is under the multipart total cap), then the handler
+    // catches and replies 400 with file_upload_error.
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("file_upload_error");
+    expect(body.details?.errors?.[0]).toContain("exceeds per-file limit");
+  });
+
+  it("rejects an upload over the multipart total cap at the middleware (413)", async () => {
+    const big = new Blob([new Uint8Array(TOTAL_LIMIT + 1024)], { type: "text/plain" });
+    const form = new FormData();
+    form.append("file", big, "too-big.txt");
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.error).toBe("payload_too_large");
+    expect(body.details?.contentType).toContain("multipart/form-data");
+  });
+
+  it("rejects a disallowed MIME type with 400 file_upload_error", async () => {
+    const form = new FormData();
+    form.append(
+      "file",
+      new Blob(["MZ\x90\x00"], { type: "application/x-msdownload" }),
+      "evil.exe",
+    );
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("file_upload_error");
+    expect(body.details?.errors?.[0]).toContain("disallowed type");
+  });
+
+  it("rejects a multipart request with no files", async () => {
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: new FormData(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("bad_request");
+  });
+
+  it("rejects upload to a workspace the caller is not a member of (403)", async () => {
+    // Provision a second workspace with no member added — DEV_IDENTITY is
+    // not in its member list, so resolveWorkspace must reject.
+    const wsStore = runtime.getWorkspaceStore();
+    const other = await wsStore.create("Other Workspace", "other");
+
+    const form = new FormData();
+    form.append("file", new Blob(["nope"], { type: "text/plain" }), "nope.txt");
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": other.id },
+      body: form,
+    });
+    expect(res.status).toBe(403);
+
+    // And no `fl_*` file landed in the foreign workspace's files dir.
+    // The dir itself exists (scaffoldWorkspace creates it with a .gitkeep)
+    // — what we're proving is that no upload bytes were written there.
+    const otherFilesDir = join(testDir, "workspaces", other.id, "files");
+    const onDisk = existsSync(otherFilesDir) ? readdirSync(otherFilesDir) : [];
+    expect(onDisk.some((name) => name.startsWith("fl_"))).toBe(false);
+  });
+});

--- a/test/integration/resource-upload.test.ts
+++ b/test/integration/resource-upload.test.ts
@@ -152,6 +152,95 @@ describe("POST /v1/resources", () => {
     expect(body.error).toBe("bad_request");
   });
 
+  it("persists tags / description / conversationId metadata onto the FileEntry", async () => {
+    const form = new FormData();
+    form.append("file", new Blob(["x"], { type: "text/plain" }), "x.txt");
+    form.append("tags", JSON.stringify(["report", "q2"]));
+    form.append("description", "Quarterly numbers");
+    form.append("conversationId", "conv_test_42");
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const entry = body.files[0];
+    expect(entry.tags).toEqual(["report", "q2"]);
+    expect(entry.description).toBe("Quarterly numbers");
+    expect(entry.conversationId).toBe("conv_test_42");
+    expect(entry.source).toBe("app");
+  });
+
+  it("rejects malformed tags JSON with 400 bad_request", async () => {
+    const form = new FormData();
+    form.append("file", new Blob(["x"], { type: "text/plain" }), "x.txt");
+    form.append("tags", "{not json"); // unterminated brace
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("bad_request");
+    expect(body.message).toContain("tags");
+  });
+
+  it("rejects tags that aren't a JSON array of strings (e.g. mixed types)", async () => {
+    const form = new FormData();
+    form.append("file", new Blob(["x"], { type: "text/plain" }), "x.txt");
+    form.append("tags", JSON.stringify(["ok", 42])); // number in array
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("bad_request");
+  });
+
+  it("ignores non-file form entries under non-`file` keys (no silent uploads)", async () => {
+    // A Blob accidentally appended under `tags` (instead of as a string)
+    // must NOT be saved as a file. The handler scans only `file` /
+    // `files` keys; everything else is form metadata.
+    const form = new FormData();
+    form.append("file", new Blob(["legit"], { type: "text/plain" }), "legit.txt");
+    form.append("tags", new Blob(["impostor"], { type: "text/plain" }), "impostor.txt");
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0].filename).toBe("legit.txt");
+  });
+
+  it("accepts the canonical `files` (plural) field the bridge sends", async () => {
+    // streamChatMultipart and the new uploadResource both use `files`;
+    // pin both spellings as supported so a future tightening doesn't
+    // silently break the bridge.
+    const form = new FormData();
+    form.append("files", new Blob(["plural"], { type: "text/plain" }), "p.txt");
+
+    const res = await fetch(`${baseUrl}/v1/resources`, {
+      method: "POST",
+      headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0].filename).toBe("p.txt");
+  });
+
   it("rejects upload to a workspace the caller is not a member of (403)", async () => {
     // Provision a second workspace with no member added — DEV_IDENTITY is
     // not in its member list, so resolveWorkspace must reject.

--- a/test/unit/files/ingest.test.ts
+++ b/test/unit/files/ingest.test.ts
@@ -52,6 +52,25 @@ describe("ingestFiles", () => {
     expect(extractedPart).toBeDefined();
   });
 
+  test("text file with charset parameter still hits the extraction path", async () => {
+    // Regression: isAllowedMime, isExtractable and isImage must all
+    // see the bare MIME. A pre-fix bug accepted `text/plain;charset=utf-8`
+    // at the gate but skipped extraction because the classifier did an
+    // exact-Set lookup against the parameter-suffixed value.
+    const store = createFileStore(join(workDir, "files"));
+    const files = [makeFile("charset content", "with-charset.txt", "text/plain;charset=utf-8")];
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.fileRefs).toHaveLength(1);
+    expect(result.fileRefs[0].extracted).toBe(true);
+
+    const extractedPart = result.contentParts.find(
+      (p) => p.type === "text" && p.text.includes("charset content"),
+    );
+    expect(extractedPart).toBeDefined();
+  });
+
   test("image file produces image content part + metadata notice", async () => {
     const store = createFileStore(join(workDir, "files"));
     const pngHeader = Buffer.from([

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -253,6 +253,66 @@ export async function readResource(server: string, uri: string): Promise<ReadRes
   });
 }
 
+/**
+ * A workspace file as returned by the upload endpoint. Mirrors the
+ * server-side `FileEntry` (src/files/types.ts), narrowed to the fields
+ * the client cares about — no `tags`/`source`/`description` here yet
+ * because the picker flow doesn't set them and consumers don't read them.
+ * Add fields when a consumer needs them.
+ */
+export interface WorkspaceFile {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
+export interface UploadResourceResult {
+  files: WorkspaceFile[];
+  errors?: string[];
+}
+
+/**
+ * Upload one or more files to the workspace file store via multipart
+ * POST. Bytes go over the right pipe (HTTP multipart, streamed) instead
+ * of being base64-encoded into a tool-call argument.
+ */
+export async function uploadResource(files: File[]): Promise<UploadResourceResult> {
+  const formData = new FormData();
+  for (const file of files) {
+    formData.append("file", file, file.name);
+  }
+
+  // Build headers WITHOUT Content-Type — let the browser set the
+  // multipart boundary. Same pattern as `streamChatMultipart`.
+  const h: Record<string, string> = {};
+  if (authToken && authToken !== "__cookie__") {
+    h.Authorization = `Bearer ${authToken}`;
+  }
+  if (activeWorkspaceId) {
+    h["X-Workspace-Id"] = activeWorkspaceId;
+  }
+
+  const res = await fetchWithRefresh(`${API_BASE}/v1/resources`, {
+    method: "POST",
+    credentials: "include",
+    headers: h,
+    body: formData,
+  });
+
+  if (res.status === 401) {
+    throw new ApiClientError("unauthorized", "Unauthorized", 401);
+  }
+  if (!res.ok) {
+    const body: ApiError = await res.json().catch(() => ({
+      error: "unknown",
+      message: res.statusText,
+    }));
+    throw new ApiClientError(body.error, body.message, res.status, body.details);
+  }
+  return res.json() as Promise<UploadResourceResult>;
+}
+
 // ---------------------------------------------------------------------------
 // Chat
 // ---------------------------------------------------------------------------

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -279,8 +279,10 @@ export interface UploadResourceResult {
  */
 export async function uploadResource(files: File[]): Promise<UploadResourceResult> {
   const formData = new FormData();
+  // Use `files` (plural) to match `streamChatMultipart`; the server
+  // accepts either, but one canonical spelling avoids surprises.
   for (const file of files) {
-    formData.append("file", file, file.name);
+    formData.append("files", file, file.name);
   }
 
   // Build headers WITHOUT Content-Type — let the browser set the

--- a/web/src/bridge/bridge.ts
+++ b/web/src/bridge/bridge.ts
@@ -32,6 +32,7 @@ import {
   GetTaskResultSchema,
   TaskStatusNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { uploadResource } from "../api/client";
 import { getMcpBridgeClient } from "../mcp-bridge-client";
 import { getHostThemeMode, getSpecThemeTokens, getThemeTokens } from "./theme";
 import type {
@@ -836,6 +837,17 @@ function filterHostContextForSpec(ctx: Record<string, unknown>): Record<string, 
 }
 
 /** Open native file picker, read selected file(s), and return base64-encoded results. */
+/**
+ * Open the OS file picker, then upload the selected files to the
+ * workspace file store via `POST /v1/resources`. Returns the
+ * persisted `WorkspaceFile` entries — bytes never traverse the
+ * iframe-bridge boundary, so files of any size the server's
+ * `maxFileSize` allows work without base64 inflation or hitting the
+ * 1 MB tool-call JSON cap.
+ *
+ * `maxSize` is enforced client-side as a fast-fail; the server is
+ * still the source of truth (`getFilesConfig().maxFileSize`).
+ */
 async function pickFiles(accept: string, maxSize: number, multiple: boolean): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const input = document.createElement("input");
@@ -869,8 +881,8 @@ async function pickFiles(accept: string, maxSize: number, multiple: boolean): Pr
       }
 
       try {
-        const results = [];
-        for (const file of Array.from(files)) {
+        const selected = Array.from(files);
+        for (const file of selected) {
           if (file.size > maxSize) {
             reject(
               new Error(
@@ -879,18 +891,9 @@ async function pickFiles(accept: string, maxSize: number, multiple: boolean): Pr
             );
             return;
           }
-          const buffer = await file.arrayBuffer();
-          const base64 = btoa(
-            new Uint8Array(buffer).reduce((data, byte) => data + String.fromCharCode(byte), ""),
-          );
-          results.push({
-            filename: file.name,
-            mimeType: file.type || "application/octet-stream",
-            size: file.size,
-            base64Data: base64,
-          });
         }
-        resolve(multiple ? results : (results[0] ?? null));
+        const result = await uploadResource(selected);
+        resolve(multiple ? result.files : (result.files[0] ?? null));
       } catch (err) {
         reject(err);
       }

--- a/web/src/bridge/bridge.ts
+++ b/web/src/bridge/bridge.ts
@@ -836,7 +836,6 @@ function filterHostContextForSpec(ctx: Record<string, unknown>): Record<string, 
   };
 }
 
-/** Open native file picker, read selected file(s), and return base64-encoded results. */
 /**
  * Open the OS file picker, then upload the selected files to the
  * workspace file store via `POST /v1/resources`. Returns the


### PR DESCRIPTION
## Summary

- Files UI uploads were base64-encoded into `tools/call` arguments and capped at 1 MB JSON. A 212 KB file inflated to ~283 KB after base64 + JSON envelope; anything above ~750 KB hit `Payload too large` deterministically.
- New `POST /v1/resources` accepts multipart with the same workspace-scoped auth + `bodyLimit` multipart-override pattern the chat upload uses (cap = `getFilesConfig().maxTotalSize`).
- The bridge's `synapse/request-file` now uploads through this endpoint and returns the persisted `FileEntry` to the iframe — bytes never traverse the iframe → tool-call → JSON boundary.
- The Files-app `create()` tool call is removed from the picker path; the iframe just refreshes once the picker resolves.
- `isAllowedMime` now strips Content-Type parameters (e.g. `text/plain;charset=utf-8` → `text/plain`), fixing a latent bug in the chat ingest path that surfaced once a fresh test exercised the same allowlist.

## Workspace isolation

Unchanged. `wsId` flows from authenticated identity through `requireWorkspace` (which validates membership) into `getWorkspaceScopedDir(wsId)`, so files physically land under the workspace's own directory. The integration test explicitly asserts a cross-workspace upload returns 403 **and** no `fl_*` file appears in the foreign workspace's `files/` dir.

## Follow-up — separate PR

The Synapse SDK (`packages/synapse`, different submodule) has a related cleanup that this PR doesn't touch:

- `FileResult.base64Data` → `id` (no consumers in tree; the field name shipped but `pickFile` was effectively dead because the SDK sent `synapse/pick-file` while the bridge listened on `synapse/request-file`)
- Rename the SDK method to `synapse/request-file` to match the bridge

That PR will land separately in `packages/synapse`.

## Test plan

- [x] `bun run verify` — full CI parity (1918 unit + 164 web + 404 integration + 16 smoke, all green)
- [x] Integration test `test/integration/resource-upload.test.ts` covers: success, multi-file, per-file cap (400), total cap (413), disallowed MIME (400), empty body (400), cross-workspace (403 + no bytes leak)
- [ ] Manual: `bun run dev`, click upload in the Files UI, confirm a 212 KB file uploads end-to-end and appears in the grid