### PR TITLE
fix(api): return 405 on GET /mcp to stop idle-killed SSE streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Files-app uploads no longer fail with `Payload too large`. Picker bytes now flow through `POST /v1/resources` (multipart, workspace-scoped) instead of being base64-encoded into a `tools/call` argument; `isAllowedMime` strips Content-Type parameters, fixing a latent miss in the chat ingest path too ([#93](https://github.com/NimbleBrainInc/nimblebrain/pull/93)).
 - `nb__read_resource` and `POST /v1/resources/read` resolve `ui://` resources published by platform built-ins (settings, home, automations, conversations, files, usage, nb). Previously the structural type guard couldn't distinguish two divergent `readResource` shapes and silently skipped any platform source ([#90](https://github.com/NimbleBrainInc/nimblebrain/issues/90)).
 - `/v1/resources/read` request-context propagation. The route handler wasn't wrapping its source-call in `runWithRequestContext`, so callback-form resource bodies that called `runtime.requireWorkspaceId()` (e.g. `instructions://workspace`) threw and surfaced as 404 "not found." Wrapping matches the existing `handleCallTool` pattern.
+- `GET /mcp` returns 405 instead of opening an idle SSE listener. The standalone server→client stream was held open with nothing to write, so Bun's `idleTimeout` (and any L7 proxy: Vite dev, ALB, nginx) silently killed it — surfacing as `[vite] http proxy error: /mcp` + `socket hang up` and exhausting the SDK client's reconnect budget. The MCP SDK treats 405 as "no GET-style listening" and runs POST-only ([#138](https://github.com/NimbleBrainInc/nimblebrain/pull/138)).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ All endpoints require authentication (Bearer token or session cookie) unless not
 | POST | /v1/auth/refresh | No | Refresh access token |
 | GET | /.well-known/oauth-protected-resource | No | MCP OAuth discovery (RFC 9728) |
 | GET | /.well-known/oauth-authorization-server | No | AuthKit metadata proxy (RFC 8414) |
-| POST/GET/DELETE | /mcp | Yes | Streamable HTTP MCP server endpoint |
+| POST/DELETE | /mcp | Yes | Streamable HTTP MCP server endpoint (GET returns 405; no standalone server→client SSE channel) |
 
 ## Architecture
 

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -372,8 +372,28 @@ function createServer(
  * Handle an incoming HTTP request on the /mcp path.
  *
  * - POST: JSON-RPC messages (initialization or subsequent)
- * - GET: SSE stream for server-initiated messages
+ * - GET:  405 — see comment below
  * - DELETE: Session termination
+ *
+ * GET /mcp is the spec's *optional* server→client SSE channel for
+ * notifications outside any in-flight request (broadcast notifications,
+ * sampling, elicitation). We don't push anything down it: tool responses
+ * and task progress flow on the POST that started them, and our own
+ * server→client signaling for the iframe app (data.changed, conversation
+ * events, heartbeats) goes through `/v1/events`, not MCP.
+ *
+ * Holding the connection open with nothing to write meant Bun's
+ * `idleTimeout` (max 255s) — and any L7 proxy in front of the API (Vite
+ * dev proxy, ALB's 60s default, nginx) — would silently kill the socket,
+ * surfacing as `socket hang up` upstream and triggering the SDK's
+ * limited reconnect loop (default `maxRetries: 2`).
+ *
+ * Returning 405 is the spec-blessed escape hatch: the SDK explicitly
+ * treats it as "server doesn't offer GET-style listening" and gracefully
+ * runs POST-only (`@modelcontextprotocol/sdk/.../client/streamableHttp.js`
+ * in `_startOrAuthSse`). If we ever start emitting standalone-stream
+ * notifications, switch this back to a real handler and add a heartbeat
+ * (see `src/api/sse-heartbeat.ts`).
  */
 export async function handleMcpRequest(
   request: Request,
@@ -387,15 +407,14 @@ export async function handleMcpRequest(
     return handlePost(request, registry, features, workspaceCtx);
   }
 
-  if (method === "GET") {
-    return handleGet(request);
-  }
-
   if (method === "DELETE") {
     return handleDelete(request);
   }
 
-  return new Response("Method not allowed", { status: 405 });
+  return new Response("Method Not Allowed", {
+    status: 405,
+    headers: { Allow: "POST, DELETE" },
+  });
 }
 
 async function handlePost(
@@ -493,19 +512,6 @@ async function handlePost(
   await server.connect(transport);
 
   return transport.handleRequest(request, { parsedBody: body });
-}
-
-async function handleGet(request: Request): Promise<Response> {
-  const sessionId = request.headers.get("mcp-session-id");
-  if (!sessionId) {
-    return new Response("Missing session ID", { status: 400 });
-  }
-  const entry = sessions.get(sessionId);
-  if (!entry) {
-    return new Response("Session not found", { status: 404 });
-  }
-  entry.lastAccessedAt = Date.now();
-  return entry.transport.handleRequest(request);
 }
 
 async function handleDelete(request: Request): Promise<Response> {

--- a/test/integration/mcp-server-endpoint.test.ts
+++ b/test/integration/mcp-server-endpoint.test.ts
@@ -166,6 +166,25 @@ describe("MCP Server Endpoint (/mcp)", () => {
 			await Promise.all([client1.close(), client2.close()]);
 		}
 	});
+
+	// Standalone GET /mcp is the spec's optional server→client SSE channel.
+	// We deliberately don't implement it (see comment on `handleMcpRequest`)
+	// because we don't push standalone notifications and a long-lived
+	// idle connection gets killed by intermediate proxies. Returning 405
+	// is the spec-blessed escape hatch — the SDK client treats it as
+	// "server doesn't offer GET-style listening" and proceeds POST-only.
+	it("returns 405 for GET /mcp so the SDK skips the standalone SSE stream", async () => {
+		const res = await fetch(`${baseUrl}/mcp`, {
+			method: "GET",
+			headers: {
+				Accept: "text/event-stream",
+				"x-workspace-id": TEST_WORKSPACE_ID,
+			},
+		});
+		expect(res.status).toBe(405);
+		expect(res.headers.get("allow")).toBe("POST, DELETE");
+		await res.body?.cancel();
+	});
 });
 
 describe("MCP Server Auth", () => {


### PR DESCRIPTION
## Summary

- `GET /mcp` is the MCP Streamable HTTP spec's *optional* server→client SSE channel. We don't push anything down it — tool responses and task progress ride the POST that started them, and our own server→client signaling for the iframe app (`data.changed`, conversation events, heartbeats) flows through `/v1/events`. Holding the connection open with nothing to write meant Bun's `idleTimeout` (max 255s), Vite's dev proxy, and any L7 proxy in front of the API (ALB's 60s default, nginx) would silently kill the socket — surfacing as `[vite] http proxy error: /mcp` + `socket hang up` locally, and an exhausted SDK reconnect budget (default `maxRetries: 2`) in the iframe.
- Return `405 Method Not Allowed` with `Allow: POST, DELETE`. The MCP SDK explicitly treats 405 as "server doesn't offer GET-style listening" and proceeds POST-only — see `_startOrAuthSse` in `@modelcontextprotocol/sdk/client/streamableHttp.js`. Zero long-lived connections, works behind any proxy.
- If we ever start emitting standalone-stream notifications (sampling, elicitation, broadcast), switch this back to a real handler and add an SSE heartbeat (`src/api/sse-heartbeat.ts` has the pattern).

## Test plan

- [x] `bun run verify` — 2181 unit + 213 web + 443 integration + 17 smoke, all green
- [x] New regression test: `GET /mcp` returns 405 with `Allow: POST, DELETE`
- [x] Existing `client.connect()` flow in `mcp-server-endpoint.test.ts` still passes (SDK gracefully degrades)
- [ ] Local repro: with this branch, `bun run dev` no longer logs `[vite] http proxy error: /mcp` after the idle window