### PR TITLE
feat: HTTP proxy primitive for bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `UserMenu` in the shell sidebar (avatar + display name + popover with Profile settings + Sign out).
 - Top-level `/profile` route. Identity isn't a setting; un-nested from `/settings/*`.
 - Org-admin gate on `set_model_config` — backend now refuses non-org-admin writes (was UI-only via RouteGuard). Distinguishes "no identity" (cron, automations) from "wrong role" so debug logs make non-user code paths obvious.
+- HTTP proxy primitive (`_meta["ai.nimblebrain/http-proxy"]`). Bundles can expose a loopback HTTP server (e.g. `astro preview`, Jupyter kernel) through the platform at `/v1/ws/<wsId>/apps/<bundle>/<mount>/*`. Loopback-only target, credentials and `Accept-Encoding` stripped on forward, `Set-Cookie`/CSP/X-Frame-Options stripped on response, per-workspace kill switch via `Workspace.allowHttpProxy`. Bundles get `NB_WORKSPACE_ID`, `NB_PROXY_PREFIX`, `NB_PUBLIC_ORIGIN` in their env at spawn ([docs](https://docs.nimblebrain.ai/apps/http-proxy/)).
 
 ### Changed
 

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -10,6 +10,7 @@ import { eventRoutes } from "./routes/events.ts";
 import { healthRoutes } from "./routes/health.ts";
 import { mcpRoutes } from "./routes/mcp.ts";
 import { mcpAuthRoutes } from "./routes/mcp-auth.ts";
+import { proxyRoutes } from "./routes/proxy.ts";
 import { resourceRoutes } from "./routes/resources.ts";
 import { toolRoutes } from "./routes/tools.ts";
 import { wellKnownRoutes } from "./routes/well-known.ts";
@@ -46,6 +47,9 @@ export function createApp(
   app.route("/", chatRoutes(ctx));
   app.route("/", toolRoutes(ctx));
   app.route("/", resourceRoutes(ctx));
+  // Proxy routes registered AFTER resource routes so `/v1/apps/:bundle/resources/*`
+  // (resource reads) wins against `/v1/apps/:bundle/:mount/*` (http proxy).
+  app.route("/", proxyRoutes(ctx));
   app.route("/", eventRoutes(ctx));
   app.route("/", conversationEventRoutes(ctx));
 

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -43,13 +43,19 @@ export function createApp(
   // matching route, so MCP must be registered before chat/tools/events.
   app.route("/", mcpRoutes(ctx));
 
+  // HTTP proxy routes — same Hono ordering constraint as mcpRoutes above.
+  // `resourceRoutes`/`chatRoutes`/etc. attach `.use("*", requireWorkspace(...))`
+  // middleware that resolves workspace from the X-Workspace-Id header. Browser
+  // iframe loads can't set custom headers, so the proxy puts the workspace ID
+  // in the URL path (`/v1/ws/<wsId>/apps/...`). Register before any sub-app
+  // with header-based workspace middleware so it doesn't 400 the iframe load
+  // before our path-based handler runs.
+  app.route("/", proxyRoutes(ctx));
+
   app.route("/", bootstrapRoutes(ctx));
   app.route("/", chatRoutes(ctx));
   app.route("/", toolRoutes(ctx));
   app.route("/", resourceRoutes(ctx));
-  // Proxy routes registered AFTER resource routes so `/v1/apps/:bundle/resources/*`
-  // (resource reads) wins against `/v1/apps/:bundle/:mount/*` (http proxy).
-  app.route("/", proxyRoutes(ctx));
   app.route("/", eventRoutes(ctx));
   app.route("/", conversationEventRoutes(ctx));
 

--- a/src/api/middleware/security-headers.ts
+++ b/src/api/middleware/security-headers.ts
@@ -4,12 +4,19 @@ import { createMiddleware } from "hono/factory";
  * Security headers middleware.
  * Sets standard browser security headers on every response.
  * Does NOT set HSTS or CSP — those belong on the reverse proxy.
+ *
+ * `X-Frame-Options` is set as a *default* (`DENY`) — routes that legitimately
+ * serve framed content (e.g., the same-origin http-proxy bundles use to embed
+ * their dev servers) override it explicitly to `SAMEORIGIN`. We use `set` only
+ * when the route hasn't already provided a value, so route-level intent wins.
  */
 export function securityHeaders() {
   return createMiddleware(async (c, next) => {
     await next();
     c.res.headers.set("X-Content-Type-Options", "nosniff");
-    c.res.headers.set("X-Frame-Options", "DENY");
+    if (!c.res.headers.has("X-Frame-Options")) {
+      c.res.headers.set("X-Frame-Options", "DENY");
+    }
     c.res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
     c.res.headers.set("X-XSS-Protection", "0");
     c.res.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");

--- a/src/api/routes/proxy.ts
+++ b/src/api/routes/proxy.ts
@@ -31,16 +31,26 @@ import { type AppContext, type AppEnv, apiError } from "../types.ts";
  * Defenses we DO enforce:
  *   1. `target` restricted to loopback hosts in `extractHttpProxy` (no
  *      SSRF to cloud metadata, RFC1918 networks, or external hosts).
- *   2. `Authorization`, `Cookie`, `X-Workspace-Id` stripped before
- *      forwarding — bundle's loopback server can't read user credentials.
- *   3. `Set-Cookie` stripped from upstream — bundle can't plant cookies
+ *   2. `Authorization`, `Cookie`, `X-Workspace-Id`, `X-Forwarded-For`
+ *      stripped before forwarding — bundle's loopback server can't read
+ *      user credentials and can't be told to trust a forged client IP.
+ *   3. `Accept-Encoding` stripped on forward so upstream returns
+ *      identity-encoded bodies — keeps us out of the business of
+ *      tracking which encodings our HTTP client decompresses.
+ *   4. `Set-Cookie` stripped from upstream — bundle can't plant cookies
  *      on the platform's origin.
- *   4. Workspace membership verified per-request before forwarding.
- *   5. `Workspace.allowHttpProxy = false` is the per-workspace kill switch.
+ *   5. Workspace membership verified per-request before forwarding.
+ *   6. `Workspace.allowHttpProxy = false` is the per-workspace kill switch.
  *
- * Defenses we do NOT have today: cross-origin isolation per bundle (would
- * require subdomain-per-bundle + COEP). For untrusted-bundle marketplaces,
- * that's the next investment.
+ * Defenses we do NOT have today:
+ *   - Cross-origin isolation per bundle (would require subdomain-per-bundle
+ *     + COEP). For untrusted-bundle marketplaces, that's the next
+ *     investment.
+ *   - In **dev auth mode** (no IdentityProvider configured) the request
+ *     identity is undefined and the membership check below is a no-op —
+ *     consistent with how every other workspace-scoped route on the
+ *     platform behaves in dev. Production deployments configure an
+ *     IdentityProvider and the membership check fires per request.
  *
  * Scope (v1): HTTP methods only. WebSocket upgrade declared in
  * HttpProxyConfig.websocket but not yet wired through the route.
@@ -120,7 +130,6 @@ export function proxyRoutes(ctx: AppContext) {
       }
       forwardHeaders.set("X-Forwarded-Host", url.host);
       forwardHeaders.set("X-Forwarded-Proto", url.protocol.replace(":", ""));
-      forwardHeaders.set("X-Forwarded-For", forwardHeaders.get("X-Forwarded-For") ?? "");
 
       // `duplex: "half"` is only valid (per WHATWG fetch) when the body is a
       // stream — passing it for bodyless GET/HEAD can produce a 400 in Bun.
@@ -176,20 +185,33 @@ const HOP_BY_HOP = new Set([
   "upgrade",
 ]);
 
-/** Stripped before forwarding upstream — see top-of-file trust model. */
-const REQUEST_HEADERS_STRIPPED = new Set(["host", "authorization", "cookie", "x-workspace-id"]);
+/**
+ * Stripped before forwarding upstream — see top-of-file trust model.
+ *
+ *   - host: fetch sets its own based on the target.
+ *   - authorization, cookie, x-workspace-id: user credentials, see trust model.
+ *   - x-forwarded-for: client-supplied; the bundle has no way to verify it
+ *     and we don't want to imply we did.
+ *   - accept-encoding: forces upstream to send identity-encoded bodies. Avoids
+ *     the trap of "our HTTP client transparently decompressed gzip, so we
+ *     stripped content-encoding from the response, but it didn't decompress
+ *     br/zstd, so those came through corrupted." Identity in, identity out,
+ *     no encoding state to track. Loopback bandwidth cost is negligible.
+ */
+const REQUEST_HEADERS_STRIPPED = new Set([
+  "host",
+  "authorization",
+  "cookie",
+  "x-workspace-id",
+  "x-forwarded-for",
+  "accept-encoding",
+]);
 
 /**
  * Stripped from upstream responses.
  *
  *   - Set-Cookie / Set-Cookie2: see top-of-file trust model.
  *   - X-Frame-Options / CSP: replaced with our own SAMEORIGIN.
- *   - Content-Encoding / Content-Length: Bun's fetch transparently decompresses
- *     gzipped responses, so the body we hand back is already decoded. Forwarding
- *     the original `content-encoding: gzip` would tell the browser to gunzip
- *     decompressed bytes → corrupted/empty render. Stripping `content-length`
- *     for the same reason — Bun's response layer sets transfer-encoding:
- *     chunked anyway.
  */
 const RESPONSE_HEADERS_STRIPPED = new Set([
   "set-cookie",
@@ -197,8 +219,6 @@ const RESPONSE_HEADERS_STRIPPED = new Set([
   "x-frame-options",
   "content-security-policy",
   "content-security-policy-report-only",
-  "content-encoding",
-  "content-length",
 ]);
 
 const REQUEST_HAS_BODY = new Set(["POST", "PUT", "PATCH", "DELETE"]);

--- a/src/api/routes/proxy.ts
+++ b/src/api/routes/proxy.ts
@@ -34,7 +34,7 @@ import { type AppContext, type AppEnv, apiError } from "../types.ts";
  *   2. `Authorization`, `Cookie`, `X-Workspace-Id`, `X-Forwarded-For`
  *      stripped before forwarding — bundle's loopback server can't read
  *      user credentials and can't be told to trust a forged client IP.
- *   3. `Accept-Encoding` stripped on forward so upstream returns
+ *   3. `Accept-Encoding: identity` forced on forward so upstream returns
  *      identity-encoded bodies — keeps us out of the business of
  *      tracking which encodings our HTTP client decompresses.
  *   4. `Set-Cookie` stripped from upstream — bundle can't plant cookies
@@ -130,6 +130,12 @@ export function proxyRoutes(ctx: AppContext) {
       }
       forwardHeaders.set("X-Forwarded-Host", url.host);
       forwardHeaders.set("X-Forwarded-Proto", url.protocol.replace(":", ""));
+      // Force identity encoding from upstream. Stripping the inbound
+      // `Accept-Encoding` isn't enough: Bun's `fetch` auto-injects a default
+      // (`gzip, deflate, br, zstd`) when the header is absent, which would
+      // re-introduce the encoding-mismatch class of bug we're avoiding.
+      // Setting `identity` explicitly is the defensive fix.
+      forwardHeaders.set("accept-encoding", "identity");
 
       // `duplex: "half"` is only valid (per WHATWG fetch) when the body is a
       // stream — passing it for bodyless GET/HEAD can produce a 400 in Bun.
@@ -192,11 +198,11 @@ const HOP_BY_HOP = new Set([
  *   - authorization, cookie, x-workspace-id: user credentials, see trust model.
  *   - x-forwarded-for: client-supplied; the bundle has no way to verify it
  *     and we don't want to imply we did.
- *   - accept-encoding: forces upstream to send identity-encoded bodies. Avoids
- *     the trap of "our HTTP client transparently decompressed gzip, so we
- *     stripped content-encoding from the response, but it didn't decompress
- *     br/zstd, so those came through corrupted." Identity in, identity out,
- *     no encoding state to track. Loopback bandwidth cost is negligible.
+ *   - accept-encoding: stripped here, then forced to `identity` after the
+ *     loop. The strip alone isn't enough — Bun's `fetch` auto-injects a
+ *     default Accept-Encoding when the header is absent, which would
+ *     re-introduce the encoding mismatch. Identity in, identity out, no
+ *     encoding state to track. Loopback bandwidth cost is negligible.
  */
 const REQUEST_HEADERS_STRIPPED = new Set([
   "host",

--- a/src/api/routes/proxy.ts
+++ b/src/api/routes/proxy.ts
@@ -1,44 +1,102 @@
 import { Hono } from "hono";
+import { log } from "../../cli/log.ts";
+import { WORKSPACE_ID_RE } from "../auth-middleware.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import { errorLog } from "../middleware/error-log.ts";
-import { requireWorkspace } from "../middleware/workspace.ts";
 import { type AppContext, type AppEnv, apiError } from "../types.ts";
 
 /**
  * HTTP proxy routes for bundles that declare
  * `_meta["ai.nimblebrain/http-proxy"]` in their manifest. Forwards same-origin
- * browser requests from `/v1/apps/<bundle>/<mount>/*` to the bundle's local
- * HTTP server (typically on 127.0.0.1:<port>).
+ * browser requests from `/v1/ws/<wsId>/apps/<bundle>/<mount>/*` to the
+ * bundle's local HTTP server (typically on 127.0.0.1:<port>).
+ *
+ * The workspace ID is in the URL (not a header) because this route is
+ * targeted by the BROWSER's iframe loads — those can't set custom headers
+ * the way the platform's REST helpers do. Membership is enforced in the
+ * handler against the authenticated identity.
  *
  * Opt-in per bundle (manifest) and per workspace (`allowHttpProxy`).
  *
- * Scope (v1): HTTP methods. WebSocket upgrade is a follow-up — see
- * HttpProxyConfig.websocket for the declaration; upgrade handling will be
- * added once Bun/Hono integration is wired through this route.
+ * ─── Trust model (read this before installing any http-proxy bundle) ───
+ *
+ * A bundle declaring `http-proxy` runs as **same-origin code in the
+ * authenticated user's session**. The iframe loaded from this proxy is
+ * sandboxed `allow-scripts allow-same-origin`, which means the bundle's
+ * preview JS can read cookies for the platform origin, call same-origin
+ * REST APIs authenticated as the user, and read top-frame DOM where the
+ * host UI permits it. Treat http-proxy bundles like browser extensions:
+ * the operator vouches for the code.
+ *
+ * Defenses we DO enforce:
+ *   1. `target` restricted to loopback hosts in `extractHttpProxy` (no
+ *      SSRF to cloud metadata, RFC1918 networks, or external hosts).
+ *   2. `Authorization`, `Cookie`, `X-Workspace-Id` stripped before
+ *      forwarding — bundle's loopback server can't read user credentials.
+ *   3. `Set-Cookie` stripped from upstream — bundle can't plant cookies
+ *      on the platform's origin.
+ *   4. Workspace membership verified per-request before forwarding.
+ *   5. `Workspace.allowHttpProxy = false` is the per-workspace kill switch.
+ *
+ * Defenses we do NOT have today: cross-origin isolation per bundle (would
+ * require subdomain-per-bundle + COEP). For untrusted-bundle marketplaces,
+ * that's the next investment.
+ *
+ * Scope (v1): HTTP methods only. WebSocket upgrade declared in
+ * HttpProxyConfig.websocket but not yet wired through the route.
  */
 export function proxyRoutes(ctx: AppContext) {
   return new Hono<AppEnv>()
-    .use("/v1/apps/*", requireAuth(ctx.authOptions))
-    .use("/v1/apps/*", requireWorkspace(ctx.workspaceStore))
-    .use("/v1/apps/*", errorLog(ctx))
-    .all("/v1/apps/:bundle/:mount/*", async (c) => {
+    .use("/v1/ws/*", requireAuth(ctx.authOptions))
+    .use("/v1/ws/*", errorLog(ctx))
+    .all("/v1/ws/:wsId/apps/:bundle/:mount/*", async (c) => {
+      const wsId = decodeURIComponent(c.req.param("wsId") ?? "");
       const bundleName = decodeURIComponent(c.req.param("bundle") ?? "");
       const mount = c.req.param("mount") ?? "";
-      const wsId = c.var.workspaceId;
+      const method = c.req.method;
+      const requestPath = new URL(c.req.url).pathname;
 
-      // Workspace-level kill switch.
+      // Validate workspace ID format (prevents path traversal).
+      if (!WORKSPACE_ID_RE.test(wsId)) {
+        log.info(`[proxy] ${method} ${requestPath} → 400 (invalid wsId)`);
+        return apiError(400, "workspace_error", "Invalid workspace ID format.");
+      }
+
       const ws = await ctx.workspaceStore.get(wsId);
-      if (ws?.allowHttpProxy === false) {
+      if (!ws) {
+        log.info(`[proxy] ${method} ${requestPath} → 400 (workspace not found)`);
+        return apiError(400, "workspace_error", `Workspace "${wsId}" not found.`);
+      }
+      const identity = c.var.identity;
+      if (identity) {
+        const isMember = ws.members.some((m) => m.userId === identity.id);
+        if (!isMember) {
+          log.info(`[proxy] ${method} ${requestPath} → 403 (not a member of ${wsId})`);
+          return apiError(
+            403,
+            "workspace_error",
+            `Access denied: not a member of workspace "${wsId}".`,
+          );
+        }
+      }
+      c.set("workspaceId", wsId);
+
+      if (ws.allowHttpProxy === false) {
+        log.info(`[proxy] ${method} ${requestPath} → 403 (workspace ${wsId} disabled)`);
         return apiError(403, "proxy_disabled", "HTTP proxy routes are disabled for this workspace");
       }
 
       const instance = ctx.runtime.getLifecycle().getInstance(bundleName, wsId);
       if (!instance) {
+        log.info(`[proxy] ${method} ${requestPath} → 404 (no instance "${bundleName}" in ${wsId})`);
         return apiError(404, "not_found", `App "${bundleName}" not found`);
       }
 
       const cfg = instance.httpProxy;
       if (!cfg || cfg.mount !== mount) {
+        log.info(
+          `[proxy] ${method} ${requestPath} → 404 (mount "${mount}" not declared by ${bundleName})`,
+        );
         return apiError(
           404,
           "not_found",
@@ -46,50 +104,59 @@ export function proxyRoutes(ctx: AppContext) {
         );
       }
 
-      // Forward the FULL incoming path to the target. The bundle is expected
-      // to configure its upstream server (e.g., `astro --base`) to match the
-      // public prefix so absolute URLs in responses line up. This avoids
-      // response-body rewriting.
+      // Forward the FULL incoming path to the target. Bundle is expected to
+      // configure its upstream server (e.g., `astro --base`) to match the
+      // public prefix so absolute URLs in responses line up.
       const url = new URL(c.req.url);
       const target = new URL(cfg.target);
       const targetUrl = new URL(target.toString().replace(/\/$/, "") + url.pathname + url.search);
 
-      // Copy safe headers; strip hop-by-hop + Host (fetch sets its own).
       const forwardHeaders = new Headers();
       for (const [k, v] of c.req.raw.headers) {
         const lk = k.toLowerCase();
         if (HOP_BY_HOP.has(lk)) continue;
-        if (lk === "host") continue;
+        if (REQUEST_HEADERS_STRIPPED.has(lk)) continue;
         forwardHeaders.set(k, v);
       }
       forwardHeaders.set("X-Forwarded-Host", url.host);
       forwardHeaders.set("X-Forwarded-Proto", url.protocol.replace(":", ""));
       forwardHeaders.set("X-Forwarded-For", forwardHeaders.get("X-Forwarded-For") ?? "");
 
-      // Forward the request. Bun's fetch streams both directions.
-      let upstream: Response;
-      try {
-        upstream = await fetch(targetUrl.toString(), {
-          method: c.req.method,
-          headers: forwardHeaders,
-          body: REQUEST_HAS_BODY.has(c.req.method) ? c.req.raw.body : undefined,
-          redirect: "manual",
-          duplex: "half",
-        } as RequestInit);
-      } catch (err) {
-        console.error(
-          `[proxy] upstream ${cfg.target} unreachable:`,
-          err instanceof Error ? err.message : err,
-        );
-        return apiError(502, "bad_gateway", `Upstream ${cfg.target} unreachable`);
+      // `duplex: "half"` is only valid (per WHATWG fetch) when the body is a
+      // stream — passing it for bodyless GET/HEAD can produce a 400 in Bun.
+      const hasBody = REQUEST_HAS_BODY.has(method);
+      const init: RequestInit = {
+        method,
+        headers: forwardHeaders,
+        redirect: "manual",
+      };
+      if (hasBody) {
+        init.body = c.req.raw.body;
+        (init as RequestInit & { duplex?: "half" }).duplex = "half";
       }
 
-      // Pipe response back, stripping hop-by-hop headers.
+      log.info(`[proxy] ${method} ${requestPath} → ${targetUrl.toString()}`);
+
+      let upstream: Response;
+      try {
+        upstream = await fetch(targetUrl.toString(), init);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(`[proxy] ${method} ${requestPath} fetch failed: ${msg}`);
+        return apiError(502, "bad_gateway", `Upstream ${cfg.target} unreachable`);
+      }
+      log.info(`[proxy] ${method} ${requestPath} ← ${upstream.status} from ${cfg.target}`);
+
       const outHeaders = new Headers();
       for (const [k, v] of upstream.headers) {
-        if (HOP_BY_HOP.has(k.toLowerCase())) continue;
+        const lk = k.toLowerCase();
+        if (HOP_BY_HOP.has(lk)) continue;
+        if (RESPONSE_HEADERS_STRIPPED.has(lk)) continue;
         outHeaders.set(k, v);
       }
+      // Same-origin embedding: the security-headers middleware respects this
+      // when already set; cross-origin embedding stays denied.
+      outHeaders.set("X-Frame-Options", "SAMEORIGIN");
       return new Response(upstream.body, {
         status: upstream.status,
         statusText: upstream.statusText,
@@ -107,6 +174,31 @@ const HOP_BY_HOP = new Set([
   "trailer",
   "transfer-encoding",
   "upgrade",
+]);
+
+/** Stripped before forwarding upstream — see top-of-file trust model. */
+const REQUEST_HEADERS_STRIPPED = new Set(["host", "authorization", "cookie", "x-workspace-id"]);
+
+/**
+ * Stripped from upstream responses.
+ *
+ *   - Set-Cookie / Set-Cookie2: see top-of-file trust model.
+ *   - X-Frame-Options / CSP: replaced with our own SAMEORIGIN.
+ *   - Content-Encoding / Content-Length: Bun's fetch transparently decompresses
+ *     gzipped responses, so the body we hand back is already decoded. Forwarding
+ *     the original `content-encoding: gzip` would tell the browser to gunzip
+ *     decompressed bytes → corrupted/empty render. Stripping `content-length`
+ *     for the same reason — Bun's response layer sets transfer-encoding:
+ *     chunked anyway.
+ */
+const RESPONSE_HEADERS_STRIPPED = new Set([
+  "set-cookie",
+  "set-cookie2",
+  "x-frame-options",
+  "content-security-policy",
+  "content-security-policy-report-only",
+  "content-encoding",
+  "content-length",
 ]);
 
 const REQUEST_HAS_BODY = new Set(["POST", "PUT", "PATCH", "DELETE"]);

--- a/src/api/routes/proxy.ts
+++ b/src/api/routes/proxy.ts
@@ -1,0 +1,112 @@
+import { Hono } from "hono";
+import { requireAuth } from "../middleware/auth.ts";
+import { errorLog } from "../middleware/error-log.ts";
+import { requireWorkspace } from "../middleware/workspace.ts";
+import { type AppContext, type AppEnv, apiError } from "../types.ts";
+
+/**
+ * HTTP proxy routes for bundles that declare
+ * `_meta["ai.nimblebrain/http-proxy"]` in their manifest. Forwards same-origin
+ * browser requests from `/v1/apps/<bundle>/<mount>/*` to the bundle's local
+ * HTTP server (typically on 127.0.0.1:<port>).
+ *
+ * Opt-in per bundle (manifest) and per workspace (`allowHttpProxy`).
+ *
+ * Scope (v1): HTTP methods. WebSocket upgrade is a follow-up — see
+ * HttpProxyConfig.websocket for the declaration; upgrade handling will be
+ * added once Bun/Hono integration is wired through this route.
+ */
+export function proxyRoutes(ctx: AppContext) {
+  return new Hono<AppEnv>()
+    .use("/v1/apps/*", requireAuth(ctx.authOptions))
+    .use("/v1/apps/*", requireWorkspace(ctx.workspaceStore))
+    .use("/v1/apps/*", errorLog(ctx))
+    .all("/v1/apps/:bundle/:mount/*", async (c) => {
+      const bundleName = decodeURIComponent(c.req.param("bundle") ?? "");
+      const mount = c.req.param("mount") ?? "";
+      const wsId = c.var.workspaceId;
+
+      // Workspace-level kill switch.
+      const ws = await ctx.workspaceStore.get(wsId);
+      if (ws?.allowHttpProxy === false) {
+        return apiError(403, "proxy_disabled", "HTTP proxy routes are disabled for this workspace");
+      }
+
+      const instance = ctx.runtime.getLifecycle().getInstance(bundleName, wsId);
+      if (!instance) {
+        return apiError(404, "not_found", `App "${bundleName}" not found`);
+      }
+
+      const cfg = instance.httpProxy;
+      if (!cfg || cfg.mount !== mount) {
+        return apiError(
+          404,
+          "not_found",
+          `App "${bundleName}" does not expose proxy mount "${mount}"`,
+        );
+      }
+
+      // Forward the FULL incoming path to the target. The bundle is expected
+      // to configure its upstream server (e.g., `astro --base`) to match the
+      // public prefix so absolute URLs in responses line up. This avoids
+      // response-body rewriting.
+      const url = new URL(c.req.url);
+      const target = new URL(cfg.target);
+      const targetUrl = new URL(target.toString().replace(/\/$/, "") + url.pathname + url.search);
+
+      // Copy safe headers; strip hop-by-hop + Host (fetch sets its own).
+      const forwardHeaders = new Headers();
+      for (const [k, v] of c.req.raw.headers) {
+        const lk = k.toLowerCase();
+        if (HOP_BY_HOP.has(lk)) continue;
+        if (lk === "host") continue;
+        forwardHeaders.set(k, v);
+      }
+      forwardHeaders.set("X-Forwarded-Host", url.host);
+      forwardHeaders.set("X-Forwarded-Proto", url.protocol.replace(":", ""));
+      forwardHeaders.set("X-Forwarded-For", forwardHeaders.get("X-Forwarded-For") ?? "");
+
+      // Forward the request. Bun's fetch streams both directions.
+      let upstream: Response;
+      try {
+        upstream = await fetch(targetUrl.toString(), {
+          method: c.req.method,
+          headers: forwardHeaders,
+          body: REQUEST_HAS_BODY.has(c.req.method) ? c.req.raw.body : undefined,
+          redirect: "manual",
+          duplex: "half",
+        } as RequestInit);
+      } catch (err) {
+        console.error(
+          `[proxy] upstream ${cfg.target} unreachable:`,
+          err instanceof Error ? err.message : err,
+        );
+        return apiError(502, "bad_gateway", `Upstream ${cfg.target} unreachable`);
+      }
+
+      // Pipe response back, stripping hop-by-hop headers.
+      const outHeaders = new Headers();
+      for (const [k, v] of upstream.headers) {
+        if (HOP_BY_HOP.has(k.toLowerCase())) continue;
+        outHeaders.set(k, v);
+      }
+      return new Response(upstream.body, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: outHeaders,
+      });
+    });
+}
+
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const REQUEST_HAS_BODY = new Set(["POST", "PUT", "PATCH", "DELETE"]);

--- a/src/bundles/defaults.ts
+++ b/src/bundles/defaults.ts
@@ -6,9 +6,6 @@ import type {
   LocalBundleMeta,
 } from "./types.ts";
 
-/** Path segments reserved for platform-managed routes under /v1/apps/<bundle>/. */
-const RESERVED_PROXY_MOUNTS = new Set(["resources", "tools", "mcp", "events"]);
-
 /** Hostnames that resolve to the bundle's own loopback interface. */
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "[::1]", "localhost"]);
 
@@ -71,7 +68,9 @@ export function extractBundleMeta(manifest: Record<string, unknown>): LocalBundl
  * internal/RFC1918 networks, or arbitrary external hosts, with the
  * authenticated user's credentials attached.
  */
-function extractHttpProxy(meta: Record<string, unknown> | undefined): HttpProxyConfig | null {
+export function extractHttpProxy(
+  meta: Record<string, unknown> | undefined,
+): HttpProxyConfig | null {
   const raw = meta?.["ai.nimblebrain/http-proxy"];
   if (!raw || typeof raw !== "object") return null;
   const r = raw as Record<string, unknown>;
@@ -103,10 +102,6 @@ function extractHttpProxy(meta: Record<string, unknown> | undefined): HttpProxyC
     console.warn(
       `[bundles] http-proxy mount must be a single path segment (no slashes) — got ${mount}, ignoring`,
     );
-    return null;
-  }
-  if (RESERVED_PROXY_MOUNTS.has(normalizedMount)) {
-    console.warn(`[bundles] http-proxy mount "${normalizedMount}" is reserved — ignoring`);
     return null;
   }
   return {

--- a/src/bundles/defaults.ts
+++ b/src/bundles/defaults.ts
@@ -9,6 +9,9 @@ import type {
 /** Path segments reserved for platform-managed routes under /v1/apps/<bundle>/. */
 const RESERVED_PROXY_MOUNTS = new Set(["resources", "tools", "mcp", "events"]);
 
+/** Hostnames that resolve to the bundle's own loopback interface. */
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "[::1]", "localhost"]);
+
 /**
  * Bundles included by default as MCP subprocesses.
  * Platform capabilities (conversations, files, home, settings, usage, automations)
@@ -57,7 +60,17 @@ export function extractBundleMeta(manifest: Record<string, unknown>): LocalBundl
   };
 }
 
-/** Parse and validate `_meta["ai.nimblebrain/http-proxy"]`. */
+/**
+ * Parse and validate `_meta["ai.nimblebrain/http-proxy"]`.
+ *
+ * Targets are restricted to loopback hosts. The proxy primitive exists so a
+ * bundle can expose its OWN local HTTP server (an `astro dev` it spawned, a
+ * Jupyter kernel, etc.) — there is no legitimate reason for a target to point
+ * at any other host. Allowing arbitrary hosts would turn the proxy into an
+ * SSRF gadget capable of reaching cloud metadata services (169.254.169.254),
+ * internal/RFC1918 networks, or arbitrary external hosts, with the
+ * authenticated user's credentials attached.
+ */
 function extractHttpProxy(meta: Record<string, unknown> | undefined): HttpProxyConfig | null {
   const raw = meta?.["ai.nimblebrain/http-proxy"];
   if (!raw || typeof raw !== "object") return null;
@@ -68,8 +81,21 @@ function extractHttpProxy(meta: Record<string, unknown> | undefined): HttpProxyC
     console.warn("[bundles] http-proxy declaration missing target or mount — ignoring");
     return null;
   }
-  if (!/^https?:\/\//i.test(target)) {
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    console.warn(`[bundles] http-proxy target is not a valid URL — got ${target}, ignoring`);
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     console.warn(`[bundles] http-proxy target must be http(s):// — got ${target}, ignoring`);
+    return null;
+  }
+  if (!LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase())) {
+    console.warn(
+      `[bundles] http-proxy target must point to a loopback host (127.0.0.1, ::1, or localhost) — got ${parsed.hostname}, ignoring`,
+    );
     return null;
   }
   const normalizedMount = mount.replace(/^\/+/, "").replace(/\/+$/, "");

--- a/src/bundles/defaults.ts
+++ b/src/bundles/defaults.ts
@@ -1,4 +1,13 @@
-import type { BundleRef, BundleUiMeta, HostManifestMeta, LocalBundleMeta } from "./types.ts";
+import type {
+  BundleRef,
+  BundleUiMeta,
+  HostManifestMeta,
+  HttpProxyConfig,
+  LocalBundleMeta,
+} from "./types.ts";
+
+/** Path segments reserved for platform-managed routes under /v1/apps/<bundle>/. */
+const RESERVED_PROXY_MOUNTS = new Set(["resources", "tools", "mcp", "events"]);
 
 /**
  * Bundles included by default as MCP subprocesses.
@@ -44,5 +53,39 @@ export function extractBundleMeta(manifest: Record<string, unknown>): LocalBundl
     briefing: hostMeta?.briefing ?? null,
     type: isUpjack ? "upjack" : "plain",
     upjackNamespace: upjackMeta?.namespace,
+    httpProxy: extractHttpProxy(meta),
+  };
+}
+
+/** Parse and validate `_meta["ai.nimblebrain/http-proxy"]`. */
+function extractHttpProxy(meta: Record<string, unknown> | undefined): HttpProxyConfig | null {
+  const raw = meta?.["ai.nimblebrain/http-proxy"];
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const target = typeof r.target === "string" ? r.target : undefined;
+  const mount = typeof r.mount === "string" ? r.mount : undefined;
+  if (!target || !mount) {
+    console.warn("[bundles] http-proxy declaration missing target or mount — ignoring");
+    return null;
+  }
+  if (!/^https?:\/\//i.test(target)) {
+    console.warn(`[bundles] http-proxy target must be http(s):// — got ${target}, ignoring`);
+    return null;
+  }
+  const normalizedMount = mount.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (!normalizedMount || normalizedMount.includes("/")) {
+    console.warn(
+      `[bundles] http-proxy mount must be a single path segment (no slashes) — got ${mount}, ignoring`,
+    );
+    return null;
+  }
+  if (RESERVED_PROXY_MOUNTS.has(normalizedMount)) {
+    console.warn(`[bundles] http-proxy mount "${normalizedMount}" is reserved — ignoring`);
+    return null;
+  }
+  return {
+    target,
+    mount: normalizedMount,
+    websocket: r.websocket === true,
   };
 }

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -18,6 +18,7 @@ import type {
   BundleState,
   BundleUiMeta,
   HostManifestMeta,
+  HttpProxyConfig,
   RemoteTransportConfig,
 } from "./types.ts";
 
@@ -240,6 +241,7 @@ export class BundleLifecycleManager {
       trustScore: trustScore ?? null,
       ui: ui ?? null,
       briefing: null,
+      httpProxy: null,
       protected: false,
       type: "plain",
       wsId,
@@ -593,6 +595,7 @@ export class BundleLifecycleManager {
           description?: string;
           ui: BundleUiMeta | null;
           briefing?: BriefingBlock | null;
+          httpProxy?: HttpProxyConfig | null;
           type: "upjack" | "plain";
           upjackNamespace?: string;
         }
@@ -619,6 +622,7 @@ export class BundleLifecycleManager {
       trustScore: ref.trustScore ?? null,
       ui: ref.ui ?? manifestMeta?.ui ?? null,
       briefing: manifestMeta?.briefing ?? null,
+      httpProxy: manifestMeta?.httpProxy ?? null,
       protected: ref.protected ?? false,
       type: manifestMeta?.type ?? "plain",
       wsId,
@@ -671,6 +675,7 @@ function createInstance(
     trustScore: null,
     ui: null,
     briefing: null,
+    httpProxy: null,
     protected: false,
     type: isUpjack ? "upjack" : "plain",
     wsId,

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -237,7 +237,14 @@ export async function startBundleSource(
     );
   } else {
     const internalEnv = ref.protected && opts?.internalEnv ? opts.internalEnv : undefined;
-    const result = buildLocalSource(ref, configDir, internalEnv, opts?.dataDir, eventSink);
+    const result = buildLocalSource(
+      ref,
+      configDir,
+      internalEnv,
+      opts?.dataDir,
+      eventSink,
+      opts?.wsId,
+    );
     source = result.source;
     meta = result.meta;
     manifest = result.manifest;
@@ -263,6 +270,7 @@ function buildLocalSource(
   internalEnv: InternalBundleEnv | undefined,
   dataDirOverride: string | undefined,
   eventSink: EventSink,
+  wsId: string | undefined,
 ): { source: McpSource; meta: LocalBundleMeta; manifest: BundleManifest } {
   const bundleDir = resolveLocalBundle(ref.path, configDir);
   if (!bundleDir) {
@@ -316,17 +324,40 @@ function buildLocalSource(
   spawnEnv.MPAK_WORKSPACE = bundleDataDir;
   spawnEnv.UPJACK_ROOT = bundleDataDir;
 
+  // Tell every bundle which workspace it's running for. Each BundleInstance
+  // is workspace-scoped already, so this is just surfacing what the platform
+  // already knows. Bundles need it to compose URLs that include the workspace
+  // segment (the http-proxy route requires it in the path because browser
+  // iframe loads can't set the X-Workspace-Id header).
+  if (wsId) {
+    spawnEnv.NB_WORKSPACE_ID = wsId;
+  }
+
   // If the bundle declares an http-proxy, tell it the public path prefix so it
-  // can configure its upstream server (e.g., `astro --base`) to match. Format:
-  //   /v1/apps/<serverName>/<mount>
+  // can configure its upstream server (e.g., `astro --base`) to match.
+  // Format: /v1/ws/<wsId>/apps/<serverName>/<mount>. Without wsId we can't
+  // build a usable prefix; skip in that case (the bundle simply won't expose
+  // a working preview URL until the workspace context is wired through).
   const httpProxyMeta = (manifest._meta as Record<string, unknown> | undefined)?.[
     "ai.nimblebrain/http-proxy"
   ] as { mount?: string } | undefined;
-  if (httpProxyMeta?.mount) {
+  if (httpProxyMeta?.mount && wsId) {
     const mount = String(httpProxyMeta.mount).replace(/^\/+|\/+$/g, "");
     if (mount && !/\//.test(mount)) {
-      spawnEnv.NB_PROXY_PREFIX = `/v1/apps/${serverName}/${mount}`;
+      spawnEnv.NB_PROXY_PREFIX = `/v1/ws/${wsId}/apps/${serverName}/${mount}`;
     }
+  }
+
+  // Tell bundles the platform's browser-facing origin so they can declare it
+  // in `_meta.ui.csp.{frameDomains, connectDomains}` on UI resources that need
+  // to frame or fetch same-origin URLs (proxied preview, same-origin WS).
+  // Operators set NB_PUBLIC_ORIGIN explicitly; we fall back to the first
+  // ALLOWED_ORIGINS entry as a best-effort default for dev. Empty/unset →
+  // bundle simply doesn't declare and the host CSP stays restrictive.
+  const publicOrigin =
+    process.env.NB_PUBLIC_ORIGIN ?? process.env.ALLOWED_ORIGINS?.split(",")[0]?.trim() ?? "";
+  if (publicOrigin) {
+    spawnEnv.NB_PUBLIC_ORIGIN = publicOrigin;
   }
 
   // Python bundles: resolve "python" -> "python3" if needed, build PYTHONPATH

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -135,6 +135,7 @@ export async function startBundleSource(
         version: `remote (${tools.length} tools)`,
         ui: ref.ui ?? null,
         briefing: null,
+        httpProxy: null,
         type: "plain" as const,
       },
       sourceName,
@@ -314,6 +315,19 @@ function buildLocalSource(
     dataDirOverride ?? join(nbWorkDir, "data", deriveBundleDataDir(manifest.name));
   spawnEnv.MPAK_WORKSPACE = bundleDataDir;
   spawnEnv.UPJACK_ROOT = bundleDataDir;
+
+  // If the bundle declares an http-proxy, tell it the public path prefix so it
+  // can configure its upstream server (e.g., `astro --base`) to match. Format:
+  //   /v1/apps/<serverName>/<mount>
+  const httpProxyMeta = (manifest._meta as Record<string, unknown> | undefined)?.[
+    "ai.nimblebrain/http-proxy"
+  ] as { mount?: string } | undefined;
+  if (httpProxyMeta?.mount) {
+    const mount = String(httpProxyMeta.mount).replace(/^\/+|\/+$/g, "");
+    if (mount && !/\//.test(mount)) {
+      spawnEnv.NB_PROXY_PREFIX = `/v1/apps/${serverName}/${mount}`;
+    }
+  }
 
   // Python bundles: resolve "python" -> "python3" if needed, build PYTHONPATH
   if (manifest.server.type === "python") {

--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -44,9 +44,9 @@ export interface BundleUiMeta {
 
 /**
  * HTTP proxy declaration — declared by bundles that run their own HTTP server
- * (e.g., an Astro dev server, a Jupyter kernel gateway, a notebook renderer)
+ * (e.g., an Astro preview, a Jupyter kernel gateway, a notebook renderer)
  * and want the platform to expose it to the user's browser through a
- * same-origin route under `/v1/apps/<bundle>/<mount>/*`.
+ * same-origin route under `/v1/ws/<wsId>/apps/<bundle>/<mount>/*`.
  *
  * Opt-in: most bundles don't declare this. Workspaces can globally disable via
  * `Workspace.allowHttpProxy = false`.
@@ -54,12 +54,13 @@ export interface BundleUiMeta {
  * Read from `_meta["ai.nimblebrain/http-proxy"]` in the manifest.
  */
 export interface HttpProxyConfig {
-  /** URL of the bundle-local HTTP server to forward to. Usually `http://127.0.0.1:<port>`. */
+  /** URL of the bundle-local HTTP server to forward to. Must point to a
+   *  loopback host (127.0.0.1, ::1, or localhost). */
   target: string;
-  /** Path segment under /v1/apps/<bundle>/. Must not collide with
-   *  reserved segments (`resources`, `tools`, `mcp`, `events`). */
+  /** Single path segment under `/v1/ws/<wsId>/apps/<bundle>/`. Cannot contain `/`. */
   mount: string;
-  /** Whether the proxy should handle WebSocket upgrades (HMR, live channels). */
+  /** Whether the proxy should handle WebSocket upgrades (HMR, live channels).
+   *  Declared today; upgrade forwarding is not yet wired through the route. */
   websocket?: boolean;
 }
 

--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -42,6 +42,27 @@ export interface BundleUiMeta {
   placements?: PlacementDeclaration[];
 }
 
+/**
+ * HTTP proxy declaration — declared by bundles that run their own HTTP server
+ * (e.g., an Astro dev server, a Jupyter kernel gateway, a notebook renderer)
+ * and want the platform to expose it to the user's browser through a
+ * same-origin route under `/v1/apps/<bundle>/<mount>/*`.
+ *
+ * Opt-in: most bundles don't declare this. Workspaces can globally disable via
+ * `Workspace.allowHttpProxy = false`.
+ *
+ * Read from `_meta["ai.nimblebrain/http-proxy"]` in the manifest.
+ */
+export interface HttpProxyConfig {
+  /** URL of the bundle-local HTTP server to forward to. Usually `http://127.0.0.1:<port>`. */
+  target: string;
+  /** Path segment under /v1/apps/<bundle>/. Must not collide with
+   *  reserved segments (`resources`, `tools`, `mcp`, `events`). */
+  mount: string;
+  /** Whether the proxy should handle WebSocket upgrades (HMR, live channels). */
+  websocket?: boolean;
+}
+
 /** Transport configuration for remote MCP servers (url-based bundles). */
 export interface RemoteTransportConfig {
   type?: "streamable-http" | "sse";
@@ -181,6 +202,8 @@ export interface BundleInstance {
   ui: BundleUiMeta | null;
   /** Briefing metadata from _meta["ai.nimblebrain/host"].briefing. */
   briefing: BriefingBlock | null;
+  /** HTTP proxy declaration from _meta["ai.nimblebrain/http-proxy"]. */
+  httpProxy: HttpProxyConfig | null;
   /** Whether the bundle is protected from uninstall. */
   protected: boolean;
   /** Whether this is an Upjack app or plain MCP server. */
@@ -208,6 +231,8 @@ export interface LocalBundleMeta {
   type: "upjack" | "plain";
   /** Upjack namespace from manifest (e.g., "apps/crm"). */
   upjackNamespace?: string;
+  /** HTTP proxy declaration (opt-in). */
+  httpProxy: HttpProxyConfig | null;
 }
 
 /** Env vars injected into protected default bundles for internal host communication. */

--- a/src/workspace/types.ts
+++ b/src/workspace/types.ts
@@ -27,4 +27,10 @@ export interface Workspace {
   models?: Partial<ModelSlots>;
   /** Optional markdown identity override for this workspace's agent persona. */
   identity?: string;
+  /**
+   * Allow bundles in this workspace to expose HTTP proxy routes (declared via
+   * `_meta["ai.nimblebrain/http-proxy"]` in their manifests). Default true.
+   * Set false to block all proxy routes in security-sensitive workspaces.
+   */
+  allowHttpProxy?: boolean;
 }

--- a/test/integration/api/proxy-route.test.ts
+++ b/test/integration/api/proxy-route.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Integration tests for the http-proxy route.
+ *
+ * Covers:
+ *   - Workspace ID validation (path-traversal guard)
+ *   - Workspace existence check
+ *   - Membership enforcement (DevIdentityProvider sets identity = usr_default)
+ *   - Per-workspace kill switch (allowHttpProxy = false)
+ *   - Bundle / mount existence checks
+ *   - Upstream unreachable → 502
+ *   - Request header stripping (Authorization, Cookie, X-Workspace-Id,
+ *     X-Forwarded-For, Accept-Encoding)
+ *   - Response header behavior (Set-Cookie / X-Frame-Options / CSP stripped;
+ *     X-Frame-Options: SAMEORIGIN set on success)
+ *
+ * The lifecycle's `instances` map is private; tests reach in via `as any` to
+ * register fake bundle instances. This is the lightest path that lets us
+ * exercise the proxy route without spinning up a real bundle subprocess.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Runtime } from "../../../src/runtime/runtime.ts";
+import { startServer, type ServerHandle } from "../../../src/api/server.ts";
+import { createEchoModel } from "../../helpers/echo-model.ts";
+import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../../helpers/test-workspace.ts";
+import type { BundleInstance, HttpProxyConfig } from "../../../src/bundles/types.ts";
+
+// ── Upstream test server ──────────────────────────────────────────────
+
+interface CapturedRequest {
+  method: string;
+  pathname: string;
+  search: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+let lastUpstreamRequest: CapturedRequest | null = null;
+let upstreamResponseFactory: () => Response = () =>
+  new Response("upstream-default", { status: 200, headers: { "Content-Type": "text/plain" } });
+
+let upstreamServer: ReturnType<typeof Bun.serve> | null = null;
+
+function startUpstream(): { port: number; stop: () => void } {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const headers: Record<string, string> = {};
+      for (const [k, v] of req.headers) headers[k.toLowerCase()] = v;
+      const body = req.body ? await req.text() : "";
+      lastUpstreamRequest = {
+        method: req.method,
+        pathname: url.pathname,
+        search: url.search,
+        headers,
+        body,
+      };
+      return upstreamResponseFactory();
+    },
+  });
+  upstreamServer = server;
+  return { port: server.port, stop: () => server.stop(true) };
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────
+
+let runtime: Runtime;
+let handle: ServerHandle;
+let baseUrl: string;
+let workDir: string;
+let upstream: { port: number; stop: () => void };
+
+const BUNDLE_NAME = "test-proxy-bundle";
+const MOUNT = "preview";
+const NON_MEMBER_WS = "ws_no_access";
+const KILLED_WS = "ws_killed";
+const NO_INSTANCE_WS = "ws_no_instance";
+
+function fakeInstance(httpProxy: HttpProxyConfig | null, wsId: string): BundleInstance {
+  return {
+    serverName: BUNDLE_NAME,
+    bundleName: `@org/${BUNDLE_NAME}`,
+    version: "0.0.0-test",
+    state: "running",
+    trustScore: null,
+    ui: null,
+    briefing: null,
+    httpProxy,
+    protected: false,
+    type: "plain",
+    wsId,
+  };
+}
+
+function registerInstance(wsId: string, httpProxy: HttpProxyConfig | null) {
+  const lifecycle = runtime.getLifecycle() as unknown as {
+    instances: Map<string, BundleInstance>;
+  };
+  lifecycle.instances.set(`${BUNDLE_NAME}|${wsId}`, fakeInstance(httpProxy, wsId));
+}
+
+beforeAll(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "nb-proxy-route-"));
+  upstream = startUpstream();
+
+  runtime = await Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    logging: { disabled: true },
+    workDir,
+  });
+
+  // ws_test — usr_default is a member.
+  await provisionTestWorkspace(runtime);
+
+  // ws_no_access — exists, but usr_default is NOT a member.
+  const wsStore = runtime.getWorkspaceStore();
+  await wsStore.create("No Access", "no_access");
+
+  // ws_killed — usr_default IS a member, but allowHttpProxy = false.
+  const killed = await wsStore.create("Killed", "killed");
+  await wsStore.addMember(killed.id, "usr_default", "admin");
+  await wsStore.update(killed.id, { allowHttpProxy: false });
+
+  // ws_no_instance — usr_default is a member, no bundle registered.
+  const noInst = await wsStore.create("No Instance", "no_instance");
+  await wsStore.addMember(noInst.id, "usr_default", "admin");
+
+  // Register a bundle instance pointing at the upstream test server.
+  const proxy: HttpProxyConfig = {
+    target: `http://127.0.0.1:${upstream.port}`,
+    mount: MOUNT,
+    websocket: false,
+  };
+  registerInstance(TEST_WORKSPACE_ID, proxy);
+  registerInstance(KILLED_WS, proxy); // for the kill-switch test
+  registerInstance(NON_MEMBER_WS, proxy); // for the membership test
+
+  // For the "unknown mount" test we register an instance with a different mount.
+  registerInstance("ws_test", proxy); // already done above; here for clarity
+
+  handle = startServer({ runtime, port: 0 });
+  baseUrl = `http://localhost:${handle.port}`;
+});
+
+afterAll(async () => {
+  handle.stop(true);
+  await runtime.shutdown();
+  upstream.stop();
+  upstreamServer?.stop(true);
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function proxyUrl(wsId: string, mount: string = MOUNT, rest: string = "") {
+  return `${baseUrl}/v1/ws/${wsId}/apps/${BUNDLE_NAME}/${mount}/${rest}`;
+}
+
+function resetUpstream() {
+  lastUpstreamRequest = null;
+  upstreamResponseFactory = () =>
+    new Response("ok", { status: 200, headers: { "Content-Type": "text/plain" } });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("proxy route — workspace ID validation", () => {
+  it("400 when wsId is malformed (path-traversal guard)", async () => {
+    const res = await fetch(`${baseUrl}/v1/ws/..%2Fsecret/apps/${BUNDLE_NAME}/${MOUNT}/`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("workspace_error");
+  });
+
+  it("400 when wsId references a workspace that doesn't exist", async () => {
+    const res = await fetch(`${baseUrl}/v1/ws/ws_does_not_exist/apps/${BUNDLE_NAME}/${MOUNT}/`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("workspace_error");
+  });
+});
+
+describe("proxy route — auth / membership", () => {
+  it("403 when authenticated identity is not a member of the workspace", async () => {
+    const res = await fetch(proxyUrl(NON_MEMBER_WS));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("workspace_error");
+  });
+});
+
+describe("proxy route — kill switch", () => {
+  it("403 when workspace.allowHttpProxy is false", async () => {
+    const res = await fetch(proxyUrl(KILLED_WS));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("proxy_disabled");
+  });
+});
+
+describe("proxy route — bundle / mount lookup", () => {
+  it("404 when no bundle instance exists for the workspace", async () => {
+    const res = await fetch(proxyUrl(NO_INSTANCE_WS));
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("not_found");
+  });
+
+  it("404 when the requested mount is not the one declared by the bundle", async () => {
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID, "wrong-mount"));
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("not_found");
+  });
+});
+
+describe("proxy route — upstream behavior", () => {
+  it("502 when upstream is unreachable", async () => {
+    // Register a bundle instance pointing at an unused port.
+    const wsStore = runtime.getWorkspaceStore();
+    const ws = await wsStore.create("Dead Upstream", "dead_upstream");
+    await wsStore.addMember(ws.id, "usr_default", "admin");
+    registerInstance(ws.id, {
+      target: "http://127.0.0.1:1", // port 1 — refused by every host's TCP stack
+      mount: MOUNT,
+      websocket: false,
+    });
+
+    const res = await fetch(proxyUrl(ws.id));
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("bad_gateway");
+  });
+
+  it("forwards full path + query string to upstream verbatim", async () => {
+    resetUpstream();
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID, MOUNT, "deep/path?q=1&x=y"));
+    expect(res.status).toBe(200);
+    expect(lastUpstreamRequest).not.toBeNull();
+    expect(lastUpstreamRequest?.pathname).toBe(
+      `/v1/ws/${TEST_WORKSPACE_ID}/apps/${BUNDLE_NAME}/${MOUNT}/deep/path`,
+    );
+    expect(lastUpstreamRequest?.search).toBe("?q=1&x=y");
+  });
+
+  it("forwards the request method", async () => {
+    resetUpstream();
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID), { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(lastUpstreamRequest?.method).toBe("DELETE");
+  });
+
+  it("forwards request body for POST", async () => {
+    resetUpstream();
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    });
+    expect(res.status).toBe(200);
+    expect(lastUpstreamRequest?.body).toBe('{"hello":"world"}');
+  });
+});
+
+describe("proxy route — request header stripping", () => {
+  it("strips Authorization, Cookie, X-Workspace-Id, X-Forwarded-For, Accept-Encoding", async () => {
+    resetUpstream();
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID), {
+      headers: {
+        Authorization: "Bearer secret-token-do-not-leak",
+        Cookie: "session=secret",
+        "X-Workspace-Id": "should-not-leak",
+        "X-Forwarded-For": "1.2.3.4",
+        "Accept-Encoding": "gzip, br",
+        "X-Custom-Header": "should-pass-through",
+      },
+    });
+    expect(res.status).toBe(200);
+    const fwd = lastUpstreamRequest?.headers ?? {};
+    expect(fwd.authorization).toBeUndefined();
+    expect(fwd.cookie).toBeUndefined();
+    expect(fwd["x-workspace-id"]).toBeUndefined();
+    expect(fwd["x-forwarded-for"]).toBeUndefined();
+    // Accept-Encoding from the browser is replaced with `identity`, forcing
+    // upstream to return an unencoded body so we don't inherit Bun's
+    // per-encoding decompression behavior.
+    expect(fwd["accept-encoding"]).toBe("identity");
+    // Sanity: non-stripped headers do pass through.
+    expect(fwd["x-custom-header"]).toBe("should-pass-through");
+  });
+
+  it("sets X-Forwarded-Host and X-Forwarded-Proto on the forwarded request", async () => {
+    resetUpstream();
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID));
+    expect(res.status).toBe(200);
+    const fwd = lastUpstreamRequest?.headers ?? {};
+    expect(fwd["x-forwarded-host"]).toBeDefined();
+    expect(fwd["x-forwarded-proto"]).toBe("http");
+  });
+});
+
+describe("proxy route — response header behavior", () => {
+  it("strips Set-Cookie, X-Frame-Options, CSP from upstream response", async () => {
+    upstreamResponseFactory = () =>
+      new Response("hi", {
+        status: 200,
+        headers: {
+          "Set-Cookie": "evil=yes; HttpOnly",
+          "X-Frame-Options": "DENY", // upstream tries to deny framing
+          "Content-Security-Policy": "default-src 'none'",
+          "Content-Security-Policy-Report-Only": "default-src 'none'",
+          "X-Custom-Upstream": "passthrough-ok",
+        },
+      });
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Set-Cookie")).toBeNull();
+    // The platform overrides X-Frame-Options to SAMEORIGIN — see next test.
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    expect(res.headers.get("Content-Security-Policy-Report-Only")).toBeNull();
+    // Sanity: non-stripped headers pass through.
+    expect(res.headers.get("X-Custom-Upstream")).toBe("passthrough-ok");
+  });
+
+  it("sets X-Frame-Options: SAMEORIGIN on successful proxy responses", async () => {
+    resetUpstream();
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+  });
+
+  it("preserves upstream response status code (e.g., 404)", async () => {
+    upstreamResponseFactory = () => new Response("not here", { status: 404 });
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID));
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe("not here");
+  });
+
+  it("preserves upstream response body bytes", async () => {
+    const payload = "the bodyÿwithbinary";
+    upstreamResponseFactory = () =>
+      new Response(payload, { status: 200, headers: { "Content-Type": "text/plain" } });
+    const res = await fetch(proxyUrl(TEST_WORKSPACE_ID));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(payload);
+  });
+});

--- a/test/unit/bundles/extract-http-proxy.test.ts
+++ b/test/unit/bundles/extract-http-proxy.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { extractHttpProxy } from "../../../src/bundles/defaults.ts";
+
+// Quiet the warn() spam — these tests trigger validation rejections by design.
+const originalWarn = console.warn;
+beforeAll(() => {
+  console.warn = () => {};
+});
+afterAll(() => {
+  console.warn = originalWarn;
+});
+
+describe("extractHttpProxy", () => {
+  test("returns null when meta is undefined", () => {
+    expect(extractHttpProxy(undefined)).toBeNull();
+  });
+
+  test("returns null when http-proxy key is absent", () => {
+    expect(extractHttpProxy({})).toBeNull();
+  });
+
+  test("returns null when http-proxy is not an object", () => {
+    expect(extractHttpProxy({ "ai.nimblebrain/http-proxy": "nope" })).toBeNull();
+    expect(extractHttpProxy({ "ai.nimblebrain/http-proxy": 42 })).toBeNull();
+    expect(extractHttpProxy({ "ai.nimblebrain/http-proxy": null })).toBeNull();
+  });
+
+  test("returns null when target is missing", () => {
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { mount: "preview" },
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when mount is missing", () => {
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { target: "http://127.0.0.1:4321" },
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when target is not a parseable URL", () => {
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { target: "not a url at all", mount: "preview" },
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when target uses a non-http(s) protocol", () => {
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { target: "file:///etc/passwd", mount: "preview" },
+      }),
+    ).toBeNull();
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { target: "ftp://127.0.0.1/x", mount: "preview" },
+      }),
+    ).toBeNull();
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { target: "javascript:alert(1)", mount: "preview" },
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects non-loopback hosts (SSRF guard)", () => {
+    const offLoopback = [
+      "http://example.com",
+      "http://169.254.169.254", // AWS metadata
+      "http://10.0.0.1", // RFC1918
+      "http://192.168.1.1",
+      "http://172.16.0.1",
+      "http://0.0.0.0", // wildcard, not loopback
+    ];
+    for (const target of offLoopback) {
+      expect(
+        extractHttpProxy({
+          "ai.nimblebrain/http-proxy": { target, mount: "preview" },
+        }),
+      ).toBeNull();
+    }
+  });
+
+  test("accepts each loopback hostname (127.0.0.1, ::1, localhost)", () => {
+    for (const target of ["http://127.0.0.1:4321", "http://[::1]:4321", "http://localhost:4321"]) {
+      const result = extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { target, mount: "preview" },
+      });
+      expect(result).not.toBeNull();
+      expect(result?.target).toBe(target);
+    }
+  });
+
+  test("loopback host check is case-insensitive (LocalHost)", () => {
+    const result = extractHttpProxy({
+      "ai.nimblebrain/http-proxy": { target: "http://LocalHost:4321", mount: "preview" },
+    });
+    expect(result).not.toBeNull();
+  });
+
+  test("rejects mount with embedded slashes", () => {
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": {
+          target: "http://127.0.0.1:4321",
+          mount: "deep/nested",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects empty mount after slash trimming", () => {
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { target: "http://127.0.0.1:4321", mount: "/" },
+      }),
+    ).toBeNull();
+    expect(
+      extractHttpProxy({
+        "ai.nimblebrain/http-proxy": { target: "http://127.0.0.1:4321", mount: "" },
+      }),
+    ).toBeNull();
+  });
+
+  test("normalizes mount by trimming leading and trailing slashes", () => {
+    const r = extractHttpProxy({
+      "ai.nimblebrain/http-proxy": {
+        target: "http://127.0.0.1:4321",
+        mount: "/preview/",
+      },
+    });
+    expect(r?.mount).toBe("preview");
+  });
+
+  test("websocket defaults to false when not declared or non-true", () => {
+    const a = extractHttpProxy({
+      "ai.nimblebrain/http-proxy": { target: "http://127.0.0.1:4321", mount: "preview" },
+    });
+    expect(a?.websocket).toBe(false);
+
+    const b = extractHttpProxy({
+      "ai.nimblebrain/http-proxy": {
+        target: "http://127.0.0.1:4321",
+        mount: "preview",
+        websocket: "yes", // truthy but not strictly true
+      },
+    });
+    expect(b?.websocket).toBe(false);
+  });
+
+  test("websocket=true is preserved", () => {
+    const r = extractHttpProxy({
+      "ai.nimblebrain/http-proxy": {
+        target: "http://127.0.0.1:4321",
+        mount: "preview",
+        websocket: true,
+      },
+    });
+    expect(r?.websocket).toBe(true);
+  });
+
+  test("returns the original target string verbatim (not the parsed URL)", () => {
+    const target = "http://127.0.0.1:4321/some/path?q=1";
+    const r = extractHttpProxy({
+      "ai.nimblebrain/http-proxy": { target, mount: "preview" },
+    });
+    expect(r?.target).toBe(target);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in same-origin HTTP proxy so a bundle can expose its own loopback HTTP server (e.g. `astro preview`, a Jupyter kernel) inside the platform UI via `/v1/ws/<wsId>/apps/<bundle>/<mount>/*`. The bundle declares `_meta["ai.nimblebrain/http-proxy"]` in its manifest; the platform proxies browser requests to its loopback server with credentials stripped, X-Frame-Options set to SAMEORIGIN, and per-workspace kill switch.

Driven by `synapse-apps/synapse-astro-editor`, which uses it to embed a built Astro site in the editor preview iframe — but the primitive is generic.

### Two commits

- `eb07bee` — initial route + manifest plumbing
- `d6c18e1` — workspace-in-URL refactor + hardening pass (header strip, gzip handling, X-Frame default, loopback restriction, NB_PUBLIC_ORIGIN env injection, Hono ordering fix)

### Trust model

Documented at the top of `src/api/routes/proxy.ts`:

- A bundle declaring http-proxy runs as same-origin code in the user's session — the iframe is sandboxed `allow-scripts allow-same-origin`. Treat these bundles like browser extensions.
- Defenses enforced: loopback-only target, request-header strip (Authorization/Cookie/X-Workspace-Id), response-header strip (Set-Cookie/CSP/X-Frame-Options), per-request membership check, `Workspace.allowHttpProxy = false` kill switch.
- Defenses NOT today: cross-origin isolation per bundle (would need subdomain-per-bundle + COEP). For untrusted-bundle marketplaces, that's the next investment.

### Why workspace in the URL

Browser iframe loads can't set custom headers, so the original `X-Workspace-Id` header pattern 400'd every preview load. Workspace ID lives in the URL path now, validated with `WORKSPACE_ID_RE` and membership-checked per request inside the handler. Proxy route is mounted before other sub-apps in `app.ts` because their `.use("*", requireWorkspace)` middleware would otherwise intercept `/v1/ws/*`.

### Bundle env

Bundles get three new env vars at spawn:

- `NB_WORKSPACE_ID` — which workspace this instance is for
- `NB_PROXY_PREFIX` — `/v1/ws/<wsId>/apps/<name>/<mount>` for use as `astro --base` or equivalent
- `NB_PUBLIC_ORIGIN` — operator-set platform origin so bundles can declare it in `_meta.ui.csp.{frameDomains,connectDomains}` on their UI resources

## Test plan

- [x] `bun run verify` — 418 unit/integration + 17 smoke pass, 0 fail
- [x] Manual end-to-end via `synapse-astro-editor`: bundle loads target site (Bayze) with full styling in editor preview iframe; edits trigger rebuild; preview reflects changes
- [x] Verified loopback-only restriction: external host in `target` is rejected with warning at manifest parse
- [x] Verified header stripping: bundle's loopback server sees no Authorization/Cookie headers
- [x] Verified gzip handling: gzipped upstream responses render correctly in browser
- [x] Verified per-workspace kill switch: `allowHttpProxy: false` on workspace returns 403