### PR TITLE
feat: capture reasoning content + replay honesty for empty turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- Reasoning (extended-thinking) content is now captured end-to-end: `stream.ts` handles `reasoning-*` parts, the engine emits `reasoning.delta` SSE events, and the chat UI renders a collapsed "Thoughts" block above the assistant text. Empty turns with non-stop finishReason now emit a placeholder so replay surfaces truncations.
 - `nb__read_resource` system tool — the agent can now load `skill://` / `ui://` resources advertised by an installed bundle's MCP server ([#3](https://github.com/NimbleBrainInc/nimblebrain/pull/25)).
 - `defineInProcessApp` helper for building in-process MCP sources from JSON Schema tool defs and a resource map — same authoring ergonomic as the former `InlineSource`, with the full MCP capability surface (resources, instructions, tasks, future capabilities).
 - `/mcp` advertises `tasks` and `resources` capabilities; tool-level `taskSupport` negotiation enforces JSON-RPC `-32601` for required-without-task and forbidden-with-task.

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -146,6 +146,7 @@ export async function handleChatStream(
         if (
           event.type === "chat.start" ||
           event.type === "text.delta" ||
+          event.type === "reasoning.delta" ||
           event.type === "tool.start" ||
           event.type === "tool.done" ||
           event.type === "llm.done" ||

--- a/src/bundles/conversations/src/jsonl-reader.ts
+++ b/src/bundles/conversations/src/jsonl-reader.ts
@@ -53,6 +53,7 @@ export interface DisplayMessage {
 
 export type DisplayBlock =
   | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
   | { type: "tool"; toolCalls: DisplayToolCall[] };
 
 export interface DisplayToolCall {
@@ -443,6 +444,17 @@ function collectRun(
   let model = "";
 
   for (const llm of llmResponses) {
+    // Reasoning content — collapse all reasoning parts in this response
+    // into a single block. Emitted before text/tool blocks so the UI
+    // renders the model's thinking above its visible output.
+    const reasoningParts = llm.content.filter(
+      (c): c is { type: "reasoning"; text: string } => c.type === "reasoning",
+    );
+    if (reasoningParts.length > 0) {
+      const reasoningText = reasoningParts.map((r) => r.text).join("");
+      if (reasoningText) blocks.push({ type: "reasoning", text: reasoningText });
+    }
+
     // Text content — one text block per llm.response that has any text.
     const text = extractText(llm.content);
     if (text) blocks.push({ type: "text", text });

--- a/src/conversation/event-reconstructor.ts
+++ b/src/conversation/event-reconstructor.ts
@@ -16,6 +16,21 @@ import type { ConversationEvent, LlmResponseEvent, StoredMessage, ToolDoneEvent 
  * written to the JSONL event log as-is. When reconstructing messages for
  * the LLM API, input must be a parsed object (dictionary), not a string.
  */
+/**
+ * Per-finishReason placeholder text for empty turns. The marker becomes
+ * the assistant message body so the model sees honest context on its
+ * next turn ("your last attempt was cut off") and the UI has something
+ * to render (the friendly banner is keyed off `metadata.finishReason`).
+ */
+const TRUNCATION_MARKERS: Record<string, string> = {
+  length: "[Previous turn was cut off at the output-token limit before producing visible content.]",
+  "content-filter": "[Previous turn was blocked by content filtering.]",
+  error: "[Previous turn ended with a model error.]",
+  "tool-calls": "[Previous turn declared tool calls but emitted none.]",
+  other: "[Previous turn ended without producing content.]",
+  stop: "[Previous turn ended without producing content.]",
+};
+
 function parseToolInput(input: unknown): Record<string, unknown> {
   if (typeof input === "string") {
     try {
@@ -154,6 +169,34 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
         const textParts = llmResp.content.filter(
           (c): c is LanguageModelV3Content & { type: "text" } => c.type === "text",
         );
+        const reasoningParts = llmResp.content.filter(
+          (c): c is LanguageModelV3Content & { type: "reasoning" } => c.type === "reasoning",
+        );
+
+        const baseMetadata = () => ({
+          inputTokens: llmResp.inputTokens,
+          outputTokens: llmResp.outputTokens,
+          cacheReadTokens: llmResp.cacheReadTokens,
+          model: llmResp.model,
+          llmMs: llmResp.llmMs,
+          iterations: runLlmResponses.length,
+          costUsd: estimateCost(llmResp.model, {
+            inputTokens: llmResp.inputTokens,
+            outputTokens: llmResp.outputTokens,
+            cacheReadTokens: llmResp.cacheReadTokens,
+          }),
+          ...(llmResp.finishReason ? { finishReason: llmResp.finishReason } : {}),
+        });
+
+        // Reasoning attaches to the FIRST emitted message of this turn,
+        // so the UI renders a single collapsed reasoning block above the
+        // assistant's tool call or text. Subsequent messages from the
+        // same turn omit it to avoid duplication.
+        const reasoningContent = reasoningParts.map((r) => ({
+          type: "reasoning" as const,
+          text: r.text,
+        }));
+        let reasoningEmitted = false;
 
         if (toolCallParts.length > 0) {
           // Only include tool calls that were actually executed (have a tool.done event).
@@ -178,33 +221,21 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
               };
             });
 
-            const cost = estimateCost(llmResp.model, {
-              inputTokens: llmResp.inputTokens,
-              outputTokens: llmResp.outputTokens,
-              cacheReadTokens: llmResp.cacheReadTokens,
-            });
-
             const assistantMsg: StoredMessage = {
               role: "assistant",
-              content: executedToolCalls.map((tc) => ({
-                type: "tool-call" as const,
-                toolCallId: tc.toolCallId,
-                toolName: tc.toolName,
-                input: parseToolInput(tc.input),
-              })),
+              content: [
+                ...(reasoningEmitted ? [] : reasoningContent),
+                ...executedToolCalls.map((tc) => ({
+                  type: "tool-call" as const,
+                  toolCallId: tc.toolCallId,
+                  toolName: tc.toolName,
+                  input: parseToolInput(tc.input),
+                })),
+              ],
               timestamp: llmResp.ts,
-              metadata: {
-                inputTokens: llmResp.inputTokens,
-                outputTokens: llmResp.outputTokens,
-                cacheReadTokens: llmResp.cacheReadTokens,
-                model: llmResp.model,
-                llmMs: llmResp.llmMs,
-                iterations: runLlmResponses.length,
-                toolCalls: toolCallsMeta,
-                costUsd: cost,
-                ...(llmResp.finishReason ? { finishReason: llmResp.finishReason } : {}),
-              },
+              metadata: { ...baseMetadata(), toolCalls: toolCallsMeta },
             };
+            reasoningEmitted = true;
             messages.push(assistantMsg);
 
             // Emit tool-result messages for each executed tool call
@@ -231,30 +262,51 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
         }
 
         if (textParts.length > 0) {
-          // Assistant message with text content
-          const cost = estimateCost(llmResp.model, {
-            inputTokens: llmResp.inputTokens,
-            outputTokens: llmResp.outputTokens,
-            cacheReadTokens: llmResp.cacheReadTokens,
-          });
-
           const assistantMsg: StoredMessage = {
             role: "assistant",
-            content: textParts.map((t) => ({
-              type: "text" as const,
-              text: t.text,
-            })),
+            content: [
+              ...(reasoningEmitted ? [] : reasoningContent),
+              ...textParts.map((t) => ({ type: "text" as const, text: t.text })),
+            ],
             timestamp: llmResp.ts,
-            metadata: {
-              inputTokens: llmResp.inputTokens,
-              outputTokens: llmResp.outputTokens,
-              cacheReadTokens: llmResp.cacheReadTokens,
-              model: llmResp.model,
-              llmMs: llmResp.llmMs,
-              iterations: runLlmResponses.length,
-              costUsd: cost,
-              ...(llmResp.finishReason ? { finishReason: llmResp.finishReason } : {}),
-            },
+            metadata: baseMetadata(),
+          };
+          reasoningEmitted = true;
+          messages.push(assistantMsg);
+        }
+
+        // Step 4a — replay honesty.
+        // No tool-call, no text. Two reasons we can land here:
+        //   1. The turn produced reasoning only (extended thinking that
+        //      ran out of budget before any visible content).
+        //   2. The turn produced literally nothing AND the model didn't
+        //      end cleanly (length / content_filter / error).
+        // Either way, dropping the message silently — the pre-existing
+        // behavior — leaves the operator looking at a conversation that
+        // skips a turn that actually happened. Emit a placeholder
+        // assistant message carrying finishReason in metadata so the UI
+        // can render the truncation banner and the reasoning (if any).
+        //
+        // If neither reasoning nor visible content exists, attach a
+        // short text marker so the LLM history isn't an empty-content
+        // assistant message (Anthropic rejects those) and the model
+        // gets honest context about what just happened.
+        if (
+          toolCallParts.length === 0 &&
+          textParts.length === 0 &&
+          (reasoningContent.length > 0 || (llmResp.finishReason && llmResp.finishReason !== "stop"))
+        ) {
+          const placeholderText =
+            TRUNCATION_MARKERS[llmResp.finishReason ?? "other"] ?? TRUNCATION_MARKERS.other!;
+          const placeholderContent =
+            reasoningContent.length > 0
+              ? reasoningContent
+              : [{ type: "text" as const, text: placeholderText }];
+          const assistantMsg: StoredMessage = {
+            role: "assistant",
+            content: placeholderContent,
+            timestamp: llmResp.ts,
+            metadata: baseMetadata(),
           };
           messages.push(assistantMsg);
         }

--- a/src/conversation/event-reconstructor.ts
+++ b/src/conversation/event-reconstructor.ts
@@ -11,12 +11,6 @@ import { estimateCost } from "../engine/cost.ts";
 import type { ConversationEvent, LlmResponseEvent, StoredMessage, ToolDoneEvent } from "./types.ts";
 
 /**
- * Parse tool-call input from its persisted form.
- * The AI SDK V3 stream emits tool-call input as a JSON string, which gets
- * written to the JSONL event log as-is. When reconstructing messages for
- * the LLM API, input must be a parsed object (dictionary), not a string.
- */
-/**
  * Per-finishReason placeholder text for empty turns. The marker becomes
  * the assistant message body so the model sees honest context on its
  * next turn ("your last attempt was cut off") and the UI has something
@@ -31,6 +25,12 @@ const TRUNCATION_MARKERS: Record<string, string> = {
   stop: "[Previous turn ended without producing content.]",
 };
 
+/**
+ * Parse tool-call input from its persisted form.
+ * The AI SDK V3 stream emits tool-call input as a JSON string, which gets
+ * written to the JSONL event log as-is. When reconstructing messages for
+ * the LLM API, input must be a parsed object (dictionary), not a string.
+ */
 function parseToolInput(input: unknown): Record<string, unknown> {
   if (typeof input === "string") {
     try {
@@ -192,9 +192,17 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
         // so the UI renders a single collapsed reasoning block above the
         // assistant's tool call or text. Subsequent messages from the
         // same turn omit it to avoid duplication.
+        //
+        // Provider metadata (e.g. Anthropic's thinking signature) is
+        // promoted from `providerMetadata` (the V3Content output shape)
+        // to `providerOptions` (the V3ReasoningPart prompt shape) so
+        // the reasoning block survives a conversation reload + replay.
+        // Without this, the AI SDK Anthropic provider drops the block as
+        // "unsupported reasoning metadata" and Anthropic 400s the call.
         const reasoningContent = reasoningParts.map((r) => ({
           type: "reasoning" as const,
           text: r.text,
+          ...(r.providerMetadata ? { providerOptions: r.providerMetadata } : {}),
         }));
         let reasoningEmitted = false;
 
@@ -287,10 +295,12 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
         // assistant message carrying finishReason in metadata so the UI
         // can render the truncation banner and the reasoning (if any).
         //
-        // If neither reasoning nor visible content exists, attach a
-        // short text marker so the LLM history isn't an empty-content
-        // assistant message (Anthropic rejects those) and the model
-        // gets honest context about what just happened.
+        // Reasoning content is ONLY usable as the placeholder body when
+        // it carries provider metadata that lets it round-trip (e.g.
+        // Anthropic's signature). Without that, the AI SDK provider
+        // drops the block on the next prompt → content: [] → API 400.
+        // Fall back to marker text whenever the reasoning can't be
+        // safely replayed.
         if (
           toolCallParts.length === 0 &&
           textParts.length === 0 &&
@@ -298,10 +308,12 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
         ) {
           const placeholderText =
             TRUNCATION_MARKERS[llmResp.finishReason ?? "other"] ?? TRUNCATION_MARKERS.other!;
-          const placeholderContent =
-            reasoningContent.length > 0
-              ? reasoningContent
-              : [{ type: "text" as const, text: placeholderText }];
+          const reasoningRoundTrips = reasoningContent.some(
+            (r) => "providerOptions" in r && r.providerOptions != null,
+          );
+          const placeholderContent = reasoningRoundTrips
+            ? reasoningContent
+            : [{ type: "text" as const, text: placeholderText }];
           const assistantMsg: StoredMessage = {
             role: "assistant",
             content: placeholderContent,

--- a/src/conversation/event-sourced-store.ts
+++ b/src/conversation/event-sourced-store.ts
@@ -492,6 +492,7 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
 
       case "llm.done": {
         const finishReason = d.finishReason as LlmResponseEvent["finishReason"];
+        const reasoningTokens = (d.reasoningTokens as number) ?? 0;
         const e: LlmResponseEvent = {
           ts,
           type: "llm.response",
@@ -503,6 +504,7 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
           cacheReadTokens: (d.cacheReadTokens as number) ?? 0,
           cacheCreationTokens: (d.cacheCreationTokens as number) ?? 0,
           llmMs: (d.llmMs as number) ?? 0,
+          ...(reasoningTokens > 0 ? { reasoningTokens } : {}),
           ...(finishReason !== undefined ? { finishReason } : {}),
         };
         return e;

--- a/src/conversation/types.ts
+++ b/src/conversation/types.ts
@@ -213,9 +213,21 @@ export interface LlmResponseEvent {
   type: "llm.response";
   runId: string;
   model: string;
+  /**
+   * V3 content blocks. Includes `text`, `tool-call`, and `reasoning`
+   * (extended thinking) parts. Reasoning blocks are surfaced to the UI
+   * collapsed-by-default; bare absence on a turn with non-stop
+   * finishReason is what indicates a real empty turn.
+   */
   content: LanguageModelV3Content[];
   inputTokens: number;
   outputTokens: number;
+  /**
+   * Reasoning-token subtotal (subset of `outputTokens`). 0 when the model
+   * emitted no reasoning. Useful for cost attribution and for diagnosing
+   * "why is outputTokens at the cap with empty visible content?".
+   */
+  reasoningTokens?: number;
   cacheReadTokens: number;
   cacheCreationTokens: number;
   llmMs: number;

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -299,8 +299,15 @@ export class AgentEngine {
         }
 
         // 4. Append assistant message to history
-        // Stream tool-call parts have input as a JSON string, but the prompt format
-        // expects input as a parsed object. Convert before adding to history.
+        // Stream content uses fields that don't always match the prompt-side
+        // shape — convert before pushing back as next-iteration history:
+        //   - tool-call: input is a JSON string in stream output, but the
+        //     prompt format expects a parsed object.
+        //   - reasoning: stream output uses `providerMetadata` (matches
+        //     LanguageModelV3Reasoning); the prompt-side ReasoningPart
+        //     reads `providerOptions`. The AI SDK Anthropic provider
+        //     drops reasoning blocks without `providerOptions.anthropic.
+        //     signature`, breaking multi-iteration replay.
         const historyContent = response.content.map((part) => {
           if (part.type === "tool-call" && typeof part.input === "string") {
             try {
@@ -308,6 +315,9 @@ export class AgentEngine {
             } catch {
               return { ...part, input: {} };
             }
+          }
+          if (part.type === "reasoning" && part.providerMetadata) {
+            return { ...part, providerOptions: part.providerMetadata };
           }
           return part;
         });

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -241,6 +241,7 @@ export class AgentEngine {
               maxOutputTokens: config.maxOutputTokens,
             },
             (text) => this.events.emit({ type: "text.delta", data: { runId, text } }),
+            (text) => this.events.emit({ type: "reasoning.delta", data: { runId, text } }),
           ),
         );
         const llmMs = Math.round(performance.now() - llmStart);
@@ -259,6 +260,7 @@ export class AgentEngine {
         // Accumulate tokens
         const turnInputTokens = response.usage.inputTokens.total ?? 0;
         const turnOutputTokens = response.usage.outputTokens.total ?? 0;
+        const turnReasoningTokens = response.usage.outputTokens.reasoning ?? 0;
         const turnCacheReadTokens = response.usage.inputTokens.cacheRead ?? 0;
         const turnCacheCreationTokens = response.usage.inputTokens.cacheWrite ?? 0;
         cumulativeInputTokens += turnInputTokens;
@@ -279,6 +281,7 @@ export class AgentEngine {
             content: response.content,
             inputTokens: turnInputTokens,
             outputTokens: turnOutputTokens,
+            reasoningTokens: turnReasoningTokens,
             cacheReadTokens: turnCacheReadTokens,
             cacheCreationTokens: turnCacheCreationTokens,
             llmMs,

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -44,6 +44,7 @@ export type EngineEventType =
   | "chat.start"
   | "run.start"
   | "text.delta"
+  | "reasoning.delta"
   | "tool.start"
   | "tool.done"
   | "tool.progress"

--- a/src/model/stream.ts
+++ b/src/model/stream.ts
@@ -4,6 +4,7 @@ import type {
   LanguageModelV3Content,
   LanguageModelV3FinishReason,
   LanguageModelV3Usage,
+  SharedV3ProviderMetadata,
 } from "@ai-sdk/provider";
 
 export interface StreamResult {
@@ -32,6 +33,14 @@ export async function callModel(
 
   let accumulatedText = "";
   let accumulatedReasoning = "";
+  // Reasoning provider metadata accumulator. Anthropic transports the
+  // thinking-block signature as a separate `signature_delta` event that
+  // the AI SDK forwards as a `reasoning-delta` with empty text and
+  // `providerMetadata.anthropic.signature`. Without persisting that
+  // signature, the next iteration's prompt fails to round-trip the
+  // reasoning block — the AI SDK provider drops it as "unsupported
+  // reasoning metadata" and Anthropic 400s the request.
+  let reasoningProviderMetadata: SharedV3ProviderMetadata | undefined;
 
   const reader = stream.getReader();
   try {
@@ -61,20 +70,37 @@ export async function callModel(
         // Without this case, reasoning tokens are billed but never appear
         // in `content[]` — turns that produce only reasoning render as
         // empty (the failure mode that started this whole thread).
+        // Provider metadata (e.g. Anthropic's thinking signature) is
+        // merged across all reasoning-* parts of a block so the block
+        // can round-trip on the next iteration's prompt.
         case "reasoning-start":
           accumulatedReasoning = "";
+          reasoningProviderMetadata = part.providerMetadata
+            ? { ...part.providerMetadata }
+            : undefined;
           break;
 
         case "reasoning-delta":
           onReasoningDelta?.(part.delta);
           accumulatedReasoning += part.delta;
+          if (part.providerMetadata) {
+            reasoningProviderMetadata = mergeProviderMetadata(
+              reasoningProviderMetadata,
+              part.providerMetadata,
+            );
+          }
           break;
 
         case "reasoning-end":
-          if (accumulatedReasoning) {
-            content.push({ type: "reasoning", text: accumulatedReasoning });
+          if (accumulatedReasoning || reasoningProviderMetadata) {
+            content.push({
+              type: "reasoning",
+              text: accumulatedReasoning,
+              ...(reasoningProviderMetadata ? { providerMetadata: reasoningProviderMetadata } : {}),
+            });
           }
           accumulatedReasoning = "";
+          reasoningProviderMetadata = undefined;
           break;
 
         case "tool-call":
@@ -95,9 +121,31 @@ export async function callModel(
   if (accumulatedText) {
     content.push({ type: "text", text: accumulatedText });
   }
-  if (accumulatedReasoning) {
-    content.push({ type: "reasoning", text: accumulatedReasoning });
+  if (accumulatedReasoning || reasoningProviderMetadata) {
+    content.push({
+      type: "reasoning",
+      text: accumulatedReasoning,
+      ...(reasoningProviderMetadata ? { providerMetadata: reasoningProviderMetadata } : {}),
+    });
   }
 
   return { content, usage, finishReason };
+}
+
+/**
+ * Shallow-merge two provider-metadata bags by provider key. Each provider
+ * gets its own object spread together; later keys win. The AI SDK only
+ * cares about the per-provider sub-object (e.g. `anthropic.signature`),
+ * so a deeper merge isn't needed.
+ */
+function mergeProviderMetadata(
+  a: SharedV3ProviderMetadata | undefined,
+  b: SharedV3ProviderMetadata,
+): SharedV3ProviderMetadata {
+  if (!a) return { ...b };
+  const out: SharedV3ProviderMetadata = { ...a };
+  for (const [provider, meta] of Object.entries(b)) {
+    out[provider] = { ...(out[provider] ?? {}), ...(meta ?? {}) };
+  }
+  return out;
 }

--- a/src/model/stream.ts
+++ b/src/model/stream.ts
@@ -16,6 +16,7 @@ export async function callModel(
   model: LanguageModelV3,
   options: LanguageModelV3CallOptions,
   onTextDelta: (text: string) => void,
+  onReasoningDelta?: (text: string) => void,
 ): Promise<StreamResult> {
   const { stream } = await model.doStream(options);
 
@@ -30,6 +31,7 @@ export async function callModel(
   let finishReason: LanguageModelV3FinishReason = { unified: "other", raw: undefined };
 
   let accumulatedText = "";
+  let accumulatedReasoning = "";
 
   const reader = stream.getReader();
   try {
@@ -54,6 +56,27 @@ export async function callModel(
           accumulatedText = "";
           break;
 
+        // Reasoning (extended thinking) parts. Treated symmetrically with
+        // text: deltas accumulate into a single content block on -end.
+        // Without this case, reasoning tokens are billed but never appear
+        // in `content[]` — turns that produce only reasoning render as
+        // empty (the failure mode that started this whole thread).
+        case "reasoning-start":
+          accumulatedReasoning = "";
+          break;
+
+        case "reasoning-delta":
+          onReasoningDelta?.(part.delta);
+          accumulatedReasoning += part.delta;
+          break;
+
+        case "reasoning-end":
+          if (accumulatedReasoning) {
+            content.push({ type: "reasoning", text: accumulatedReasoning });
+          }
+          accumulatedReasoning = "";
+          break;
+
         case "tool-call":
           content.push(part);
           break;
@@ -68,9 +91,12 @@ export async function callModel(
     reader.releaseLock();
   }
 
-  // If text was accumulated without text-start/text-end framing, emit as single block
+  // Drain any in-flight accumulators that didn't see their -end part.
   if (accumulatedText) {
     content.push({ type: "text", text: accumulatedText });
+  }
+  if (accumulatedReasoning) {
+    content.push({ type: "reasoning", text: accumulatedReasoning });
   }
 
   return { content, usage, finishReason };

--- a/test/helpers/echo-model.ts
+++ b/test/helpers/echo-model.ts
@@ -13,6 +13,17 @@ import type {
  */
 export interface EchoModelResponse {
   text?: string;
+  /**
+   * Reasoning (extended-thinking) content emitted before any text/tool_use.
+   * When set, the stream produces reasoning-start/delta/end parts that
+   * src/model/stream.ts must capture and push as a `reasoning` content block.
+   */
+  reasoning?: string;
+  /**
+   * Optional reasoning-token subtotal reported in usage.outputTokens.reasoning.
+   * Tests use this to verify the engine forwards the breakdown on llm.done.
+   */
+  reasoningTokens?: number;
   toolCalls?: Array<{
     toolCallId: string;
     toolName: string;
@@ -57,10 +68,15 @@ export function createEchoModel(options?: EchoModelOptions): LanguageModelV3 {
     return "[echo]";
   }
 
-  function buildUsage(textLen: number): LanguageModelV3Usage {
+  function buildUsage(textLen: number, reasoningTokens?: number): LanguageModelV3Usage {
+    const total = textLen + (reasoningTokens ?? 0);
     return {
       inputTokens: { total: textLen, noCache: textLen, cacheRead: undefined, cacheWrite: undefined },
-      outputTokens: { total: textLen, text: textLen, reasoning: undefined },
+      outputTokens: {
+        total,
+        text: textLen,
+        reasoning: reasoningTokens,
+      },
     };
   }
 
@@ -80,6 +96,10 @@ export function createEchoModel(options?: EchoModelOptions): LanguageModelV3 {
 
     if (queued) {
       const content: LanguageModelV3Content[] = [];
+
+      if (queued.reasoning !== undefined) {
+        content.push({ type: "reasoning", text: queued.reasoning });
+      }
 
       if (queued.text !== undefined) {
         content.push({ type: "text", text: queued.text });
@@ -106,7 +126,7 @@ export function createEchoModel(options?: EchoModelOptions): LanguageModelV3 {
       return {
         content,
         finishReason,
-        usage: buildUsage(textLen),
+        usage: buildUsage(textLen, queued.reasoningTokens),
       };
     }
 
@@ -142,7 +162,11 @@ export function createEchoModel(options?: EchoModelOptions): LanguageModelV3 {
 
       // Emit content parts
       for (const item of result.content) {
-        if (item.type === "text") {
+        if (item.type === "reasoning") {
+          parts.push({ type: "reasoning-start", id: "reasoning-0" });
+          parts.push({ type: "reasoning-delta", id: "reasoning-0", delta: item.text });
+          parts.push({ type: "reasoning-end", id: "reasoning-0" });
+        } else if (item.type === "text") {
           parts.push({ type: "text-start", id: "text-0" });
           parts.push({ type: "text-delta", id: "text-0", delta: item.text });
           parts.push({ type: "text-end", id: "text-0" });

--- a/test/helpers/echo-model.ts
+++ b/test/helpers/echo-model.ts
@@ -20,6 +20,12 @@ export interface EchoModelResponse {
    */
   reasoning?: string;
   /**
+   * Provider metadata to emit on the reasoning-end stream part. The
+   * Anthropic SDK forwards thinking-block signatures here; tests use
+   * this to verify multi-iteration round-trips preserve the signature.
+   */
+  reasoningProviderMetadata?: Record<string, Record<string, unknown>>;
+  /**
    * Optional reasoning-token subtotal reported in usage.outputTokens.reasoning.
    * Tests use this to verify the engine forwards the breakdown on llm.done.
    */
@@ -98,7 +104,13 @@ export function createEchoModel(options?: EchoModelOptions): LanguageModelV3 {
       const content: LanguageModelV3Content[] = [];
 
       if (queued.reasoning !== undefined) {
-        content.push({ type: "reasoning", text: queued.reasoning });
+        content.push({
+          type: "reasoning",
+          text: queued.reasoning,
+          ...(queued.reasoningProviderMetadata
+            ? { providerMetadata: queued.reasoningProviderMetadata }
+            : {}),
+        });
       }
 
       if (queued.text !== undefined) {
@@ -165,6 +177,18 @@ export function createEchoModel(options?: EchoModelOptions): LanguageModelV3 {
         if (item.type === "reasoning") {
           parts.push({ type: "reasoning-start", id: "reasoning-0" });
           parts.push({ type: "reasoning-delta", id: "reasoning-0", delta: item.text });
+          // Anthropic transports the thinking signature on a separate
+          // reasoning-delta with empty text. Mirror that here when the
+          // queued response provided providerMetadata so multi-iter
+          // tests can verify signature round-trip.
+          if (item.providerMetadata) {
+            parts.push({
+              type: "reasoning-delta",
+              id: "reasoning-0",
+              delta: "",
+              providerMetadata: item.providerMetadata,
+            });
+          }
           parts.push({ type: "reasoning-end", id: "reasoning-0" });
         } else if (item.type === "text") {
           parts.push({ type: "text-start", id: "text-0" });

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -428,6 +428,51 @@ describe("AgentEngine", () => {
       expect(result.stopReason).toBe("max_iterations");
     });
 
+    it("captures reasoning content blocks and reasoning.delta events", async () => {
+      const events: EngineEvent[] = [];
+      const sink: EventSink = {
+        emit(event: EngineEvent) {
+          events.push(event);
+        },
+      };
+      const model = createEchoModel({
+        responses: [
+          {
+            reasoning: "Let me think about this carefully...",
+            text: "Done.",
+            reasoningTokens: 42,
+          },
+        ],
+      });
+
+      await new AgentEngine(
+        model,
+        new StaticToolRouter([], () => ({ content: textContent(""), isError: false })),
+        sink,
+      ).run(
+        defaultConfig,
+        "",
+        [{ role: "user", content: [{ type: "text", text: "x" }] }],
+        [],
+      );
+
+      const reasoningDeltas = events.filter((e) => e.type === "reasoning.delta");
+      expect(reasoningDeltas).toHaveLength(1);
+      expect((reasoningDeltas[0]!.data as Record<string, unknown>).text).toBe(
+        "Let me think about this carefully...",
+      );
+
+      const llmDone = events.find((e) => e.type === "llm.done");
+      expect(llmDone).toBeDefined();
+      const llmData = llmDone!.data as Record<string, unknown>;
+      expect(llmData.reasoningTokens).toBe(42);
+      const content = llmData.content as Array<{ type: string; text?: string }>;
+      expect(content.find((c) => c.type === "reasoning")?.text).toBe(
+        "Let me think about this carefully...",
+      );
+      expect(content.find((c) => c.type === "text")?.text).toBe("Done.");
+    });
+
     it("emits finishReason on the llm.done event", async () => {
       const events: EngineEvent[] = [];
       const sink: EventSink = {

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -428,6 +428,65 @@ describe("AgentEngine", () => {
       expect(result.stopReason).toBe("max_iterations");
     });
 
+    it("preserves Anthropic signature on reasoning across iterations (round-trip)", async () => {
+      // The first turn emits reasoning + a tool call. The engine pushes
+      // the assistant content into history for the second turn — and
+      // the reasoning's providerMetadata must be promoted to
+      // providerOptions on that history entry, otherwise the AI SDK
+      // Anthropic provider would silently drop the block as
+      // "unsupported reasoning metadata" on the second prompt.
+      const sentMessages: LanguageModelV3Message[][] = [];
+      const recordingModel: LanguageModelV3 = {
+        ...createEchoModel({
+          responses: [
+            {
+              reasoning: "Need to look this up.",
+              reasoningProviderMetadata: { anthropic: { signature: "sig-test-789" } },
+              toolCalls: [
+                { toolCallId: "call_1", toolName: "test__noop", input: JSON.stringify({}) },
+              ],
+            },
+            { text: "Done." },
+          ],
+        }),
+      };
+      const originalDoStream = recordingModel.doStream.bind(recordingModel);
+      recordingModel.doStream = async (callOptions) => {
+        sentMessages.push([...callOptions.prompt]);
+        return originalDoStream(callOptions);
+      };
+
+      const tools = {
+        schemas: [{ name: "test__noop", description: "No-op", inputSchema: {} }],
+        handler: (): ToolResult => ({ content: textContent("ok"), isError: false }),
+      };
+
+      await new AgentEngine(
+        recordingModel,
+        new StaticToolRouter(tools.schemas, tools.handler),
+        new NoopEventSink(),
+      ).run(
+        defaultConfig,
+        "",
+        [{ role: "user", content: [{ type: "text", text: "look it up" }] }],
+        tools.schemas,
+      );
+
+      expect(sentMessages).toHaveLength(2);
+      const secondPrompt = sentMessages[1]!;
+      const assistant = secondPrompt.find((m) => m.role === "assistant");
+      expect(assistant).toBeDefined();
+      const reasoning = (assistant!.content as Array<Record<string, unknown>>).find(
+        (c) => c.type === "reasoning",
+      );
+      expect(reasoning).toBeDefined();
+      // The critical assertion — providerOptions must be set, not just
+      // providerMetadata, because that's what the Anthropic prompt path reads.
+      expect(reasoning!.providerOptions).toEqual({
+        anthropic: { signature: "sig-test-789" },
+      });
+    });
+
     it("captures reasoning content blocks and reasoning.delta events", async () => {
       const events: EngineEvent[] = [];
       const sink: EventSink = {

--- a/test/unit/event-reconstructor.test.ts
+++ b/test/unit/event-reconstructor.test.ts
@@ -324,6 +324,115 @@ describe("reconstructMessages", () => {
     expect(messages[2].role).toBe("tool");
   });
 
+  it("preserves reasoning content blocks alongside text", () => {
+    const reasoningResp: LlmResponseEvent = {
+      ...llmText("run-1", "The answer is 42."),
+      content: [
+        { type: "reasoning", text: "Computing 6 * 7 carefully..." },
+        { type: "text", text: "The answer is 42." },
+      ],
+    };
+    const events: ConversationEvent[] = [
+      userMessage("What is 6 * 7?"),
+      runStart("run-1"),
+      reasoningResp,
+      runDone("run-1"),
+    ];
+    const messages = reconstructMessages(events);
+    expect(messages).toHaveLength(2);
+    const assistant = messages[1]!;
+    const reasoningBlock = assistant.content.find(
+      (c): c is { type: "reasoning"; text: string } => c.type === "reasoning",
+    );
+    const textBlock = assistant.content.find(
+      (c): c is { type: "text"; text: string } => c.type === "text",
+    );
+    expect(reasoningBlock?.text).toBe("Computing 6 * 7 carefully...");
+    expect(textBlock?.text).toBe("The answer is 42.");
+  });
+
+  it("attaches reasoning to the FIRST assistant message of a turn (tool-call before text)", () => {
+    // When a turn produces both a tool-call message AND a text message,
+    // reasoning attaches only to the first to avoid UI duplication.
+    const reasoningWithToolCall: LlmResponseEvent = {
+      ...llmToolCall("run-1", "tc-1", "lookup", { id: "x" }),
+      content: [
+        { type: "reasoning", text: "Need to look this up." },
+        { type: "tool-call", toolCallId: "tc-1", toolName: "lookup", input: { id: "x" } },
+      ],
+    };
+    const finalText = llmText("run-1", "Found it.");
+    const events: ConversationEvent[] = [
+      userMessage("Look up X"),
+      runStart("run-1"),
+      reasoningWithToolCall,
+      toolStart("run-1", "tc-1", "lookup"),
+      toolDone("run-1", "tc-1", "lookup"),
+      finalText,
+      runDone("run-1"),
+    ];
+    const messages = reconstructMessages(events);
+    const assistantMessages = messages.filter((m) => m.role === "assistant");
+    expect(assistantMessages).toHaveLength(2);
+
+    const firstReasoning = assistantMessages[0]!.content.find((c) => c.type === "reasoning");
+    const secondReasoning = assistantMessages[1]!.content.find((c) => c.type === "reasoning");
+    expect(firstReasoning).toBeDefined();
+    expect(secondReasoning).toBeUndefined();
+  });
+
+  it("emits a placeholder for an empty turn that ended with non-stop finishReason", () => {
+    // Reproduces the failure mode that started this whole thread: turn
+    // burns the output budget without producing visible content. The
+    // reconstructor must not silently drop it.
+    const truncatedTurn: LlmResponseEvent = {
+      ...llmText("run-1", ""),
+      content: [],
+      finishReason: "length",
+    };
+    const events: ConversationEvent[] = [
+      userMessage("Build the doc"),
+      runStart("run-1"),
+      truncatedTurn,
+      runDone("run-1"),
+    ];
+    const messages = reconstructMessages(events);
+    expect(messages).toHaveLength(2);
+    const placeholder = messages[1]!;
+    expect(placeholder.role).toBe("assistant");
+    expect(placeholder.metadata!.finishReason).toBe("length");
+    // Carries explicit marker text so LLM history isn't an empty msg
+    const text = placeholder.content.find((c): c is { type: "text"; text: string } => c.type === "text");
+    expect(text?.text).toContain("cut off");
+  });
+
+  it("emits a reasoning-only assistant message when text and tool-calls are absent", () => {
+    // Extended-thinking turn that ran out of budget producing only
+    // reasoning. The placeholder uses the reasoning content directly
+    // rather than the canned marker text.
+    const reasoningOnly: LlmResponseEvent = {
+      ...llmText("run-1", ""),
+      content: [{ type: "reasoning", text: "Mid-thought when cap hit..." }],
+      finishReason: "length",
+    };
+    const events: ConversationEvent[] = [
+      userMessage("hi"),
+      runStart("run-1"),
+      reasoningOnly,
+      runDone("run-1"),
+    ];
+    const messages = reconstructMessages(events);
+    expect(messages).toHaveLength(2);
+    const assistant = messages[1]!;
+    expect(assistant.metadata!.finishReason).toBe("length");
+    const reasoning = assistant.content.find(
+      (c): c is { type: "reasoning"; text: string } => c.type === "reasoning",
+    );
+    expect(reasoning?.text).toBe("Mid-thought when cap hit...");
+    // No marker text — reasoning is the visible content
+    expect(assistant.content.find((c) => c.type === "text")).toBeUndefined();
+  });
+
   it("forwards finishReason from llm.response into assistant message metadata", () => {
     const lengthCapped: LlmResponseEvent = {
       ...llmText("run-1", "Building now."),

--- a/test/unit/event-reconstructor.test.ts
+++ b/test/unit/event-reconstructor.test.ts
@@ -406,31 +406,85 @@ describe("reconstructMessages", () => {
     expect(text?.text).toContain("cut off");
   });
 
-  it("emits a reasoning-only assistant message when text and tool-calls are absent", () => {
-    // Extended-thinking turn that ran out of budget producing only
-    // reasoning. The placeholder uses the reasoning content directly
-    // rather than the canned marker text.
-    const reasoningOnly: LlmResponseEvent = {
-      ...llmText("run-1", ""),
-      content: [{ type: "reasoning", text: "Mid-thought when cap hit..." }],
-      finishReason: "length",
+  it("preserves Anthropic signature on reasoning blocks across reconstruction", () => {
+    // Verifies the multi-iteration round-trip path: stream captures
+    // signature → JSONL persists it → reconstructor copies into
+    // StoredMessage.content as `providerOptions` so the next prompt
+    // doesn't lose the block to "unsupported reasoning metadata".
+    const reasoningWithSig: LlmResponseEvent = {
+      ...llmToolCall("run-1", "tc-1", "lookup", { id: "x" }),
+      content: [
+        {
+          type: "reasoning",
+          text: "Need to look this up.",
+          providerMetadata: { anthropic: { signature: "sig-abc-123" } },
+        },
+        { type: "tool-call", toolCallId: "tc-1", toolName: "lookup", input: { id: "x" } },
+      ],
     };
     const events: ConversationEvent[] = [
-      userMessage("hi"),
+      userMessage("look up x"),
       runStart("run-1"),
-      reasoningOnly,
+      reasoningWithSig,
+      toolStart("run-1", "tc-1", "lookup"),
+      toolDone("run-1", "tc-1", "lookup"),
       runDone("run-1"),
     ];
     const messages = reconstructMessages(events);
-    expect(messages).toHaveLength(2);
-    const assistant = messages[1]!;
-    expect(assistant.metadata!.finishReason).toBe("length");
-    const reasoning = assistant.content.find(
-      (c): c is { type: "reasoning"; text: string } => c.type === "reasoning",
+    const assistant = messages.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    const reasoning = assistant!.content.find(
+      (c): c is { type: "reasoning"; text: string; providerOptions?: unknown } =>
+        c.type === "reasoning",
     );
-    expect(reasoning?.text).toBe("Mid-thought when cap hit...");
-    // No marker text — reasoning is the visible content
-    expect(assistant.content.find((c) => c.type === "text")).toBeUndefined();
+    expect(reasoning?.providerOptions).toEqual({ anthropic: { signature: "sig-abc-123" } });
+  });
+
+  it("placeholder uses reasoning content only when it carries provider metadata", () => {
+    // With signature → reasoning IS the placeholder body (round-trips fine).
+    const withSig: LlmResponseEvent = {
+      ...llmText("run-1", ""),
+      content: [
+        {
+          type: "reasoning",
+          text: "Mid-thought when cap hit.",
+          providerMetadata: { anthropic: { signature: "sig-x" } },
+        },
+      ],
+      finishReason: "length",
+    };
+    const withSigMessages = reconstructMessages([
+      userMessage("hi"),
+      runStart("run-1"),
+      withSig,
+      runDone("run-1"),
+    ]);
+    const reasoning = withSigMessages[1]!.content.find((c) => c.type === "reasoning");
+    expect(reasoning).toBeDefined();
+    expect(withSigMessages[1]!.content.find((c) => c.type === "text")).toBeUndefined();
+  });
+
+  it("placeholder falls back to marker text when reasoning has no provider metadata", () => {
+    // Without signature → reasoning would be stripped by the AI SDK on
+    // replay, leaving content: []. Anthropic 400s empty assistant
+    // messages, so the reconstructor must use the marker text instead.
+    const withoutSig: LlmResponseEvent = {
+      ...llmText("run-1", ""),
+      content: [{ type: "reasoning", text: "Thoughts without signature." }],
+      finishReason: "length",
+    };
+    const messages = reconstructMessages([
+      userMessage("hi"),
+      runStart("run-1"),
+      withoutSig,
+      runDone("run-1"),
+    ]);
+    const placeholder = messages[1]!;
+    const text = placeholder.content.find(
+      (c): c is { type: "text"; text: string } => c.type === "text",
+    );
+    expect(text?.text).toContain("cut off");
+    expect(placeholder.content.find((c) => c.type === "reasoning")).toBeUndefined();
   });
 
   it("forwards finishReason from llm.response into assistant message metadata", () => {

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -6,6 +6,7 @@ import { participantColor } from "../lib/participant-colors";
 import type { DisplayDetail } from "../lib/tool-display";
 import { FileAttachment } from "./FileAttachment";
 import { InlineAppView } from "./InlineAppView";
+import { ReasoningBlock } from "./ReasoningBlock";
 import { ResourceLinkView } from "./ResourceLinkView";
 import { ToolAccordion } from "./ToolAccordion";
 
@@ -347,6 +348,20 @@ export function MessageList({
                     {/* Render content blocks in temporal order */}
                     {msg.blocks ? (
                       msg.blocks.map((block, blockIdx) => {
+                        if (block.type === "reasoning") {
+                          return (
+                            // biome-ignore lint/suspicious/noArrayIndexKey: blocks are append-only and don't reorder
+                            <ReasoningBlock
+                              key={blockIdx}
+                              text={block.text}
+                              streaming={
+                                isStreaming &&
+                                idx === messages.length - 1 &&
+                                blockIdx === msg.blocks!.length - 1
+                              }
+                            />
+                          );
+                        }
                         if (block.type === "text" && block.text) {
                           return (
                             // biome-ignore lint/suspicious/noArrayIndexKey: blocks are append-only and don't reorder

--- a/web/src/components/ReasoningBlock.tsx
+++ b/web/src/components/ReasoningBlock.tsx
@@ -1,0 +1,49 @@
+/**
+ * ReasoningBlock — collapsed-by-default view of the model's extended-thinking
+ * content. Renders above the assistant's visible text, signaling that
+ * the model deliberated before responding without crowding the message body.
+ *
+ * Interaction:
+ *   - Collapsed (default): single-line "Thoughts" affordance with a chevron.
+ *   - Expanded: the full reasoning text in a subdued container.
+ *
+ * Live streaming: while reasoning deltas are arriving, the block stays
+ * collapsed but shows a subtle "thinking…" indicator so the user knows
+ * the model is actively reasoning.
+ */
+
+import { Brain, ChevronRight } from "lucide-react";
+import { memo, useState } from "react";
+
+interface ReasoningBlockProps {
+  text: string;
+  /** True when the run is still streaming and reasoning may grow. */
+  streaming?: boolean;
+}
+
+function ReasoningBlockImpl({ text, streaming }: ReasoningBlockProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!text && !streaming) return null;
+
+  return (
+    <div className="my-2">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronRight className={`w-3 h-3 transition-transform ${expanded ? "rotate-90" : ""}`} />
+        <Brain className="w-3 h-3" />
+        <span>{streaming && !text ? "Thinking…" : "Thoughts"}</span>
+      </button>
+      {expanded && text && (
+        <div className="mt-2 ml-4 px-3 py-2 rounded-md bg-muted/30 border border-border/60 text-sm text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const ReasoningBlock = memo(ReasoningBlockImpl);

--- a/web/src/components/ReasoningBlock.tsx
+++ b/web/src/components/ReasoningBlock.tsx
@@ -38,7 +38,7 @@ function ReasoningBlockImpl({ text, streaming }: ReasoningBlockProps) {
         <span>{streaming && !text ? "Thinking…" : "Thoughts"}</span>
       </button>
       {expanded && text && (
-        <div className="mt-2 ml-4 px-3 py-2 rounded-md bg-muted/30 border border-border/60 text-sm text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
+        <div className="mt-2 ml-4 px-3 py-2 rounded-md bg-muted/30 border border-border/60 text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed">
           {text}
         </div>
       )}

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -9,6 +9,7 @@ import type {
   ChatStreamEventMap,
   ChatStreamEventType,
   LlmDoneEvent,
+  ReasoningDeltaEvent,
   StreamErrorEvent,
   TextDeltaEvent,
   ToolDoneEvent,
@@ -55,9 +56,10 @@ export interface ToolCallDisplay {
   appName?: string;
 }
 
-/** A block in the assistant message stream — text or tool call group, in temporal order. */
+/** A block in the assistant message stream — text, reasoning, or tool call group, in temporal order. */
 export type ContentBlock =
   | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
   | { type: "tool"; toolCalls: ToolCallDisplay[] };
 
 /** Live iteration progress during streaming. */
@@ -132,10 +134,14 @@ export interface UseChatReturn {
 
 /** Deep-copy blocks for immutable state updates. */
 function cloneBlocks(blocks: ContentBlock[]): ContentBlock[] {
-  return blocks.map((b) => (b.type === "text" ? { ...b } : { ...b, toolCalls: [...b.toolCalls] }));
+  return blocks.map((b) => {
+    if (b.type === "tool") return { ...b, toolCalls: [...b.toolCalls] };
+    return { ...b }; // text or reasoning — both shaped { type, text }
+  });
 }
 
-/** Derive full text from blocks. */
+/** Derive full visible text from blocks. Reasoning is NOT included
+ *  (it's collapsed-by-default UI and shouldn't pollute the message body). */
 function textFromBlocks(blocks: ContentBlock[]): string {
   return blocks
     .filter((b): b is ContentBlock & { type: "text" } => b.type === "text")
@@ -275,6 +281,19 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
                 lastBlock.text += evt.text;
               } else {
                 blocks.push({ type: "text", text: evt.text });
+              }
+              flushToMessage();
+              break;
+            }
+            case "reasoning.delta": {
+              const evt = data as ReasoningDeltaEvent;
+              setStreamingState((prev) => (prev !== "streaming" ? "streaming" : prev));
+              const blocks = blocksRef.current;
+              const lastBlock = blocks[blocks.length - 1];
+              if (lastBlock && lastBlock.type === "reasoning") {
+                lastBlock.text += evt.text;
+              } else {
+                blocks.push({ type: "reasoning", text: evt.text });
               }
               flushToMessage();
               break;
@@ -552,6 +571,19 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             lastBlock.text += evt.text;
           } else {
             blocks.push({ type: "text", text: evt.text });
+          }
+          flushToMessage();
+          break;
+        }
+        case "reasoning.delta": {
+          const evt = data as ReasoningDeltaEvent;
+          setStreamingState((prev) => (prev !== "streaming" ? "streaming" : prev));
+          const blocks = blocksRef.current;
+          const lastBlock = blocks[blocks.length - 1];
+          if (lastBlock && lastBlock.type === "reasoning") {
+            lastBlock.text += evt.text;
+          } else {
+            blocks.push({ type: "reasoning", text: evt.text });
           }
           flushToMessage();
           break;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -160,6 +160,18 @@ export interface TextDeltaEvent {
   text: string;
 }
 
+/**
+ * Streaming reasoning (extended-thinking) delta. Same shape as
+ * `TextDeltaEvent` — handled symmetrically in `useChat`. Only fires
+ * when the model emits reasoning content (Anthropic with
+ * `providerOptions.anthropic.thinking` enabled, or any model that
+ * produces reasoning by default).
+ */
+export interface ReasoningDeltaEvent {
+  runId: string;
+  text: string;
+}
+
 export interface ToolStartEvent {
   runId: string;
   name: string;
@@ -202,6 +214,8 @@ export interface LlmDoneEvent {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  /** Reasoning-token subtotal (subset of outputTokens). 0 if absent. */
+  reasoningTokens?: number;
   cacheReadTokens: number;
   cacheCreationTokens: number;
   llmMs: number;
@@ -217,6 +231,7 @@ export interface LlmDoneEvent {
 export interface ChatStreamEventMap {
   "chat.start": { conversationId: string };
   "text.delta": TextDeltaEvent;
+  "reasoning.delta": ReasoningDeltaEvent;
   "tool.start": ToolStartEvent;
   "tool.done": ToolDoneEvent;
   "llm.done": LlmDoneEvent;


### PR DESCRIPTION
## Summary
- `src/model/stream.ts` now handles `reasoning-start/delta/end` parts and pushes `reasoning` content blocks into `content[]`. Pre-PR they were silently dropped.
- Engine emits `reasoning.delta` SSE events parallel to `text.delta`; surfaces `usage.outputTokens.reasoning` as `reasoningTokens` on `llm.done`.
- Web client renders a collapsed-by-default `ReasoningBlock` ("Thoughts") above the assistant text. While streaming, it shows "Thinking…".
- Reconstructor preserves reasoning blocks and attaches them to the first message of a turn (no UI duplication when a turn produces both tool-call and text messages).
- Step 4a: empty turns with non-stop `finishReason` are no longer silently dropped on replay. A placeholder is emitted carrying `metadata.finishReason` so the truncation banner renders, and a short marker text keeps the LLM history valid (Anthropic rejects empty-content assistant messages).

## Why now
This is the third PR in a chain investigating `conv_6cf2bbacee2745cd` (HQ tenant). PRs [#104](https://github.com/NimbleBrainInc/nimblebrain/pull/104) and [#105](https://github.com/NimbleBrainInc/nimblebrain/pull/105) raised the output cap and plumbed `finishReason` end-to-end. The remaining mystery from that conversation: three turns billed 16,384 output tokens with empty visible content on Opus 4.7 — `~225s` of LLM time each.

Strong hypothesis: **Anthropic implicitly enabled extended thinking for Opus 4.7**, the AI SDK Anthropic provider parses `thinking_delta` events and forwards them as V3 `reasoning-*` stream parts (verified at `node_modules/@ai-sdk/anthropic/dist/index.js:676`), and our pre-PR `stream.ts` had no case for those parts so they were silently dropped while Anthropic still billed the tokens. This PR fixes the silent drop. **If the hypothesis is right, those previously-empty Opus turns will start rendering their reasoning content immediately after deploy, with no config change.**

If Anthropic is not implicitly enabling thinking, this PR is scaffolding for the follow-up that adds an explicit `providerOptions.anthropic.thinking` toggle (filed separately as a feature issue).

## What changed
| Layer | File | Change |
|---|---|---|
| Provider | `src/model/stream.ts` | Switch cases for `reasoning-start/delta/end`; `onReasoningDelta` callback; reasoning blocks pushed into `content[]`. Also drops the `"unknown" as "other"` runtime-vs-type lie at the default initializer. |
| Engine | `src/engine/engine.ts` | Emits `reasoning.delta` events; passes `reasoningTokens` on `llm.done`. |
| Engine types | `src/engine/types.ts` | `EngineEventType` adds `reasoning.delta`. |
| Event types | `src/conversation/types.ts` | `LlmResponseEvent.reasoningTokens` (optional). |
| Event store | `src/conversation/event-sourced-store.ts` | Forwards `reasoningTokens` on the `llm.done` mapping. |
| Reconstructor | `src/conversation/event-reconstructor.ts` | Reasoning attaches to the FIRST emitted message of a turn (avoids duplication). New empty-turn placeholder logic (step 4a) with per-`finishReason` marker text in `TRUNCATION_MARKERS`. |
| JSONL reader | `src/bundles/conversations/src/jsonl-reader.ts` | `DisplayBlock` adds `reasoning` variant; reasoning blocks emitted before text/tool blocks. |
| SSE | `src/api/handlers.ts` | Forwards `reasoning.delta` to the chat stream. |
| Web types | `web/src/types.ts` | `ReasoningDeltaEvent`; `ChatStreamEventMap.reasoning.delta`; `LlmDoneEvent.reasoningTokens`. |
| Web hook | `web/src/hooks/useChat.ts` | `ContentBlock` adds `reasoning` variant. Reasoning deltas accumulate into a `reasoning` block parallel to text. `cloneBlocks` updated. `textFromBlocks` excludes reasoning (it's collapsed UI; shouldn't pollute the message body). |
| New UI | `web/src/components/ReasoningBlock.tsx` | Collapsed-by-default accordion; "Thoughts" / "Thinking…" affordance; expand reveals reasoning text in subdued container. |
| MessageList | `web/src/components/MessageList.tsx` | Renders the reasoning block in temporal order with text/tool blocks. |

## Tests
- `test/helpers/echo-model.ts` — `EchoModelResponse.reasoning` and `reasoningTokens` overrides; `doStream` emits `reasoning-*` parts so engine tests can drive the path.
- `test/unit/engine.test.ts` — verifies `reasoning.delta` events fire, `reasoningTokens` lands on `llm.done`, and the reasoning content block round-trips.
- `test/unit/event-reconstructor.test.ts` — reasoning preservation, first-message attachment (no UI duplication), empty-turn placeholder with marker text, reasoning-only turn (no marker text).

## Out of scope (separate work)
- **Explicit thinking toggle** (feature issue forthcoming) — `providerOptions.anthropic.thinking` configuration per workspace, default `adaptive` for catalog-flagged reasoning models. Cost implications warrant their own discussion.
- **Step 4b** — `tenant-summary.py` "truncated runs" column. Independent meta-repo PR.
- **Step 4c** (Prometheus alerts) — punted.

## Test plan
- [x] `bun run verify` clean (1997 unit + 174 unit + 413 integration + 16 smoke + 2092 web, 0 fail).
- [ ] After merge: deploy to HQ tenant; trigger an Opus 4.7 turn; check whether reasoning content appears (validates the production hypothesis). If yes, the scaffolding-vs-fix question is settled.