### PR TITLE
test: fix three sources of unit-test flakiness

### DIFF
--- a/test/smoke/system-tools-registry.test.ts
+++ b/test/smoke/system-tools-registry.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Smoke test for `nb__search` with `scope: "registry"`.
+ *
+ * Exercises the full `system-tools.search` → `mpak.client.searchBundles`
+ * → live registry HTTP path. Lives here (not in test/unit/) because it
+ * reaches the network and the registry must contain a known bundle for
+ * the assertion to hold — both make it unsuitable for the deterministic
+ * unit gate.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { extractText, textContent } from "../../src/engine/content-helpers.ts";
+import { makeInProcessSource } from "../helpers/in-process-source.ts";
+import { ToolRegistry } from "../../src/tools/registry.ts";
+import { createSystemTools } from "../../src/tools/system-tools.ts";
+
+async function makeRegistry(): Promise<ToolRegistry> {
+  const registry = new ToolRegistry();
+  const source = await makeInProcessSource("test", [
+    {
+      name: "greet",
+      description: "Say hello",
+      inputSchema: { type: "object", properties: { name: { type: "string" } } },
+      handler: async (input) => ({
+        content: textContent(`Hello ${input.name}!`),
+        isError: false,
+      }),
+    },
+  ]);
+  registry.addSource(source);
+  return registry;
+}
+
+describe("nb__search scope=registry — live mpak registry", () => {
+  it("returns results for a known published bundle", async () => {
+    const registry = await makeRegistry();
+    const systemTools = await createSystemTools(() => registry);
+
+    const result = await systemTools.execute("search", {
+      scope: "registry",
+      query: "ipinfo",
+    });
+
+    expect(result.isError).toBe(false);
+    expect(extractText(result.content)).toContain("ipinfo");
+  }, 30_000);
+});

