### PR TITLE
Remove mcpServer feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ A fully specified example:
   "store":     { "type": "jsonl", "dir": "~/.nimblebrain/conversations" },
   "telemetry": { "enabled": true },
   "files":     { "maxFileSize": 26214400, "maxFilesPerMessage": 10 },
-  "features":  { "bundleManagement": true, "mcpServer": true },
+  "features":  { "bundleManagement": true },
   "maxIterations": 25,
   "maxInputTokens": 500000,
   "maxOutputTokens": 16384,
@@ -594,7 +594,7 @@ Bundles can be installed per-workspace (tracked via `BundleInstance.wsId`). Each
 
 **CORS:** Dynamic. Dev mode: `Access-Control-Allow-Origin: *`. With auth: only `ALLOWED_ORIGINS` env var origins, with credentials support.
 
-**MCP endpoint (`/mcp`):** Streamable HTTP for external MCP clients. 100 concurrent sessions (env: `MCP_MAX_SESSIONS`), 30-minute TTL (env: `MCP_SESSION_TTL_MS`). Disabled when `features.mcpServer` is `false`. When `authkitDomain` is configured, returns `WWW-Authenticate` header on 401 for automatic OAuth discovery by MCP clients. Full setup guide: [MCP Endpoint](https://docs.nimblebrain.ai/api/mcp-endpoint/) and [Connecting External Clients](https://docs.nimblebrain.ai/guide/mcp-connect/) on docs.nimblebrain.ai.
+**MCP endpoint (`/mcp`):** Streamable HTTP. The bundled web UI uses this endpoint to drive the platform, and external MCP clients (Claude Code, Claude Desktop, Cursor) can connect to the same endpoint. 100 concurrent sessions (env: `MCP_MAX_SESSIONS`), 30-minute TTL (env: `MCP_SESSION_TTL_MS`). When `authkitDomain` is configured, returns `WWW-Authenticate` header on 401 for automatic OAuth discovery by MCP clients. Full setup guide: [MCP Endpoint](https://docs.nimblebrain.ai/api/mcp-endpoint/) and [Connecting External Clients](https://docs.nimblebrain.ai/guide/mcp-connect/) on docs.nimblebrain.ai.
 
 **Deploying behind a TLS-terminating proxy:** OAuth discovery advertises its `resource` URL from `X-Forwarded-Proto`, falling back to the request scheme. Upstream proxies (AWS ALB, nginx, Cloudflare, etc.) must set that header to the client-facing scheme (`https`) for MCP OAuth to work. The bundled `nimblebrain-web` Caddy container already honors it via `trusted_proxies static private_ranges`; if you front it with an additional proxy, ensure that proxy also propagates `X-Forwarded-Proto`. Without this, `/.well-known/oauth-protected-resource` returns `resource: http://...` and modern MCP clients reject the response. See [MCP OAuth behind a reverse proxy](https://docs.nimblebrain.ai/deploy/security/#mcp-oauth-behind-a-reverse-proxy) for ALB / nginx / Caddy snippets.
 
@@ -668,7 +668,6 @@ All default to `true`. Setting to `false` removes the capability entirely — to
 | `delegation` | Multi-agent delegation | `nb__delegate` |
 | `toolDiscovery` | Tool search (scope=tools) | `nb__search` |
 | `bundleDiscovery` | Registry search (scope=registry) | `nb__search` |
-| `mcpServer` | External MCP access via `/mcp` | `/mcp` endpoint |
 | `fileContext` | File upload and context extraction | File processing |
 | `userManagement` | Create/delete users | `nb__manage_users` |
 | `workspaceManagement` | Workspaces, members, sharing | `nb__manage_workspaces` |

--- a/src/api/routes/mcp.ts
+++ b/src/api/routes/mcp.ts
@@ -77,9 +77,6 @@ export function mcpRoutes(ctx: AppContext) {
 
   app.all("/mcp", bodyLimit(1_048_576), async (c) => {
     const features = ctx.runtime.getFeatures();
-    if (!features.mcpServer) {
-      return apiError(404, "not_found", "Not found");
-    }
 
     // Every MCP request must be workspace-scoped
     const identity = c.var.identity;

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -10,7 +10,6 @@ export interface FeatureFlags {
   delegation?: boolean;
   toolDiscovery?: boolean;
   bundleDiscovery?: boolean;
-  mcpServer?: boolean;
   fileContext?: boolean;
   userManagement?: boolean;
   workspaceManagement?: boolean;
@@ -25,7 +24,6 @@ const DEFAULTS: ResolvedFeatures = {
   delegation: true,
   toolDiscovery: true,
   bundleDiscovery: true,
-  mcpServer: true,
   fileContext: true,
   userManagement: true,
   workspaceManagement: true,
@@ -40,7 +38,6 @@ export function resolveFeatures(config?: FeatureFlags): ResolvedFeatures {
     delegation: config.delegation ?? true,
     toolDiscovery: config.toolDiscovery ?? true,
     bundleDiscovery: config.bundleDiscovery ?? true,
-    mcpServer: config.mcpServer ?? true,
     fileContext: config.fileContext ?? true,
     userManagement: config.userManagement ?? true,
     workspaceManagement: config.workspaceManagement ?? true,

--- a/src/config/nimblebrain-config.schema.json
+++ b/src/config/nimblebrain-config.schema.json
@@ -298,11 +298,6 @@
           "description": "Enable registry search via nb__search scope=registry. Default: true.",
           "default": true
         },
-        "mcpServer": {
-          "type": "boolean",
-          "description": "Enable MCP server endpoint. Default: true.",
-          "default": true
-        },
         "fileContext": {
           "type": "boolean",
           "description": "Enable file context (workspace files, chat attachments). Default: true.",

--- a/test/unit/api/mcp-oauth.test.ts
+++ b/test/unit/api/mcp-oauth.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "bun:test";
 import { Hono } from "hono";
 import type { AppContext } from "../../../src/api/types.ts";
 import { mcpRoutes } from "../../../src/api/routes/mcp.ts";
+import { resolveFeatures } from "../../../src/config/features.ts";
 
 // ── Test helpers ──────────────────────────────────────────────────
 
@@ -44,7 +45,7 @@ function makeCtx(opts: { authkitDomain?: string } = {}): AppContext {
       internalToken: "test-internal-token",
     },
     runtime: {
-      getFeatures: () => ({}),
+      getFeatures: () => resolveFeatures(),
     },
     workspaceStore: null,
   } as unknown as AppContext;

--- a/test/unit/api/mcp-oauth.test.ts
+++ b/test/unit/api/mcp-oauth.test.ts
@@ -44,7 +44,7 @@ function makeCtx(opts: { authkitDomain?: string } = {}): AppContext {
       internalToken: "test-internal-token",
     },
     runtime: {
-      getFeatures: () => ({ mcpServer: true }),
+      getFeatures: () => ({}),
     },
     workspaceStore: null,
   } as unknown as AppContext;

--- a/test/unit/audit-events.test.ts
+++ b/test/unit/audit-events.test.ts
@@ -216,7 +216,7 @@ describe("createPrivilegeHook audit emission", () => {
       promptConfigValue: async () => null,
     };
 
-    const hook = createPrivilegeHook(denyGate, captureSink, { bundleManagement: true, skillManagement: true, delegation: true, toolDiscovery: true, bundleDiscovery: true, mcpServer: true, fileContext: true, userManagement: true, workspaceManagement: true });
+    const hook = createPrivilegeHook(denyGate, captureSink, { bundleManagement: true, skillManagement: true, delegation: true, toolDiscovery: true, bundleDiscovery: true, fileContext: true, userManagement: true, workspaceManagement: true });
 
     const result = await hook({
       id: "call_1",

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -89,7 +89,6 @@ describe("loadConfig", () => {
     const configPath = writeTestConfig("features.json", {
       features: {
         delegation: false,
-        mcpServer: false,
         workspaceManagement: false,
       },
     });
@@ -97,7 +96,6 @@ describe("loadConfig", () => {
     const config = loadConfig({ config: configPath });
     expect(config.features).toEqual({
       delegation: false,
-      mcpServer: false,
       workspaceManagement: false,
     });
   });

--- a/test/unit/features.test.ts
+++ b/test/unit/features.test.ts
@@ -9,7 +9,6 @@ describe("resolveFeatures", () => {
 		expect(features.delegation).toBe(true);
 		expect(features.toolDiscovery).toBe(true);
 		expect(features.bundleDiscovery).toBe(true);
-		expect(features.mcpServer).toBe(true);
 	});
 
 	it("merges partial config correctly", () => {

--- a/test/unit/runtime/features-identity.test.ts
+++ b/test/unit/runtime/features-identity.test.ts
@@ -35,7 +35,6 @@ describe("identity & workspace feature flags", () => {
 			expect(features.delegation).toBe(true);
 			expect(features.toolDiscovery).toBe(true);
 			expect(features.bundleDiscovery).toBe(true);
-			expect(features.mcpServer).toBe(true);
 			expect(features.fileContext).toBe(true);
 		});
 	});

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -287,7 +287,7 @@ describe("search — feature flag gating", () => {
 		const features = {
 			bundleManagement: true, skillManagement: true, delegation: true,
 			toolDiscovery: false, bundleDiscovery: true,
-			mcpServer: true, fileContext: true, userManagement: true, workspaceManagement: true,
+			fileContext: true, userManagement: true, workspaceManagement: true,
 		};
 		const systemTools = await createSystemTools(
 			() => registry,
@@ -304,7 +304,7 @@ describe("search — feature flag gating", () => {
 		const features = {
 			bundleManagement: true, skillManagement: true, delegation: true,
 			toolDiscovery: true, bundleDiscovery: false,
-			mcpServer: true, fileContext: true, userManagement: true, workspaceManagement: true,
+			fileContext: true, userManagement: true, workspaceManagement: true,
 		};
 		const systemTools = await createSystemTools(
 			() => registry,
@@ -321,7 +321,7 @@ describe("search — feature flag gating", () => {
 		const features = {
 			bundleManagement: true, skillManagement: true, delegation: true,
 			toolDiscovery: true, bundleDiscovery: false,
-			mcpServer: true, fileContext: true, userManagement: true, workspaceManagement: true,
+			fileContext: true, userManagement: true, workspaceManagement: true,
 		};
 		const systemTools = await createSystemTools(
 			() => registry,


### PR DESCRIPTION
## Summary

- The `/mcp` endpoint is the only transport the bundled web UI uses to drive the platform (see `web/src/mcp-bridge-client.ts:97` and `web/src/bridge/bridge.ts`). Disabling it via `features.mcpServer` broke the SPA outright, so the flag had no defensible "off" state — just a footgun for new tenants whose chart default landed as `false`.
- Drops the field from `FeatureFlags` type, `DEFAULTS` / `resolveFeatures`, the JSON schema, the gate at `src/api/routes/mcp.ts:80-82`, the README, and the unit tests that referenced it.
- Auth is still gated by the existing `requireMcpAuth` middleware, OAuth `WWW-Authenticate` discovery, and per-workspace authorization downstream — only the kill-switch goes away.

## Backwards compatibility

Stale tenant configs that still set `features.mcpServer` will trigger the existing "unknown key" warning at runtime startup but otherwise have no effect.

## Land order

This must merge **first**:

1. **This PR** — runtime stops gating on the flag.
2. `NimbleBrainInc/infra#6` — chart drops the field from values + ConfigMap template.
3. `NimbleBrainInc/deployments#9` — drops the per-tenant overrides on `hq`, `bayze` + fixes `CLAUDE.md` (`ipsdi.yaml` does not appear in that diff because the override was applied live as a hot fix and never landed on `main`).

Reversing the order would leave a window where the runtime still gates but no value is being set, which would 404 every UI request.

## Test plan

- [x] `bun test` over the touched unit files (`features.test.ts`, `features-identity.test.ts`, `mcp-oauth.test.ts`, `audit-events.test.ts`, `system-tools.test.ts`, `cli.test.ts`) — 105 pass
- [x] `bun run verify:static` — passes (one pre-existing unrelated lint warning in `url-validator.ts`)
- [ ] CI green
- [ ] After merge: redeploy ipsdi/hq/bayze and verify `/data/nimblebrain.json` no longer contains `mcpServer` (post-chart-PR) and the web UI continues to load

