### PR TITLE
fix(ui): show "Calling X…" while model streams tool input

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -147,6 +147,8 @@ export async function handleChatStream(
           event.type === "chat.start" ||
           event.type === "text.delta" ||
           event.type === "reasoning.delta" ||
+          event.type === "tool.preparing" ||
+          event.type === "tool.preparing.done" ||
           event.type === "tool.start" ||
           event.type === "tool.done" ||
           event.type === "llm.done" ||

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -372,6 +372,8 @@ export class AgentEngine {
             },
             (text) => this.events.emit({ type: "text.delta", data: { runId, text } }),
             (text) => this.events.emit({ type: "reasoning.delta", data: { runId, text } }),
+            (id, name) => this.events.emit({ type: "tool.preparing", data: { runId, id, name } }),
+            (id) => this.events.emit({ type: "tool.preparing.done", data: { runId, id } }),
           ),
         );
         const llmMs = Math.round(performance.now() - llmStart);

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -45,6 +45,8 @@ export type EngineEventType =
   | "run.start"
   | "text.delta"
   | "reasoning.delta"
+  | "tool.preparing"
+  | "tool.preparing.done"
   | "tool.start"
   | "tool.done"
   | "tool.progress"

--- a/src/model/stream.ts
+++ b/src/model/stream.ts
@@ -18,6 +18,19 @@ export async function callModel(
   options: LanguageModelV3CallOptions,
   onTextDelta: (text: string) => void,
   onReasoningDelta?: (text: string) => void,
+  /**
+   * Called once when the model begins emitting a tool-call block, with
+   * the tool name already known. Lets the engine surface "Calling X…"
+   * during the dark gap where the model is streaming a large tool
+   * input — `tool.start` only fires after `callModel` returns.
+   *
+   * Provider-agnostic: AI SDK V3 normalizes `tool-input-start` across
+   * Anthropic / OpenAI / Google. Providers that never emit it simply
+   * skip the callback (engine falls back to `tool.start`-only signals,
+   * matching legacy behavior).
+   */
+  onToolInputStart?: (id: string, toolName: string) => void,
+  onToolInputEnd?: (id: string) => void,
 ): Promise<StreamResult> {
   const { stream } = await model.doStream(options);
 
@@ -101,6 +114,21 @@ export async function callModel(
           }
           accumulatedReasoning = "";
           reasoningProviderMetadata = undefined;
+          break;
+
+        // Tool-input parts: surface model-side tool intent before the
+        // engine actually dispatches the tool. `-delta` is intentionally
+        // not forwarded — per-char SSE traffic for no UI gain (the chat
+        // shows tool *intent*, not the JSON forming).
+        case "tool-input-start":
+          onToolInputStart?.(part.id, part.toolName);
+          break;
+
+        case "tool-input-delta":
+          break;
+
+        case "tool-input-end":
+          onToolInputEnd?.(part.id);
           break;
 
         case "tool-call":

--- a/test/helpers/echo-model.ts
+++ b/test/helpers/echo-model.ts
@@ -196,6 +196,23 @@ export function createEchoModel(options?: EchoModelOptions): LanguageModelV3 {
           parts.push({ type: "text-end", id: "text-0" });
         } else if (item.type === "tool-call") {
           const tc = item as LanguageModelV3ToolCall;
+          // Real providers (Anthropic / OpenAI / Google) emit
+          // tool-input-start, then a stream of tool-input-delta, then
+          // tool-input-end *before* the assembled tool-call. Mirror
+          // that shape so callModel's tool-input-* callbacks see the
+          // signals they would in production. Stub deltas keep tests
+          // realistic without requiring per-char fixtures.
+          parts.push({
+            type: "tool-input-start",
+            id: tc.toolCallId,
+            toolName: tc.toolName,
+          });
+          parts.push({
+            type: "tool-input-delta",
+            id: tc.toolCallId,
+            delta: tc.input as string,
+          });
+          parts.push({ type: "tool-input-end", id: tc.toolCallId });
           parts.push({
             type: "tool-call",
             toolCallId: tc.toolCallId,

--- a/test/unit/model-stream.test.ts
+++ b/test/unit/model-stream.test.ts
@@ -76,6 +76,62 @@ describe("callModel", () => {
     expect(textBlocks[0]).toEqual({ type: "text", text: "accumulate" });
   });
 
+  it("emits tool-input start/end callbacks before the tool-call block", async () => {
+    const model = createEchoModel({
+      responses: [{ text: "preface", toolCalls: [sampleToolCall] }],
+    });
+    const events: string[] = [];
+
+    await callModel(
+      model,
+      userPrompt("prep"),
+      (t) => events.push(`text:${t}`),
+      undefined,
+      (id, name) => events.push(`prep-start:${id}:${name}`),
+      (id) => events.push(`prep-end:${id}`),
+    );
+
+    // Tool-input start fires once per tool, with the tool name already known
+    // (this is what lets the UI show "Calling X…" before execution begins).
+    // Per-char tool-input-delta is intentionally swallowed in stream.ts —
+    // verify by asserting only one start and one end event for this tool.
+    const startEvents = events.filter((e) => e.startsWith("prep-start:"));
+    const endEvents = events.filter((e) => e.startsWith("prep-end:"));
+    expect(startEvents).toEqual([`prep-start:${sampleToolCall.toolCallId}:${sampleToolCall.toolName}`]);
+    expect(endEvents).toEqual([`prep-end:${sampleToolCall.toolCallId}`]);
+
+    // Order: text deltas precede prep-start (text emitted before tool-use
+    // block in this fixture); prep-end precedes nothing relevant for this test
+    // but must precede the assembled tool-call returned in result.content.
+    const textIdx = events.findIndex((e) => e === "text:preface");
+    const startIdx = events.indexOf(startEvents[0]);
+    const endIdx = events.indexOf(endEvents[0]);
+    expect(textIdx).toBeLessThan(startIdx);
+    expect(startIdx).toBeLessThan(endIdx);
+  });
+
+  it("does not invoke tool-input callbacks for text-only responses", async () => {
+    const model = createEchoModel();
+    let starts = 0;
+    let ends = 0;
+
+    await callModel(
+      model,
+      userPrompt("no tools"),
+      () => {},
+      undefined,
+      () => {
+        starts++;
+      },
+      () => {
+        ends++;
+      },
+    );
+
+    expect(starts).toBe(0);
+    expect(ends).toBe(0);
+  });
+
   it("extracts nested usage structure", async () => {
     const model = createEchoModel();
 

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -48,7 +48,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
   const inputWrapperRef = useRef<HTMLDivElement>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [copiedId, setCopiedId] = useState(false);
-  const { conversationId, streamingState } = useChatContext();
+  const { conversationId, streamingState, preparingTool } = useChatContext();
   const { currentUserId, participantMap } = useChatConfigContext();
 
   // Derive a title from the first user message, stripping markdown syntax
@@ -216,6 +216,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
         messages={messages}
         isStreaming={isStreaming}
         streamingState={streamingState}
+        preparingTool={preparingTool}
         displayDetail={displayDetail}
         compact={compact}
         currentUserId={currentUserId}
@@ -229,6 +230,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
           disabled={isStreaming}
           onNewConversation={handleNewChat}
           streamingState={streamingState}
+          preparingTool={preparingTool}
         />
       </div>
 

--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -1,6 +1,7 @@
 import { ArrowUp, Paperclip } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { StreamingState } from "../hooks/useChat";
+import type { PreparingTool, StreamingState } from "../hooks/useChat";
+import { stripServerPrefix } from "../lib/format";
 import { FileAttachmentChips } from "./FileAttachmentChips";
 
 const MAX_TEXTAREA_HEIGHT = 200;
@@ -10,6 +11,7 @@ interface MessageInputProps {
   disabled: boolean;
   onNewConversation?: () => void;
   streamingState?: StreamingState;
+  preparingTool?: PreparingTool | null;
 }
 
 export function MessageInput({
@@ -17,6 +19,7 @@ export function MessageInput({
   disabled,
   onNewConversation,
   streamingState,
+  preparingTool,
 }: MessageInputProps) {
   const [text, setText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
@@ -148,7 +151,10 @@ export function MessageInput({
   );
 
   const isActive =
-    streamingState === "thinking" || streamingState === "working" || streamingState === "analyzing";
+    streamingState === "thinking" ||
+    streamingState === "working" ||
+    streamingState === "analyzing" ||
+    streamingState === "preparing";
   const canSend = (text.trim() || attachedFiles.length > 0) && !disabled;
 
   return (
@@ -234,11 +240,13 @@ export function MessageInput({
       <div className="flex items-center justify-center gap-3 mt-2 text-[10px] text-muted-foreground">
         {isActive && (
           <span className="text-processing font-mono font-medium">
-            {streamingState === "working"
-              ? "Working..."
-              : streamingState === "analyzing"
-                ? "Analyzing..."
-                : "Thinking..."}
+            {streamingState === "preparing" && preparingTool
+              ? `Calling ${stripServerPrefix(preparingTool.name)}...`
+              : streamingState === "working"
+                ? "Working..."
+                : streamingState === "analyzing"
+                  ? "Analyzing..."
+                  : "Thinking..."}
           </span>
         )}
         {onNewConversation && (

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -1,7 +1,8 @@
 import { AlertCircle, Check, ChevronDown, Copy, RotateCcw, Zap } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Streamdown } from "streamdown";
-import type { ChatMessage, StreamingState } from "../hooks/useChat";
+import type { ChatMessage, PreparingTool, StreamingState } from "../hooks/useChat";
+import { stripServerPrefix } from "../lib/format";
 import { participantColor } from "../lib/participant-colors";
 import type { DisplayDetail } from "../lib/tool-display";
 import { FileAttachment } from "./FileAttachment";
@@ -119,6 +120,8 @@ interface MessageListProps {
   messages: ChatMessage[];
   isStreaming: boolean;
   streamingState: StreamingState;
+  /** Set while the model is emitting a tool-call block (pre-execution). */
+  preparingTool?: PreparingTool | null;
   displayDetail: DisplayDetail;
   compact?: boolean;
   /** Current user's ID — messages from this user get no speaker label. */
@@ -220,6 +223,7 @@ export function MessageList({
   messages,
   isStreaming,
   streamingState,
+  preparingTool,
   displayDetail,
   compact = false,
   currentUserId,
@@ -451,6 +455,18 @@ export function MessageList({
                         </Streamdown>
                       </div>
                     )}
+                    {/* "Calling X…" — the model has emitted a tool-call
+                        block (tool-input-start) but the engine hasn't
+                        executed it yet. Without this, the indicator
+                        goes dark for the entire tool-args streaming
+                        window (minutes for large inputs). */}
+                    {idx === messages.length - 1 &&
+                      streamingState === "preparing" &&
+                      preparingTool && (
+                        <span className="text-xs font-mono text-muted-foreground/60 presence-thinking">
+                          Calling {stripServerPrefix(preparingTool.name)}...
+                        </span>
+                      )}
                     {/* File attachments */}
                     {msg.files && msg.files.length > 0 && (
                       <div className="flex flex-wrap gap-2">

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -13,21 +13,44 @@ import type {
   StreamErrorEvent,
   TextDeltaEvent,
   ToolDoneEvent,
+  ToolPreparingDoneEvent,
+  ToolPreparingEvent,
   ToolStartEvent,
 } from "../types";
 
 /**
  * Streaming state machine:
  *
- *   null → thinking → streaming ↔ working → analyzing → streaming → null
- *                                                    ↘ working (next tool.start)
+ *   null → thinking → streaming ↔ preparing → working → analyzing → streaming → null
+ *                                                              ↘ working (next tool.start)
  *
  * `analyzing` fills the gap between the last tool.done (all tools finished)
  * and the next text.delta / tool.start, when the model is inferring on tool
- * results but the UI would otherwise look frozen. Any `tool.start` can
- * re-enter `working` from a non-terminal state.
+ * results but the UI would otherwise look frozen.
+ *
+ * `preparing` fills the model-side gap: after text/reasoning has streamed
+ * within an iteration, the model may continue emitting a large tool-call
+ * input block (45 KB+ for full-document writes). No deltas fire during
+ * that window — without `preparing`, the indicator goes dark for as long
+ * as it takes the LLM to emit the args. `tool.preparing` fires on
+ * `tool-input-start` from the AI SDK; `tool.start` follows once the
+ * iteration finishes and the engine begins execution.
+ *
+ * Any `tool.start` can re-enter `working` from a non-terminal state.
  */
-export type StreamingState = null | "thinking" | "streaming" | "working" | "analyzing";
+export type StreamingState =
+  | null
+  | "thinking"
+  | "streaming"
+  | "preparing"
+  | "working"
+  | "analyzing";
+
+/** Identifies the tool the model is currently building a call for. */
+export interface PreparingTool {
+  id: string;
+  name: string;
+}
 
 /** Typed tool result shape forwarded through the bridge. */
 export interface ToolResultForUI {
@@ -111,6 +134,8 @@ export interface UseChatReturn {
   messages: ChatMessage[];
   isStreaming: boolean;
   streamingState: StreamingState;
+  /** Set while streamingState === "preparing"; null otherwise. */
+  preparingTool: PreparingTool | null;
   conversationId: string | null;
   conversationMeta: LoadedConversationMeta | null;
   error: string | null;
@@ -180,6 +205,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
   );
   const [error, setError] = useState<string | null>(null);
   const [streamingState, setStreamingState] = useState<StreamingState>(null);
+  const [preparingTool, setPreparingTool] = useState<PreparingTool | null>(null);
   const [conversationMeta, setConversationMeta] = useState<LoadedConversationMeta | null>(null);
 
   // Refs for building the current assistant message during streaming.
@@ -298,9 +324,22 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
               flushToMessage();
               break;
             }
+            case "tool.preparing": {
+              const evt = data as ToolPreparingEvent;
+              setStreamingState("preparing");
+              setPreparingTool({ id: evt.id, name: evt.name });
+              break;
+            }
+            case "tool.preparing.done": {
+              // No state change — `tool.start` follows once the iteration
+              // ends and the engine begins execution. Holding `preparing`
+              // through the gap keeps the indicator stable.
+              break;
+            }
             case "tool.start": {
               const evt = data as ToolStartEvent;
               setStreamingState("working");
+              setPreparingTool(null);
               const separatorIdx = evt.name.indexOf("__");
               const newTool: ToolCallDisplay = {
                 id: evt.id,
@@ -355,6 +394,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             case "done": {
               const result = data as ChatResult;
               setStreamingState(null);
+              setPreparingTool(null);
               setConversationId(result.conversationId);
 
               // Backfill tool results from done event
@@ -410,6 +450,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             case "error": {
               const evt = data as StreamErrorEvent;
               setStreamingState(null);
+              setPreparingTool(null);
               // Stamp the error on the last assistant message so it renders
               // inline — not as a disconnected banner at the top.
               setMessages((prev) => {
@@ -467,6 +508,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
       } finally {
         setIsStreaming(false);
         setStreamingState(null);
+        setPreparingTool(null);
       }
     },
     // biome-ignore lint/correctness/useExhaustiveDependencies: sendMessage captures streaming/conversation state via refs
@@ -480,6 +522,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
     setError(null);
     setIsStreaming(false);
     setStreamingState(null);
+    setPreparingTool(null);
     blocksRef.current = [];
     toolCallsRef.current = [];
     iterationRef.current = undefined;
@@ -588,9 +631,19 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
           flushToMessage();
           break;
         }
+        case "tool.preparing": {
+          const evt = data as ToolPreparingEvent;
+          setStreamingState("preparing");
+          setPreparingTool({ id: evt.id, name: evt.name });
+          break;
+        }
+        case "tool.preparing.done": {
+          break;
+        }
         case "tool.start": {
           const evt = data as ToolStartEvent;
           setStreamingState("working");
+          setPreparingTool(null);
           const separatorIdx = evt.name.indexOf("__");
           const newTool: ToolCallDisplay = {
             id: evt.id,
@@ -638,6 +691,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
         case "done": {
           const result = data as ChatResult;
           setStreamingState(null);
+          setPreparingTool(null);
           setIsStreaming(false);
 
           if (result.toolCalls) {
@@ -708,6 +762,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
     setError(null);
     setIsStreaming(false);
     setStreamingState(null);
+    setPreparingTool(null);
   }, []);
 
   // Effect: once isStreaming is false and there's a pending retry, fire it.
@@ -741,6 +796,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
       return updated;
     });
     setStreamingState(null);
+    setPreparingTool(null);
     setIsStreaming(false);
   }, []);
 
@@ -748,6 +804,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
     messages,
     isStreaming,
     streamingState,
+    preparingTool,
     conversationId,
     conversationMeta,
     error,

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -300,6 +300,12 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             case "text.delta": {
               const evt = data as TextDeltaEvent;
               setStreamingState((prev) => (prev !== "streaming" ? "streaming" : prev));
+              // Defensive: keeps `preparingTool` paired with the
+              // `"preparing"` streamingState. Render sites gate on the
+              // state, so stale data never shows today, but a future
+              // caller reading `preparingTool` directly would otherwise
+              // see a tool name from a long-finished iteration.
+              setPreparingTool(null);
               // Append to last text block or create a new one
               const blocks = blocksRef.current;
               const lastBlock = blocks[blocks.length - 1];
@@ -314,6 +320,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
             case "reasoning.delta": {
               const evt = data as ReasoningDeltaEvent;
               setStreamingState((prev) => (prev !== "streaming" ? "streaming" : prev));
+              setPreparingTool(null);
               const blocks = blocksRef.current;
               const lastBlock = blocks[blocks.length - 1];
               if (lastBlock && lastBlock.type === "reasoning") {
@@ -608,6 +615,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
         case "text.delta": {
           const evt = data as TextDeltaEvent;
           setStreamingState((prev) => (prev !== "streaming" ? "streaming" : prev));
+          setPreparingTool(null);
           const blocks = blocksRef.current;
           const lastBlock = blocks[blocks.length - 1];
           if (lastBlock && lastBlock.type === "text") {
@@ -621,6 +629,7 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
         case "reasoning.delta": {
           const evt = data as ReasoningDeltaEvent;
           setStreamingState((prev) => (prev !== "streaming" ? "streaming" : prev));
+          setPreparingTool(null);
           const blocks = blocksRef.current;
           const lastBlock = blocks[blocks.length - 1];
           if (lastBlock && lastBlock.type === "reasoning") {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -180,6 +180,24 @@ export interface ToolStartEvent {
   input?: Record<string, unknown>;
 }
 
+/**
+ * Fired when the model begins emitting a tool-call block, before the
+ * tool actually executes. Bridges the dark gap between the last text
+ * delta and `tool.start` when the model is streaming a large tool
+ * input (e.g. a 45 KB document body) — without this, the UI has no
+ * signal during that window.
+ */
+export interface ToolPreparingEvent {
+  runId: string;
+  id: string;
+  name: string;
+}
+
+export interface ToolPreparingDoneEvent {
+  runId: string;
+  id: string;
+}
+
 export interface ResourceLinkInfo {
   uri: string;
   name?: string;
@@ -232,6 +250,8 @@ export interface ChatStreamEventMap {
   "chat.start": { conversationId: string };
   "text.delta": TextDeltaEvent;
   "reasoning.delta": ReasoningDeltaEvent;
+  "tool.preparing": ToolPreparingEvent;
+  "tool.preparing.done": ToolPreparingDoneEvent;
   "tool.start": ToolStartEvent;
   "tool.done": ToolDoneEvent;
   "llm.done": LlmDoneEvent;


### PR DESCRIPTION
## Summary

- The chat UI went visually dark for the entire duration of large tool-input streams. Reproduced in production `conv_6cf2bbacee2745cd` (hq tenant): a 45 KB `set_source` call took 4m18s with no breathing border, no label, and no inline placeholder — only the static "Waiting for response…" textarea hint. Cause: `src/model/stream.ts` was discarding the AI SDK's `tool-input-{start,delta,end}` parts that fire while the model assembles a tool call within an iteration.
- Surface those parts as two new engine events (`tool.preparing` on `tool-input-start`, `tool.preparing.done` on `tool-input-end`) and forward them through the existing `EventSink` → SSE path. `useChat` adds a `"preparing"` `StreamingState` plus a `preparingTool { id, name }` field; `MessageInput` renders **`Calling <tool>...`** with the breathing border, and `MessageList` shows an inline placeholder under the last assistant block.
- Provider-agnostic: AI SDK V3's `LanguageModelV3StreamPart` is the unified abstraction — verified that Anthropic, OpenAI, and Google adapters all normalize their native streaming protocols into `tool-input-{start,delta,end}` (against installed `@ai-sdk/*` dist). Gateway passes them through. Zero per-provider code. Per-char `tool-input-delta` is intentionally swallowed in `stream.ts` — only `start`/`end` propagate, so steady-state SSE traffic is unchanged.

## Design notes

Three options were considered: (A) UI-side idle timeout, (B) forward AI SDK part events end-to-end, (C) engine heartbeat. **B** chosen — A and C fix the visible symptom but leave information loss in place; B surfaces the actual phase the model is in, names the tool 4 minutes earlier than today on large calls, and is provider-agnostic. The bigger refactor of `streamingState` into a full phase union is left for follow-up; this PR adds `"preparing"` as a new value plus a sibling `preparingTool` field for the smallest blast radius that still fixes the bug and surfaces the tool name.

## Test plan

- [x] `bun run verify` green (static + 416 unit + 24 web + integration + 17 smoke)
- [x] New `model-stream.test.ts` cases: `tool-input` callbacks fire once per tool with correct ordering; not invoked for text-only responses
- [x] Echo model fixture updated to emit `tool-input-{start,delta,end}` parts so existing tool-call tests exercise the new code path automatically
- [ ] Manual: send a prompt that triggers a long tool-args stream (e.g. set_source with a large body) — confirm "Calling set_source..." appears immediately after the model starts the tool block, persists for the full streaming window, and transitions to "Working..." once the engine begins execution
- [ ] Manual: confirm short / fast tool calls (set_source on a small doc, get_workspace) flicker through `"preparing"` → `"working"` cleanly with no UI artifacts
- [ ] Manual: verify shared-conversation remote stream (`processRemoteStreamEvent`) shows the same indicator for a participant watching another user's session

## Files

- `src/engine/types.ts` — new event types in the union
- `src/model/stream.ts` — consume `tool-input-*`; new optional callbacks
- `src/engine/engine.ts` — wire callbacks → emit events
- `src/api/handlers.ts` — forward to SSE allow-list
- `web/src/types.ts` — wire event types and `ChatStreamEventMap` entries
- `web/src/hooks/useChat.ts` — `"preparing"` state + `preparingTool` field; local and remote handlers
- `web/src/components/{ChatPanel,MessageInput,MessageList}.tsx` — thread state, render label and inline placeholder
- `test/helpers/echo-model.ts` — emit `tool-input-{start,delta,end}` parts before `tool-call`
- `test/unit/model-stream.test.ts` — callback ordering tests