### PR TITLE
test(integration): bump configure-credentials timeout from 10s → 20s

### DIFF
--- a/test/integration/configure-credentials.test.ts
+++ b/test/integration/configure-credentials.test.ts
@@ -201,6 +201,14 @@ describe("manage_app configure — end-to-end", () => {
         restoreEnv();
       }
     },
-    10_000,
+    // 20s: spawns a real Node MCP subprocess and completes the full stdio
+    // handshake + tools/list. The platform's own MCP-stdio CONNECT_TIMEOUT
+    // is 30s (`src/tools/mcp-source.ts`), so the prior 10s outer guard
+    // tripped on slow CI runners while the platform was still well within
+    // its own connect budget. 20s matches the suite convention for
+    // subprocess-spawning tests (see remote-integration.test.ts) and
+    // stays under the platform ceiling so a genuine connect hang still
+    // surfaces as a failure rather than a test timeout.
+    20_000,
   );
 });


### PR DESCRIPTION
## Summary

The `manage_app configure — end-to-end` test in `test/integration/configure-credentials.test.ts` spawns a real Node MCP subprocess and completes the full stdio handshake + `tools/list`. Local runs complete in ~370ms, but on slow CI runners the test occasionally tripped its 10s outer guard while the platform was still well within its own MCP-stdio `CONNECT_TIMEOUT` of 30s (`src/tools/mcp-source.ts:294`).

20s matches the suite convention for subprocess-spawning tests (`remote-integration.test.ts` uses 15–25s for similar paths) and stays under the platform ceiling, so a genuine connect hang still surfaces as a real failure rather than a test-side timeout.

## Why this number

| Bound | Value | Reason |
|---|---|---|
| Local runtime | ~370ms | Plenty of headroom |
| Old timeout | 10s | Below platform connect budget — false positives on slow CI |
| **New timeout** | **20s** | Matches peer subprocess tests; stays under platform ceiling |
| Platform `CONNECT_TIMEOUT` | 30s | Real hangs surface as failures, not timeouts |

Surfaced on PR #114's CI run.

## Test plan

- [x] Test passes locally (`bun test test/integration/configure-credentials.test.ts`)
- [ ] CI passes