### PR TITLE
fix: surface bundle subprocess stderr in runtime logs (#116)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,10 @@ Namespaces (`src/cli/log.ts`):
 
 Add a namespace by calling `log.debug("ns", "message")` (from `src/cli/log.ts`). Keep this table and the `log.ts` doc comment in sync.
 
+### Bundle subprocess stderr (default-on)
+
+Lines a bundle writes to stderr — Python tracebacks, warnings, application logs — are surfaced verbatim and prefixed `[bundle:<sourceName>]`, dimmed. **No flag required.** This is the bundle author's deliberate diagnostic output, separate from NB's own `NB_DEBUG=mcp` tracing; hiding it costs hours when a bundle crashes (issue #116). To quiet a chatty bundle, silence at the bundle level (logger config) or redirect at the shell (`bun run dev 2> >(grep -v '\[bundle:')`). The last 50 lines are also captured into the `source.crashed` event payload as `stderrTail`, so post-mortem consumers see the cause-of-death.
+
 ### Browser (`localStorage.nb_debug`)
 
 ```js

--- a/scripts/repro-issue-116.ts
+++ b/scripts/repro-issue-116.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end reproducer for issue #116 (bundle subprocess stderr surfacing).
+ *
+ * Spawns a deliberately-broken Python MCP server as a stdio bundle, runs
+ * the production `McpSource` against it, and verifies:
+ *
+ *   1. The subprocess's stderr lines reach the developer (live `[bundle:…]`
+ *      print path).
+ *   2. The death is reported via exactly one `source.crashed` event.
+ *   3. That event's `stderrTail` payload contains the Python traceback.
+ *
+ * Run: `bun run scripts/repro-issue-116.ts`
+ *
+ * Exits non-zero on any contract failure so it can be wired into a smoke
+ * check.
+ */
+
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { McpSource, type McpTransportMode } from "../src/tools/mcp-source.ts";
+import type { EngineEvent, EventSink } from "../src/engine/types.ts";
+
+const RESET = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const DIM = "\x1b[2m";
+const BOLD = "\x1b[1m";
+
+function pass(msg: string) {
+  console.log(`${GREEN}✓${RESET} ${msg}`);
+}
+
+function fail(msg: string, detail?: string) {
+  console.log(`${RED}✗${RESET} ${msg}`);
+  if (detail) console.log(`${DIM}    ${detail}${RESET}`);
+  failures++;
+}
+
+let failures = 0;
+
+const bundleDir = join(tmpdir(), `nb-repro-issue-116-${Date.now()}`);
+mkdirSync(bundleDir, { recursive: true });
+
+// Python server that writes some stderr lines, then raises.
+// Mirrors the original bug shape — a real ModuleNotFoundError-style death.
+const SERVER_PY = `
+import sys
+print("[broken-bundle] starting up", file=sys.stderr)
+print("[broken-bundle] reading config", file=sys.stderr)
+print("[broken-bundle] about to import a missing module", file=sys.stderr)
+raise ModuleNotFoundError("No module named 'definitely_not_real'")
+`;
+
+writeFileSync(join(bundleDir, "server.py"), SERVER_PY);
+
+console.log(`${BOLD}Issue #116 reproducer${RESET}`);
+console.log(`${DIM}bundle dir: ${bundleDir}${RESET}`);
+console.log("");
+
+// Recording sink so we can assert on emitted events.
+const events: EngineEvent[] = [];
+const sink: EventSink = {
+  emit(e) {
+    events.push(e);
+  },
+};
+
+// Intercept the live drain (log.bundle writes via console.error) so we can
+// confirm lines reached the renderer. Restore on cleanup.
+const originalConsoleError = console.error;
+const consoleLines: string[] = [];
+console.error = (...args: unknown[]) => {
+  const line = args.map((a) => (typeof a === "string" ? a : String(a))).join(" ");
+  consoleLines.push(line);
+  originalConsoleError(...args);
+};
+
+const mode: McpTransportMode = {
+  type: "stdio",
+  spawn: {
+    command: "python3",
+    args: [join(bundleDir, "server.py")],
+    env: process.env as Record<string, string>,
+  },
+};
+const source = new McpSource("broken-bundle", mode, sink);
+
+// Run start() — expected to throw because the subprocess dies during the
+// MCP handshake. We catch and inspect the side effects.
+let startError: unknown;
+try {
+  await source.start();
+} catch (err) {
+  startError = err;
+}
+
+// Brief wait so the transport's onclose has a chance to run after the
+// thrown error from connect(). The PassThrough on stderr also needs a tick
+// for the final 'end' event.
+await new Promise((r) => setTimeout(r, 200));
+
+// Restore console before printing results.
+console.error = originalConsoleError;
+
+console.log(`${BOLD}Results:${RESET}`);
+console.log("");
+
+if (!startError) {
+  fail("start() should have thrown — the broken bundle exits during initialize");
+} else {
+  pass(`start() threw as expected (${(startError as Error).message?.slice(0, 60) ?? "unknown"}…)`);
+}
+
+const bundleLines = consoleLines.filter((l) => l.includes("[bundle:broken-bundle]"));
+if (bundleLines.length === 0) {
+  fail(
+    "No [bundle:broken-bundle] lines were rendered to console.error",
+    "Expected the live drain to print stderr lines as they were written.",
+  );
+} else {
+  pass(`Live drain rendered ${bundleLines.length} [bundle:…] line(s) to the developer`);
+}
+
+const sawStartupBanner = bundleLines.some((l) => l.includes("starting up"));
+if (!sawStartupBanner) {
+  fail("Live drain did not include the 'starting up' line written before crash");
+} else {
+  pass("Live drain captured pre-crash stderr (proves attach-at-construction works)");
+}
+
+const crashes = events.filter(
+  (e) => e.type === "run.error" && (e.data as { event?: string }).event === "source.crashed",
+);
+if (crashes.length === 0) {
+  fail("No source.crashed event was emitted");
+} else if (crashes.length > 1) {
+  fail(`Expected exactly 1 source.crashed event, got ${crashes.length}`, "Dead-guard de-dup is broken.");
+} else {
+  pass("Exactly one source.crashed event was emitted (dead-guard works)");
+}
+
+if (crashes.length > 0) {
+  const data = crashes[0]!.data as { stderrTail?: string };
+  const tail = data.stderrTail ?? "";
+  if (!tail) {
+    fail("source.crashed payload has empty stderrTail", "Ring buffer didn't capture pre-crash output.");
+  } else if (!tail.includes("ModuleNotFoundError")) {
+    fail(
+      "source.crashed.stderrTail is non-empty but doesn't contain 'ModuleNotFoundError'",
+      `tail (first 200 chars): ${tail.slice(0, 200)}`,
+    );
+  } else {
+    pass("source.crashed.stderrTail contains the ModuleNotFoundError traceback");
+  }
+}
+
+// Cleanup
+rmSync(bundleDir, { recursive: true, force: true });
+
+console.log("");
+if (failures > 0) {
+  console.log(`${RED}${BOLD}FAIL${RESET} — ${failures} contract violation(s). Issue #116 fix is broken.`);
+  process.exit(1);
+}
+console.log(`${GREEN}${BOLD}PASS${RESET} — issue #116 fix is wired end-to-end.`);

--- a/src/adapters/console-events.ts
+++ b/src/adapters/console-events.ts
@@ -28,9 +28,20 @@ export class ConsoleEventSink implements EventSink {
       case "run.done":
         console.error(`[engine] run done: ${event.data.stopReason}`);
         break;
-      case "run.error":
+      case "run.error": {
         console.error(`[engine] error: ${event.data.error}`);
+        // Render bundle stderr tail (if any) immediately after the error
+        // line, dimmed and indented so it's visually nested under the
+        // crash. Issue #116: keeps the cause-of-death visible without
+        // requiring the developer to reproduce the failure outside NB.
+        const tail = event.data.stderrTail;
+        if (typeof tail === "string" && tail.length > 0) {
+          for (const line of tail.split("\n")) {
+            console.error(`\x1b[2m  | ${line}\x1b[0m`);
+          }
+        }
         break;
+      }
     }
   }
 }

