### PR TITLE
chore: bump @nimblebrain/synapse to ^0.8.0 across the platform

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/ext-apps": "^1.3.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@nimblebrain/mpak-sdk": "0.6.0",
-        "@nimblebrain/synapse": "^0.4.0",
+        "@nimblebrain/synapse": "^0.8.0",
         "@workos-inc/node": "^8.12.1",
         "ai": "^6.0.138",
         "ajv": "^8.18.0",
@@ -86,7 +86,7 @@
 
     "@nimblebrain/mpak-sdk": ["@nimblebrain/mpak-sdk@0.6.0", "", { "dependencies": { "@nimblebrain/mpak-schemas": "0.2.0", "yauzl": "^3.2.0", "zod": "^4.3.6" } }, "sha512-xH2fHc5OlBQmZUFr96yBIdM519yatq8lEaMQZSOM+6kRDviTsl15DBT39fkavfkp7VJIww7Ubftn8GC2trSzog=="],
 
-    "@nimblebrain/synapse": ["@nimblebrain/synapse@0.4.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-7VLuwPhAgp7n7Ok9IVRs/qtK64KTl7RAPMWR2IGmiyjXW/552vwuMrAgDkksuPrIiZECalXSx08Zaks/+SRsxg=="],
+    "@nimblebrain/synapse": ["@nimblebrain/synapse@0.8.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-he6+9AOZFsZwnQS6IGbBrkL5OoQ1AwTpjACNQnyyqXgljZ/BhXNCSG9CzzUtS+XorYcZ4EZIEadUXFXSafZkZw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@modelcontextprotocol/ext-apps": "^1.3.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@nimblebrain/mpak-sdk": "0.6.0",
-    "@nimblebrain/synapse": "^0.4.0",
+    "@nimblebrain/synapse": "^0.8.0",
     "@workos-inc/node": "^8.12.1",
     "ai": "^6.0.138",
     "ajv": "^8.18.0",

--- a/src/bundles/automations/ui/bun.lock
+++ b/src/bundles/automations/ui/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@nimblebraininc/automations-ui",
       "dependencies": {
-        "@nimblebrain/synapse": "^0.4.0",
+        "@nimblebrain/synapse": "^0.8.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
@@ -126,7 +126,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@nimblebrain/synapse": ["@nimblebrain/synapse@0.4.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-7VLuwPhAgp7n7Ok9IVRs/qtK64KTl7RAPMWR2IGmiyjXW/552vwuMrAgDkksuPrIiZECalXSx08Zaks/+SRsxg=="],
+    "@nimblebrain/synapse": ["@nimblebrain/synapse@0.8.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-he6+9AOZFsZwnQS6IGbBrkL5OoQ1AwTpjACNQnyyqXgljZ/BhXNCSG9CzzUtS+XorYcZ4EZIEadUXFXSafZkZw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/src/bundles/automations/ui/package.json
+++ b/src/bundles/automations/ui/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nimblebrain/synapse": "^0.4.0",
+    "@nimblebrain/synapse": "^0.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/bundles/home/ui/bun.lock
+++ b/src/bundles/home/ui/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@nimblebraininc/home-ui",
       "dependencies": {
-        "@nimblebrain/synapse": "^0.6.0",
+        "@nimblebrain/synapse": "^0.8.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
@@ -126,7 +126,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@nimblebrain/synapse": ["@nimblebrain/synapse@0.6.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-r5jVc63+c9Y7GsNK7QwOzHhZ1pkPwCzBeVG8X/lPQ8oquMD8WFeYNPLwo7WT6P6giZ3s55GolHib3Xj5Rgm3xA=="],
+    "@nimblebrain/synapse": ["@nimblebrain/synapse@0.8.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-he6+9AOZFsZwnQS6IGbBrkL5OoQ1AwTpjACNQnyyqXgljZ/BhXNCSG9CzzUtS+XorYcZ4EZIEadUXFXSafZkZw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/src/bundles/home/ui/package.json
+++ b/src/bundles/home/ui/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nimblebrain/synapse": "^0.6.0",
+    "@nimblebrain/synapse": "^0.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## Summary

Bumps the Synapse SDK pin in three consumers:

- Root \`package.json\` — \`^0.4.0\` → \`^0.8.0\` (consumed by \`src/tools/core-resources/synapse-runtime.ts\` for IIFE bundle path resolution)
- \`src/bundles/home/ui/package.json\` — \`^0.6.0\` → \`^0.8.0\`
- \`src/bundles/automations/ui/package.json\` — \`^0.4.0\` → \`^0.8.0\`

## Why this isn't free

Under npm semver, \`^0.x.y\` does **not** span minor versions because major-0 minor bumps are treated as breaking. So \`^0.4.0\` and \`^0.6.0\` were never going to pick up the 0.7 / 0.8 line — including #93's host-side companion fix in [synapse#9](https://github.com/NimbleBrainInc/synapse/pull/9). The explicit bump is required.

## Migration work

**None.** Audit before bumping (across 0.4 → 0.5 → 0.6 → 0.7 → 0.8 breaking changes):

| Removed/changed API | Callers in repo |
|---|---|
| \`synapse.saveFile\` (removed in 0.5) | 0 — all \`saveFile\` matches are our own \`FileStore.saveFile\`, different namespace |
| \`HostInfo.theme\` (removed in 0.6) | 0 |
| \`Synapse\` interface mocks (need \`callToolAsTask\` stubs in 0.7) | 0 |
| \`FileResult.base64Data\` → \`.id\` (0.8) | 0 — the host's bridge implements the protocol; no in-repo bundle calls \`pickFile\` |
| \`synapse/pick-file\` → \`synapse/request-file\` method name (0.8) | 0 |

The broken APIs were never consumed here, so the accumulated breaking-change band crosses cleanly.

## What we get

- 0.7's task-aware tools (\`callToolAsTask\`, \`useCallToolAsTask\`) now available to bundle UIs that want long-running operations
- 0.6's \`useHostContext\` / \`getHostContext\` / \`onHostContextChanged\`
- 0.5's \`downloadFile\` Blob fix
- 0.8's fixed picker (latent — no consumer yet)

## Test plan

- [x] \`bun install\` at root + each bundle UI — resolves \`@nimblebrain/synapse@0.8.0\` everywhere
- [x] \`bun run build:bundles\` — both bundles build clean against the new SDK
- [x] \`bun run verify\` — 1973 unit + 174 web + 409 integration + 16 smoke; all green