### PR TITLE
feat: explicit thinking-mode config (closes #107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Added
 
-- Extended-thinking config — `thinking: "off" | "adaptive" | "enabled"` with optional `thinkingBudgetTokens` in runtime config and the Settings → Model UI. Defaults to `adaptive` for catalog-flagged reasoning models, `off` otherwise. Currently maps to Anthropic's `providerOptions.anthropic.thinking`; OpenAI/Google providers ignore it pending wiring.
+- Extended-thinking config (`thinking: off | adaptive | enabled` + `thinkingBudgetTokens`) in runtime config and Settings → Model; defaults to `adaptive` for catalog-flagged reasoning models, `off` otherwise ([#109](https://github.com/NimbleBrainInc/nimblebrain/pull/109)).
 - Reasoning (extended-thinking) content is now captured end-to-end: `stream.ts` handles `reasoning-*` parts, the engine emits `reasoning.delta` SSE events, and the chat UI renders a collapsed "Thoughts" block above the assistant text. Empty turns with non-stop finishReason now emit a placeholder so replay surfaces truncations.
 - `nb__read_resource` system tool — the agent can now load `skill://` / `ui://` resources advertised by an installed bundle's MCP server ([#3](https://github.com/NimbleBrainInc/nimblebrain/pull/25)).
 - `defineInProcessApp` helper for building in-process MCP sources from JSON Schema tool defs and a resource map — same authoring ergonomic as the former `InlineSource`, with the full MCP capability surface (resources, instructions, tasks, future capabilities).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- Extended-thinking config — `thinking: "off" | "adaptive" | "enabled"` with optional `thinkingBudgetTokens` in runtime config and the Settings → Model UI. Defaults to `adaptive` for catalog-flagged reasoning models, `off` otherwise. Currently maps to Anthropic's `providerOptions.anthropic.thinking`; OpenAI/Google providers ignore it pending wiring.
 - Reasoning (extended-thinking) content is now captured end-to-end: `stream.ts` handles `reasoning-*` parts, the engine emits `reasoning.delta` SSE events, and the chat UI renders a collapsed "Thoughts" block above the assistant text. Empty turns with non-stop finishReason now emit a placeholder so replay surfaces truncations.
 - `nb__read_resource` system tool — the agent can now load `skill://` / `ui://` resources advertised by an installed bundle's MCP server ([#3](https://github.com/NimbleBrainInc/nimblebrain/pull/25)).
 - `defineInProcessApp` helper for building in-process MCP sources from JSON Schema tool defs and a resource map — same authoring ergonomic as the former `InlineSource`, with the full MCP capability surface (resources, instructions, tasks, future capabilities).
@@ -24,6 +25,7 @@
 
 ### Fixed
 
+- `estimateCost` no longer double-bills reasoning tokens for models with a separate `cost.reasoning` rate. Reasoning is a subset of `outputTokens` per the V3 usage spec; the corrected formula splits rather than adds.
 - `stopReason` now reflects the model's real finish reason (length, content_filter, error, other) instead of always reporting `complete`; per-call `finishReason` is persisted on `llm.response` events and forwarded over SSE ([#105](https://github.com/NimbleBrainInc/nimblebrain/pull/105)).
 - `maxOutputTokens` is now derived per-call from the synced model catalog (`limits.output`) instead of a static 16,384 default — Opus 4.7 jumps from 16k → 128k, Sonnet 4.6 → 64k. Operator-pinned values still win, clamped to the model's catalog max ([#104](https://github.com/NimbleBrainInc/nimblebrain/pull/104)).
 - Files-app uploads no longer fail with `Payload too large`. Picker bytes now flow through `POST /v1/resources` (multipart, workspace-scoped) instead of being base64-encoded into a `tools/call` argument; `isAllowedMime` strips Content-Type parameters, fixing a latent miss in the chat ingest path too ([#93](https://github.com/NimbleBrainInc/nimblebrain/pull/93)).

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -8,6 +8,7 @@ import type {
   SharedV3ProviderOptions,
 } from "@ai-sdk/provider";
 import { MAX_ITERATIONS, MAX_TOOL_RESULT_CHARS } from "../limits.ts";
+import { getProviderFromModel } from "../model/catalog.ts";
 import { callModel, type StreamResult } from "../model/stream.ts";
 import { validateToolInput } from "../tools/validate-input.ts";
 import {
@@ -46,7 +47,7 @@ function buildThinkingProviderOptions(
 ): SharedV3ProviderOptions {
   if (!thinking) return {};
 
-  const provider = model.includes(":") ? model.split(":")[0] : "anthropic";
+  const provider = getProviderFromModel(model);
 
   if (provider === "anthropic") {
     if (thinking.mode === "off") {

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -5,6 +5,7 @@ import type {
   LanguageModelV3Message,
   LanguageModelV3ToolCall,
   LanguageModelV3ToolResultPart,
+  SharedV3ProviderOptions,
 } from "@ai-sdk/provider";
 import { MAX_ITERATIONS, MAX_TOOL_RESULT_CHARS } from "../limits.ts";
 import { callModel, type StreamResult } from "../model/stream.ts";
@@ -21,12 +22,53 @@ import type {
   EngineResult,
   EventSink,
   FinishReason,
+  ResolvedThinking,
   StopReason,
   ToolCallRecord,
   ToolResult,
   ToolRouter,
   ToolSchema,
 } from "./types.ts";
+
+/**
+ * Translate the platform's provider-neutral thinking config into the
+ * call's `providerOptions` shape. Each provider has its own option name
+ * and discriminated-union shape; we keep them confined to this helper
+ * so adding a new provider doesn't ripple through the engine loop.
+ *
+ * Today: Anthropic only. OpenAI o-series (`reasoningEffort`) and
+ * Google Gemini 2.5 (`thinkingConfig`) are TODO and ignored — those
+ * providers fall back to their own defaults until wired in.
+ */
+function buildThinkingProviderOptions(
+  model: string,
+  thinking: ResolvedThinking | undefined,
+): SharedV3ProviderOptions {
+  if (!thinking) return {};
+
+  const provider = model.includes(":") ? model.split(":")[0] : "anthropic";
+
+  if (provider === "anthropic") {
+    if (thinking.mode === "off") {
+      return { anthropic: { thinking: { type: "disabled" } } };
+    }
+    if (thinking.mode === "adaptive") {
+      return { anthropic: { thinking: { type: "adaptive" } } };
+    }
+    return {
+      anthropic: {
+        thinking: {
+          type: "enabled",
+          ...(thinking.budgetTokens != null ? { budgetTokens: thinking.budgetTokens } : {}),
+        },
+      },
+    };
+  }
+
+  // openai / google: not yet wired. The provider falls back to its own
+  // default behavior. Tracked for follow-up.
+  return {};
+}
 
 /**
  * Map a per-call finish reason to a run-level stop reason. Called once
@@ -222,6 +264,8 @@ export class AgentEngine {
             "remains unfinished so the user can continue in a follow-up message.]";
         }
 
+        const callProviderOptions = buildThinkingProviderOptions(config.model, config.thinking);
+
         const llmStart = performance.now();
         const response: StreamResult = await withRetry(() =>
           callModel(
@@ -239,6 +283,9 @@ export class AgentEngine {
               ],
               tools: modelTools,
               maxOutputTokens: config.maxOutputTokens,
+              ...(Object.keys(callProviderOptions).length > 0
+                ? { providerOptions: callProviderOptions }
+                : {}),
             },
             (text) => this.events.emit({ type: "text.delta", data: { runId, text } }),
             (text) => this.events.emit({ type: "reasoning.delta", data: { runId, text } }),

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -89,12 +89,35 @@ export interface EngineHooks {
   transformPrompt?: (prompt: string) => string;
 }
 
+/**
+ * Provider-neutral extended-thinking config. The engine translates this
+ * to per-provider options at call time:
+ *   - Anthropic — `providerOptions.anthropic.thinking.{type,budgetTokens?}`
+ *   - OpenAI o-series — `providerOptions.openai.reasoningEffort` (TODO)
+ *   - Google Gemini 2.5 — `providerOptions.google.thinkingConfig` (TODO)
+ *   - Any other provider — ignored
+ *
+ * Resolution priority is handled upstream (see resolveThinking in
+ * src/runtime/resolve-thinking.ts); the engine receives an already-
+ * resolved value or `undefined` for "let the provider default decide".
+ */
+export interface ResolvedThinking {
+  mode: "off" | "adaptive" | "enabled";
+  /** Token budget for `enabled`. Ignored for `off`/`adaptive`. */
+  budgetTokens?: number;
+}
+
 /** Engine configuration per run. */
 export interface EngineConfig {
   model: string;
   maxIterations: number;
   maxInputTokens: number;
   maxOutputTokens: number;
+  /**
+   * Resolved thinking option for this call. Optional; absent means the
+   * engine doesn't request thinking (provider default behavior).
+   */
+  thinking?: ResolvedThinking;
   hooks?: EngineHooks;
   /**
    * AbortSignal for run cancellation.

--- a/src/model/catalog.ts
+++ b/src/model/catalog.ts
@@ -118,6 +118,15 @@ export function getProviderName(provider: string): string {
 /**
  * Estimate cost in USD from token usage.
  * Returns 0 for models not in catalog.
+ *
+ * Pricing model: reasoning tokens are a SUBSET of `outputTokens` per the
+ * AI SDK V3 usage spec (`outputTokens.total = text + reasoning`). When a
+ * model has a distinct `cost.reasoning` rate, reasoning tokens are
+ * billed at that rate and the remainder of `outputTokens` at `cost.output`
+ * — splitting rather than adding (the previous formula double-charged
+ * reasoning tokens at the output rate AND the reasoning rate). When the
+ * model lacks `cost.reasoning`, all output tokens bill at `cost.output`,
+ * including any reasoning subtotal.
  */
 export function estimateCost(modelString: string, usage: TokenUsage): number {
   const model = getModelByString(modelString);
@@ -125,12 +134,17 @@ export function estimateCost(modelString: string, usage: TokenUsage): number {
   const c = model.cost;
 
   const cacheRead = usage.cacheReadTokens ?? 0;
+  const reasoning = usage.reasoningTokens ?? 0;
+  const outputNonReasoning =
+    c.reasoning != null ? Math.max(usage.outputTokens - reasoning, 0) : usage.outputTokens;
+  const reasoningCost = c.reasoning != null ? reasoning * c.reasoning : 0;
+
   return (
     (usage.inputTokens * c.input +
-      usage.outputTokens * c.output +
+      outputNonReasoning * c.output +
+      reasoningCost +
       cacheRead * (c.cacheRead ?? c.input) +
-      (usage.cacheWriteTokens ?? 0) * (c.cacheWrite ?? c.input) +
-      (usage.reasoningTokens ?? 0) * (c.reasoning ?? c.output)) /
+      (usage.cacheWriteTokens ?? 0) * (c.cacheWrite ?? c.input)) /
     1_000_000
   );
 }

--- a/src/model/catalog.ts
+++ b/src/model/catalog.ts
@@ -188,3 +188,12 @@ function parseModelString(modelString: string): { provider: string; modelId: str
   if (idx === -1) return { provider: "anthropic", modelId: modelString };
   return { provider: modelString.slice(0, idx), modelId: modelString.slice(idx + 1) };
 }
+
+/**
+ * Extract the provider name from a model string. Bare strings (no `:`)
+ * are treated as `"anthropic"` — same rule as `getModelByString`.
+ * Single source of truth for that convention.
+ */
+export function getProviderFromModel(modelString: string): string {
+  return parseModelString(modelString).provider;
+}

--- a/src/runtime/resolve-thinking.ts
+++ b/src/runtime/resolve-thinking.ts
@@ -1,0 +1,44 @@
+import type { ResolvedThinking } from "../engine/types.ts";
+import { getModelByString } from "../model/catalog.ts";
+
+export interface ResolveThinkingInput {
+  /** Operator/tenant config value. Wins over the model-default. */
+  configMode?: "off" | "adaptive" | "enabled";
+  /** Operator-pinned token budget for `enabled` mode. */
+  configBudgetTokens?: number;
+  /** Resolved model string (e.g. `"anthropic:claude-opus-4-7"`). */
+  model?: string;
+}
+
+/**
+ * Resolve the effective thinking mode for an LLM call.
+ *
+ * The platform's policy:
+ *   - If the operator pinned a `configMode`, use it as-is. Their call.
+ *   - Otherwise: `adaptive` for catalog-flagged reasoning-capable models,
+ *     `off` for everything else.
+ *
+ * Returns `undefined` when the resolved mode is `off` AND there's no
+ * operator override — that signals "don't pass thinking to the provider
+ * at all" (the cheapest, most boring path). When the operator explicitly
+ * sets `off`, the engine still passes a provider-specific "disabled"
+ * option so the provider doesn't fall back to its own default.
+ */
+export function resolveThinking(input: ResolveThinkingInput): ResolvedThinking | undefined {
+  if (input.configMode != null) {
+    return {
+      mode: input.configMode,
+      ...(input.configBudgetTokens != null && input.configBudgetTokens > 0
+        ? { budgetTokens: input.configBudgetTokens }
+        : {}),
+    };
+  }
+
+  // No operator override — fall back to model capability.
+  const supportsReasoning = input.model
+    ? (getModelByString(input.model)?.capabilities.reasoning ?? false)
+    : false;
+
+  if (supportsReasoning) return { mode: "adaptive" };
+  return undefined;
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1387,7 +1387,16 @@ export class Runtime {
     });
   }
 
-  /** Update live runtime config (in-memory). Called by set_config tool after disk write. */
+  /**
+   * Update live runtime config (in-memory). Called by set_config tool
+   * after disk write.
+   *
+   * For `thinking` and `thinkingBudgetTokens`, `null` is the explicit
+   * "clear my override" sentinel — distinct from `undefined` (leave the
+   * field alone). After clearing, the resolver falls back to the
+   * platform default policy (adaptive for catalog-flagged reasoning
+   * models, off otherwise).
+   */
   updateConfig(patch: {
     defaultModel?: string;
     models?: Partial<ModelSlots>;
@@ -1395,8 +1404,8 @@ export class Runtime {
     maxInputTokens?: number;
     maxOutputTokens?: number;
     maxToolResultSize?: number;
-    thinking?: "off" | "adaptive" | "enabled";
-    thinkingBudgetTokens?: number;
+    thinking?: "off" | "adaptive" | "enabled" | null;
+    thinkingBudgetTokens?: number | null;
     preferences?: Record<string, string>;
   }) {
     if (patch.models) {
@@ -1417,9 +1426,20 @@ export class Runtime {
     if (patch.maxOutputTokens !== undefined) this.config.maxOutputTokens = patch.maxOutputTokens;
     if (patch.maxToolResultSize !== undefined)
       this.config.maxToolResultSize = patch.maxToolResultSize;
-    if (patch.thinking !== undefined) this.config.thinking = patch.thinking;
-    if (patch.thinkingBudgetTokens !== undefined)
-      this.config.thinkingBudgetTokens = patch.thinkingBudgetTokens;
+    if (patch.thinking !== undefined) {
+      if (patch.thinking === null) {
+        this.config.thinking = undefined;
+      } else {
+        this.config.thinking = patch.thinking;
+      }
+    }
+    if (patch.thinkingBudgetTokens !== undefined) {
+      if (patch.thinkingBudgetTokens === null) {
+        this.config.thinkingBudgetTokens = undefined;
+      } else {
+        this.config.thinkingBudgetTokens = patch.thinkingBudgetTokens;
+      }
+    }
   }
 
   /** Get loaded context skills (for skill_status tool). */

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -74,6 +74,7 @@ const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 import { DEFAULT_MAX_INPUT_TOKENS, DEFAULT_MAX_ITERATIONS } from "../limits.ts";
 import { resolveMaxOutputTokens } from "./resolve-max-output-tokens.ts";
+import { resolveThinking } from "./resolve-thinking.ts";
 
 const DEFAULT_MAX_HISTORY_MESSAGES = 40;
 
@@ -333,8 +334,11 @@ export class Runtime {
       defaultModel: getDefaultModel(),
       defaultMaxInputTokens: maxInputTokens,
       // Raw operator config (may be undefined). Delegate resolves against
-      // the child's model via resolveMaxOutputTokens at execution time.
+      // the child's model at execution time so the resolved values fit
+      // the child's model rather than the parent's.
       configMaxOutputTokens: config.maxOutputTokens,
+      configThinking: config.thinking,
+      configThinkingBudgetTokens: config.thinkingBudgetTokens,
     };
 
     // System tools (search, manage_app, bundle_status, manage_skill, delegate)
@@ -720,6 +724,12 @@ export class Runtime {
       resolvedModelString = this.getModelSlot(aliasSlot);
     }
 
+    const resolvedThinking = resolveThinking({
+      configMode: this.config.thinking,
+      configBudgetTokens: this.config.thinkingBudgetTokens,
+      model: resolvedModelString,
+    });
+
     const engineConfig: EngineConfig = {
       model: resolvedModelString,
       maxIterations: request.maxIterations ?? this.config.maxIterations ?? DEFAULT_MAX_ITERATIONS,
@@ -728,6 +738,7 @@ export class Runtime {
         configValue: this.config.maxOutputTokens,
         model: resolvedModelString,
       }),
+      ...(resolvedThinking ? { thinking: resolvedThinking } : {}),
       maxToolResultSize: this.config.maxToolResultSize,
       hooks: this.hooks,
     };
@@ -1384,6 +1395,8 @@ export class Runtime {
     maxInputTokens?: number;
     maxOutputTokens?: number;
     maxToolResultSize?: number;
+    thinking?: "off" | "adaptive" | "enabled";
+    thinkingBudgetTokens?: number;
     preferences?: Record<string, string>;
   }) {
     if (patch.models) {
@@ -1404,6 +1417,9 @@ export class Runtime {
     if (patch.maxOutputTokens !== undefined) this.config.maxOutputTokens = patch.maxOutputTokens;
     if (patch.maxToolResultSize !== undefined)
       this.config.maxToolResultSize = patch.maxToolResultSize;
+    if (patch.thinking !== undefined) this.config.thinking = patch.thinking;
+    if (patch.thinkingBudgetTokens !== undefined)
+      this.config.thinkingBudgetTokens = patch.thinkingBudgetTokens;
   }
 
   /** Get loaded context skills (for skill_status tool). */
@@ -1428,6 +1444,9 @@ export class Runtime {
     maxIterations: number;
     maxInputTokens: number;
     maxOutputTokens: number;
+    /** Operator-pinned thinking mode if set; absent when relying on model-default policy. */
+    thinking?: "off" | "adaptive" | "enabled";
+    thinkingBudgetTokens?: number;
   } {
     return {
       models: this.getModelSlots(),
@@ -1438,6 +1457,10 @@ export class Runtime {
         configValue: this.config.maxOutputTokens,
         model: this.getDefaultModel(),
       }),
+      ...(this.config.thinking !== undefined ? { thinking: this.config.thinking } : {}),
+      ...(this.config.thinkingBudgetTokens !== undefined
+        ? { thinkingBudgetTokens: this.config.thinkingBudgetTokens }
+        : {}),
     };
   }
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -63,6 +63,27 @@ export interface RuntimeConfig {
   /** Max output tokens per LLM call. Default: 16_384. */
   maxOutputTokens?: number;
 
+  /**
+   * Extended-thinking mode. Currently maps to Anthropic's `thinking`
+   * provider option; non-Anthropic providers ignore it.
+   *
+   *   - `off`        — never request thinking. Cheapest; no reasoning content.
+   *   - `adaptive`   — model decides per call (Anthropic's recommended default
+   *                    for reasoning-capable models like Opus 4.7 / Sonnet 4.6).
+   *   - `enabled`    — always think, with optional `thinkingBudgetTokens` cap.
+   *
+   * If unset, the platform defaults to `adaptive` for catalog-flagged
+   * reasoning-capable models and `off` otherwise.
+   */
+  thinking?: "off" | "adaptive" | "enabled";
+
+  /**
+   * Token budget when `thinking === "enabled"`. Counts toward
+   * `maxOutputTokens`. Ignored for `off`/`adaptive`. Anthropic requires
+   * a minimum of 1,024 tokens.
+   */
+  thinkingBudgetTokens?: number;
+
   /** Max conversation history messages to keep. Default: 40. */
   maxHistoryMessages?: number;
 

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -169,13 +169,14 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             description: "Max output tokens per LLM call (must be > 0).",
           },
           thinking: {
-            type: "string",
-            enum: ["off", "adaptive", "enabled"],
+            type: ["string", "null"],
+            enum: ["off", "adaptive", "enabled", null],
             description:
               "Extended-thinking mode for reasoning-capable models. " +
               "off: never reason. adaptive: model decides per call. " +
               "enabled: always reason (use thinkingBudgetTokens to cap). " +
-              "Unset = adaptive for catalog-flagged reasoning models, off otherwise.",
+              "null: clear the operator override and revert to platform default " +
+              "(adaptive for catalog-flagged reasoning models, off otherwise).",
           },
           thinkingBudgetTokens: {
             type: "number",
@@ -291,16 +292,21 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               };
             }
           }
-          if (input.thinking !== undefined) {
+          // `null` is the explicit "clear my override" sentinel — distinct
+          // from `undefined` (skip this field). Validate string values
+          // against the enum; pass through nulls unchanged.
+          if (input.thinking !== undefined && input.thinking !== null) {
             const v = String(input.thinking);
             if (v !== "off" && v !== "adaptive" && v !== "enabled") {
               return {
-                content: textContent('thinking must be one of "off", "adaptive", "enabled".'),
+                content: textContent(
+                  'thinking must be "off", "adaptive", "enabled", or null (clear override).',
+                ),
                 isError: true,
               };
             }
           }
-          if (input.thinkingBudgetTokens !== undefined) {
+          if (input.thinkingBudgetTokens !== undefined && input.thinkingBudgetTokens !== null) {
             const n = Number(input.thinkingBudgetTokens);
             if (!Number.isInteger(n) || n < 1024) {
               return {
@@ -321,6 +327,28 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             // File doesn't exist or invalid — start fresh
           }
 
+          // Cross-field validation: thinking="enabled" requires a budget,
+          // either from this patch or already in the persisted config.
+          // Without one, the Anthropic SDK silently downgrades to its
+          // 1,024-token minimum — almost certainly not the operator's
+          // intent. Force the explicit choice.
+          if (input.thinking === "enabled") {
+            const patchBudget =
+              input.thinkingBudgetTokens !== undefined && input.thinkingBudgetTokens !== null
+                ? Number(input.thinkingBudgetTokens)
+                : undefined;
+            const existingBudget = existing.thinkingBudgetTokens as number | undefined;
+            if (patchBudget == null && existingBudget == null) {
+              return {
+                content: textContent(
+                  'thinking="enabled" requires thinkingBudgetTokens (≥ 1024). ' +
+                    "Provide a budget alongside enabled, or use adaptive instead.",
+                ),
+                isError: true,
+              };
+            }
+          }
+
           // Merge only allowed fields
           if (input.models !== undefined && typeof input.models === "object") {
             const modelsObj = input.models as Record<string, unknown>;
@@ -339,9 +367,20 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             existing.maxInputTokens = Number(input.maxInputTokens);
           if (input.maxOutputTokens !== undefined)
             existing.maxOutputTokens = Number(input.maxOutputTokens);
-          if (input.thinking !== undefined) existing.thinking = String(input.thinking);
-          if (input.thinkingBudgetTokens !== undefined)
+          // null = clear the operator override; undefined = leave alone.
+          if (input.thinking === null) {
+            delete existing.thinking;
+            // Clearing the mode also clears the budget — a budget without
+            // a mode is meaningless and would otherwise hang around.
+            delete existing.thinkingBudgetTokens;
+          } else if (input.thinking !== undefined) {
+            existing.thinking = String(input.thinking);
+          }
+          if (input.thinkingBudgetTokens === null) {
+            delete existing.thinkingBudgetTokens;
+          } else if (input.thinkingBudgetTokens !== undefined) {
             existing.thinkingBudgetTokens = Number(input.thinkingBudgetTokens);
+          }
           // Atomic write: write to temp file, then rename
           const tmpPath = `${configPath}.tmp.${Date.now()}`;
           await writeFile(tmpPath, `${JSON.stringify(existing, null, 2)}\n`, "utf-8");
@@ -371,11 +410,20 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             ...(input.maxOutputTokens !== undefined
               ? { maxOutputTokens: Number(input.maxOutputTokens) }
               : {}),
+            // `null` is the clear-override sentinel. It propagates to
+            // updateConfig as null so the live runtime drops the field
+            // alongside the disk write.
             ...(input.thinking !== undefined
-              ? { thinking: String(input.thinking) as "off" | "adaptive" | "enabled" }
+              ? input.thinking === null
+                ? { thinking: null, thinkingBudgetTokens: null }
+                : {
+                    thinking: String(input.thinking) as "off" | "adaptive" | "enabled",
+                  }
               : {}),
-            ...(input.thinkingBudgetTokens !== undefined
-              ? { thinkingBudgetTokens: Number(input.thinkingBudgetTokens) }
+            ...(input.thinkingBudgetTokens !== undefined && input.thinking !== null
+              ? input.thinkingBudgetTokens === null
+                ? { thinkingBudgetTokens: null }
+                : { thinkingBudgetTokens: Number(input.thinkingBudgetTokens) }
               : {}),
           });
 

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -179,10 +179,11 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               "(adaptive for catalog-flagged reasoning models, off otherwise).",
           },
           thinkingBudgetTokens: {
-            type: "number",
+            type: ["number", "null"],
             description:
               "Token budget when thinking=enabled. Counts toward maxOutputTokens. " +
-              "Anthropic requires a minimum of 1,024.",
+              "Anthropic requires a minimum of 1,024. " +
+              "null: clear any persisted budget.",
           },
         },
       },
@@ -332,12 +333,22 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
           // Without one, the Anthropic SDK silently downgrades to its
           // 1,024-token minimum — almost certainly not the operator's
           // intent. Force the explicit choice.
+          //
+          // Important edge case: when the patch is *clearing* the budget
+          // (thinkingBudgetTokens=null), the merge below deletes the
+          // existing budget. The validator must mirror that — treating
+          // existingBudget as gone — so a patch like
+          //   { thinking: "enabled", thinkingBudgetTokens: null }
+          // can't slip past by relying on a budget the merge will drop.
           if (input.thinking === "enabled") {
+            const clearingBudget = input.thinkingBudgetTokens === null;
             const patchBudget =
-              input.thinkingBudgetTokens !== undefined && input.thinkingBudgetTokens !== null
+              !clearingBudget && input.thinkingBudgetTokens !== undefined
                 ? Number(input.thinkingBudgetTokens)
                 : undefined;
-            const existingBudget = existing.thinkingBudgetTokens as number | undefined;
+            const existingBudget = clearingBudget
+              ? undefined
+              : (existing.thinkingBudgetTokens as number | undefined);
             if (patchBudget == null && existingBudget == null) {
               return {
                 content: textContent(

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -76,6 +76,7 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
           const maxIterations = runtime.getMaxIterations();
           const maxInputTokens = runtime.getMaxInputTokens();
           const maxOutputTokens = runtime.getMaxOutputTokens();
+          const runtimeConfig = runtime.getRuntimeConfig();
           const identity = runtime.getCurrentIdentity();
           const preferences = identity?.preferences ?? {};
           return {
@@ -88,6 +89,10 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               maxIterations,
               maxInputTokens,
               maxOutputTokens,
+              ...(runtimeConfig.thinking !== undefined ? { thinking: runtimeConfig.thinking } : {}),
+              ...(runtimeConfig.thinkingBudgetTokens !== undefined
+                ? { thinkingBudgetTokens: runtimeConfig.thinkingBudgetTokens }
+                : {}),
               preferences: {
                 displayName: identity?.displayName ?? "",
                 timezone: preferences.timezone ?? "",
@@ -162,6 +167,21 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
           maxOutputTokens: {
             type: "number",
             description: "Max output tokens per LLM call (must be > 0).",
+          },
+          thinking: {
+            type: "string",
+            enum: ["off", "adaptive", "enabled"],
+            description:
+              "Extended-thinking mode for reasoning-capable models. " +
+              "off: never reason. adaptive: model decides per call. " +
+              "enabled: always reason (use thinkingBudgetTokens to cap). " +
+              "Unset = adaptive for catalog-flagged reasoning models, off otherwise.",
+          },
+          thinkingBudgetTokens: {
+            type: "number",
+            description:
+              "Token budget when thinking=enabled. Counts toward maxOutputTokens. " +
+              "Anthropic requires a minimum of 1,024.",
           },
         },
       },
@@ -271,6 +291,26 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               };
             }
           }
+          if (input.thinking !== undefined) {
+            const v = String(input.thinking);
+            if (v !== "off" && v !== "adaptive" && v !== "enabled") {
+              return {
+                content: textContent('thinking must be one of "off", "adaptive", "enabled".'),
+                isError: true,
+              };
+            }
+          }
+          if (input.thinkingBudgetTokens !== undefined) {
+            const n = Number(input.thinkingBudgetTokens);
+            if (!Number.isInteger(n) || n < 1024) {
+              return {
+                content: textContent(
+                  "thinkingBudgetTokens must be a positive integer ≥ 1024 (Anthropic minimum).",
+                ),
+                isError: true,
+              };
+            }
+          }
 
           // Read current config
           let existing: Record<string, unknown> = {};
@@ -299,6 +339,9 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             existing.maxInputTokens = Number(input.maxInputTokens);
           if (input.maxOutputTokens !== undefined)
             existing.maxOutputTokens = Number(input.maxOutputTokens);
+          if (input.thinking !== undefined) existing.thinking = String(input.thinking);
+          if (input.thinkingBudgetTokens !== undefined)
+            existing.thinkingBudgetTokens = Number(input.thinkingBudgetTokens);
           // Atomic write: write to temp file, then rename
           const tmpPath = `${configPath}.tmp.${Date.now()}`;
           await writeFile(tmpPath, `${JSON.stringify(existing, null, 2)}\n`, "utf-8");
@@ -327,6 +370,12 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               : {}),
             ...(input.maxOutputTokens !== undefined
               ? { maxOutputTokens: Number(input.maxOutputTokens) }
+              : {}),
+            ...(input.thinking !== undefined
+              ? { thinking: String(input.thinking) as "off" | "adaptive" | "enabled" }
+              : {}),
+            ...(input.thinkingBudgetTokens !== undefined
+              ? { thinkingBudgetTokens: Number(input.thinkingBudgetTokens) }
               : {}),
           });
 

--- a/src/tools/delegate.ts
+++ b/src/tools/delegate.ts
@@ -12,6 +12,7 @@ import type {
 } from "../engine/types.ts";
 import { DEFAULT_CHILD_ITERATIONS, MAX_CHILD_ITERATIONS } from "../limits.ts";
 import { resolveMaxOutputTokens } from "../runtime/resolve-max-output-tokens.ts";
+import { resolveThinking } from "../runtime/resolve-thinking.ts";
 import { filterTools } from "../runtime/tools.ts";
 import type { AgentProfile } from "../runtime/types.ts";
 import type { InProcessTool } from "./in-process-app.ts";
@@ -45,6 +46,10 @@ export interface DelegateContext {
    * that fits its model rather than the parent's.
    */
   configMaxOutputTokens?: number;
+  /** Operator-pinned thinking mode (raw runtime config, may be undefined). */
+  configThinking?: "off" | "adaptive" | "enabled";
+  /** Operator-pinned thinking budget (raw runtime config, may be undefined). */
+  configThinkingBudgetTokens?: number;
 }
 
 /**
@@ -182,6 +187,12 @@ export function createDelegateTool(ctx: DelegateContext): InProcessTool {
         const parentRunId = ctx.getParentRunId();
         const childEvents = new ChildEventSink(ctx.events, parentRunId);
 
+        const childThinking = resolveThinking({
+          configMode: ctx.configThinking,
+          configBudgetTokens: ctx.configThinkingBudgetTokens,
+          model: modelString,
+        });
+
         // Create child engine config
         const childConfig: EngineConfig = {
           model: modelString,
@@ -191,6 +202,7 @@ export function createDelegateTool(ctx: DelegateContext): InProcessTool {
             configValue: ctx.configMaxOutputTokens,
             model: modelString,
           }),
+          ...(childThinking ? { thinking: childThinking } : {}),
         };
 
         // Wrap the parent router in a filtering proxy when tool globs are active.

--- a/src/tools/platform/helpers/runtime-config.ts
+++ b/src/tools/platform/helpers/runtime-config.ts
@@ -5,6 +5,8 @@ export interface RuntimeConfigResult {
   maxIterations: number;
   maxInputTokens: number;
   maxOutputTokens: number;
+  thinking?: "off" | "adaptive" | "enabled";
+  thinkingBudgetTokens?: number;
   configuredProviders: string[];
   preferences: {
     displayName: string;
@@ -35,6 +37,10 @@ export function getRuntimeConfig(runtime: Runtime): RuntimeConfigResult {
     maxIterations: cfg.maxIterations,
     maxInputTokens: cfg.maxInputTokens,
     maxOutputTokens: cfg.maxOutputTokens,
+    ...(cfg.thinking !== undefined ? { thinking: cfg.thinking } : {}),
+    ...(cfg.thinkingBudgetTokens !== undefined
+      ? { thinkingBudgetTokens: cfg.thinkingBudgetTokens }
+      : {}),
     configuredProviders: runtime.getConfiguredProviders(),
     preferences: {
       displayName: tenantPrefs.displayName ?? "",

--- a/src/tools/platform/sections/model.ts
+++ b/src/tools/platform/sections/model.ts
@@ -123,7 +123,12 @@ const CONFIG_SECTION_SCRIPT = `
 				maxOutputTokens: parseInt(document.getElementById("cfg-output").value, 10),
 			};
 			var thinkingValue = thinkingSel.value;
-			if (thinkingValue) {
+			if (thinkingValue === "") {
+				// "Default" — clear any persisted override so the resolver falls
+				// back to the platform default policy.
+				patch.thinking = null;
+				patch.thinkingBudgetTokens = null;
+			} else {
 				patch.thinking = thinkingValue;
 				if (thinkingValue === "enabled") {
 					patch.thinkingBudgetTokens = parseInt(document.getElementById("cfg-budget").value, 10);

--- a/src/tools/platform/sections/model.ts
+++ b/src/tools/platform/sections/model.ts
@@ -81,6 +81,18 @@ const CONFIG_SECTION_SCRIPT = `
 			+ '<div class="field"><label for="cfg-output">Max Output Tokens</label>'
 			+ '<input type="number" id="cfg-output" min="1" value="' + cfg.maxOutputTokens + '" />'
 			+ '<div class="hint">Maximum tokens per LLM response.</div></div>'
+			+ '<div class="field"><label for="cfg-thinking">Extended Thinking</label>'
+			+ '<select id="cfg-thinking">'
+			+ '<option value="">Default (adaptive for reasoning models, off otherwise)</option>'
+			+ '<option value="off"' + (cfg.thinking === "off" ? " selected" : "") + '>Off — never reason</option>'
+			+ '<option value="adaptive"' + (cfg.thinking === "adaptive" ? " selected" : "") + '>Adaptive — model decides per call</option>'
+			+ '<option value="enabled"' + (cfg.thinking === "enabled" ? " selected" : "") + '>Enabled — always reason</option>'
+			+ '</select>'
+			+ '<div class="hint">Anthropic-only today. Reasoning is billed; adaptive only engages when the model judges it useful.</div></div>'
+			+ '<div class="field" id="cfg-budget-row" style="' + (cfg.thinking === "enabled" ? "" : "display:none") + '">'
+			+ '<label for="cfg-budget">Thinking Budget Tokens</label>'
+			+ '<input type="number" id="cfg-budget" min="1024" value="' + (cfg.thinkingBudgetTokens || 16000) + '" />'
+			+ '<div class="hint">Min 1024. Counts toward Max Output Tokens.</div></div>'
 			+ '<div class="actions">'
 			+ '<button class="save-btn" id="cfg-save">Save</button>'
 			+ '<span class="feedback" id="cfg-feedback"></span>'
@@ -89,6 +101,11 @@ const CONFIG_SECTION_SCRIPT = `
 
 		var saveBtn = document.getElementById("cfg-save");
 		var feedback = document.getElementById("cfg-feedback");
+		var thinkingSel = document.getElementById("cfg-thinking");
+		var budgetRow = document.getElementById("cfg-budget-row");
+		thinkingSel.addEventListener("change", function() {
+			budgetRow.style.display = thinkingSel.value === "enabled" ? "" : "none";
+		});
 
 		saveBtn.addEventListener("click", async function() {
 			saveBtn.disabled = true;
@@ -105,6 +122,13 @@ const CONFIG_SECTION_SCRIPT = `
 				maxInputTokens: parseInt(document.getElementById("cfg-input").value, 10),
 				maxOutputTokens: parseInt(document.getElementById("cfg-output").value, 10),
 			};
+			var thinkingValue = thinkingSel.value;
+			if (thinkingValue) {
+				patch.thinking = thinkingValue;
+				if (thinkingValue === "enabled") {
+					patch.thinkingBudgetTokens = parseInt(document.getElementById("cfg-budget").value, 10);
+				}
+			}
 
 			try {
 				var result = await callTool("nb__set_model_config", patch);

--- a/test/integration/core-source.test.ts
+++ b/test/integration/core-source.test.ts
@@ -214,6 +214,91 @@ describe("Core Source", () => {
 		}
 	});
 
+	it("nb__set_model_config rejects thinking='enabled' without a budget", async () => {
+		const workDir = join(testDir, `work-thinking-noburget-${Date.now()}`);
+		mkdirSync(workDir, { recursive: true });
+		const configPath = join(workDir, "nimblebrain.json");
+		writeFileSync(configPath, JSON.stringify({ version: "1" }));
+
+		const runtime = await Runtime.start({
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			configPath,
+			logging: { disabled: true },
+		});
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
+			const result = await source.execute("set_model_config", {
+				thinking: "enabled",
+			});
+			expect(result.isError).toBe(true);
+			expect(extractText(result.content)).toContain("requires thinkingBudgetTokens");
+		} finally {
+			await runtime.shutdown();
+		}
+	});
+
+	it("nb__set_model_config accepts thinking='enabled' with a valid budget", async () => {
+		const workDir = join(testDir, `work-thinking-ok-${Date.now()}`);
+		mkdirSync(workDir, { recursive: true });
+		const configPath = join(workDir, "nimblebrain.json");
+		writeFileSync(configPath, JSON.stringify({ version: "1" }));
+
+		const runtime = await Runtime.start({
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			configPath,
+			logging: { disabled: true },
+		});
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
+			const result = await source.execute("set_model_config", {
+				thinking: "enabled",
+				thinkingBudgetTokens: 8192,
+			});
+			expect(result.isError).toBe(false);
+			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+			expect(raw.thinking).toBe("enabled");
+			expect(raw.thinkingBudgetTokens).toBe(8192);
+		} finally {
+			await runtime.shutdown();
+		}
+	});
+
+	it("nb__set_model_config thinking=null clears the override (and budget)", async () => {
+		const workDir = join(testDir, `work-thinking-clear-${Date.now()}`);
+		mkdirSync(workDir, { recursive: true });
+		const configPath = join(workDir, "nimblebrain.json");
+		// Pre-existing operator override
+		writeFileSync(
+			configPath,
+			JSON.stringify({ thinking: "enabled", thinkingBudgetTokens: 8192 }),
+		);
+
+		const runtime = await Runtime.start({
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			configPath,
+			logging: { disabled: true },
+		});
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
+			const result = await source.execute("set_model_config", {
+				thinking: null,
+			});
+			expect(result.isError).toBe(false);
+			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+			expect(raw.thinking).toBeUndefined();
+			// Budget is cleared together — a budget without a mode is meaningless.
+			expect(raw.thinkingBudgetTokens).toBeUndefined();
+		} finally {
+			await runtime.shutdown();
+		}
+	});
+
 	it("nb__set_model_config without configPath returns error", async () => {
 		const runtime = await makeRuntime();
 		try {

--- a/test/integration/core-source.test.ts
+++ b/test/integration/core-source.test.ts
@@ -267,6 +267,42 @@ describe("Core Source", () => {
 		}
 	});
 
+	it("nb__set_model_config rejects thinking='enabled' + budget=null even with an existing budget", async () => {
+		// The existing budget would survive validation if the validator
+		// only checked disk state, but the merge then deletes it — leaving
+		// thinking=enabled with no budget, the silent-downgrade trap.
+		const workDir = join(testDir, `work-thinking-clearbudget-${Date.now()}`);
+		mkdirSync(workDir, { recursive: true });
+		const configPath = join(workDir, "nimblebrain.json");
+		writeFileSync(
+			configPath,
+			JSON.stringify({ thinking: "enabled", thinkingBudgetTokens: 8192 }),
+		);
+
+		const runtime = await Runtime.start({
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			configPath,
+			logging: { disabled: true },
+		});
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
+			const result = await source.execute("set_model_config", {
+				thinking: "enabled",
+				thinkingBudgetTokens: null,
+			});
+			expect(result.isError).toBe(true);
+			expect(extractText(result.content)).toContain("requires thinkingBudgetTokens");
+			// Disk untouched
+			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+			expect(raw.thinking).toBe("enabled");
+			expect(raw.thinkingBudgetTokens).toBe(8192);
+		} finally {
+			await runtime.shutdown();
+		}
+	});
+
 	it("nb__set_model_config thinking=null clears the override (and budget)", async () => {
 		const workDir = join(testDir, `work-thinking-clear-${Date.now()}`);
 		mkdirSync(workDir, { recursive: true });

--- a/test/unit/catalog.test.ts
+++ b/test/unit/catalog.test.ts
@@ -140,6 +140,33 @@ describe("estimateCost from catalog", () => {
 		expect(cost).toBe(0);
 	});
 
+	it("does not double-bill reasoning tokens when cost.reasoning is set", () => {
+		// Construct synthetic usage where reasoning is the entire output.
+		// If the formula were `output*c.output + reasoning*c.reasoning`, a
+		// reasoning-heavy turn would be charged twice. With the corrected
+		// formula, the reasoning subset bills at c.reasoning and the
+		// remainder at c.output.
+		//
+		// Use a model that has cost.reasoning set in the catalog. Falls
+		// back gracefully if no such model exists in the bundled snapshot.
+		// (As of writing, no Anthropic model in the catalog has cost.reasoning
+		// — the field is reserved for providers that bill reasoning separately.
+		// We assert behavior using the equivalent default-output path.)
+		const c1 = estimateCost("anthropic:claude-opus-4-7", {
+			inputTokens: 0,
+			outputTokens: 1000,
+			reasoningTokens: 1000,
+		});
+		const c2 = estimateCost("anthropic:claude-opus-4-7", {
+			inputTokens: 0,
+			outputTokens: 1000,
+			// No reasoning subtotal.
+		});
+		// Without cost.reasoning set, both formulas should yield the same
+		// total — i.e., reasoning isn't being added on top of output.
+		expect(c1).toBe(c2);
+	});
+
 	it("cache read tokens reduce vs full input pricing", () => {
 		const model = getModelByString("anthropic:claude-sonnet-4-6");
 		expect(model!.cost.cacheRead).toBeLessThan(model!.cost.input);

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -428,6 +428,89 @@ describe("AgentEngine", () => {
       expect(result.stopReason).toBe("max_iterations");
     });
 
+    it("threads ResolvedThinking into providerOptions.anthropic.thinking on the call", async () => {
+      // Captures the call options the engine sends to the model. Asserts
+      // the platform's provider-neutral thinking config is translated to
+      // the Anthropic-specific shape without leaking through other layers.
+      const capturedOptions: Array<Record<string, unknown>> = [];
+      const recordingModel: LanguageModelV3 = {
+        ...createEchoModel({ responses: [{ text: "ok" }] }),
+      };
+      const orig = recordingModel.doStream.bind(recordingModel);
+      recordingModel.doStream = async (callOptions) => {
+        capturedOptions.push(callOptions as unknown as Record<string, unknown>);
+        return orig(callOptions);
+      };
+
+      await new AgentEngine(
+        recordingModel,
+        new StaticToolRouter([], () => ({ content: textContent(""), isError: false })),
+        new NoopEventSink(),
+      ).run(
+        {
+          ...defaultConfig,
+          model: "anthropic:claude-opus-4-7",
+          thinking: { mode: "enabled", budgetTokens: 4096 },
+        },
+        "",
+        [{ role: "user", content: [{ type: "text", text: "x" }] }],
+        [],
+      );
+
+      expect(capturedOptions).toHaveLength(1);
+      const po = capturedOptions[0]!.providerOptions as
+        | { anthropic?: { thinking?: { type: string; budgetTokens?: number } } }
+        | undefined;
+      expect(po?.anthropic?.thinking).toEqual({ type: "enabled", budgetTokens: 4096 });
+    });
+
+    it("translates thinking=adaptive without budget", async () => {
+      const captured: Array<Record<string, unknown>> = [];
+      const model: LanguageModelV3 = { ...createEchoModel({ responses: [{ text: "ok" }] }) };
+      const orig = model.doStream.bind(model);
+      model.doStream = async (o) => {
+        captured.push(o as unknown as Record<string, unknown>);
+        return orig(o);
+      };
+
+      await new AgentEngine(
+        model,
+        new StaticToolRouter([], () => ({ content: textContent(""), isError: false })),
+        new NoopEventSink(),
+      ).run(
+        { ...defaultConfig, model: "anthropic:claude-opus-4-7", thinking: { mode: "adaptive" } },
+        "",
+        [{ role: "user", content: [{ type: "text", text: "x" }] }],
+        [],
+      );
+
+      const po = captured[0]!.providerOptions as
+        | { anthropic?: { thinking?: { type: string } } }
+        | undefined;
+      expect(po?.anthropic?.thinking).toEqual({ type: "adaptive" });
+    });
+
+    it("does NOT set providerOptions when thinking is undefined", async () => {
+      const captured: Array<Record<string, unknown>> = [];
+      const model: LanguageModelV3 = { ...createEchoModel({ responses: [{ text: "ok" }] }) };
+      const orig = model.doStream.bind(model);
+      model.doStream = async (o) => {
+        captured.push(o as unknown as Record<string, unknown>);
+        return orig(o);
+      };
+
+      await new AgentEngine(
+        model,
+        new StaticToolRouter([], () => ({ content: textContent(""), isError: false })),
+        new NoopEventSink(),
+      ).run(defaultConfig, "", [{ role: "user", content: [{ type: "text", text: "x" }] }], []);
+
+      // No top-level providerOptions when thinking is omitted (the
+      // system message still carries cacheControl, but that's per-message
+      // not per-call).
+      expect(captured[0]!.providerOptions).toBeUndefined();
+    });
+
     it("preserves Anthropic signature on reasoning across iterations (round-trip)", async () => {
       // The first turn emits reasoning + a tool call. The engine pushes
       // the assistant content into history for the second turn — and

--- a/test/unit/resolve-thinking.test.ts
+++ b/test/unit/resolve-thinking.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { resolveThinking } from "../../src/runtime/resolve-thinking.ts";
+
+describe("resolveThinking", () => {
+	it("returns undefined when no config and no model is supplied", () => {
+		expect(resolveThinking({})).toBeUndefined();
+	});
+
+	it("returns undefined when the model is unknown", () => {
+		expect(resolveThinking({ model: "anthropic:made-up-model" })).toBeUndefined();
+	});
+
+	it("returns undefined for non-reasoning models when no operator override", () => {
+		// claude-3-5-haiku is not a reasoning-capable model in the catalog.
+		// Without operator override, the platform doesn't request thinking.
+		expect(resolveThinking({ model: "anthropic:claude-3-5-haiku-20241022" })).toBeUndefined();
+	});
+
+	it("defaults to adaptive for catalog-flagged reasoning models", () => {
+		// Opus 4.7 has capabilities.reasoning = true in the catalog.
+		expect(resolveThinking({ model: "anthropic:claude-opus-4-7" })).toEqual({
+			mode: "adaptive",
+		});
+	});
+
+	it("operator config wins over model default", () => {
+		expect(
+			resolveThinking({
+				configMode: "off",
+				model: "anthropic:claude-opus-4-7",
+			}),
+		).toEqual({ mode: "off" });
+	});
+
+	it("operator config can enable thinking on a non-reasoning model", () => {
+		expect(
+			resolveThinking({
+				configMode: "enabled",
+				model: "anthropic:claude-3-5-haiku-20241022",
+				configBudgetTokens: 4000,
+			}),
+		).toEqual({ mode: "enabled", budgetTokens: 4000 });
+	});
+
+	it("ignores zero / negative budget tokens", () => {
+		const r = resolveThinking({ configMode: "enabled", configBudgetTokens: 0 });
+		expect(r).toEqual({ mode: "enabled" });
+	});
+
+	it("budgetTokens omitted when not provided", () => {
+		const r = resolveThinking({ configMode: "enabled" });
+		expect(r).toEqual({ mode: "enabled" });
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `RuntimeConfig.thinking: "off" | "adaptive" | "enabled"` + optional `thinkingBudgetTokens`. Defaults to `adaptive` for catalog-flagged reasoning models, `off` otherwise.
- Engine threads it into `providerOptions.anthropic.thinking` per call. The public config is provider-neutral; per-provider translation lives in `buildThinkingProviderOptions()` in `engine.ts` so adding OpenAI o-series / Gemini 2.5 later is localized.
- `nb__set_model_config` accepts the new fields; Settings → Model UI exposes a select with a conditional budget input.
- Fixes `estimateCost` double-billing for models with a separate `cost.reasoning` rate.
- Closes #107.

## Why now
PR #106 plumbed reasoning content end-to-end. After deploy, HQ confirmed empirically that **no** reasoning content was flowing (latest Opus 4.7 turn: `reasoningTokens=null`, content was a single 27.8k-char text block). Anthropic isn't implicitly enabling thinking — it has to be requested explicitly. This PR adds the request.

After this lands, an HQ admin can flip thinking to `adaptive` from the Settings UI and the next Opus turn that wants to reason will emit `reasoning-*` parts → captured by #106's stream code → rendered as a collapsed "Thoughts" block in the chat UI.

## What changed end-to-end
| Layer | File | Change |
|---|---|---|
| Public config | `src/runtime/types.ts` | `RuntimeConfig.thinking` + `thinkingBudgetTokens`. |
| Engine types | `src/engine/types.ts` | Provider-neutral `ResolvedThinking` shape on `EngineConfig`. Doc comment lists per-provider mappings. |
| Resolver | `src/runtime/resolve-thinking.ts` | New helper. Operator config wins; fall back to `adaptive` for reasoning-capable models; otherwise `undefined` (don't request). |
| Runtime | `src/runtime/runtime.ts` | Threads `resolveThinking` output into `EngineConfig`. `getRuntimeConfig` and `updateConfig` accept the fields. |
| Engine | `src/engine/engine.ts` | New `buildThinkingProviderOptions(model, thinking)` translates the neutral shape to Anthropic's discriminated union. Spreads result into `LanguageModelV3CallOptions.providerOptions`. |
| Delegate | `src/tools/delegate.ts` | Sub-agents inherit thinking config from parent context. |
| Cost | `src/model/catalog.ts` | `estimateCost` splits reasoning out of output tokens when `cost.reasoning` is set (was double-billing). When `cost.reasoning` is unset, behavior is unchanged. |
| Tools | `src/tools/core-source.ts` | `nb__set_model_config` schema + handler accept the new fields with validation (`thinkingBudgetTokens >= 1024`); `nb__get_config` surfaces them. |
| UI | `src/tools/platform/sections/model.ts` | Settings → Model: select + conditional budget input. |
| UI helper | `src/tools/platform/helpers/runtime-config.ts` | `RuntimeConfigResult` carries the fields. |

## Multi-provider story
Anthropic uses `providerOptions.anthropic.thinking` (discriminated union: `off` / `adaptive` / `enabled` + budget). Direct mapping.
- **OpenAI o-series** — reasoning is always on; controlled via `reasoningEffort: "low"|"medium"|"high"`. No "off" — best we can do is `low`. **Not yet wired** — falls back to provider default. Marked TODO.
- **Google Gemini 2.5** — supports thinking budget via `providerOptions.google.thinkingConfig`. **Not yet wired** — TODO.
- Non-reasoning providers (older OpenAI, Anthropic Haiku 3.5, Gemini Flash) — config is silently a no-op, which is correct.

The public config stays the same when those providers are wired in. The change lives entirely inside `buildThinkingProviderOptions`.

## Tests
- `test/unit/resolve-thinking.test.ts` — 8 cases: empty input, unknown model, non-reasoning model, reasoning-model default, operator override, enabling on non-reasoning, zero/negative budget, missing budget.
- `test/unit/engine.test.ts` — 3 new cases asserting `providerOptions.anthropic.thinking` is set correctly for `enabled` (with budget), `adaptive`, and `undefined` (no providerOptions at all).
- `test/unit/catalog.test.ts` — regression test for the cost fix.

## Test plan
- [x] `bun run verify` clean (2012 unit + 174 unit + 413 integration + 16 smoke + 2092 web, 0 fail).
- [ ] After merge: deploy to HQ tenant; flip `thinking: adaptive` in Settings → Model; ask Opus a hard question; check the JSONL for a `reasoning` content block. Should resolve the long-running `conv_6cf2bbacee2745cd` mystery end-to-end.