### PR TITLE
fix: propagate workspace role, cap thinking budget, repair abandoned runs

### DIFF
--- a/src/conversation/event-reconstructor.ts
+++ b/src/conversation/event-reconstructor.ts
@@ -403,10 +403,37 @@ function ensureRoleAlternation(messages: StoredMessage[]): StoredMessage[] {
   for (const msg of messages) {
     const prev = result[result.length - 1];
     if (prev?.role === "user" && msg.role === "user") {
+      // Place the synthetic turn 1ms after the previous user message so it
+      // sorts between the two user turns instead of collapsing onto the
+      // next user's timestamp (the UI sorts strictly by `timestamp`, and a
+      // tied-timestamp placeholder rendered after the user it precedes
+      // looks like the user replied to themselves). Clamp to the next
+      // message's timestamp when it's already <1ms ahead — clock skew or
+      // tight bursts can produce equal/backwards timestamps.
+      const prevTime = Date.parse(prev.timestamp);
+      const msgTime = Date.parse(msg.timestamp);
+      const placeholderTs =
+        Number.isFinite(prevTime) && Number.isFinite(msgTime)
+          ? new Date(Math.min(prevTime + 1, msgTime)).toISOString()
+          : msg.timestamp;
       result.push({
         role: "assistant",
         content: [{ type: "text" as const, text: ABANDONED_RUN_MARKER }],
-        timestamp: msg.timestamp,
+        timestamp: placeholderTs,
+        // Carry minimal metadata so the chat UI can render the same
+        // truncation banner it uses for length / content-filter cases.
+        // `finishReason: "other"` is the closest enum value — there was no
+        // real LLM call, so the categorical reasons (length, error, etc.)
+        // don't apply.
+        metadata: {
+          finishReason: "other",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          costUsd: 0,
+          llmMs: 0,
+          iterations: 0,
+        },
       });
     }
     result.push(msg);

--- a/src/conversation/event-reconstructor.ts
+++ b/src/conversation/event-reconstructor.ts
@@ -26,6 +26,28 @@ const TRUNCATION_MARKERS: Record<string, string> = {
 };
 
 /**
+ * Marker for the case where the LLM produced tool calls but the run was
+ * cut short before any of them executed (process death, abort, stalled
+ * call). Without this placeholder the reconstructed history would skip
+ * the turn entirely, producing two adjacent `user` messages on the next
+ * append — which Anthropic rejects with
+ * `"This model does not support assistant message prefill."`. The marker
+ * preserves the role-alternation invariant and tells the model honestly
+ * what happened.
+ */
+const ORPHANED_TOOL_CALLS_MARKER =
+  "[Previous turn called tools but tool execution did not complete (the run was cut short before any tool returned). The tool calls were dropped on reload.]";
+
+/**
+ * Generic marker for a run scope that emitted no messages at all (no
+ * llm.response events between `run.start` and the run's terminator —
+ * process died before any model call returned, or some other edge case).
+ * Used by the final invariant pass to repair user→user adjacency that
+ * the per-run logic didn't catch.
+ */
+const ABANDONED_RUN_MARKER = "[Previous turn ended without producing any response.]";
+
+/**
  * Parse tool-call input from its persisted form.
  * The AI SDK V3 stream emits tool-call input as a JSON string, which gets
  * written to the JSONL event log as-is. When reconstructing messages for
@@ -95,6 +117,11 @@ export interface UsageMetrics {
  * 4. Per-run metrics accumulate into assistant message metadata.
  */
 export function reconstructMessages(events: readonly ConversationEvent[]): StoredMessage[] {
+  const messages = buildMessagesFromEvents(events);
+  return ensureRoleAlternation(messages);
+}
+
+function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMessage[] {
   const messages: StoredMessage[] = [];
 
   for (let i = 0; i < events.length; ) {
@@ -141,6 +168,16 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
         if (inner.type === "run.error" && inner.runId === runId) {
           // Run errored — we still emit messages collected so far
           i++;
+          break;
+        }
+
+        // Implicit run end: a new user.message or run.start means the
+        // previous run never closed cleanly (process died, abort fired
+        // without emitting a terminal event). Break out — but DO NOT
+        // increment `i`, so the outer loop processes the event itself.
+        // Without this, subsequent user messages get swallowed by the
+        // run loop and the conversation appears to skip turns on reload.
+        if (inner.type === "user.message" || inner.type === "run.start") {
           break;
         }
 
@@ -206,13 +243,16 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
         }));
         let reasoningEmitted = false;
 
-        if (toolCallParts.length > 0) {
-          // Only include tool calls that were actually executed (have a tool.done event).
-          // Unexecuted calls happen when a run is cut short (abort, crash, etc.)
-          // before tools could run. Including them would create orphaned tool_use blocks
-          // that the Claude API rejects, or fake empty tool results that confuse the model.
-          const executedToolCalls = toolCallParts.filter((tc) => runToolDones.has(tc.toolCallId));
+        // Only include tool calls that were actually executed (have a tool.done event).
+        // Unexecuted calls happen when a run is cut short (abort, crash, etc.)
+        // before tools could run. Including them would create orphaned tool_use blocks
+        // that the Claude API rejects, or fake empty tool results that confuse the model.
+        // Lifted out of the `if (toolCallParts.length > 0)` block so step 4a can
+        // detect the all-unexecuted case and emit a placeholder for it.
+        const executedToolCalls = toolCallParts.filter((tc) => runToolDones.has(tc.toolCallId));
+        const hasOrphanedToolCalls = toolCallParts.length > 0 && executedToolCalls.length === 0;
 
+        if (toolCallParts.length > 0) {
           if (executedToolCalls.length > 0) {
             const toolCallsMeta = executedToolCalls.map((tc) => {
               const done = runToolDones.get(tc.toolCallId)!;
@@ -284,33 +324,43 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
         }
 
         // Step 4a — replay honesty.
-        // No tool-call, no text. Two reasons we can land here:
+        // We land here when no assistant message was emitted above (no
+        // executed tool calls, no text). Several reasons:
         //   1. The turn produced reasoning only (extended thinking that
         //      ran out of budget before any visible content).
         //   2. The turn produced literally nothing AND the model didn't
         //      end cleanly (length / content_filter / error).
-        // Either way, dropping the message silently — the pre-existing
-        // behavior — leaves the operator looking at a conversation that
-        // skips a turn that actually happened. Emit a placeholder
-        // assistant message carrying finishReason in metadata so the UI
-        // can render the truncation banner and the reasoning (if any).
+        //   3. The turn produced tool calls that NEVER executed (process
+        //      death, abort, stalled call). Without a placeholder, the
+        //      next user message lands directly after the prior user
+        //      message and Anthropic rejects the conversation on reload
+        //      with "model does not support assistant message prefill".
+        //
+        // Dropping the message silently — the pre-existing behavior —
+        // either skips a turn that actually happened or breaks role
+        // alternation. Emit a placeholder assistant message carrying
+        // finishReason in metadata so the UI can render the truncation
+        // banner and the reasoning (if any) survives.
         //
         // Reasoning content is ONLY usable as the placeholder body when
         // it carries provider metadata that lets it round-trip (e.g.
         // Anthropic's signature). Without that, the AI SDK provider
         // drops the block on the next prompt → content: [] → API 400.
-        // Fall back to marker text whenever the reasoning can't be
-        // safely replayed.
-        if (
-          toolCallParts.length === 0 &&
-          textParts.length === 0 &&
-          (reasoningContent.length > 0 || (llmResp.finishReason && llmResp.finishReason !== "stop"))
-        ) {
-          const placeholderText =
-            TRUNCATION_MARKERS[llmResp.finishReason ?? "other"] ?? TRUNCATION_MARKERS.other!;
-          const reasoningRoundTrips = reasoningContent.some(
-            (r) => "providerOptions" in r && r.providerOptions != null,
-          );
+        // For the orphaned-tool-calls case we always use marker text:
+        // the reasoning may end mid-tool-call-intent, and the marker is
+        // the load-bearing signal to the model on retry.
+        const wouldEmitAssistantMessage = executedToolCalls.length > 0 || textParts.length > 0;
+        const hasReasoningOrAbnormalFinish =
+          reasoningContent.length > 0 ||
+          (llmResp.finishReason != null && llmResp.finishReason !== "stop");
+
+        if (!wouldEmitAssistantMessage && (hasReasoningOrAbnormalFinish || hasOrphanedToolCalls)) {
+          const placeholderText = hasOrphanedToolCalls
+            ? ORPHANED_TOOL_CALLS_MARKER
+            : (TRUNCATION_MARKERS[llmResp.finishReason ?? "other"] ?? TRUNCATION_MARKERS.other!);
+          const reasoningRoundTrips =
+            !hasOrphanedToolCalls &&
+            reasoningContent.some((r) => "providerOptions" in r && r.providerOptions != null);
           const placeholderContent = reasoningRoundTrips
             ? reasoningContent
             : [{ type: "text" as const, text: placeholderText }];
@@ -332,6 +382,36 @@ export function reconstructMessages(events: readonly ConversationEvent[]): Store
   }
 
   return messages;
+}
+
+/**
+ * Defense-in-depth invariant pass: ensure the reconstructed message list
+ * never has two adjacent `user` messages. Anthropic rejects such a
+ * sequence on the next append with
+ * `"This model does not support assistant message prefill."`.
+ *
+ * The per-run step-4a handler covers the cases we've seen in production
+ * (orphaned tool-calls, length-truncated empty turns). This pass catches
+ * anything we haven't enumerated — e.g. a run scope that emitted zero
+ * `llm.response` events because the process died before the model
+ * returned. Cheap O(n) scan; never fires on healthy data.
+ */
+function ensureRoleAlternation(messages: StoredMessage[]): StoredMessage[] {
+  if (messages.length < 2) return messages;
+
+  const result: StoredMessage[] = [];
+  for (const msg of messages) {
+    const prev = result[result.length - 1];
+    if (prev?.role === "user" && msg.role === "user") {
+      result.push({
+        role: "assistant",
+        content: [{ type: "text" as const, text: ABANDONED_RUN_MARKER }],
+        timestamp: msg.timestamp,
+      });
+    }
+    result.push(msg);
+  }
+  return result;
 }
 
 /**

--- a/src/runtime/resolve-thinking.ts
+++ b/src/runtime/resolve-thinking.ts
@@ -9,11 +9,14 @@ export interface ResolveThinkingInput {
   /** Resolved model string (e.g. `"anthropic:claude-opus-4-7"`). */
   model?: string;
   /**
-   * Resolved per-call output budget. Required for budget capping — without
-   * it, the platform-default and `enabled` paths fall back to a conservative
-   * floor. Always pass it from the runtime: it lets us guarantee at least
-   * `MIN_VISIBLE_OUTPUT_TOKENS` of room for visible content, even when
-   * thinking is on.
+   * Resolved per-call output budget. Strongly recommended — without it,
+   * the platform-default and `enabled` paths can't compute a useful
+   * thinking budget and fall back to the 1024-token floor, which gives
+   * reasoning models far less room than they need. Pass it from the
+   * runtime so the cap leaves at least `MIN_VISIBLE_OUTPUT_TOKENS` of
+   * room for visible content while still giving thinking enough budget
+   * to produce quality reasoning. Optional only to keep legacy callsites
+   * compiling.
    */
   maxOutputTokens?: number;
 }

--- a/src/runtime/resolve-thinking.ts
+++ b/src/runtime/resolve-thinking.ts
@@ -8,37 +8,110 @@ export interface ResolveThinkingInput {
   configBudgetTokens?: number;
   /** Resolved model string (e.g. `"anthropic:claude-opus-4-7"`). */
   model?: string;
+  /**
+   * Resolved per-call output budget. Required for budget capping — without
+   * it, the platform-default and `enabled` paths fall back to a conservative
+   * floor. Always pass it from the runtime: it lets us guarantee at least
+   * `MIN_VISIBLE_OUTPUT_TOKENS` of room for visible content, even when
+   * thinking is on.
+   */
+  maxOutputTokens?: number;
+}
+
+/**
+ * Tokens reserved for visible content when thinking is on. The Anthropic
+ * Claude Opus 4.7 model with `adaptive` thinking and a tight `max_tokens`
+ * was observed in production spending the entire output budget on internal
+ * reasoning and emitting zero visible content. This floor guarantees the
+ * model always has room to actually answer.
+ */
+const MIN_VISIBLE_OUTPUT_TOKENS = 4096;
+
+/** Anthropic's stated minimum thinking budget. Below this the API rejects. */
+const MIN_THINKING_BUDGET_TOKENS = 1024;
+
+/**
+ * Compute a thinking budget that leaves at least `MIN_VISIBLE_OUTPUT_TOKENS`
+ * for visible content. Floors at Anthropic's minimum (1024). When
+ * `requestedBudget` is provided, clamps to it (so an operator override
+ * can lower the budget but never raise it past the safe ceiling).
+ */
+function safeThinkingBudget(maxOutputTokens: number, requestedBudget?: number): number {
+  const ceiling = Math.max(MIN_THINKING_BUDGET_TOKENS, maxOutputTokens - MIN_VISIBLE_OUTPUT_TOKENS);
+  if (requestedBudget != null && requestedBudget > 0) {
+    return Math.min(requestedBudget, ceiling);
+  }
+  return ceiling;
 }
 
 /**
  * Resolve the effective thinking mode for an LLM call.
  *
- * The platform's policy:
- *   - If the operator pinned a `configMode`, use it as-is. Their call.
- *   - Otherwise: `adaptive` for catalog-flagged reasoning-capable models,
- *     `off` for everything else.
+ * Platform invariant: when thinking is on, at least
+ * `MIN_VISIBLE_OUTPUT_TOKENS` are reserved for visible content. The model
+ * can never spend the whole output budget on reasoning and emit nothing.
  *
- * Returns `undefined` when the resolved mode is `off` AND there's no
- * operator override — that signals "don't pass thinking to the provider
- * at all" (the cheapest, most boring path). When the operator explicitly
- * sets `off`, the engine still passes a provider-specific "disabled"
- * option so the provider doesn't fall back to its own default.
+ * Resolution priority:
+ *   1. Operator override (`configMode`):
+ *      - `off`       → passed through; engine emits provider-disabled.
+ *      - `enabled`   → always carries a budget. Operator's budget (if any)
+ *                      is clamped down to the safe ceiling so a too-large
+ *                      value can't fail the API call.
+ *      - `adaptive`  → passed through. The Anthropic provider does NOT
+ *                      accept a budget on adaptive — the model decides per
+ *                      call. Use `enabled` for predictable behavior.
+ *   2. No override + reasoning-capable model → `enabled` with a safe
+ *      budget. (Adaptive was the previous default but consumed entire
+ *      output budgets in production; switched to `enabled` so the
+ *      platform stays in control of thinking spend.)
+ *   3. No override + non-reasoning model → `undefined` (engine omits
+ *      thinking from the provider call entirely — cheapest path).
  */
 export function resolveThinking(input: ResolveThinkingInput): ResolvedThinking | undefined {
   if (input.configMode != null) {
+    if (input.configMode === "off") {
+      return { mode: "off" };
+    }
+    if (input.configMode === "adaptive") {
+      // Adaptive: provider picks the budget; we can't cap it. Pass any
+      // operator-supplied budget through verbatim — the engine's Anthropic
+      // adapter currently drops it for adaptive, but a future provider
+      // (or SDK update) may honor it.
+      return {
+        mode: "adaptive",
+        ...(input.configBudgetTokens != null && input.configBudgetTokens > 0
+          ? { budgetTokens: input.configBudgetTokens }
+          : {}),
+      };
+    }
+    // enabled: always carry a budget so visible-output headroom is preserved.
     return {
-      mode: input.configMode,
-      ...(input.configBudgetTokens != null && input.configBudgetTokens > 0
-        ? { budgetTokens: input.configBudgetTokens }
-        : {}),
+      mode: "enabled",
+      budgetTokens:
+        input.maxOutputTokens != null
+          ? safeThinkingBudget(input.maxOutputTokens, input.configBudgetTokens)
+          : input.configBudgetTokens && input.configBudgetTokens > 0
+            ? input.configBudgetTokens
+            : MIN_THINKING_BUDGET_TOKENS,
     };
   }
 
-  // No operator override — fall back to model capability.
   const supportsReasoning = input.model
     ? (getModelByString(input.model)?.capabilities.reasoning ?? false)
     : false;
 
-  if (supportsReasoning) return { mode: "adaptive" };
-  return undefined;
+  if (!supportsReasoning) return undefined;
+
+  // Default for reasoning models: enabled with a capped budget. The previous
+  // default was `adaptive`; production showed Opus 4.7 routinely consumed
+  // the whole 16K output budget on internal thinking and produced empty
+  // turns on long-context document tasks. Switching to `enabled` with an
+  // explicit cap restores user-visible output.
+  return {
+    mode: "enabled",
+    budgetTokens:
+      input.maxOutputTokens != null
+        ? safeThinkingBudget(input.maxOutputTokens)
+        : MIN_THINKING_BUDGET_TOKENS,
+  };
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -755,10 +755,18 @@ export class Runtime {
       resolvedModelString = this.getModelSlot(aliasSlot);
     }
 
+    // Resolve maxOutputTokens FIRST — resolveThinking needs it to clamp the
+    // thinking budget so visible-content headroom is always preserved.
+    const resolvedMaxOutputTokens = resolveMaxOutputTokens({
+      configValue: this.config.maxOutputTokens,
+      model: resolvedModelString,
+    });
+
     const resolvedThinking = resolveThinking({
       configMode: this.config.thinking,
       configBudgetTokens: this.config.thinkingBudgetTokens,
       model: resolvedModelString,
+      maxOutputTokens: resolvedMaxOutputTokens,
     });
 
     // Build pre-emit run telemetry tied to the engine's runId. The engine fires
@@ -777,10 +785,7 @@ export class Runtime {
       model: resolvedModelString,
       maxIterations: request.maxIterations ?? this.config.maxIterations ?? DEFAULT_MAX_ITERATIONS,
       maxInputTokens: this.config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS,
-      maxOutputTokens: resolveMaxOutputTokens({
-        configValue: this.config.maxOutputTokens,
-        model: resolvedModelString,
-      }),
+      maxOutputTokens: resolvedMaxOutputTokens,
       ...(resolvedThinking ? { thinking: resolvedThinking } : {}),
       maxToolResultSize: this.config.maxToolResultSize,
       hooks: this.hooks,

--- a/src/tools/delegate.ts
+++ b/src/tools/delegate.ts
@@ -187,10 +187,21 @@ export function createDelegateTool(ctx: DelegateContext): InProcessTool {
         const parentRunId = ctx.getParentRunId();
         const childEvents = new ChildEventSink(ctx.events, parentRunId);
 
+        // Resolve maxOutputTokens FIRST — resolveThinking needs it to clamp
+        // the thinking budget so visible-content headroom is preserved on
+        // delegated runs too. Without this, child agents would fall through
+        // to the 1024-token MIN_THINKING_BUDGET_TOKENS floor regardless of
+        // the model's actual output capacity.
+        const childMaxOutputTokens = resolveMaxOutputTokens({
+          configValue: ctx.configMaxOutputTokens,
+          model: modelString,
+        });
+
         const childThinking = resolveThinking({
           configMode: ctx.configThinking,
           configBudgetTokens: ctx.configThinkingBudgetTokens,
           model: modelString,
+          maxOutputTokens: childMaxOutputTokens,
         });
 
         // Create child engine config
@@ -198,10 +209,7 @@ export function createDelegateTool(ctx: DelegateContext): InProcessTool {
           model: modelString,
           maxIterations: cappedIterations,
           maxInputTokens: ctx.defaultMaxInputTokens,
-          maxOutputTokens: resolveMaxOutputTokens({
-            configValue: ctx.configMaxOutputTokens,
-            model: modelString,
-          }),
+          maxOutputTokens: childMaxOutputTokens,
           ...(childThinking ? { thinking: childThinking } : {}),
         };
 

--- a/test/unit/event-reconstructor.test.ts
+++ b/test/unit/event-reconstructor.test.ts
@@ -576,17 +576,42 @@ describe("reconstructMessages", () => {
     // run.start but BEFORE any llm.response landed in the JSONL. Without
     // the final invariant pass, the run scope contributes zero messages
     // and the next user message creates user→user adjacency.
+    //
+    // Explicit timestamps so the placeholder-position assertions below
+    // aren't subject to `Date.now()` collisions (the helper factories
+    // call `Date.now()` and multiple events in the same millisecond
+    // would tie, masking any reordering bug).
+    const t0 = "2026-04-28T12:00:00.000Z";
+    const t1 = "2026-04-28T12:00:01.000Z";
+    const t2 = "2026-04-28T12:01:00.000Z";
     const events: ConversationEvent[] = [
-      userMessage("Do thing"),
-      runStart("run-1"),
+      { ts: t0, type: "user.message", content: [{ type: "text", text: "Do thing" }] },
+      { ts: t1, type: "run.start", runId: "run-1", model: "claude-sonnet-4-5-20250929" },
       // No llm.response, no tool events, no run.done — process died here
-      userMessage("Hello?"),
+      { ts: t2, type: "user.message", content: [{ type: "text", text: "Hello?" }] },
     ];
     const messages = reconstructMessages(events);
 
     expect(messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
-    const placeholder = messages[1]!.content as Array<{ type: string; text?: string }>;
-    expect(placeholder[0]!.text).toContain("without producing any response");
+    const placeholder = messages[1]!;
+    const content = placeholder.content as Array<{ type: string; text?: string }>;
+    expect(content[0]!.text).toContain("without producing any response");
+
+    // Carries finishReason metadata so the chat UI renders the same
+    // truncation banner it uses for length / content-filter cases. There
+    // was no real LLM call, so "other" is the closest enum value.
+    expect(placeholder.metadata?.finishReason).toBe("other");
+    expect(placeholder.metadata?.inputTokens).toBe(0);
+    expect(placeholder.metadata?.outputTokens).toBe(0);
+
+    // Placeholder timestamp falls strictly between the surrounding user
+    // messages so the UI sorts it between them. Tied timestamps would
+    // collapse onto the next user turn and look like a self-reply.
+    const prevUserMs = Date.parse(t0);
+    const nextUserMs = Date.parse(t2);
+    const placeholderMs = Date.parse(placeholder.timestamp);
+    expect(placeholderMs).toBeGreaterThan(prevUserMs);
+    expect(placeholderMs).toBeLessThan(nextUserMs);
   });
 
   it("orphaned tool-calls placeholder preserves role alternation across appends", () => {

--- a/test/unit/event-reconstructor.test.ts
+++ b/test/unit/event-reconstructor.test.ts
@@ -538,10 +538,14 @@ describe("reconstructMessages", () => {
     expect(events).toEqual(frozen);
   });
 
-  it("drops unexecuted tool calls when run ends early (token_budget)", () => {
-    // Reproduces production bug: LLM response with 4 tool calls is persisted,
-    // but the run is cut short before tools execute. The reconstructor should
-    // NOT create fake empty tool results for unexecuted tool calls.
+  it("drops unexecuted tool calls when run ends early (token_budget) and emits a placeholder", () => {
+    // Reproduces production bug + role-alternation guarantee: LLM response
+    // with 4 tool calls is persisted, but the run is cut short before any
+    // tool executes. The reconstructor:
+    //   - Drops the orphaned tool-call blocks (Anthropic rejects orphans).
+    //   - Emits a placeholder assistant message so the next user message
+    //     doesn't create user→user adjacency, which Anthropic rejects with
+    //     "model does not support assistant message prefill".
     const events: ConversationEvent[] = [
       userMessage("Read all files"),
       runStart("run-1"),
@@ -556,10 +560,49 @@ describe("reconstructMessages", () => {
     ];
     const messages = reconstructMessages(events);
 
-    // Should only have the user message — no assistant or tool messages
-    // because the tool calls were never executed
-    expect(messages).toHaveLength(1);
+    // user + assistant placeholder. Critically: NO assistant tool-call
+    // blocks (those are filtered) and NO synthetic tool-result blocks.
+    expect(messages).toHaveLength(2);
     expect(messages[0]!.role).toBe("user");
+    expect(messages[1]!.role).toBe("assistant");
+    const placeholder = messages[1]!.content as Array<{ type: string; text?: string }>;
+    expect(placeholder).toHaveLength(1);
+    expect(placeholder[0]!.type).toBe("text");
+    expect(placeholder[0]!.text).toContain("tool execution did not complete");
+  });
+
+  it("abandoned run with zero llm.response events still preserves role alternation", () => {
+    // Edge case the per-run step 4a doesn't catch: process died after
+    // run.start but BEFORE any llm.response landed in the JSONL. Without
+    // the final invariant pass, the run scope contributes zero messages
+    // and the next user message creates user→user adjacency.
+    const events: ConversationEvent[] = [
+      userMessage("Do thing"),
+      runStart("run-1"),
+      // No llm.response, no tool events, no run.done — process died here
+      userMessage("Hello?"),
+    ];
+    const messages = reconstructMessages(events);
+
+    expect(messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+    const placeholder = messages[1]!.content as Array<{ type: string; text?: string }>;
+    expect(placeholder[0]!.text).toContain("without producing any response");
+  });
+
+  it("orphaned tool-calls placeholder preserves role alternation across appends", () => {
+    // Concrete cascade scenario: orphaned tool-calls run is followed by
+    // another user message. The reconstructed history must alternate
+    // user→assistant→user (Anthropic invariant), NOT user→user.
+    const events: ConversationEvent[] = [
+      userMessage("Start research"),
+      runStart("run-1"),
+      llmParallelToolCalls("run-1", [{ toolCallId: "tc-a", toolName: "research__start" }]),
+      // Process died — no tool.done, no run.done
+      userMessage("What happened?"),
+    ];
+    const messages = reconstructMessages(events);
+
+    expect(messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
   });
 
   it("keeps executed tool calls but drops unexecuted ones from same response", () => {

--- a/test/unit/resolve-thinking.test.ts
+++ b/test/unit/resolve-thinking.test.ts
@@ -16,20 +16,64 @@ describe("resolveThinking", () => {
 		expect(resolveThinking({ model: "anthropic:claude-3-5-haiku-20241022" })).toBeUndefined();
 	});
 
-	it("defaults to adaptive for catalog-flagged reasoning models", () => {
-		// Opus 4.7 has capabilities.reasoning = true in the catalog.
+	it("defaults to enabled-with-capped-budget for catalog-flagged reasoning models", () => {
+		// Opus 4.7 has capabilities.reasoning = true. The platform default is
+		// `enabled` (not `adaptive`) so we keep direct control over thinking
+		// spend; budget is clamped to leave room for visible output.
+		expect(
+			resolveThinking({ model: "anthropic:claude-opus-4-7", maxOutputTokens: 16384 }),
+		).toEqual({ mode: "enabled", budgetTokens: 16384 - 4096 });
+	});
+
+	it("default budget floors at 1024 (Anthropic minimum) when maxOutputTokens is tiny", () => {
+		// Even when maxOutputTokens is below the visible-tokens floor, we
+		// emit at least 1024 — the API rejects anything lower.
+		expect(
+			resolveThinking({ model: "anthropic:claude-opus-4-7", maxOutputTokens: 2000 }),
+		).toEqual({ mode: "enabled", budgetTokens: 1024 });
+	});
+
+	it("default budget falls back to 1024 when maxOutputTokens is omitted", () => {
+		// Caller didn't pass maxOutputTokens (legacy callsite). Fall back to
+		// the safe minimum rather than emitting a budget-less `enabled`,
+		// which the SDK rejects with a warning.
 		expect(resolveThinking({ model: "anthropic:claude-opus-4-7" })).toEqual({
-			mode: "adaptive",
+			mode: "enabled",
+			budgetTokens: 1024,
 		});
 	});
 
-	it("operator config wins over model default", () => {
+	it("operator off wins over model default", () => {
 		expect(
 			resolveThinking({
 				configMode: "off",
 				model: "anthropic:claude-opus-4-7",
+				maxOutputTokens: 16384,
 			}),
 		).toEqual({ mode: "off" });
+	});
+
+	it("operator adaptive is passed through (provider picks budget)", () => {
+		expect(
+			resolveThinking({
+				configMode: "adaptive",
+				model: "anthropic:claude-opus-4-7",
+				maxOutputTokens: 16384,
+			}),
+		).toEqual({ mode: "adaptive" });
+	});
+
+	it("operator adaptive with budget is passed through verbatim", () => {
+		// The Anthropic SDK currently drops the budget on adaptive, but we
+		// pass it through so a future SDK that honors it gets the value.
+		expect(
+			resolveThinking({
+				configMode: "adaptive",
+				configBudgetTokens: 8000,
+				model: "anthropic:claude-opus-4-7",
+				maxOutputTokens: 16384,
+			}),
+		).toEqual({ mode: "adaptive", budgetTokens: 8000 });
 	});
 
 	it("operator config can enable thinking on a non-reasoning model", () => {
@@ -38,17 +82,47 @@ describe("resolveThinking", () => {
 				configMode: "enabled",
 				model: "anthropic:claude-3-5-haiku-20241022",
 				configBudgetTokens: 4000,
+				maxOutputTokens: 16384,
 			}),
 		).toEqual({ mode: "enabled", budgetTokens: 4000 });
 	});
 
-	it("ignores zero / negative budget tokens", () => {
-		const r = resolveThinking({ configMode: "enabled", configBudgetTokens: 0 });
-		expect(r).toEqual({ mode: "enabled" });
+	it("operator-set budget on enabled is clamped to leave visible-output room", () => {
+		// Operator says "give me 50K of thinking" but maxOutputTokens is 16K.
+		// We clamp down so visible content gets at least MIN_VISIBLE_OUTPUT_TOKENS.
+		expect(
+			resolveThinking({
+				configMode: "enabled",
+				configBudgetTokens: 50_000,
+				maxOutputTokens: 16384,
+			}),
+		).toEqual({ mode: "enabled", budgetTokens: 16384 - 4096 });
 	});
 
-	it("budgetTokens omitted when not provided", () => {
-		const r = resolveThinking({ configMode: "enabled" });
-		expect(r).toEqual({ mode: "enabled" });
+	it("operator-set lower budget is preserved (not raised)", () => {
+		// Clamping is one-directional: we lower a too-large budget, never
+		// raise a deliberately small one.
+		expect(
+			resolveThinking({
+				configMode: "enabled",
+				configBudgetTokens: 2000,
+				maxOutputTokens: 16384,
+			}),
+		).toEqual({ mode: "enabled", budgetTokens: 2000 });
+	});
+
+	it("zero / negative budget tokens are ignored (treated as unset)", () => {
+		expect(
+			resolveThinking({ configMode: "enabled", configBudgetTokens: 0, maxOutputTokens: 16384 }),
+		).toEqual({ mode: "enabled", budgetTokens: 16384 - 4096 });
+	});
+
+	it("enabled without maxOutputTokens or budget falls back to 1024", () => {
+		// Legacy callsite path. Always emit a budget — the SDK rejects
+		// `enabled` without one (warning + default of 1024 anyway).
+		expect(resolveThinking({ configMode: "enabled" })).toEqual({
+			mode: "enabled",
+			budgetTokens: 1024,
+		});
 	});
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,11 +30,15 @@ import { SessionProvider } from "./context/SessionContext";
 import { ShellProvider } from "./context/ShellContext";
 import { SidebarProvider } from "./context/SidebarContext";
 import { ThemeProvider, useTheme } from "./context/ThemeContext.tsx";
-import type { WorkspaceInfo } from "./context/WorkspaceContext";
-import { useWorkspaceContext, WorkspaceProvider } from "./context/WorkspaceContext";
+import {
+  useWorkspaceContext,
+  type WorkspaceInfo,
+  WorkspaceProvider,
+} from "./context/WorkspaceContext";
 import { useDataSync } from "./hooks/useDataSync";
 import { useEvents } from "./hooks/useEvents";
 import { useShell } from "./hooks/useShell";
+import { bootstrapWorkspacesToInfo } from "./lib/bootstrap";
 import { toSlug } from "./lib/workspace-slug";
 import { ProfilePage } from "./pages/ProfilePage";
 import { SettingsPage } from "./pages/SettingsPage";
@@ -82,13 +86,7 @@ function AuthenticatedApp({
       .catch(() => {});
   }, []);
 
-  // Map bootstrap workspace shape to WorkspaceInfo for the provider
-  const initialWorkspaces: WorkspaceInfo[] = bootstrap.workspaces.map((ws) => ({
-    id: ws.id,
-    name: ws.name,
-    memberCount: ws.memberCount,
-    bundles: [],
-  }));
+  const initialWorkspaces: WorkspaceInfo[] = bootstrapWorkspacesToInfo(bootstrap.workspaces);
 
   const initialShell: ShellData = bootstrap.shell;
 

--- a/web/src/__tests__/bootstrap.test.ts
+++ b/web/src/__tests__/bootstrap.test.ts
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+// bootstrapWorkspacesToInfo — bootstrap → WorkspaceInfo mapping
+//
+// Pins the load-bearing field propagation so a future contributor can't
+// silently drop `userRole`. The pure-resolution test for `useScopedRole`
+// already covers what *should* happen given a userRole; this test covers
+// the upstream half — that the field actually arrives at the resolver.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test } from "bun:test";
+
+import { bootstrapWorkspacesToInfo } from "../lib/bootstrap";
+import type { BootstrapResponse } from "../types";
+
+function bootstrapWs(
+  partial: Partial<BootstrapResponse["workspaces"][number]> & {
+    role: "admin" | "member";
+  },
+): BootstrapResponse["workspaces"][number] {
+  return {
+    id: "ws_test",
+    name: "Test",
+    memberCount: 1,
+    bundleCount: 0,
+    ...partial,
+  };
+}
+
+describe("bootstrapWorkspacesToInfo", () => {
+  test("propagates role as userRole — admin", () => {
+    const [info] = bootstrapWorkspacesToInfo([bootstrapWs({ role: "admin" })]);
+    expect(info?.userRole).toBe("admin");
+  });
+
+  test("propagates role as userRole — member", () => {
+    const [info] = bootstrapWorkspacesToInfo([bootstrapWs({ role: "member" })]);
+    expect(info?.userRole).toBe("member");
+  });
+
+  test("preserves id, name, memberCount; bundles starts empty", () => {
+    const [info] = bootstrapWorkspacesToInfo([
+      bootstrapWs({ id: "ws_1", name: "Acme", memberCount: 5, role: "admin" }),
+    ]);
+    expect(info?.id).toBe("ws_1");
+    expect(info?.name).toBe("Acme");
+    expect(info?.memberCount).toBe(5);
+    expect(info?.bundles).toEqual([]);
+  });
+
+  test("maps every workspace independently", () => {
+    const result = bootstrapWorkspacesToInfo([
+      bootstrapWs({ id: "ws_1", role: "admin" }),
+      bootstrapWs({ id: "ws_2", role: "member" }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.userRole).toBe("admin");
+    expect(result[1]?.userRole).toBe("member");
+  });
+
+  test("empty input → empty output", () => {
+    expect(bootstrapWorkspacesToInfo([])).toEqual([]);
+  });
+});

--- a/web/src/__tests__/bootstrap.test.ts
+++ b/web/src/__tests__/bootstrap.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { bootstrapWorkspacesToInfo } from "../lib/bootstrap";
+import { bootstrapWorkspacesToInfo, parseWorkspaceListResponse } from "../lib/bootstrap";
 import type { BootstrapResponse } from "../types";
 
 function bootstrapWs(
@@ -59,5 +59,68 @@ describe("bootstrapWorkspacesToInfo", () => {
 
   test("empty input → empty output", () => {
     expect(bootstrapWorkspacesToInfo([])).toEqual([]);
+  });
+});
+
+describe("parseWorkspaceListResponse", () => {
+  test("propagates userRole when server returns it (manage_workspaces.list shape)", () => {
+    // Today's `manage_workspaces.list` server handler emits `userRole`
+    // directly (workspace-mgmt-tools.ts handleList).
+    const result = parseWorkspaceListResponse({
+      workspaces: [{ id: "ws_1", name: "A", memberCount: 2, userRole: "admin" }],
+    });
+    expect(result[0]?.userRole).toBe("admin");
+  });
+
+  test("propagates role when server returns it (bootstrap shape)", () => {
+    // Defense against future contract drift: if either side renames the
+    // field, the other should still find it. Pinning this in a test makes
+    // the contract bidirectional rather than silently fragile.
+    const result = parseWorkspaceListResponse({
+      workspaces: [{ id: "ws_1", name: "A", memberCount: 2, role: "member" }],
+    });
+    expect(result[0]?.userRole).toBe("member");
+  });
+
+  test("prefers userRole over role when both are present", () => {
+    // The newer field wins — server's intent is authoritative.
+    const result = parseWorkspaceListResponse({
+      workspaces: [{ id: "ws_1", name: "A", memberCount: 1, role: "member", userRole: "admin" }],
+    });
+    expect(result[0]?.userRole).toBe("admin");
+  });
+
+  test("accepts bare array envelope", () => {
+    const result = parseWorkspaceListResponse([
+      { id: "ws_1", name: "A", memberCount: 1, userRole: "admin" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.userRole).toBe("admin");
+  });
+
+  test("ignores unrecognized role values rather than passing them through", () => {
+    // Belt-and-suspenders: if the server starts returning "owner" or some
+    // other value we haven't whitelisted, drop it rather than letting an
+    // unexpected string flow into the role resolver.
+    const result = parseWorkspaceListResponse({
+      workspaces: [{ id: "ws_1", name: "A", memberCount: 1, userRole: "owner" }],
+    });
+    expect(result[0]?.userRole).toBeUndefined();
+  });
+
+  test("returns empty array for null / undefined / unrecognized envelope", () => {
+    expect(parseWorkspaceListResponse(null)).toEqual([]);
+    expect(parseWorkspaceListResponse(undefined)).toEqual([]);
+    expect(parseWorkspaceListResponse({ unrelated: 1 })).toEqual([]);
+  });
+
+  test("filters out malformed workspace entries", () => {
+    const result = parseWorkspaceListResponse([
+      { id: "ws_1", name: "Good", memberCount: 1, userRole: "member" },
+      null,
+      "not-an-object",
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("ws_1");
   });
 });

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -41,7 +41,12 @@ function stopReasonMessage(stopReason: string): string {
     case "max_iterations":
       return "I reached my step limit for this turn. Send another message and I'll pick up where I left off.";
     case "length":
-      return "I ran out of room mid-response (hit the output-token limit). Send another message and I'll continue.";
+      // The two common causes of `length` are (a) writing a long response
+      // and running out of room and (b) extended thinking burning the
+      // output budget before any visible content lands. The platform now
+      // caps thinking to leave headroom (see resolveThinking), but breaking
+      // the task up still helps when the response itself is large.
+      return "I ran out of room mid-response (hit the output-token limit). Send another message to continue, or try splitting the task into smaller pieces.";
     case "content_filter":
       return "The response was blocked by content filtering. Try rephrasing your request.";
     case "error":

--- a/web/src/context/WorkspaceContext.tsx
+++ b/web/src/context/WorkspaceContext.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { callTool, setActiveWorkspaceId } from "../api/client";
+import { parseWorkspaceListResponse } from "../lib/bootstrap";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -100,13 +101,12 @@ export function WorkspaceProvider({
           }
         }
 
-        // The response may be { workspaces: [...] } or an array directly
-        let list: WorkspaceInfo[] = [];
-        if (Array.isArray(raw)) {
-          list = raw as WorkspaceInfo[];
-        } else if (raw && typeof raw === "object" && "workspaces" in raw) {
-          list = (raw as { workspaces: WorkspaceInfo[] }).workspaces;
-        }
+        // Route through the shared parser so `userRole` propagates regardless
+        // of whether the server returns it under `role` (bootstrap shape) or
+        // `userRole` (`manage_workspaces.list` shape today). Without this,
+        // any drift between the two contracts silently filters every
+        // workspace-scoped settings nav item for non-org-admins.
+        const list = parseWorkspaceListResponse(raw);
 
         setWorkspaces(list);
 

--- a/web/src/lib/bootstrap.ts
+++ b/web/src/lib/bootstrap.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// Bootstrap mappers — server response → client context state
+//
+// `userRole` is load-bearing: it drives every workspace-scoped permission
+// gate via `useScopedRole`. Dropping it on the way through resolves any
+// non-org-admin member to role="none" and filters their settings nav down
+// to "About" only — a bug we shipped once and won't ship again. Anchor
+// the mapping in a tested helper so a future contributor can't accidentally
+// re-introduce the omission.
+// ---------------------------------------------------------------------------
+
+import type { WorkspaceInfo } from "../context/WorkspaceContext";
+import type { BootstrapResponse } from "../types";
+
+/**
+ * Convert the bootstrap response's per-workspace shape into the
+ * `WorkspaceInfo` the `WorkspaceProvider` consumes. Caller is expected to
+ * pass `bootstrap.workspaces` directly. `bundles` starts empty and is
+ * populated lazily; `userRole` propagates so role gating works.
+ */
+export function bootstrapWorkspacesToInfo(
+  workspaces: BootstrapResponse["workspaces"],
+): WorkspaceInfo[] {
+  return workspaces.map((ws) => ({
+    id: ws.id,
+    name: ws.name,
+    memberCount: ws.memberCount,
+    bundles: [],
+    userRole: ws.role,
+  }));
+}

--- a/web/src/lib/bootstrap.ts
+++ b/web/src/lib/bootstrap.ts
@@ -5,8 +5,9 @@
 // gate via `useScopedRole`. Dropping it on the way through resolves any
 // non-org-admin member to role="none" and filters their settings nav down
 // to "About" only — a bug we shipped once and won't ship again. Anchor
-// the mapping in a tested helper so a future contributor can't accidentally
-// re-introduce the omission.
+// the mapping in tested helpers so a future contributor can't accidentally
+// re-introduce the omission via either entry path (bootstrap response or
+// `manage_workspaces.list` fallback).
 // ---------------------------------------------------------------------------
 
 import type { WorkspaceInfo } from "../context/WorkspaceContext";
@@ -28,4 +29,41 @@ export function bootstrapWorkspacesToInfo(
     bundles: [],
     userRole: ws.role,
   }));
+}
+
+/**
+ * Parse the `manage_workspaces.list` tool response into `WorkspaceInfo[]`.
+ * Used by the WorkspaceProvider's fallback fetch path (when bootstrap data
+ * isn't provided — e.g. tests, hot-reload, or a future code path that
+ * bypasses bootstrap).
+ *
+ * Defensive about field naming: the bootstrap response uses `role`, while
+ * this tool returns `userRole` directly. Accept either so either contract
+ * change can land without silently dropping the role and re-introducing
+ * the "settings nav shows About only" regression.
+ *
+ * Tolerates either `[{...}]` or `{ workspaces: [{...}] }` envelopes.
+ */
+export function parseWorkspaceListResponse(raw: unknown): WorkspaceInfo[] {
+  const list = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === "object" && "workspaces" in raw && Array.isArray(raw.workspaces)
+      ? raw.workspaces
+      : [];
+
+  return list
+    .filter((ws): ws is Record<string, unknown> => ws != null && typeof ws === "object")
+    .map((ws) => {
+      const rawRole = ws.userRole ?? ws.role;
+      const userRole = rawRole === "admin" || rawRole === "member" ? rawRole : undefined;
+      return {
+        id: String(ws.id ?? ""),
+        name: String(ws.name ?? ""),
+        memberCount: typeof ws.memberCount === "number" ? ws.memberCount : 0,
+        bundles: Array.isArray(ws.bundles)
+          ? (ws.bundles as Array<{ name?: string; path?: string }>)
+          : [],
+        ...(userRole ? { userRole } : {}),
+      };
+    });
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -269,7 +269,14 @@ export interface BootstrapResponse {
   workspaces: Array<{
     id: string;
     name: string;
-    role: string;
+    /**
+     * The signed-in user's role within this workspace. Drives the
+     * workspace-scoped permission UX (see `useScopedRole`). Tightened to
+     * the literal union so a future server change can't silently widen it
+     * back to `string` — that regression dropped every non-admin's
+     * settings nav to "About only" until detected in production.
+     */
+    role: "admin" | "member";
     memberCount: number;
     bundleCount: number;
   }>;


### PR DESCRIPTION
## Summary

Three production bugs surfaced during HQ tenant debugging on 2026-04-28 HST.

- **Settings nav:** non-admin workspace members see only \"About\" because the bootstrap mapper drops `userRole`. Orgs admins/owners short-circuit before the read, which is why dogfood missed this.
- **Thinking budget:** platform default `adaptive` lets Opus 4.7 spend the entire output budget on internal thinking and emit zero visible content. Switched the default to `enabled` with a capped budget; new platform invariant is at least 4K of visible-output room is always reserved.
- **Conversation replay:** orphaned tool-calls (process death mid-run) caused the reconstructor to drop the LLM turn, producing user→user adjacency that Anthropic rejects with `\"model does not support assistant message prefill\"`. Repaired with an honest placeholder + a final role-alternation invariant pass.

## Changes by file

| File | Change |
|---|---|
| `web/src/lib/bootstrap.ts` (new) | Extracted `bootstrapWorkspacesToInfo` mapper — propagates `userRole` |
| `web/src/__tests__/bootstrap.test.ts` (new) | Pins the role-propagation contract |
| `web/src/App.tsx` | Use the new helper |
| `web/src/types.ts` | Tighten `BootstrapResponse.workspaces[].role` to `\"admin\" \| \"member\"` |
| `web/src/components/MessageList.tsx` | Length-truncation copy points at \"split the task\" |
| `src/runtime/resolve-thinking.ts` | Cap thinking budget; default switched from `adaptive` → `enabled` |
| `src/runtime/runtime.ts` | Compute `maxOutputTokens` before `resolveThinking` so cap applies |
| `src/conversation/event-reconstructor.ts` | Step 4a fires on orphaned tool-calls; abandoned-run break; final role-alternation pass |
| `test/unit/resolve-thinking.test.ts` | Rewritten — 13 tests for cap behavior + operator overrides |
| `test/unit/event-reconstructor.test.ts` | Two new tests for orphaned-tool-calls placeholder + abandoned-run repair |

## Security review

The workspace-role propagation is UI-visibility-only — backend re-checks role on every write tool call. The role field was already in the bootstrap response (server-derived from `ws.members.find(m.userId === identity.id)!.role`), just being dropped on the floor. Type tightening (`string` → `\"admin\" \| \"member\"`) is purely compile-time and matches the server's `WorkspaceRole` union. No new attack surface; the change is strictly *narrowing*.

## Test plan

- [x] `bun run verify` — 2126 unit + 200 web + 424 integration + 16 smoke tests pass
- [ ] Deploy to HQ tenant on production and confirm Matthew Gerard sees the full settings nav
- [ ] Confirm the next \"build a proposal\" prompt on `synapse-collateral` produces visible output (no more length-truncation cycles)
- [ ] Verify a previously-broken conversation (e.g. `conv_035093f18cc84eed`) loads without the prefill-error 400

## Out of scope (follow-ups)

- `synapse-research__start_research` reliability (15 failures Apr 20–24 with mixed `-32603 Task failed` and `-32001 timeout` shapes — bundle-side investigation)
- `manage_workspaces` action `list` is currently org-admin-gated; should be allowed for any authenticated user, scoped to their workspaces (separate fix)
- `metadata.totals` events in JSONL so out-of-process tooling (tenant-summary script) doesn't need a duplicated pricing table