### PR TITLE
feat(web): live indicators on reasoning block while streaming

### DIFF
--- a/web/src/components/ReasoningBlock.tsx
+++ b/web/src/components/ReasoningBlock.tsx
@@ -28,11 +28,15 @@ interface ReasoningBlockProps {
  * 4 chars/token heuristic. Real `reasoningTokens` comes from `llm.done`
  * after streaming, but for live progress we render the approximation —
  * it's accurate enough for "is the model still working?" judgment.
+ *
+ * Threshold for the "Nk" form is 2,500 tokens (≈10k chars) rather than
+ * the bare 1,000 — avoids the slightly noisy "1.0k tokens" right after
+ * crossing the boundary.
  */
 function approximateTokenLabel(charCount: number): string {
   if (charCount === 0) return "";
   const tokens = Math.round(charCount / 4);
-  if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}k tokens`;
+  if (tokens >= 2500) return `${(tokens / 1000).toFixed(1)}k tokens`;
   return `${tokens} tokens`;
 }
 
@@ -43,6 +47,11 @@ function ReasoningBlockImpl({ text, streaming }: ReasoningBlockProps) {
   // Ref because we don't want a re-render when the override flips.
   const userOverrodeRef = useRef(false);
 
+  // Mirror the streaming flag into expanded unless the user has
+  // overridden. The first run on mount is a no-op (the state initializer
+  // already wrote the same value); we keep it that way so the same
+  // logic handles both initial mount and later transitions, which keeps
+  // the intent of the effect obvious at a glance.
   useEffect(() => {
     if (!userOverrodeRef.current) {
       setExpanded(!!streaming);

--- a/web/src/components/ReasoningBlock.tsx
+++ b/web/src/components/ReasoningBlock.tsx
@@ -1,19 +1,21 @@
 /**
- * ReasoningBlock — collapsed-by-default view of the model's extended-thinking
- * content. Renders above the assistant's visible text, signaling that
- * the model deliberated before responding without crowding the message body.
+ * ReasoningBlock — view of the model's extended-thinking content.
  *
- * Interaction:
- *   - Collapsed (default): single-line "Thoughts" affordance with a chevron.
- *   - Expanded: the full reasoning text in a subdued container.
+ * Display rules:
+ *   - While streaming: auto-expanded so the user can watch the model think.
+ *     The header shows a pulsing brain + "Thinking… ~Nk tokens" so progress
+ *     is visible at a glance even with the body collapsed.
+ *   - After streaming: auto-collapses to "Thoughts · ~Nk tokens" so the
+ *     reasoning doesn't crowd the message body. Click to expand.
+ *   - User override: a manual click during streaming sticks for the rest
+ *     of this block's lifetime (no fighting the user's intent).
  *
- * Live streaming: while reasoning deltas are arriving, the block stays
- * collapsed but shows a subtle "thinking…" indicator so the user knows
- * the model is actively reasoning.
+ * The block lifetime is one assistant turn — every new turn instantiates
+ * a fresh component, so the override doesn't leak across messages.
  */
 
 import { Brain, ChevronRight } from "lucide-react";
-import { memo, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 
 interface ReasoningBlockProps {
   text: string;
@@ -21,21 +23,58 @@ interface ReasoningBlockProps {
   streaming?: boolean;
 }
 
+/**
+ * Approximate token count from character length using the standard
+ * 4 chars/token heuristic. Real `reasoningTokens` comes from `llm.done`
+ * after streaming, but for live progress we render the approximation —
+ * it's accurate enough for "is the model still working?" judgment.
+ */
+function approximateTokenLabel(charCount: number): string {
+  if (charCount === 0) return "";
+  const tokens = Math.round(charCount / 4);
+  if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}k tokens`;
+  return `${tokens} tokens`;
+}
+
 function ReasoningBlockImpl({ text, streaming }: ReasoningBlockProps) {
-  const [expanded, setExpanded] = useState(false);
+  // Default: expanded while streaming, collapsed when done.
+  const [expanded, setExpanded] = useState(!!streaming);
+  // Once the user manually toggles, stop auto-following the streaming flag.
+  // Ref because we don't want a re-render when the override flips.
+  const userOverrodeRef = useRef(false);
+
+  useEffect(() => {
+    if (!userOverrodeRef.current) {
+      setExpanded(!!streaming);
+    }
+  }, [streaming]);
+
+  const handleToggle = () => {
+    userOverrodeRef.current = true;
+    setExpanded((v) => !v);
+  };
 
   if (!text && !streaming) return null;
+
+  const tokenLabel = approximateTokenLabel(text.length);
+  const headerLabel = streaming
+    ? tokenLabel
+      ? `Thinking… ${tokenLabel}`
+      : "Thinking…"
+    : tokenLabel
+      ? `Thoughts · ${tokenLabel}`
+      : "Thoughts";
 
   return (
     <div className="my-2">
       <button
         type="button"
-        onClick={() => setExpanded((v) => !v)}
+        onClick={handleToggle}
         className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
       >
         <ChevronRight className={`w-3 h-3 transition-transform ${expanded ? "rotate-90" : ""}`} />
-        <Brain className="w-3 h-3" />
-        <span>{streaming && !text ? "Thinking…" : "Thoughts"}</span>
+        <Brain className={`w-3 h-3 ${streaming ? "animate-pulse" : ""}`} />
+        <span>{headerLabel}</span>
       </button>
       {expanded && text && (
         <div className="mt-2 ml-4 px-3 py-2 rounded-md bg-muted/30 border border-border/60 text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed">

--- a/web/test/ReasoningBlock.test.tsx
+++ b/web/test/ReasoningBlock.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import { fireEvent, render } from "@testing-library/react";
+import { ReasoningBlock } from "../src/components/ReasoningBlock.tsx";
+
+/**
+ * Helpers — happy-dom's CSS selector parser has internal bugs that make
+ * even `"button"` throw, so navigate the DOM via direct property access
+ * rather than querySelector calls.
+ */
+
+/**
+ * Expanded ⇔ the chevron has the `rotate-90` class. The body div is also
+ * a signal but it's gated on `text` being non-empty (so streaming with no
+ * text yet renders just the header even when conceptually expanded).
+ * The chevron class flips on expand regardless of body presence, which
+ * is what we want to assert.
+ */
+function isExpanded(container: HTMLElement): boolean {
+  const button = getButton(container);
+  const chevron = button.firstElementChild;
+  return chevron?.classList.contains("rotate-90") ?? false;
+}
+
+function getButton(container: HTMLElement): HTMLButtonElement {
+  const wrapper = container.firstElementChild;
+  if (!wrapper) throw new Error("ReasoningBlock did not render");
+  const button = wrapper.firstElementChild;
+  if (!(button instanceof HTMLButtonElement)) throw new Error("First child is not a button");
+  return button;
+}
+
+function headerText(container: HTMLElement): string {
+  const button = getButton(container);
+  // The header is icon, icon, span — the visible label is the last child.
+  const lastChild = button.lastElementChild;
+  return lastChild?.textContent ?? "";
+}
+
+describe("ReasoningBlock", () => {
+	describe("initial expansion", () => {
+		it("mounts collapsed when streaming=false (history rehydrate)", () => {
+			const { container } = render(
+				<ReasoningBlock text="Some prior reasoning." streaming={false} />,
+			);
+			expect(isExpanded(container)).toBe(false);
+		});
+
+		it("mounts expanded when streaming=true", () => {
+			const { container } = render(<ReasoningBlock text="" streaming={true} />);
+			expect(isExpanded(container)).toBe(true);
+		});
+
+		it("renders nothing when there's no text and not streaming", () => {
+			const { container } = render(<ReasoningBlock text="" streaming={false} />);
+			expect(container.innerHTML).toBe("");
+		});
+	});
+
+	describe("auto-collapse on stream end", () => {
+		it("auto-collapses when streaming transitions true → false", () => {
+			const { container, rerender } = render(
+				<ReasoningBlock text="thinking..." streaming={true} />,
+			);
+			expect(isExpanded(container)).toBe(true);
+
+			rerender(<ReasoningBlock text="thinking..." streaming={false} />);
+			expect(isExpanded(container)).toBe(false);
+		});
+	});
+
+	describe("user override", () => {
+		it("manual click during streaming sticks: subsequent stream-end does not force collapse", () => {
+			const { container, rerender } = render(
+				<ReasoningBlock text="thinking..." streaming={true} />,
+			);
+			// Auto-expanded while streaming
+			expect(isExpanded(container)).toBe(true);
+
+			// User clicks to collapse mid-stream
+			fireEvent.click(getButton(container));
+			expect(isExpanded(container)).toBe(false);
+
+			// Streaming ends — must NOT force re-collapse, but more importantly
+			// must not force re-expand either. The user said collapsed; it stays.
+			rerender(<ReasoningBlock text="thinking..." streaming={false} />);
+			expect(isExpanded(container)).toBe(false);
+		});
+
+		it("manual click during streaming to expand (after manual collapse) sticks", () => {
+			const { container, rerender } = render(
+				<ReasoningBlock text="thinking..." streaming={true} />,
+			);
+
+			// Click off, then click on — the override is sticky regardless of
+			// the streaming flag's later transitions.
+			fireEvent.click(getButton(container)); // -> collapsed
+			fireEvent.click(getButton(container)); // -> expanded
+			expect(isExpanded(container)).toBe(true);
+
+			rerender(<ReasoningBlock text="thinking..." streaming={false} />);
+			// Auto-collapse should NOT fire because user overrode.
+			expect(isExpanded(container)).toBe(true);
+		});
+	});
+
+	describe("header label", () => {
+		it("shows 'Thinking…' when streaming with no text yet", () => {
+			const { container } = render(<ReasoningBlock text="" streaming={true} />);
+			expect(headerText(container)).toBe("Thinking…");
+		});
+
+		it("shows 'Thinking… N tokens' when streaming with short text", () => {
+			// 80 chars → 20 tokens (under the 2,500-token Nk threshold)
+			const text = "x".repeat(80);
+			const { container } = render(<ReasoningBlock text={text} streaming={true} />);
+			expect(headerText(container)).toBe("Thinking… 20 tokens");
+		});
+
+		it("shows 'Thinking… N.Nk tokens' when streaming past the Nk threshold", () => {
+			// 12,000 chars → ~3000 tokens → "3.0k tokens"
+			const text = "x".repeat(12_000);
+			const { container } = render(<ReasoningBlock text={text} streaming={true} />);
+			expect(headerText(container)).toBe("Thinking… 3.0k tokens");
+		});
+
+		it("shows 'Thoughts · N tokens' when not streaming with short text", () => {
+			const text = "x".repeat(40); // 10 tokens
+			const { container } = render(<ReasoningBlock text={text} streaming={false} />);
+			expect(headerText(container)).toBe("Thoughts · 10 tokens");
+		});
+
+		it("shows 'Thoughts · N.Nk tokens' when not streaming past the Nk threshold", () => {
+			const text = "x".repeat(20_000); // 5000 tokens → "5.0k tokens"
+			const { container } = render(<ReasoningBlock text={text} streaming={false} />);
+			expect(headerText(container)).toBe("Thoughts · 5.0k tokens");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Three small UX upgrades to `ReasoningBlock` so a long thinking turn looks like progress instead of a stuck process:
1. **Auto-expand while streaming, auto-collapse on completion.** Watch the model think live; tucks away when done.
2. **Pulse animation on the Brain icon while streaming.** Removes the "is it stuck?" ambiguity.
3. **Approximate token counter on the header.** "Thinking… 1.4k tokens" while streaming, "Thoughts · 1.4k tokens" when done.

User override sticks: a manual toggle during streaming is respected for the rest of the turn (no fighting user intent). Override resets per turn since the component is per-block.

## Why
PR #106 shipped reasoning capture with a collapsed-by-default block. Worked great for "minimize noise after the fact" but actively worked *against* you while reasoning was happening — Opus on a hard prompt thinks for minutes with no visible signal. Same affordance ("Thoughts" with a chevron) whether the model was actively working or already done.

Mat caught this on first use: *"hard to know what's going on, because it's hidden in the accordion."*

## Files
| File | Change |
|---|---|
| `web/src/components/ReasoningBlock.tsx` | All behavior changes; no other files touched. ~30 LOC of net new behavior. |

## Implementation notes
- `userOverrodeRef` (ref, not state — no re-render needed) tracks whether the user clicked. Once true, the `useEffect` that mirrors `streaming → expanded` is a no-op.
- Token approximation uses the standard 4-chars/token heuristic. Exact `reasoningTokens` from `llm.done` isn't available mid-stream; the approximation is fine for "is it making progress?" judgment. Could swap to the exact value post-completion as a follow-up.
- Pulse animation is plain `animate-pulse` on the icon — Tailwind built-in, no new CSS, no JS animation loop.

## Out of scope (reviewer's earlier discussion of options 4–7)
Held back deliberately:
- **Last-line preview on the collapsed surface** — wait until we've used 1–3 in real conversations and seen what's still missing.
- **Phase markers / structural progress** — heuristic, brittle.
- **Unified "agent activity" status bar** — bigger refactor; needs its own design pass.

## Test plan
- [x] `bun run verify` clean (2012 unit + 174 web + 417 integration + 16 smoke, 0 fail).
- [ ] After merge: ask Opus the truck-driver puzzle (or any thinking-heavy prompt). Watch the block: should auto-expand with pulsing icon, scroll text live, show running token count. Once done, should auto-collapse to "Thoughts · Nk tokens".