### PR TITLE
fix(ui): show solo workspace in workspace dropdown

### DIFF
--- a/web/src/components/WorkspaceSelector.tsx
+++ b/web/src/components/WorkspaceSelector.tsx
@@ -107,9 +107,6 @@ export const WorkspaceSelector = memo(function WorkspaceSelector({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const canSwitch = workspaces.length > 1;
-  // Always allow opening the dropdown — even with one workspace, the
-  // "Settings" link inside is useful.
   const canOpen = true;
 
   useEffect(() => {
@@ -172,54 +169,50 @@ export const WorkspaceSelector = memo(function WorkspaceSelector({
       )}
     >
       {/* Workspace list */}
-      {canSwitch && (
-        <div className="p-1">
-          {sortedWorkspaces.map((ws) => {
-            const isActive = ws.id === activeWorkspace.id;
-            return (
-              <button
-                type="button"
-                key={ws.id}
-                onClick={() => handleSelect(ws)}
-                className={cn(
-                  "flex items-center gap-2.5 w-full rounded-md px-2 py-2 text-sm text-left transition-all duration-150",
-                  "text-sidebar-foreground",
-                  isActive
-                    ? "bg-sidebar-foreground/10 font-medium"
-                    : "hover:bg-sidebar-foreground/5",
-                )}
-              >
-                <WorkspaceAvatar name={ws.name} size="sm" variant="colored" />
-                <div className="flex-1 min-w-0">
-                  <span className="block truncate">{ws.name}</span>
-                </div>
-                {ws.memberCount <= 1 ? (
-                  <span className="shrink-0" title="Personal">
-                    <Lock className="w-3 h-3 text-sidebar-foreground/30" />
-                  </span>
-                ) : (
-                  <span
-                    className="flex items-center gap-1 text-[11px] text-sidebar-foreground/40 shrink-0"
-                    title={`${ws.memberCount} members`}
-                  >
-                    <Users className="w-3 h-3" />
-                    <span className="tabular-nums">{ws.memberCount}</span>
-                  </span>
-                )}
-                <span className="w-4 shrink-0 flex items-center justify-center">
-                  {isActive && <Check className="w-3.5 h-3.5 text-sidebar-primary" />}
+      <div className="p-1">
+        {sortedWorkspaces.map((ws) => {
+          const isActive = ws.id === activeWorkspace.id;
+          return (
+            <button
+              type="button"
+              key={ws.id}
+              onClick={() => handleSelect(ws)}
+              className={cn(
+                "flex items-center gap-2.5 w-full rounded-md px-2 py-2 text-sm text-left transition-all duration-150",
+                "text-sidebar-foreground",
+                isActive ? "bg-sidebar-foreground/10 font-medium" : "hover:bg-sidebar-foreground/5",
+              )}
+            >
+              <WorkspaceAvatar name={ws.name} size="sm" variant="colored" />
+              <div className="flex-1 min-w-0">
+                <span className="block truncate">{ws.name}</span>
+              </div>
+              {ws.memberCount <= 1 ? (
+                <span className="shrink-0" title="Personal">
+                  <Lock className="w-3 h-3 text-sidebar-foreground/30" />
                 </span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+              ) : (
+                <span
+                  className="flex items-center gap-1 text-[11px] text-sidebar-foreground/40 shrink-0"
+                  title={`${ws.memberCount} members`}
+                >
+                  <Users className="w-3 h-3" />
+                  <span className="tabular-nums">{ws.memberCount}</span>
+                </span>
+              )}
+              <span className="w-4 shrink-0 flex items-center justify-center">
+                {isActive && <Check className="w-3.5 h-3.5 text-sidebar-primary" />}
+              </span>
+            </button>
+          );
+        })}
+      </div>
 
       {/* Settings link — keeps the workspace dropdown a one-stop shop for
           "I'm in workspace X, take me to its settings." Sign out lives in
           the UserMenu (bottom-left) since it's an identity action, not a
           workspace one. */}
-      {canSwitch && <div className="mx-2 border-t border-sidebar-border" />}
+      <div className="mx-2 border-t border-sidebar-border" />
       <div className="p-1">
         <button
           type="button"

--- a/web/src/components/WorkspaceSelector.tsx
+++ b/web/src/components/WorkspaceSelector.tsx
@@ -107,8 +107,6 @@ export const WorkspaceSelector = memo(function WorkspaceSelector({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const canOpen = true;
-
   useEffect(() => {
     if (!open) return;
     function handleClick(e: MouseEvent) {
@@ -160,7 +158,7 @@ export const WorkspaceSelector = memo(function WorkspaceSelector({
   }
 
   // --- Dropdown panel ---
-  const dropdown = open && canOpen && (
+  const dropdown = open && (
     <div
       className={cn(
         "absolute z-50 mt-1 rounded-lg border border-sidebar-border bg-sidebar shadow-lg",
@@ -235,15 +233,11 @@ export const WorkspaceSelector = memo(function WorkspaceSelector({
       <div ref={containerRef} className="relative shrink-0 mx-2 py-1">
         <button
           type="button"
-          onClick={() => canOpen && setOpen(!open)}
+          onClick={() => setOpen(!open)}
           title={activeWorkspace.name}
           aria-label={`Workspace: ${activeWorkspace.name}`}
           aria-expanded={open}
-          className={cn(
-            "flex items-center justify-center w-full rounded-lg p-1.5 transition-all duration-150",
-            canOpen && "hover:bg-sidebar-foreground/5 cursor-pointer",
-            !canOpen && "cursor-default",
-          )}
+          className="flex items-center justify-center w-full rounded-lg p-1.5 transition-all duration-150 hover:bg-sidebar-foreground/5 cursor-pointer"
         >
           <WorkspaceAvatar name={activeWorkspace.name} size="md" />
         </button>
@@ -257,12 +251,12 @@ export const WorkspaceSelector = memo(function WorkspaceSelector({
     <div ref={containerRef} className="relative shrink-0 mx-2 py-1">
       <button
         type="button"
-        onClick={() => canOpen && setOpen(!open)}
+        onClick={() => setOpen(!open)}
         aria-label={`Workspace: ${activeWorkspace.name}`}
         aria-expanded={open}
         className={cn(
           "flex items-center gap-2.5 w-full rounded-lg px-2 py-2 text-sm transition-all duration-150",
-          canOpen ? "hover:bg-sidebar-foreground/5 cursor-pointer" : "cursor-default",
+          "hover:bg-sidebar-foreground/5 cursor-pointer",
           open && "bg-sidebar-foreground/5",
         )}
       >
@@ -270,14 +264,12 @@ export const WorkspaceSelector = memo(function WorkspaceSelector({
         <span className="flex-1 truncate text-left font-semibold text-sidebar-foreground">
           {activeWorkspace.name}
         </span>
-        {canOpen && (
-          <ChevronDown
-            className={cn(
-              "shrink-0 w-4 h-4 text-sidebar-foreground/40 transition-transform duration-200",
-              open && "rotate-180",
-            )}
-          />
-        )}
+        <ChevronDown
+          className={cn(
+            "shrink-0 w-4 h-4 text-sidebar-foreground/40 transition-transform duration-200",
+            open && "rotate-180",
+          )}
+        />
       </button>
       {dropdown}
     </div>


### PR DESCRIPTION
## Summary

- Workspace dropdown gated the list on `workspaces.length > 1`, so users with a single workspace opened the dropdown and saw only **Settings** — their own workspace was hidden.
- Always render the list (with the active checkmark) so the dropdown reflects the current workspace regardless of count.

Before / after with one workspace: empty list above Settings → solo workspace shown above Settings, marked active.

## Test plan

- [ ] Sign in to a tenant with only one workspace; open the workspace dropdown and confirm the workspace appears above the Settings link with a checkmark.
- [ ] Confirm a tenant with two or more workspaces still shows all of them (active first, others alphabetical), unchanged.
- [ ] Collapsed sidebar variant: open the popout and confirm the list renders in both single- and multi-workspace cases.