--- a/src/cli/log.ts
+++ b/src/cli/log.ts
@@ -17,6 +17,12 @@
  *
  * Keep this list in sync with the CLAUDE.md "Debugging" section so it's
  * discoverable without reading source.
+ *
+ * `log.bundle(sourceName, line)` is intentionally NOT gated. Bundle stderr
+ * is the bundle author's deliberate diagnostic output (tracebacks, warnings,
+ * logs) — different concern than NB's protocol tracing, and the dev-loop
+ * cost of hiding it (see issue #116) outweighs the cost of dimmed lines on
+ * a chatty bundle. Visual prefix + dim formatting makes it tunable by eye.
  */
 
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
@@ -56,4 +62,11 @@ export const log = {
   },
   /** Check whether a namespace is enabled, e.g. to skip expensive log args. */
   debugEnabled: isDebugEnabled,
+  /**
+   * Emit a single line of bundle subprocess stderr output. Default-on,
+   * dimmed, prefixed `[bundle:<name>]` so it's visually distinct from NB's
+   * own output. See file header for rationale.
+   */
+  bundle: (sourceName: string, line: string) =>
+    console.error(dim(`[bundle:${sourceName}] ${line}`)),
 };

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -294,7 +294,10 @@ export class McpSource implements ToolSource {
       // there explicitly notes this is to avoid losing early child output),
       // so listeners attached now will catch bytes written during
       // initialize-time crashes.
-      this.attachStderrReader(stdioTransport);
+      // SDK types `stderr` as bare `Stream | null`, but the actual return
+      // is always a Node Readable (`PassThrough` when piped, otherwise
+      // `child_process.stderr`). Narrow at the boundary.
+      this.attachStderrReader(stdioTransport.stderr as NodeJS.ReadableStream | null);
 
       // Stdio close handler. The SDK's Protocol.connect() chains existing
       // onclose handlers (it captures the prior callback and calls it
@@ -302,19 +305,7 @@ export class McpSource implements ToolSource {
       // correct and survives the handshake. Without this handler, a
       // subprocess that exits mid-session is only detected lazily inside
       // execute()'s catch branch — issue #116 root cause #2.
-      stdioTransport.onclose = () => {
-        if (this.stopping) return;
-        this.dead = true;
-        this.eventSink.emit({
-          type: "run.error",
-          data: {
-            source: this.name,
-            event: "source.crashed",
-            error: "Stdio subprocess exited",
-            stderrTail: this.stderrTail.join("\n"),
-          },
-        });
-      };
+      stdioTransport.onclose = () => this.emitSourceCrashed("Stdio subprocess exited");
     } else if (this.mode.type === "remote") {
       this.transport = createRemoteTransport(
         this.mode.url,
@@ -323,19 +314,7 @@ export class McpSource implements ToolSource {
       );
 
       // Remote: watch for transport close — mark source as dead
-      this.transport.onclose = () => {
-        if (this.stopping) return;
-        this.dead = true;
-        this.eventSink.emit({
-          type: "run.error",
-          data: {
-            source: this.name,
-            event: "source.crashed",
-            error: "Remote transport closed",
-            stderrTail: "",
-          },
-        });
-      };
+      this.transport.onclose = () => this.emitSourceCrashed("Remote transport closed");
     } else {
       // In-process: the factory builds a fresh InMemoryTransport pair and an
       // already-connected Server on each call, so restart is a clean slate.
@@ -346,19 +325,7 @@ export class McpSource implements ToolSource {
       this.inProcessServer = server;
       this.transport = clientTransport;
 
-      this.transport.onclose = () => {
-        if (this.stopping) return;
-        this.dead = true;
-        this.eventSink.emit({
-          type: "run.error",
-          data: {
-            source: this.name,
-            event: "source.crashed",
-            error: "In-process transport closed",
-            stderrTail: "",
-          },
-        });
-      };
+      this.transport.onclose = () => this.emitSourceCrashed("In-process transport closed");
     }
 
     // Advertise client-side tasks capability per MCP spec draft 2025-11-25:
@@ -418,6 +385,12 @@ export class McpSource implements ToolSource {
           await this.cleanupOnStartFailure();
           this.rebuildRemoteTransport();
           this.client = this.buildClient();
+          // Re-arm crash detection for the retry: cleanupOnStartFailure
+          // set `stopping = true` to suppress its own teardown noise; we
+          // need it false again before the new transport's onclose can
+          // fire usefully. If this retry connect also fails, the catch
+          // below calls cleanupOnStartFailure again and re-suppresses.
+          this.stopping = false;
 
           await this.connectWithTimeout(CONNECT_TIMEOUT);
           this.startedAt = Date.now();
@@ -467,6 +440,13 @@ export class McpSource implements ToolSource {
   }
 
   private async cleanupOnStartFailure(): Promise<void> {
+    // A start that never reached the "running" state is not a crash —
+    // the caller is about to throw the real error. Suppress the
+    // `source.crashed` event that would otherwise fire when
+    // `transport.close()` triggers our onclose handler. Without this,
+    // every failed connect would emit a parallel crash event for a
+    // source the listener has never seen "running."
+    this.stopping = true;
     try {
       if (this.transport) await this.transport.close();
       if (this.inProcessServer) await this.inProcessServer.close();
@@ -476,6 +456,40 @@ export class McpSource implements ToolSource {
     this.client = null;
     this.transport = null;
     this.inProcessServer = null;
+  }
+
+  /**
+   * Single emit point for `source.crashed`. Two guards, two invariants:
+   *
+   *   - `stopping` — set in `stop()` and `cleanupOnStartFailure()`. The
+   *     SDK fires `transport.onclose` synchronously inside
+   *     `transport.close()`, so without this guard every deliberate
+   *     teardown would surface as a crash event.
+   *
+   *   - `dead` — set on first death-observation. The transport's
+   *     `onclose` and `execute()`'s catch can BOTH observe a single
+   *     subprocess death (the call throws because the pipe broke; the
+   *     subprocess exit also fires onclose). Without this guard,
+   *     listeners would see two `source.crashed` events for one death,
+   *     which any deduplicating consumer (UI, telemetry) gets wrong.
+   *     Whichever path runs first wins; its payload is canonical.
+   *
+   * `stderrTail` is sourced from the ring buffer, so it's empty for
+   * non-stdio modes (which never populate it) and populated for stdio
+   * regardless of which path triggered the emit.
+   */
+  private emitSourceCrashed(error: string): void {
+    if (this.stopping || this.dead) return;
+    this.dead = true;
+    this.eventSink.emit({
+      type: "run.error",
+      data: {
+        source: this.name,
+        event: "source.crashed",
+        error,
+        stderrTail: this.stderrTail.join("\n"),
+      },
+    });
   }
 
   /**
@@ -494,19 +508,7 @@ export class McpSource implements ToolSource {
       this.mode.transportConfig,
       this.mode.authProvider,
     );
-    this.transport.onclose = () => {
-      if (this.stopping) return;
-      this.dead = true;
-      this.eventSink.emit({
-        type: "run.error",
-        data: {
-          source: this.name,
-          event: "source.crashed",
-          error: "Remote transport closed",
-          stderrTail: "",
-        },
-      });
-    };
+    this.transport.onclose = () => this.emitSourceCrashed("Remote transport closed");
   }
 
   /**
@@ -533,8 +535,7 @@ export class McpSource implements ToolSource {
    * subprocess exit and the listeners are released by the transport's
    * own teardown — no explicit unsubscribe needed.
    */
-  private attachStderrReader(stdioTransport: StdioClientTransport): void {
-    const stream = stdioTransport.stderr;
+  private attachStderrReader(stream: NodeJS.ReadableStream | null): void {
     if (!stream) return;
     const decoder = new TextDecoder("utf-8", { fatal: false });
 
@@ -832,16 +833,12 @@ export class McpSource implements ToolSource {
         };
       }
 
-      this.dead = true;
-      this.eventSink.emit({
-        type: "run.error",
-        data: {
-          source: this.name,
-          event: "source.crashed",
-          error: String(err),
-          stderrTail: this.stderrTail.join("\n"),
-        },
-      });
+      // De-duped via the `dead` guard inside emitSourceCrashed: if the
+      // transport's `onclose` already fired (subprocess died before our
+      // catch ran), this is a no-op and the onclose-side payload — which
+      // includes stderrTail — wins. If we get here first, the thrown
+      // error is the more informative payload.
+      this.emitSourceCrashed(String(err));
 
       // Crash-retry is ONLY safe for inline calls. A task-augmented call has
       // spawned server-side state (the task, an entity, possibly external
@@ -1427,6 +1424,35 @@ export class McpSource implements ToolSource {
    */
   _taskHandleCountForTesting(): number {
     return this.taskHandles.size;
+  }
+
+  /**
+   * Test-only — drive the stderr reader against a synthetic Readable so
+   * tests can exercise chunk-boundary, CRLF, partial-line, and runaway-
+   * line handling without spawning a real subprocess.
+   * Production code MUST NOT call this.
+   */
+  _attachStderrReaderForTesting(stream: NodeJS.ReadableStream): void {
+    this.attachStderrReader(stream);
+  }
+
+  /** Test-only — read the current stderr ring-buffer contents. */
+  _stderrTailForTesting(): readonly string[] {
+    return this.stderrTail;
+  }
+
+  /** Test-only — observe `dead` to verify the de-dup guard. */
+  _isDeadForTesting(): boolean {
+    return this.dead;
+  }
+
+  /**
+   * Test-only — directly invoke the crash emitter to verify de-dup
+   * (second call must be a no-op once `dead` is set).
+   * Production code MUST NOT call this.
+   */
+  _emitSourceCrashedForTesting(error: string): void {
+    this.emitSourceCrashed(error);
   }
 
   private async tryRestart(): Promise<boolean> {

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -45,6 +45,21 @@ const TASK_SWEEPER_INTERVAL_MS = 60_000;
  */
 const TASK_CREATED_TIMEOUT_MS = 60_000;
 
+/**
+ * Bundle stderr ring buffer cap. Keeps the last N lines of subprocess
+ * stderr so we can attach them to a `source.crashed` event payload — long
+ * enough for a typical Python traceback, short enough not to drown the
+ * event payload in a runaway log.
+ */
+const STDERR_TAIL_MAX_LINES = 50;
+
+/**
+ * Hard cap on a single stderr line we'll log or buffer. A bundle that
+ * writes a 100MB single line should not OOM the host or balloon an event
+ * payload. Truncation is marked so the developer knows it happened.
+ */
+const STDERR_LINE_MAX_CHARS = 8192;
+
 export type { ResourceData } from "./types.ts";
 
 export interface McpSpawnConfig {
@@ -200,6 +215,34 @@ export class McpSource implements ToolSource {
   private sweeperInterval: ReturnType<typeof setInterval> | null = null;
 
   /**
+   * Last-N lines of subprocess stderr, fed by `attachStderrReader`. Read
+   * by the `transport.onclose` handler to attach `stderrTail` to the
+   * outgoing `source.crashed` event so postmortem consumers (console event
+   * sink, web UI later) can render the traceback. Reset at the top of
+   * every `start()` so a restart doesn't inherit a dead instance's tail.
+   *
+   * Empty (and stays empty) for `remote` and `inProcess` modes — they
+   * don't have a subprocess and there is no stderr to drain.
+   */
+  private stderrTail: string[] = [];
+  /**
+   * Holds bytes received from the stderr stream that haven't yet been
+   * terminated by a newline. Pythonic `print(end="")` and progress-bar
+   * carriage-return updates don't terminate with `\n`, so we accumulate
+   * here until we see one (or the stream ends, at which point the
+   * partial-line is flushed verbatim).
+   */
+  private stderrLineBuf = "";
+  /**
+   * Set inside `stop()` so the transport's `onclose` handler — which
+   * fires synchronously during `transport.close()` — can distinguish a
+   * deliberate teardown from an unexpected death and skip emitting a
+   * `source.crashed` event in the first case. Without this guard,
+   * graceful stops would surface as spurious crash events to listeners.
+   */
+  private stopping = false;
+
+  /**
    * `eventSink` is REQUIRED, not optional. Emitted events include
    * `tool.progress` during task-augmented calls — when those events reach
    * the runtime sink wrap in `src/api/server.ts`, they turn into SSE
@@ -226,14 +269,52 @@ export class McpSource implements ToolSource {
   }
 
   async start(): Promise<void> {
+    // Fresh stderr state on every start. Restart cycles must not bleed
+    // a dead instance's tail into the new instance's crash report.
+    this.stderrTail = [];
+    this.stderrLineBuf = "";
+    // Clear deliberate-teardown flag so a restart re-enables crash detection
+    // on the new transport. Set in `stop()` to suppress onclose-emitted
+    // `source.crashed` events during graceful teardown.
+    this.stopping = false;
+
     if (this.mode.type === "stdio") {
-      this.transport = new StdioClientTransport({
+      const stdioTransport = new StdioClientTransport({
         command: this.mode.spawn.command,
         args: this.mode.spawn.args,
         env: this.mode.spawn.env,
         cwd: this.mode.spawn.cwd,
         stderr: "pipe",
       });
+      this.transport = stdioTransport;
+
+      // Attach the stderr drain BEFORE connect. The SDK exposes
+      // `transport.stderr` as a PassThrough synchronously from the
+      // constructor (see node_modules/.../client/stdio.js — the comment
+      // there explicitly notes this is to avoid losing early child output),
+      // so listeners attached now will catch bytes written during
+      // initialize-time crashes.
+      this.attachStderrReader(stdioTransport);
+
+      // Stdio close handler. The SDK's Protocol.connect() chains existing
+      // onclose handlers (it captures the prior callback and calls it
+      // before its own _onclose), so setting this before connect is
+      // correct and survives the handshake. Without this handler, a
+      // subprocess that exits mid-session is only detected lazily inside
+      // execute()'s catch branch — issue #116 root cause #2.
+      stdioTransport.onclose = () => {
+        if (this.stopping) return;
+        this.dead = true;
+        this.eventSink.emit({
+          type: "run.error",
+          data: {
+            source: this.name,
+            event: "source.crashed",
+            error: "Stdio subprocess exited",
+            stderrTail: this.stderrTail.join("\n"),
+          },
+        });
+      };
     } else if (this.mode.type === "remote") {
       this.transport = createRemoteTransport(
         this.mode.url,
@@ -243,10 +324,16 @@ export class McpSource implements ToolSource {
 
       // Remote: watch for transport close — mark source as dead
       this.transport.onclose = () => {
+        if (this.stopping) return;
         this.dead = true;
         this.eventSink.emit({
           type: "run.error",
-          data: { source: this.name, event: "source.crashed", error: "Remote transport closed" },
+          data: {
+            source: this.name,
+            event: "source.crashed",
+            error: "Remote transport closed",
+            stderrTail: "",
+          },
         });
       };
     } else {
@@ -260,6 +347,7 @@ export class McpSource implements ToolSource {
       this.transport = clientTransport;
 
       this.transport.onclose = () => {
+        if (this.stopping) return;
         this.dead = true;
         this.eventSink.emit({
           type: "run.error",
@@ -267,6 +355,7 @@ export class McpSource implements ToolSource {
             source: this.name,
             event: "source.crashed",
             error: "In-process transport closed",
+            stderrTail: "",
           },
         });
       };
@@ -406,12 +495,108 @@ export class McpSource implements ToolSource {
       this.mode.authProvider,
     );
     this.transport.onclose = () => {
+      if (this.stopping) return;
       this.dead = true;
       this.eventSink.emit({
         type: "run.error",
-        data: { source: this.name, event: "source.crashed", error: "Remote transport closed" },
+        data: {
+          source: this.name,
+          event: "source.crashed",
+          error: "Remote transport closed",
+          stderrTail: "",
+        },
       });
     };
+  }
+
+  /**
+   * Drain the stdio subprocess's stderr stream into the developer's
+   * terminal and a bounded in-memory ring buffer.
+   *
+   * Why default-on (not gated behind `NB_DEBUG`): bundle stderr is the
+   * bundle author's deliberate diagnostic output — tracebacks, warnings,
+   * runtime logs. That's a different concern than NB's own protocol
+   * tracing (`NB_DEBUG=mcp`). Hiding signal that costs hours to recreate
+   * (issue #116) is a worse default than dimmed lines a developer can
+   * scan past or silence at the bundle level. Visual prefix + dim
+   * formatting via `log.bundle` makes the channel tunable by eye.
+   *
+   * Why a ring buffer in addition to live print: when the subprocess
+   * exits, the `transport.onclose` handler attaches `stderrTail` to the
+   * outgoing `source.crashed` event so non-CLI consumers (web UI later,
+   * persisted event logs) can render the cause-of-death without us
+   * keeping the entire log around.
+   *
+   * Stream contract: `transport.stderr` is a Node-style Readable
+   * (PassThrough in the SDK). Listeners attached here run for the
+   * lifetime of the subprocess; the stream's `end` event fires on
+   * subprocess exit and the listeners are released by the transport's
+   * own teardown — no explicit unsubscribe needed.
+   */
+  private attachStderrReader(stdioTransport: StdioClientTransport): void {
+    const stream = stdioTransport.stderr;
+    if (!stream) return;
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+
+    stream.on("data", (chunk: unknown) => {
+      let text: string;
+      if (typeof chunk === "string") {
+        text = chunk;
+      } else if (chunk instanceof Uint8Array) {
+        text = decoder.decode(chunk, { stream: true });
+      } else {
+        text = String(chunk);
+      }
+      this.stderrLineBuf += text;
+
+      // Drain complete lines.
+      let nl = this.stderrLineBuf.indexOf("\n");
+      while (nl !== -1) {
+        let line = this.stderrLineBuf.slice(0, nl);
+        this.stderrLineBuf = this.stderrLineBuf.slice(nl + 1);
+        if (line.endsWith("\r")) line = line.slice(0, -1);
+        this.recordStderrLine(line);
+        nl = this.stderrLineBuf.indexOf("\n");
+      }
+
+      // Guard against an unbounded line — flush whatever we have, marked.
+      if (this.stderrLineBuf.length > STDERR_LINE_MAX_CHARS) {
+        const truncated = `${this.stderrLineBuf.slice(0, STDERR_LINE_MAX_CHARS)} […truncated]`;
+        this.stderrLineBuf = "";
+        this.recordStderrLine(truncated);
+      }
+    });
+
+    // Stream end: flush any pending bytes from the decoder + line buffer
+    // so a `print(end="")`-style final write is not silently dropped.
+    stream.on("end", () => {
+      const trailing = decoder.decode();
+      if (trailing) this.stderrLineBuf += trailing;
+      if (this.stderrLineBuf.length > 0) {
+        this.recordStderrLine(this.stderrLineBuf);
+        this.stderrLineBuf = "";
+      }
+    });
+
+    // Don't crash the host on a stream-level error from the pipe — log
+    // and let the subprocess's own close path handle source death.
+    stream.on("error", (err: unknown) => {
+      log.debug("mcp", `[${this.name}] stderr stream error: ${String(err)}`);
+    });
+  }
+
+  /** Push one logical stderr line: live render + ring buffer. */
+  private recordStderrLine(line: string): void {
+    if (line.length === 0) return;
+    const capped =
+      line.length > STDERR_LINE_MAX_CHARS
+        ? `${line.slice(0, STDERR_LINE_MAX_CHARS)} […truncated]`
+        : line;
+    log.bundle(this.name, capped);
+    this.stderrTail.push(capped);
+    if (this.stderrTail.length > STDERR_TAIL_MAX_LINES) {
+      this.stderrTail.shift();
+    }
   }
 
   private buildClient(): Client {
@@ -446,6 +631,10 @@ export class McpSource implements ToolSource {
   }
 
   async stop(): Promise<void> {
+    // Tell our onclose handlers this is a deliberate teardown — see
+    // `stopping` field. Without this, every graceful stop would emit a
+    // `source.crashed` event when `transport.close()` triggers onclose.
+    this.stopping = true;
     // Abort any in-flight streams so their drainers unblock and the handle
     // map can be cleared without leaking outstanding `awaitToolTaskResult`
     // callers. Each drainer will reject its terminalDeferred, which is
@@ -646,7 +835,12 @@ export class McpSource implements ToolSource {
       this.dead = true;
       this.eventSink.emit({
         type: "run.error",
-        data: { source: this.name, event: "source.crashed", error: String(err) },
+        data: {
+          source: this.name,
+          event: "source.crashed",
+          error: String(err),
+          stderrTail: this.stderrTail.join("\n"),
+        },
       });
 
       // Crash-retry is ONLY safe for inline calls. A task-augmented call has

--- a/test/unit/mcp-source-stderr.test.ts
+++ b/test/unit/mcp-source-stderr.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "bun:test";
+import { PassThrough } from "node:stream";
+import { McpSource, type McpTransportMode } from "../../src/tools/mcp-source.ts";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import type { EngineEvent, EventSink } from "../../src/engine/types.ts";
+
+/** Build a stdio-mode source for tests that don't actually spawn. */
+function makeStdioSource(name = "stderr-test", sink: EventSink = new NoopEventSink()) {
+  const mode: McpTransportMode = {
+    type: "stdio",
+    spawn: { command: "true", args: [], env: {} },
+  };
+  return new McpSource(name, mode, sink);
+}
+
+/** Collecting EventSink. */
+function recorder(): { events: EngineEvent[]; sink: EventSink } {
+  const events: EngineEvent[] = [];
+  return {
+    events,
+    sink: {
+      emit(e) {
+        events.push(e);
+      },
+    },
+  };
+}
+
+describe("McpSource stderr drain", () => {
+  it("splits a single chunk on newlines and stores complete lines in the ring buffer", () => {
+    const source = makeStdioSource();
+    const stream = new PassThrough();
+    source._attachStderrReaderForTesting(stream);
+
+    stream.write("hello\nworld\n");
+    // PassThrough delivers data synchronously to listeners; no microtask wait needed.
+
+    const tail = source._stderrTailForTesting();
+    expect(tail).toEqual(["hello", "world"]);
+  });
+
+  it("buffers partial lines across chunks until a newline arrives", () => {
+    const source = makeStdioSource();
+    const stream = new PassThrough();
+    source._attachStderrReaderForTesting(stream);
+
+    stream.write("Trace");
+    stream.write("back (most ");
+    stream.write("recent call last):\n");
+
+    expect(source._stderrTailForTesting()).toEqual(["Traceback (most recent call last):"]);
+  });
+
+  it("flushes a final partial line on stream end (no trailing newline)", async () => {
+    const source = makeStdioSource();
+    const stream = new PassThrough();
+    source._attachStderrReaderForTesting(stream);
+
+    stream.write("ModuleNotFoundError: rpds.rpds");
+    const ended = new Promise<void>((resolve) => stream.once("end", () => resolve()));
+    stream.end();
+    await ended;
+    // The reader's own `end` listener runs in the same emission cycle —
+    // wait one more microtask so its mutation of stderrTail is visible.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(source._stderrTailForTesting()).toEqual(["ModuleNotFoundError: rpds.rpds"]);
+  });
+
+  it("strips trailing CR on CRLF lines", () => {
+    const source = makeStdioSource();
+    const stream = new PassThrough();
+    source._attachStderrReaderForTesting(stream);
+
+    stream.write("first\r\nsecond\r\n");
+
+    expect(source._stderrTailForTesting()).toEqual(["first", "second"]);
+  });
+
+  it("caps the ring buffer at 50 lines (FIFO eviction)", () => {
+    const source = makeStdioSource();
+    const stream = new PassThrough();
+    source._attachStderrReaderForTesting(stream);
+
+    // Write 60 lines; only the last 50 should survive.
+    let payload = "";
+    for (let i = 0; i < 60; i++) payload += `line ${i}\n`;
+    stream.write(payload);
+
+    const tail = source._stderrTailForTesting();
+    expect(tail.length).toBe(50);
+    expect(tail[0]).toBe("line 10");
+    expect(tail[49]).toBe("line 59");
+  });
+
+  it("truncates a runaway single line that exceeds the byte cap", () => {
+    const source = makeStdioSource();
+    const stream = new PassThrough();
+    source._attachStderrReaderForTesting(stream);
+
+    // 9 KB of bytes with no newline — exceeds 8 KB cap, must be flushed
+    // with a truncation marker instead of growing unboundedly.
+    const huge = "x".repeat(9000);
+    stream.write(huge);
+
+    const tail = source._stderrTailForTesting();
+    expect(tail.length).toBe(1);
+    expect(tail[0]!.endsWith("[…truncated]")).toBe(true);
+    expect(tail[0]!.length).toBeLessThanOrEqual(8192 + " […truncated]".length);
+  });
+
+  it("ignores empty lines (consecutive newlines)", () => {
+    const source = makeStdioSource();
+    const stream = new PassThrough();
+    source._attachStderrReaderForTesting(stream);
+
+    stream.write("a\n\n\nb\n");
+    expect(source._stderrTailForTesting()).toEqual(["a", "b"]);
+  });
+});
+
+describe("McpSource crash event semantics", () => {
+  it("emitSourceCrashed fires exactly once even when called twice (dead-guard)", () => {
+    const { events, sink } = recorder();
+    const source = makeStdioSource("dedup", sink);
+
+    source._emitSourceCrashedForTesting("first");
+    source._emitSourceCrashedForTesting("second");
+
+    const crashes = events.filter(
+      (e) => e.type === "run.error" && (e.data as { event?: string }).event === "source.crashed",
+    );
+    expect(crashes).toHaveLength(1);
+    expect((crashes[0]!.data as { error: string }).error).toBe("first");
+    expect(source._isDeadForTesting()).toBe(true);
+  });
+
+  it("source.crashed payload includes stderrTail joined by newlines", () => {
+    const { events, sink } = recorder();
+    const source = makeStdioSource("payload", sink);
+
+    const stream = new PassThrough();
+    source._attachStderrReaderForTesting(stream);
+    stream.write("traceback line 1\ntraceback line 2\n");
+
+    source._emitSourceCrashedForTesting("Stdio subprocess exited");
+
+    const crash = events.find(
+      (e) => e.type === "run.error" && (e.data as { event?: string }).event === "source.crashed",
+    );
+    expect(crash).toBeDefined();
+    const data = crash!.data as { error: string; stderrTail: string };
+    expect(data.error).toBe("Stdio subprocess exited");
+    expect(data.stderrTail).toBe("traceback line 1\ntraceback line 2");
+  });
+});
+
+describe("McpSource lifecycle guards", () => {
+  it("graceful stop() does not emit source.crashed when transport.close fires onclose", async () => {
+    const { events, sink } = recorder();
+    const { defineInProcessApp } = await import("../../src/tools/in-process-app.ts");
+    const source = defineInProcessApp(
+      { name: "graceful-stop", version: "1.0.0", tools: [] },
+      sink,
+    );
+    await source.start();
+    await source.stop();
+
+    const crashes = events.filter(
+      (e) => e.type === "run.error" && (e.data as { event?: string }).event === "source.crashed",
+    );
+    expect(crashes).toHaveLength(0);
+  });
+
+  it("failed start() does not emit source.crashed for a source that never ran", async () => {
+    const { events, sink } = recorder();
+    // In-process factory that throws synchronously — the connect path
+    // never reaches "running"; cleanupOnStartFailure then closes the
+    // (already-half-built) transport, which must not surface as a crash
+    // event since the listener never saw the source alive.
+    const mode: McpTransportMode = {
+      type: "inProcess",
+      createServer: async () => {
+        throw new Error("createServer failed");
+      },
+    };
+    const source = new McpSource("never-started", mode, sink);
+    await expect(source.start()).rejects.toThrow("createServer failed");
+
+    const crashes = events.filter(
+      (e) => e.type === "run.error" && (e.data as { event?: string }).event === "source.crashed",
+    );
+    expect(crashes).toHaveLength(0);
+  });
+
+  it("restart re-arms crash detection (stopping flag clears on start)", async () => {
+    const { events, sink } = recorder();
+    const { defineInProcessApp } = await import("../../src/tools/in-process-app.ts");
+    const source = defineInProcessApp(
+      { name: "restart-rearm", version: "1.0.0", tools: [] },
+      sink,
+    );
+    await source.start();
+    await source.stop();
+    // Restart cycle.
+    await source.start();
+    // After restart, dead is false and a fresh emit should produce one event.
+    expect(source._isDeadForTesting()).toBe(false);
+    source._emitSourceCrashedForTesting("post-restart crash");
+    await source.stop();
+
+    const crashes = events.filter(
+      (e) => e.type === "run.error" && (e.data as { event?: string }).event === "source.crashed",
+    );
+    expect(crashes).toHaveLength(1);
+    expect((crashes[0]!.data as { error: string }).error).toBe("post-restart crash");
+  });
+
+  it("stderr ring buffer resets on start (no bleed across restart)", async () => {
+    const source = makeStdioSource();
+    const stream1 = new PassThrough();
+    source._attachStderrReaderForTesting(stream1);
+    stream1.write("old instance line\n");
+    expect(source._stderrTailForTesting()).toEqual(["old instance line"]);
+
+    // Simulate the start() reset path. start() itself spawns a real
+    // process for stdio mode; we just verify the documented invariant
+    // that fresh state at the top of start() clears the tail.
+    await source
+      .start()
+      .catch(() => {
+        // `true` is a real binary that exits cleanly with no MCP handshake;
+        // we expect start() to fail at the handshake. What we care about
+        // is that the stderr buffer was reset at the top of start() before
+        // anything else — including the failure — happened.
+      });
+
+    // Tail should not contain the "old instance line" anymore.
+    const tail = source._stderrTailForTesting();
+    expect(tail.includes("old instance line")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #116.

## Summary

- Drain the MCP bundle subprocess's `transport.stderr` into a per-source 50-line ring buffer and a default-on dimmed `[bundle:<name>]` live print. Attached at construction so initialize-time crashes are captured.
- Add the previously missing stdio `onclose` handler so subprocess exits are detected eagerly instead of on the next tool call. Include `stderrTail` in the `source.crashed` payload across all transport modes.
- Render `stderrTail` in `ConsoleEventSink`, dimmed and indented under the error line, so the traceback is visible without digging through separate streams.
- Suppress `source.crashed` on graceful `stop()` via a `stopping` flag — `transport.close()` fires `onclose` synchronously, which would otherwise surface every deliberate teardown as a crash. This was a latent bug across remote/in-process; adding stdio made it loud.

## Why default-on (not `NB_DEBUG`-gated)

Bundle stderr is the bundle author's deliberate diagnostic output — Python uses stderr for tracebacks, warnings, deprecation notices, logs. Different concern than NB's own protocol tracing (`NB_DEBUG=mcp`). The cost asymmetry is severe: hiding signal causes the multi-hour debug loop the issue was filed about; showing dimmed prefixed lines is recoverable with shell redirection or by quieting the bundle. Visual prefix + dim formatting makes the channel tunable by eye without a config flag — same pattern as Docker / `foreman` / `overmind`.

## Architecture

Three concerns kept separate:
1. **Live drain** — bytes-to-lines, attached for the subprocess's lifetime.
2. **Tail capture** — bounded ring buffer (50 lines, 8 KB per line) feeding the crash event payload.
3. **Surfacing** — dev console (default-on) + `run.error.data.stderrTail` (additive field for downstream consumers like a future web UI).

Edge cases handled: partial lines (`print(end="")`), CRLF endings, runaway-line truncation, lossy UTF-8 decode, restart cycles (ring buffer reset at `start()`), graceful stops (suppressed via `stopping` flag).

Reader is attached **at transport construction**, not after `connect()`, because `StdioClientTransport.stderr` is a `PassThrough` exposed synchronously from the constructor — the SDK's own doc-comment calls this out specifically to avoid losing early child output. No race, no monkey-patching of `start()`.

Did NOT introduce a new `bundle.log` engine event for live lines. Out of scope per the issue, and live console output covers the dev-loop case. Web UI surfacing falls out cheaply later by reading `event.data.stderrTail`.

## Test plan

- [x] `bun run verify` passes (2141 unit + 213 web + 416 integration + 17 smoke, exit 0)
- [x] Smoke output shows live `[bundle:echo] ...` lines streaming through during real subprocess runs
- [ ] Manual: trigger a Python `ModuleNotFoundError` in a bundle and confirm the traceback appears under the crash line in `bun run dev`
- [ ] Manual: `bun run dev`, restart a bundle (stop + start) and confirm no spurious `source.crashed` events fire