--- a/test/unit/bundles/conversations/index-cache.test.ts
+++ b/test/unit/bundles/conversations/index-cache.test.ts
@@ -413,37 +413,37 @@ describe("get", () => {
 // ---------------------------------------------------------------------------
 
 describe("fs.watch integration", () => {
-	test("detects new file after debounce", async () => {
+	test("indexes a new file when processPendingFiles runs", async () => {
+		// Tests the deterministic post-debounce path. We do NOT exercise
+		// fs.watch here because macOS FSEvents is unreliable for new-file
+		// creation under parallel-test load — it occasionally drops the
+		// event entirely, producing a flake. The sibling deletion test
+		// uses the same private-method pattern. The actual fs.watch →
+		// debounce → processPendingFiles wiring is exercised end-to-end
+		// in the integration suite where retries / longer timeouts apply.
 		const index = new ConversationIndex();
 		await index.build(TMP_DIR);
 		expect(index.size).toBe(0);
 
-		index.startWatching(TMP_DIR);
+		writeConvFile({
+			id: "watch1",
+			createdAt: "2025-01-01T00:00:00.000Z",
+			updatedAt: "2025-01-01T00:00:00.000Z",
+			title: "Watched file",
+			messages: [{ role: "user", content: "new message", timestamp: "2025-01-01T00:01:00.000Z" }],
+		});
 
-		try {
-			// Write a new file
-			writeConvFile({
-				id: "watch1",
-				createdAt: "2025-01-01T00:00:00.000Z",
-				updatedAt: "2025-01-01T00:00:00.000Z",
-				title: "Watched file",
-				messages: [
-					{ role: "user", content: "new message", timestamp: "2025-01-01T00:01:00.000Z" },
-				],
-			});
+		// Drive the debounce-flush path directly. Mirrors what fs.watch's
+		// 500ms timer eventually invokes.
+		const priv = index as any;
+		priv.dir = TMP_DIR;
+		priv.pendingFiles.add("conv_watch1.jsonl");
+		await priv.processPendingFiles();
 
-			// Wait for debounce (500ms) + processing — poll to handle slow CI/load
-			for (let attempt = 0; attempt < 20 && index.size === 0; attempt++) {
-				await new Promise((resolve) => setTimeout(resolve, 250));
-			}
-
-			expect(index.size).toBe(1);
-			expect(index.get("watch1")).toBeDefined();
-			expect(index.get("watch1")!.title).toBe("Watched file");
-		} finally {
-			index.stopWatching();
-		}
-	}, 10_000);
+		expect(index.size).toBe(1);
+		expect(index.get("watch1")).toBeDefined();
+		expect(index.get("watch1")!.title).toBe("Watched file");
+	});
 
 	test("removes deleted file from index when processPendingFiles runs", async () => {
 		const filePath = writeConvFile({

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -50,32 +50,40 @@ describe("LoginRateLimiter", () => {
 	});
 
 	it("global limit resets after window expires", () => {
-		// Use a 1ms window so it expires immediately
-		const limiter = new LoginRateLimiter(10, 1, 5);
+		// 50ms window: long enough that the recordGlobal() loop below finishes
+		// inside one window (a 1ms window was racy under load — the loop
+		// itself could span >1ms and reset the counter mid-burst, dropping
+		// the post-loop count below the limit), short enough that the
+		// busy-wait afterwards is still cheap.
+		const windowMs = 50;
+		const limiter = new LoginRateLimiter(10, windowMs, 5);
 		for (let i = 0; i < 5; i++) {
 			limiter.recordGlobal();
 		}
 		expect(limiter.checkGlobal()).toBe(false);
 
-		// Wait for the window to expire
+		// Wait comfortably past the window.
 		const start = Date.now();
-		while (Date.now() - start < 5) {
-			// busy-wait a few ms for the 1ms window to expire
+		while (Date.now() - start < windowMs * 2) {
+			// busy-wait
 		}
 
 		expect(limiter.checkGlobal()).toBe(true);
 	});
 
 	it("removes expired windows on cleanup", () => {
-		// Use a very short window so entries expire immediately
-		const limiter = new LoginRateLimiter(10, 1);
+		// 50ms window — see above; same race applies to single-record entries
+		// under load. Window must be small enough that the busy-wait stays
+		// cheap, large enough that a single record() reliably lands inside
+		// it.
+		const windowMs = 50;
+		const limiter = new LoginRateLimiter(10, windowMs);
 		const ip = "192.0.2.1";
 		limiter.record(ip);
 
-		// Wait for the window to expire, then cleanup
 		const start = Date.now();
-		while (Date.now() - start < 5) {
-			// busy-wait a few ms for the 1ms window to expire
+		while (Date.now() - start < windowMs * 2) {
+			// busy-wait
 		}
 
 		limiter.cleanup();
@@ -112,14 +120,17 @@ describe("RequestRateLimiter", () => {
 	});
 
 	it("resets after window expires", () => {
-		const limiter = new RequestRateLimiter(2, 1); // 1ms window
+		// 50ms window — the consume() pair below must land inside the same
+		// window. A 1ms window was racy under load (loop spanned >1ms,
+		// silently resetting the count between calls).
+		const windowMs = 50;
+		const limiter = new RequestRateLimiter(2, windowMs);
 		expect(limiter.consume("user-1")).toBe(true);
 		expect(limiter.consume("user-1")).toBe(true);
 		expect(limiter.consume("user-1")).toBe(false);
 
-		// Wait for window to expire
 		const start = Date.now();
-		while (Date.now() - start < 5) {
+		while (Date.now() - start < windowMs * 2) {
 			// busy-wait
 		}
 

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -89,17 +89,11 @@ describe("System Tools", () => {
 		expect(extractText(result.content)).toContain('No tools matched "nonexistent"');
 	});
 
-	it("search with scope=registry searches mpak registry", async () => {
-		const registry = await makeRegistry();
-		const systemTools = await createSystemTools(() => registry);
-		const result = await systemTools.execute("search", {
-			scope: "registry",
-			query: "ipinfo",
-		});
-		expect(result.isError).toBe(false);
-		// Should contain actual search results (mpak must be installed)
-		expect(extractText(result.content)).toContain("ipinfo");
-	}, 15_000);
+	// `search with scope=registry` lives in test/smoke/system-tools-registry.test.ts.
+	// It hits the live mpak registry over the network, which makes it a smoke
+	// test by definition (CLAUDE.md: smoke tier owns "real MCP server spawns,
+	// network calls"). Unit gate stays deterministic; smoke job continues to
+	// validate the live wiring on main.
 
 	it("manage_app install requires lifecycle context", async () => {
 		const registry = await makeRegistry();


### PR DESCRIPTION
## Summary

Three pre-existing tests intermittently failed under parallel-test load on macOS (~1 in 5 full runs of `bun run test:unit`). All three are test-side issues, not regressions in the code under test. Surfaced during PR #113 QA review.

## Fixes

| Test | Root cause | Fix |
|---|---|---|
| `test/unit/system-tools.test.ts` — `scope=registry searches mpak registry` | Hits the live mpak registry over HTTP from the unit tier. Network blip → `isError: true` → fail. | Moved verbatim to `test/smoke/system-tools-registry.test.ts`. CLAUDE.md classifies "real MCP server spawns, network calls" as smoke. Smoke job (main-only) still validates the live wiring. |
| `test/unit/bundles/conversations/index-cache.test.ts` — `detects new file after debounce` | Relied on macOS FSEvents firing within a 5s polling window. Under load, FSEvents drops/delays create events. | Drive `processPendingFiles()` directly via the `priv as any` escape hatch, matching the sibling deletion test's pattern. Production wiring is still exercised end-to-end in integration. |
| `test/unit/rate-limiter.test.ts` — `global limit resets after window expires` (+ sibling `RequestRateLimiter` test) | Used `windowMs=1`; the `recordGlobal()` loop itself can span >1ms, silently resetting the counter mid-burst. | Bumped to `windowMs=50` and busy-wait to `windowMs * 2`. Still cheap, no longer racy. |

## Test plan

- [x] 15 consecutive `bun run test:unit` runs all green (2117/2117)
- [x] `bun run verify:static` passes
- [x] `bun run verify:test-unit` passes (unit + web)
- [ ] Smoke job (main-only) still picks up the moved registry test after merge