### PR TITLE
feat: emit contentHash on skills.loaded events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Added
 
-- `skills.loaded` events now carry a `contentHash` (SHA-256 hex) per skill — telemetry foundation for the upcoming `compose_effective_context` debug tool (#119), which uses the hash to detect whether an on-disk skill body has been mutated between when the skill loaded and when an operator inspects the run. ~64 bytes per skill per turn; backward-compatible (field is optional on the type so old persisted events still parse).
+- `skills.loaded` events now carry a `contentHash` (SHA-256 hex) per skill — telemetry foundation for the upcoming `compose_effective_context` debug tool (#119), which uses the hash to detect whether an on-disk skill body has been mutated between when the skill loaded and when an operator inspects the run. ~64 bytes per skill per turn.
 - Extended-thinking config (`thinking: off | adaptive | enabled` + `thinkingBudgetTokens`) in runtime config and Settings → Model; defaults to `adaptive` for catalog-flagged reasoning models, `off` otherwise ([#109](https://github.com/NimbleBrainInc/nimblebrain/pull/109)).
 - Reasoning (extended-thinking) content is now captured end-to-end: `stream.ts` handles `reasoning-*` parts, the engine emits `reasoning.delta` SSE events, and the chat UI renders a collapsed "Thoughts" block above the assistant text. Empty turns with non-stop finishReason now emit a placeholder so replay surfaces truncations.
 - `nb__read_resource` system tool — the agent can now load `skill://` / `ui://` resources advertised by an installed bundle's MCP server ([#3](https://github.com/NimbleBrainInc/nimblebrain/pull/25)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Added
 
+- `skills.loaded` events now carry a `contentHash` (SHA-256 hex) per skill — telemetry foundation for the upcoming `compose_effective_context` debug tool (#119), which uses the hash to detect whether an on-disk skill body has been mutated between when the skill loaded and when an operator inspects the run. ~64 bytes per skill per turn; backward-compatible (field is optional on the type so old persisted events still parse).
 - Extended-thinking config (`thinking: off | adaptive | enabled` + `thinkingBudgetTokens`) in runtime config and Settings → Model; defaults to `adaptive` for catalog-flagged reasoning models, `off` otherwise ([#109](https://github.com/NimbleBrainInc/nimblebrain/pull/109)).
 - Reasoning (extended-thinking) content is now captured end-to-end: `stream.ts` handles `reasoning-*` parts, the engine emits `reasoning.delta` SSE events, and the chat UI renders a collapsed "Thoughts" block above the assistant text. Empty turns with non-stop finishReason now emit a placeholder so replay surfaces truncations.
 - `nb__read_resource` system tool — the agent can now load `skill://` / `ui://` resources advertised by an installed bundle's MCP server ([#3](https://github.com/NimbleBrainInc/nimblebrain/pull/25)).

--- a/src/conversation/event-sourced-store.ts
+++ b/src/conversation/event-sourced-store.ts
@@ -603,6 +603,13 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
       }
 
       case "skills.loaded": {
+        // Trust boundary: persisted JSON → typed projection. The cast assumes
+        // every emitter populates the full `SkillsLoadedEntry` shape (the
+        // platform's only emitter, `buildSkillsLoadedPayload`, does). Tools
+        // that depend on per-field guarantees on read should validate at
+        // their consumption point rather than assume the cast is sound for
+        // arbitrary on-disk data — the broader event-shape validation is its
+        // own audit, not in scope here.
         const skills = Array.isArray(d.skills)
           ? (d.skills as SkillsLoadedEntry[])
           : ([] as SkillsLoadedEntry[]);

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -179,6 +179,21 @@ export interface ContextAssembledPayload {
  * Per-skill telemetry attached to a `skills.loaded` event. Re-exported
  * from `src/conversation/types.ts` so emitters and persisters reference
  * one definition; drift surfaces as a type error.
+ *
+ * `contentHash` is the SHA-256 (hex) of the skill body that was actually
+ * composed into the prompt. New emissions always populate it; the field
+ * is optional only to preserve backward compat with events written
+ * before the hash field was added. Debug tools that read the field MUST
+ * handle missing values explicitly (e.g. surface "this skill loaded
+ * before content-hash telemetry — can't verify it hasn't drifted").
+ *
+ * The hash lets debug tools detect mutation between when the skill
+ * loaded and when an operator inspects it: equal hashes mean the
+ * current on-disk body matches what ran, and can be displayed
+ * verbatim; differing hashes can be looked up against `_versions/`
+ * snapshots to find the body that actually loaded. Cheap (~64 bytes
+ * per skill per turn); decoupled from the body itself so event size
+ * stays bounded.
  */
 export interface SkillsLoadedEntry {
   id: string;
@@ -186,6 +201,8 @@ export interface SkillsLoadedEntry {
   scope: "org" | "workspace" | "user" | "bundle";
   version: string;
   tokens: number;
+  /** SHA-256 hex of the skill body. Always populated on new events. */
+  contentHash?: string;
   loadedBy: "always" | "tool_affinity";
   reason: string;
 }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -180,20 +180,16 @@ export interface ContextAssembledPayload {
  * from `src/conversation/types.ts` so emitters and persisters reference
  * one definition; drift surfaces as a type error.
  *
- * `contentHash` is the SHA-256 (hex) of the skill body that was actually
- * composed into the prompt. New emissions always populate it; the field
- * is optional only to preserve backward compat with events written
- * before the hash field was added. Debug tools that read the field MUST
- * handle missing values explicitly (e.g. surface "this skill loaded
- * before content-hash telemetry — can't verify it hasn't drifted").
+ * `contentHash` is the SHA-256 (hex) of the skill body that was composed
+ * into the prompt. Lets debug tools detect mutation between when the
+ * skill loaded and when an operator inspects it:
+ *   - hash matches current source → display body verbatim, full fidelity
+ *   - hash differs → look up against `_versions/` snapshots to find the
+ *     body that actually loaded, or surface a "this skill changed since"
+ *     warning if no matching snapshot exists.
  *
- * The hash lets debug tools detect mutation between when the skill
- * loaded and when an operator inspects it: equal hashes mean the
- * current on-disk body matches what ran, and can be displayed
- * verbatim; differing hashes can be looked up against `_versions/`
- * snapshots to find the body that actually loaded. Cheap (~64 bytes
- * per skill per turn); decoupled from the body itself so event size
- * stays bounded.
+ * Cheap (~64 bytes per skill per turn); decoupled from the body itself
+ * so event size stays bounded.
  */
 export interface SkillsLoadedEntry {
   id: string;
@@ -201,8 +197,8 @@ export interface SkillsLoadedEntry {
   scope: "org" | "workspace" | "user" | "bundle";
   version: string;
   tokens: number;
-  /** SHA-256 hex of the skill body. Always populated on new events. */
-  contentHash?: string;
+  /** SHA-256 hex of the skill body composed into the prompt. */
+  contentHash: string;
   loadedBy: "always" | "tool_affinity";
   reason: string;
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -55,7 +55,6 @@ import {
 } from "../skills/loader.ts";
 import { SkillMatcher } from "../skills/matcher.ts";
 import { selectLayer3Skills } from "../skills/select.ts";
-import { buildSkillsLoadedPayload } from "./skills-loaded-payload.ts";
 import { approxTokens } from "../skills/tokens.ts";
 import type { Skill } from "../skills/types.ts";
 import { TelemetryManager } from "../telemetry/manager.ts";
@@ -73,6 +72,7 @@ import {
   type RequestContext,
   runWithRequestContext,
 } from "./request-context.ts";
+import { buildSkillsLoadedPayload } from "./skills-loaded-payload.ts";
 import { surfaceTools } from "./tools.ts";
 import type { ChatRequest, ChatResult, ModelSlots, RuntimeConfig, TurnUsage } from "./types.ts";
 import { createWorkspaceRegistry, startWorkspaceBundles } from "./workspace-runtime.ts";
@@ -1871,13 +1871,6 @@ function stampDerivedScope(workDir: string, skill: Skill): Skill {
     manifest: { ...skill.manifest, scope: isOrg ? "org" : "bundle" },
   };
 }
-
-/**
- * Build the `skills.loaded` payload from the Layer 3 selection result. Each
- * entry carries id (sourcePath or "in-memory" sentinel), scope, version
- * (file mtime), tokens (approximate), `loadedBy`, and the matcher's reason
- * string. Total is the sum of per-skill tokens.
- */
 
 /**
  * Build the `context.assembled` snapshot from the assembled prompt + tool

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -52,10 +52,10 @@ import {
   loadSkillDir,
   mergeScopedSkills,
   partitionSkills,
-  readSkillMtime,
 } from "../skills/loader.ts";
 import { SkillMatcher } from "../skills/matcher.ts";
-import { type SelectedSkill, selectLayer3Skills } from "../skills/select.ts";
+import { selectLayer3Skills } from "../skills/select.ts";
+import { buildSkillsLoadedPayload } from "./skills-loaded-payload.ts";
 import { approxTokens } from "../skills/tokens.ts";
 import type { Skill } from "../skills/types.ts";
 import { TelemetryManager } from "../telemetry/manager.ts";
@@ -1878,24 +1878,6 @@ function stampDerivedScope(workDir: string, skill: Skill): Skill {
  * (file mtime), tokens (approximate), `loadedBy`, and the matcher's reason
  * string. Total is the sum of per-skill tokens.
  */
-function buildSkillsLoadedPayload(selected: SelectedSkill[]): SkillsLoadedPayload {
-  const entries = selected.map((s) => {
-    const body = s.skill.body;
-    const tokens = approxTokens(body);
-    const sourcePath = s.skill.sourcePath || "";
-    return {
-      id: sourcePath || `skill-in-memory:${s.skill.manifest.name}`,
-      layer: 3 as const,
-      scope: (s.skill.manifest.scope ?? "org") as "org" | "workspace" | "user" | "bundle",
-      version: sourcePath ? readSkillMtime(sourcePath) : "",
-      tokens,
-      loadedBy: s.loadedBy,
-      reason: s.reason,
-    };
-  });
-  const totalTokens = entries.reduce((sum, e) => sum + e.tokens, 0);
-  return { skills: entries, totalTokens };
-}
 
 /**
  * Build the `context.assembled` snapshot from the assembled prompt + tool

--- a/src/runtime/skills-loaded-payload.ts
+++ b/src/runtime/skills-loaded-payload.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
-import type { SelectedSkill } from "../skills/select.ts";
 import type { SkillsLoadedPayload } from "../engine/types.ts";
 import { readSkillMtime } from "../skills/loader.ts";
+import type { SelectedSkill } from "../skills/select.ts";
 import { approxTokens } from "../skills/tokens.ts";
 
 /**

--- a/src/runtime/skills-loaded-payload.ts
+++ b/src/runtime/skills-loaded-payload.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import type { SelectedSkill } from "../skills/select.ts";
+import type { SkillsLoadedPayload } from "../engine/types.ts";
+import { readSkillMtime } from "../skills/loader.ts";
+import { approxTokens } from "../skills/tokens.ts";
+
+/**
+ * Build the `skills.loaded` payload from the Layer 3 selection result.
+ *
+ * Each entry carries:
+ *   - `id` — sourcePath, or an in-memory sentinel for skills synthesized at
+ *     runtime (workspace identity overrides, etc.)
+ *   - `scope` — defaults to `org` when the manifest doesn't pin one
+ *   - `version` — file mtime as a stable change marker, "" for in-memory
+ *   - `tokens` — approximate, summed into the payload total
+ *   - `contentHash` — SHA-256 hex of the body that was composed into the
+ *     prompt. Lets debug tools detect mutation between when the skill loaded
+ *     and when an operator inspects it (see `SkillsLoadedEntry` for full
+ *     rationale).
+ *   - `loadedBy` / `reason` — propagated from the selector for telemetry.
+ *
+ * Pure function; no FS access beyond the mtime read for `version`.
+ */
+export function buildSkillsLoadedPayload(selected: SelectedSkill[]): SkillsLoadedPayload {
+  const entries = selected.map((s) => {
+    const body = s.skill.body;
+    const tokens = approxTokens(body);
+    const sourcePath = s.skill.sourcePath || "";
+    return {
+      id: sourcePath || `skill-in-memory:${s.skill.manifest.name}`,
+      layer: 3 as const,
+      scope: (s.skill.manifest.scope ?? "org") as "org" | "workspace" | "user" | "bundle",
+      version: sourcePath ? readSkillMtime(sourcePath) : "",
+      tokens,
+      contentHash: hashSkillBody(body),
+      loadedBy: s.loadedBy,
+      reason: s.reason,
+    };
+  });
+  const totalTokens = entries.reduce((sum, e) => sum + e.tokens, 0);
+  return { skills: entries, totalTokens };
+}
+
+/**
+ * SHA-256 hex of a skill body. The hash is over the body text alone (not
+ * the frontmatter) since the composed prompt only embeds the body.
+ *
+ * Exported separately so debug tools that re-hash an on-disk skill use the
+ * exact same bytes-to-digest pipeline as the emitter — drift between the
+ * two paths would silently break mutation detection.
+ */
+export function hashSkillBody(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
+}

--- a/test/unit/runtime/skills-loaded-payload.test.ts
+++ b/test/unit/runtime/skills-loaded-payload.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  buildSkillsLoadedPayload,
+  hashSkillBody,
+} from "../../../src/runtime/skills-loaded-payload.ts";
+import type { SelectedSkill } from "../../../src/skills/select.ts";
+
+function selected(overrides: Partial<SelectedSkill["skill"]>, loadedBy: "always" | "tool_affinity" = "always"): SelectedSkill {
+  return {
+    skill: {
+      manifest: {
+        name: "test-skill",
+        description: "A test skill",
+        version: "1.0.0",
+        type: "context",
+        priority: 50,
+        ...(overrides.manifest ?? {}),
+      },
+      body: overrides.body ?? "Default body content.",
+      sourcePath: overrides.sourcePath ?? "",
+    },
+    loadedBy,
+    reason: loadedBy === "always" ? "loading_strategy: always" : "applies_to_tools matched foo__*",
+  };
+}
+
+describe("hashSkillBody", () => {
+  test("returns SHA-256 hex of the body string", () => {
+    const body = "Always use patch_source for revisions.";
+    const expected = createHash("sha256").update(body).digest("hex");
+    expect(hashSkillBody(body)).toBe(expected);
+  });
+
+  test("is deterministic — same input, same hash", () => {
+    const body = "Voice rule: no em-dashes in user-facing copy.";
+    expect(hashSkillBody(body)).toBe(hashSkillBody(body));
+  });
+
+  test("hashes the empty string to a known sentinel", () => {
+    // Cheap canary that catches any future regression in the digest pipeline:
+    // SHA-256("") is a well-known constant.
+    expect(hashSkillBody("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  test("a single-byte change in the body produces a completely different hash", () => {
+    const a = hashSkillBody("Use patch_source for revisions.");
+    const b = hashSkillBody("Use set_source for revisions.");
+    expect(a).not.toBe(b);
+    // SHA-256 should differ in roughly half the bits — assert non-trivial difference.
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) diff++;
+    }
+    expect(diff).toBeGreaterThan(20);
+  });
+});
+
+describe("buildSkillsLoadedPayload", () => {
+  test("populates contentHash on every entry", () => {
+    const payload = buildSkillsLoadedPayload([
+      selected({ body: "Body one." }),
+      selected({ body: "Body two — entirely different." }, "tool_affinity"),
+    ]);
+    expect(payload.skills).toHaveLength(2);
+    expect(payload.skills[0]!.contentHash).toBe(hashSkillBody("Body one."));
+    expect(payload.skills[1]!.contentHash).toBe(hashSkillBody("Body two — entirely different."));
+  });
+
+  test("contentHash differs for skills with different bodies even if names match", () => {
+    // Two skills with the same name but different bodies (e.g. one was edited
+    // mid-session) must produce different hashes — that's the whole point of
+    // the field. This guards against any future code path that hashes by id
+    // or path instead of content.
+    const a = buildSkillsLoadedPayload([selected({ body: "version A" })]);
+    const b = buildSkillsLoadedPayload([selected({ body: "version B" })]);
+    expect(a.skills[0]!.contentHash).not.toBe(b.skills[0]!.contentHash);
+  });
+
+  test("sums per-skill tokens into totalTokens", () => {
+    const payload = buildSkillsLoadedPayload([
+      selected({ body: "short" }),
+      selected({ body: "this body is materially longer than the first one for sure" }),
+    ]);
+    expect(payload.totalTokens).toBe(
+      payload.skills.reduce((sum, s) => sum + s.tokens, 0),
+    );
+  });
+
+  test("uses the in-memory sentinel id for skills without a sourcePath", () => {
+    const payload = buildSkillsLoadedPayload([
+      selected({ sourcePath: "", manifest: { name: "synthesized" } }),
+    ]);
+    expect(payload.skills[0]!.id).toBe("skill-in-memory:synthesized");
+    expect(payload.skills[0]!.version).toBe("");
+    // Hash is still computed even for in-memory skills.
+    expect(payload.skills[0]!.contentHash).toBeTruthy();
+  });
+
+  test("propagates loadedBy and reason from the selector", () => {
+    const payload = buildSkillsLoadedPayload([
+      selected({ body: "x" }, "always"),
+      selected({ body: "y" }, "tool_affinity"),
+    ]);
+    expect(payload.skills[0]!.loadedBy).toBe("always");
+    expect(payload.skills[0]!.reason).toContain("loading_strategy");
+    expect(payload.skills[1]!.loadedBy).toBe("tool_affinity");
+    expect(payload.skills[1]!.reason).toContain("applies_to_tools");
+  });
+});

--- a/test/unit/skills/events.test.ts
+++ b/test/unit/skills/events.test.ts
@@ -45,6 +45,12 @@ class CollectingSink implements EventSink {
   }
 }
 
+// Two distinct SHA-256 hex placeholders for skill body content. The fixtures
+// here exercise event projection / order — none of these tests verify hash
+// math, so the actual values just need to be syntactically valid and stable.
+const TEST_HASH_A = "a".repeat(64);
+const TEST_HASH_B = "b".repeat(64);
+
 function makeConfigWithMetadata(): EngineConfig {
   return {
     model: "test-model",
@@ -60,6 +66,7 @@ function makeConfigWithMetadata(): EngineConfig {
             scope: "org",
             version: "2026-04-27T00:00:00.000Z",
             tokens: 240,
+            contentHash: TEST_HASH_A,
             loadedBy: "always",
             reason: "loading_strategy: always",
           },
@@ -69,6 +76,7 @@ function makeConfigWithMetadata(): EngineConfig {
             scope: "workspace",
             version: "2026-04-26T00:00:00.000Z",
             tokens: 890,
+            contentHash: TEST_HASH_B,
             loadedBy: "tool_affinity",
             reason: "applies_to_tools matched synapse-collateral__*",
           },
@@ -275,6 +283,7 @@ describe("EventSourcedConversationStore — persistence", () => {
             scope: "org",
             version: "2026-01-01T00:00:00.000Z",
             tokens: 100,
+            contentHash: TEST_HASH_A,
             loadedBy: "always",
             reason: "loading_strategy: always",
           },

--- a/test/unit/tools/platform/skills-tools.test.ts
+++ b/test/unit/tools/platform/skills-tools.test.ts
@@ -24,6 +24,11 @@ import type { Skill } from "../../../../src/skills/types.ts";
 import { McpSource } from "../../../../src/tools/mcp-source.ts";
 import { createSkillsSource } from "../../../../src/tools/platform/skills.ts";
 
+// SHA-256 hex placeholder. Tests in this file exercise event projection /
+// filtering / dispatch — none verify hash math, so the actual value just
+// needs to be syntactically valid and stable across fixture rows.
+const TEST_HASH = "0".repeat(64);
+
 // ── Fake Runtime ─────────────────────────────────────────────────────────
 
 interface FakeIdentity {
@@ -517,6 +522,7 @@ describe("skills__active_for", () => {
             scope: "org",
             version: "",
             tokens: 50,
+            contentHash: TEST_HASH,
             loadedBy: "always",
             reason: "loading_strategy: always",
           },
@@ -535,6 +541,7 @@ describe("skills__active_for", () => {
             scope: "workspace",
             version: "",
             tokens: 100,
+            contentHash: TEST_HASH,
             loadedBy: "tool_affinity",
             reason: "applies_to_tools matched foo__*",
           },
@@ -602,6 +609,7 @@ describe("skills__loading_log", () => {
             scope: "org",
             version: "",
             tokens: 10,
+            contentHash: TEST_HASH,
             loadedBy: "always",
             reason: "r",
           },
@@ -618,6 +626,7 @@ describe("skills__loading_log", () => {
             scope: "org",
             version: "",
             tokens: 20,
+            contentHash: TEST_HASH,
             loadedBy: "always",
             reason: "r",
           },
@@ -634,6 +643,7 @@ describe("skills__loading_log", () => {
             scope: "org",
             version: "",
             tokens: 30,
+            contentHash: TEST_HASH,
             loadedBy: "always",
             reason: "r",
           },
@@ -643,6 +653,7 @@ describe("skills__loading_log", () => {
             scope: "user",
             version: "",
             tokens: 40,
+            contentHash: TEST_HASH,
             loadedBy: "tool_affinity",
             reason: "r",
           },


### PR DESCRIPTION
## Summary

Adds SHA-256 hex of each skill's body to `SkillsLoadedEntry`, populated whenever the runtime emits a `skills.loaded` event. **Telemetry-only change — no behavior impact today.** Foundation for the upcoming `compose_effective_context` debug tool (#119).

## Why

We're shipping #119 next — a tool that returns "what was in the system prompt for run X, with provenance per layer." For historical-mode reconstruction, the tool needs to detect whether a skill's body has been mutated between when it loaded and when the operator inspects the run. Without that, the tool would silently display the *current* skill content as if it were the historical content (the body that actually fed the model).

The cheapest reliable detector is a content hash recorded at load time:
- **Hash matches current source** → display the body verbatim, full fidelity.
- **Hash differs** → look up the recorded hash against `_versions/` snapshots to find the actual loaded body, or surface an explicit "this skill changed since this run" warning.

Doing this without the hash would require either (a) embedding the full body in every `skills.loaded` event (10-100× event size; rejected as too expensive), or (b) accepting silent fidelity loss (rejected as user-hostile during debugging).

## Cost

~64 bytes per skill per turn (SHA-256 hex is 64 chars). For a typical conversation with 10 skills loading per turn × 30 turns, that's ~20 KB of additional telemetry over the conversation's lifetime. Negligible against the existing event volume.

## Contract: `contentHash` is **required**, not optional

The platform isn't deployed anywhere with persisted `skills.loaded` events, so there's no historical data to be backward-compatible with. Required field gives clean, first-principles types: emitters guarantee the field, consumers can rely on it. Test fixtures across three files (`skills/events`, `tools/platform/skills-tools`, `runtime/skills-loaded-payload`) updated with `TEST_HASH` sentinels for the cases that don't verify hash math.

(An earlier commit on this branch made the field optional. That decision was reversed — see commit `f2a8501`. Don't read the optional pattern as a guide to how new fields should be modeled.)

## Refactor included

Extracted `buildSkillsLoadedPayload` and `hashSkillBody` from `runtime.ts` into a small focused module (`src/runtime/skills-loaded-payload.ts`) so the function can be unit-tested directly without polluting `runtime.ts`'s public surface. Pure function over inputs; no behavior change beyond the new field.

## Test plan

- [x] `bun test test/unit/runtime/skills-loaded-payload.test.ts` — 9 new tests (hash determinism, body sensitivity, empty-string sentinel, propagation through `buildSkillsLoadedPayload`)
- [x] `bun run test:unit` — 2137 pass (was 2128; added 9)
- [x] `bun test test/integration/skill-lifecycle.test.ts test/integration/skills-read-tools.test.ts` — 7 pass (no regression)
- [x] `bun run verify:static` — clean (the gate CI runs; matches `format:check + lint + check + check:cycles`)

## Out of scope

- The debug tool that consumes the hash → #119 (next PR, depends on this landing).
- Hashes for bundle instructions / overlays / app instructions → separate PRs if needed; L3 skills are the most volatile so the highest-leverage layer to instrument first.
- Snapshotting full layer bodies into events → not doing it. Hashes give enough fidelity for the debugging use cases we care about, at 1/100th the cost.
- Validation of persisted-event shape on read (the trust boundary at `event-sourced-store.ts:607`) → its own audit; flagged with a comment at the cast site.

## Refs

- `SKILL_MANAGEMENT_DESIGN.md` § "Provenance" (Phase 5 deterministic recomputation pattern)
- Closes the telemetry prerequisite for #119