### PR TITLE
fix: Gemini schema, thinking-block replay, layered config persistence

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -18,8 +18,23 @@ export interface CliFlags {
   defaultWorkDir?: string;
 }
 
-/** Validate config file contents using JSON Schema. Throws on structural errors, warns on unknown keys. */
-function validateConfig(config: Record<string, unknown>, path: string): void {
+/**
+ * Validate config file contents using JSON Schema. Throws on structural
+ * errors. Warns on unknown keys when `warnUnknownKeys` is true (default).
+ *
+ * The override file is written by `set_model_config` and contains a known
+ * small surface — its valid keys (e.g., `thinking`, `thinkingBudgetTokens`)
+ * are not yet in the published JSON schema, so unknown-key warnings would
+ * fire on every boot for any tenant that's run `set_model_config`. The
+ * structural validation (type errors) still fires; only the key-name
+ * warning is suppressed for that file.
+ */
+function validateConfig(
+  config: Record<string, unknown>,
+  path: string,
+  opts: { warnUnknownKeys?: boolean } = {},
+): void {
+  const warnUnknownKeys = opts.warnUnknownKeys ?? true;
   const validate = getValidator();
   const valid = validate(config);
 
@@ -38,8 +53,10 @@ function validateConfig(config: Record<string, unknown>, path: string): void {
       }
     }
 
-    for (const key of warnings) {
-      console.error(`[config] Warning: unknown key "${key}" in ${path} (ignored)`);
+    if (warnUnknownKeys) {
+      for (const key of warnings) {
+        console.error(`[config] Warning: unknown key "${key}" in ${path} (ignored)`);
+      }
     }
 
     if (errors.length > 0) {
@@ -95,7 +112,11 @@ export function loadConfig(flags: CliFlags = {}): RuntimeConfig {
     try {
       const overrideRaw = readFileSync(configOverridePath, "utf-8");
       const override = JSON.parse(overrideRaw) as Record<string, unknown>;
-      validateConfig(override, configOverridePath);
+      // Suppress unknown-key warnings: the override file's vocabulary
+      // (thinking, thinkingBudgetTokens) is not yet in the published
+      // JSON schema, and warning every boot for every tenant that's
+      // run set_model_config is noise. Structural errors still throw.
+      validateConfig(override, configOverridePath, { warnUnknownKeys: false });
       const overrideKeys = Object.keys(override);
       if (overrideKeys.length > 0) {
         fileConfig = mergeConfigs(seedConfig, override) as Partial<RuntimeConfig> &

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { getValidator } from "../config/index.ts";
+import { deriveOverridePath, mergeConfigs } from "../config/overrides.ts";
 import type { RuntimeConfig } from "../runtime/types.ts";
 
 const DEFAULT_CONFIG_FILE = "nimblebrain.json";
@@ -67,12 +68,13 @@ function resolveConfigPath(flags: CliFlags): string {
 /** Load RuntimeConfig from a nimblebrain.json file, merged with CLI flags. */
 export function loadConfig(flags: CliFlags = {}): RuntimeConfig {
   const configPath = resolveConfigPath(flags);
+  const configOverridePath = deriveOverridePath(configPath);
 
-  let fileConfig: Partial<RuntimeConfig> & Record<string, unknown> = {};
+  let seedConfig: Record<string, unknown> = {};
   if (existsSync(configPath)) {
     const raw = readFileSync(configPath, "utf-8");
-    fileConfig = JSON.parse(raw);
-    validateConfig(fileConfig, configPath);
+    seedConfig = JSON.parse(raw);
+    validateConfig(seedConfig, configPath);
   } else if (flags.config) {
     // Explicit --config/-c path must exist
     throw new Error(`Config file not found: ${configPath}`);
@@ -80,6 +82,35 @@ export function loadConfig(flags: CliFlags = {}): RuntimeConfig {
     // Auto-create default config if the parent directory exists
     if (existsSync(dirname(configPath))) {
       writeFileSync(configPath, `${JSON.stringify(DEFAULT_CONFIG_CONTENT, null, 2)}\n`, "utf-8");
+    }
+  }
+
+  // Layer the override file (if present) over the seed. The override is
+  // user-managed (set_model_config writes here) and preserved across
+  // deploys; the seed is operator-managed and overwritten on every deploy
+  // by the init container. Override values win on every key.
+  let fileConfig: Partial<RuntimeConfig> & Record<string, unknown> =
+    seedConfig as Partial<RuntimeConfig> & Record<string, unknown>;
+  if (existsSync(configOverridePath)) {
+    try {
+      const overrideRaw = readFileSync(configOverridePath, "utf-8");
+      const override = JSON.parse(overrideRaw) as Record<string, unknown>;
+      validateConfig(override, configOverridePath);
+      const overrideKeys = Object.keys(override);
+      if (overrideKeys.length > 0) {
+        fileConfig = mergeConfigs(seedConfig, override) as Partial<RuntimeConfig> &
+          Record<string, unknown>;
+        console.error(
+          `[config] Applied ${overrideKeys.length} runtime override${overrideKeys.length === 1 ? "" : "s"} from ${configOverridePath}: ${overrideKeys.join(", ")}`,
+        );
+      }
+    } catch (err) {
+      // A malformed override file should NOT take down startup — the seed
+      // is still valid and the operator can fix the override file later.
+      // Log loudly so the divergence is visible.
+      console.error(
+        `[config] Failed to load override file ${configOverridePath}: ${err instanceof Error ? err.message : String(err)}. Using seed config only.`,
+      );
     }
   }
 
@@ -120,6 +151,8 @@ export function loadConfig(flags: CliFlags = {}): RuntimeConfig {
     maxOutputTokens: fileConfig.maxOutputTokens,
     maxHistoryMessages: fileConfig.maxHistoryMessages,
     maxToolResultSize: fileConfig.maxToolResultSize,
+    thinking: fileConfig.thinking as RuntimeConfig["thinking"],
+    thinkingBudgetTokens: fileConfig.thinkingBudgetTokens as RuntimeConfig["thinkingBudgetTokens"],
     events: fileConfig.events,
     logging: fileConfig.logging as RuntimeConfig["logging"],
     http: fileConfig.http as RuntimeConfig["http"],
@@ -127,6 +160,7 @@ export function loadConfig(flags: CliFlags = {}): RuntimeConfig {
     files: fileConfig.files as RuntimeConfig["files"],
     // Pass config path for bundle install/uninstall persistence
     configPath,
+    configOverridePath,
     workDir:
       process.env.NB_WORK_DIR ?? (fileConfig.workDir as string | undefined) ?? flags.defaultWorkDir,
     telemetry: fileConfig.telemetry as RuntimeConfig["telemetry"],

--- a/src/config/overrides.ts
+++ b/src/config/overrides.ts
@@ -1,0 +1,64 @@
+/**
+ * Layered config helpers: the seed file (`nimblebrain.json`, Helm-managed,
+ * overwritten on every deploy by the init container) and the override file
+ * (`nimblebrain.overrides.json`, sibling on the PVC, written by
+ * `set_model_config`, preserved across deploys).
+ *
+ * The runtime loader reads both and 1-level deep-merges override over seed.
+ * Override values win on every key. The override file ONLY contains the
+ * subset of fields `set_model_config` knows how to write — operator-managed
+ * fields (providers, auth, http, features, telemetry) belong in the seed.
+ */
+
+import { dirname, join } from "node:path";
+
+const DEFAULT_OVERRIDE_FILE = "nimblebrain.overrides.json";
+
+/**
+ * Derive the override-file path from the seed config path. Sibling file
+ * with a fixed suffix so a deployment that mounts only `nimblebrain.json`
+ * has a predictable place for runtime overrides.
+ */
+export function deriveOverridePath(configPath: string): string {
+  return join(dirname(configPath), DEFAULT_OVERRIDE_FILE);
+}
+
+/**
+ * Shallow merge with a one-level deep step for nested object values.
+ *
+ * Top-level scalars are replaced; top-level objects (e.g., `models`) get
+ * key-by-key merged so an override of `models.fast` doesn't blow away the
+ * seed's `models.default` and `models.reasoning`. Arrays are replaced
+ * wholesale — same as `Object.assign`.
+ *
+ * Deeper nesting falls back to replacement; we don't recurse arbitrarily.
+ * The override file is a known small surface (set_model_config writes only
+ * model-related top-level keys), so two-level merge is enough and simpler
+ * than a generic deep-merge that has to reason about arrays, nulls, and
+ * provider-config edge cases.
+ */
+export function mergeConfigs(
+  seed: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...seed };
+  for (const [key, value] of Object.entries(override)) {
+    const seedValue = seed[key];
+    const bothObjects =
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      seedValue !== null &&
+      typeof seedValue === "object" &&
+      !Array.isArray(seedValue);
+    if (bothObjects) {
+      out[key] = {
+        ...(seedValue as Record<string, unknown>),
+        ...(value as Record<string, unknown>),
+      };
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}

--- a/src/conversation/event-reconstructor.ts
+++ b/src/conversation/event-reconstructor.ts
@@ -8,6 +8,7 @@
 
 import type { LanguageModelV3Content } from "@ai-sdk/provider";
 import { estimateCost } from "../engine/cost.ts";
+import { normalizeForReplay } from "../model/inbound-fit.ts";
 import type { ConversationEvent, LlmResponseEvent, StoredMessage, ToolDoneEvent } from "./types.ts";
 
 /**
@@ -198,18 +199,24 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
       // If we ran out of events without run.done/run.error, still emit what we have
       // (handles incomplete runs)
 
-      // Now produce messages from llm.response events in order
+      // Now produce messages from llm.response events in order.
+      //
+      // Faithful replay shape: each llm.response becomes ONE assistant
+      // message whose content array preserves the provider's original
+      // block ordering — text, reasoning, and executed tool-calls in the
+      // exact order Anthropic returned them. Unexecuted (orphaned) tool-
+      // calls are filtered out (the API rejects orphans), but no other
+      // reordering happens.
+      //
+      // Why ordering matters: Anthropic validates the LATEST assistant
+      // message byte-for-byte ("thinking blocks in the latest assistant
+      // message cannot be modified"). An older implementation grouped
+      // content by category (reasoning / text / tool-call) and emitted
+      // them as separate messages — convenient for UI rendering but a
+      // 400 on multi-iteration runs with thinking enabled. The chat UI
+      // consumes its own projection from src/bundles/conversations/src/
+      // jsonl-reader.ts; this function is the LLM-replay projection.
       for (const llmResp of runLlmResponses) {
-        const toolCallParts = llmResp.content.filter(
-          (c): c is LanguageModelV3Content & { type: "tool-call" } => c.type === "tool-call",
-        );
-        const textParts = llmResp.content.filter(
-          (c): c is LanguageModelV3Content & { type: "text" } => c.type === "text",
-        );
-        const reasoningParts = llmResp.content.filter(
-          (c): c is LanguageModelV3Content & { type: "reasoning" } => c.type === "reasoning",
-        );
-
         const baseMetadata = () => ({
           inputTokens: llmResp.inputTokens,
           outputTokens: llmResp.outputTokens,
@@ -225,107 +232,87 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
           ...(llmResp.finishReason ? { finishReason: llmResp.finishReason } : {}),
         });
 
-        // Reasoning attaches to the FIRST emitted message of this turn,
-        // so the UI renders a single collapsed reasoning block above the
-        // assistant's tool call or text. Subsequent messages from the
-        // same turn omit it to avoid duplication.
-        //
-        // Provider metadata (e.g. Anthropic's thinking signature) is
-        // promoted from `providerMetadata` (the V3Content output shape)
-        // to `providerOptions` (the V3ReasoningPart prompt shape) so
-        // the reasoning block survives a conversation reload + replay.
-        // Without this, the AI SDK Anthropic provider drops the block as
-        // "unsupported reasoning metadata" and Anthropic 400s the call.
-        const reasoningContent = reasoningParts.map((r) => ({
-          type: "reasoning" as const,
-          text: r.text,
-          ...(r.providerMetadata ? { providerOptions: r.providerMetadata } : {}),
-        }));
-        let reasoningEmitted = false;
+        const executedToolCalls = llmResp.content.filter(
+          (c): c is LanguageModelV3Content & { type: "tool-call" } =>
+            c.type === "tool-call" && runToolDones.has(c.toolCallId),
+        );
+        const totalToolCalls = llmResp.content.filter((c) => c.type === "tool-call").length;
+        const hasOrphanedToolCalls = totalToolCalls > executedToolCalls.length;
 
-        // Only include tool calls that were actually executed (have a tool.done event).
-        // Unexecuted calls happen when a run is cut short (abort, crash, etc.)
-        // before tools could run. Including them would create orphaned tool_use blocks
-        // that the Claude API rejects, or fake empty tool results that confuse the model.
-        // Lifted out of the `if (toolCallParts.length > 0)` block so step 4a can
-        // detect the all-unexecuted case and emit a placeholder for it.
-        const executedToolCalls = toolCallParts.filter((tc) => runToolDones.has(tc.toolCallId));
-        const hasOrphanedToolCalls = toolCallParts.length > 0 && executedToolCalls.length === 0;
+        // Filter out orphaned tool-calls; preserve all other blocks in
+        // their original order. normalizeForReplay then handles the
+        // stream→prompt shape mismatches (reasoning providerMetadata→
+        // providerOptions, tool-call input string→object).
+        const replayContent = normalizeForReplay(
+          llmResp.content.filter((c) => c.type !== "tool-call" || runToolDones.has(c.toolCallId)),
+        );
 
-        if (toolCallParts.length > 0) {
-          if (executedToolCalls.length > 0) {
-            const toolCallsMeta = executedToolCalls.map((tc) => {
-              const done = runToolDones.get(tc.toolCallId)!;
-              return {
-                id: tc.toolCallId,
-                name: tc.toolName,
-                input: (runToolInputs.get(tc.toolCallId) ?? parseToolInput(tc.input)) as Record<
-                  string,
-                  unknown
-                >,
-                output: done.output ?? "",
-                ok: done.ok ?? true,
-                ms: done.ms ?? 0,
-              };
-            });
+        // Tool-call metadata for the chat UI (input/output rendering).
+        // Carried on the assistant message; not part of the LLM replay.
+        const toolCallsMeta = executedToolCalls.map((tc) => {
+          const done = runToolDones.get(tc.toolCallId)!;
+          return {
+            id: tc.toolCallId,
+            name: tc.toolName,
+            input: (runToolInputs.get(tc.toolCallId) ?? parseToolInput(tc.input)) as Record<
+              string,
+              unknown
+            >,
+            output: done.output ?? "",
+            ok: done.ok ?? true,
+            ms: done.ms ?? 0,
+          };
+        });
 
-            const assistantMsg: StoredMessage = {
-              role: "assistant",
+        const hasRealContent =
+          replayContent.some((c) => c.type === "text") || executedToolCalls.length > 0;
+
+        if (hasRealContent) {
+          // Normal path: one assistant message, original block order.
+          // Orphaned tool-calls (if any) were already filtered out of
+          // replayContent — text alongside them survives as the visible
+          // assistant turn, no placeholder needed.
+          //
+          // Cast: stream-side `LanguageModelV3Content` is wider than the
+          // assistant-role content union (it includes tool-result/source
+          // which only appear on tool/system messages). The data IS
+          // assistant-valid by construction — orphan filter is the only
+          // mutation — but TS can't prove it without a runtime type guard
+          // on every block. Same cast used by engine.ts after doStream.
+          const assistantMsg = {
+            role: "assistant",
+            content: replayContent,
+            timestamp: llmResp.ts,
+            metadata: {
+              ...baseMetadata(),
+              ...(toolCallsMeta.length > 0 ? { toolCalls: toolCallsMeta } : {}),
+            },
+          } as StoredMessage;
+          messages.push(assistantMsg);
+
+          // Tool-result message per executed tool-call (one per result so
+          // role alternation alternates assistant→tool→tool→… cleanly).
+          for (const tc of executedToolCalls) {
+            const done = runToolDones.get(tc.toolCallId)!;
+            const toolMsg: StoredMessage = {
+              role: "tool",
               content: [
-                ...(reasoningEmitted ? [] : reasoningContent),
-                ...executedToolCalls.map((tc) => ({
-                  type: "tool-call" as const,
+                {
+                  type: "tool-result" as const,
                   toolCallId: tc.toolCallId,
                   toolName: tc.toolName,
-                  input: parseToolInput(tc.input),
-                })),
+                  output: { type: "text", value: done.output ?? "" },
+                },
               ],
-              timestamp: llmResp.ts,
-              metadata: { ...baseMetadata(), toolCalls: toolCallsMeta },
+              timestamp: done.ts ?? llmResp.ts,
             };
-            reasoningEmitted = true;
-            messages.push(assistantMsg);
-
-            // Emit tool-result messages for each executed tool call
-            for (const tc of executedToolCalls) {
-              const done = runToolDones.get(tc.toolCallId)!;
-              const toolMsg: StoredMessage = {
-                role: "tool",
-                content: [
-                  {
-                    type: "tool-result" as const,
-                    toolCallId: tc.toolCallId,
-                    toolName: tc.toolName,
-                    output: {
-                      type: "text",
-                      value: done.output ?? "",
-                    },
-                  },
-                ],
-                timestamp: done.ts ?? llmResp.ts,
-              };
-              messages.push(toolMsg);
-            }
+            messages.push(toolMsg);
           }
-        }
-
-        if (textParts.length > 0) {
-          const assistantMsg: StoredMessage = {
-            role: "assistant",
-            content: [
-              ...(reasoningEmitted ? [] : reasoningContent),
-              ...textParts.map((t) => ({ type: "text" as const, text: t.text })),
-            ],
-            timestamp: llmResp.ts,
-            metadata: baseMetadata(),
-          };
-          reasoningEmitted = true;
-          messages.push(assistantMsg);
+          continue;
         }
 
         // Step 4a — replay honesty.
-        // We land here when no assistant message was emitted above (no
-        // executed tool calls, no text). Several reasons:
+        // No real content emitted above. Reasons:
         //   1. The turn produced reasoning only (extended thinking that
         //      ran out of budget before any visible content).
         //   2. The turn produced literally nothing AND the model didn't
@@ -336,12 +323,6 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
         //      message and Anthropic rejects the conversation on reload
         //      with "model does not support assistant message prefill".
         //
-        // Dropping the message silently — the pre-existing behavior —
-        // either skips a turn that actually happened or breaks role
-        // alternation. Emit a placeholder assistant message carrying
-        // finishReason in metadata so the UI can render the truncation
-        // banner and the reasoning (if any) survives.
-        //
         // Reasoning content is ONLY usable as the placeholder body when
         // it carries provider metadata that lets it round-trip (e.g.
         // Anthropic's signature). Without that, the AI SDK provider
@@ -349,29 +330,33 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
         // For the orphaned-tool-calls case we always use marker text:
         // the reasoning may end mid-tool-call-intent, and the marker is
         // the load-bearing signal to the model on retry.
-        const wouldEmitAssistantMessage = executedToolCalls.length > 0 || textParts.length > 0;
-        const hasReasoningOrAbnormalFinish =
-          reasoningContent.length > 0 ||
-          (llmResp.finishReason != null && llmResp.finishReason !== "stop");
+        const reasoningWithMeta = replayContent.filter(
+          (c): c is LanguageModelV3Content & { type: "reasoning" } =>
+            c.type === "reasoning" &&
+            "providerOptions" in c &&
+            (c as { providerOptions?: unknown }).providerOptions != null,
+        );
+        const hasAbnormalFinish = llmResp.finishReason != null && llmResp.finishReason !== "stop";
+        const hasAnyReasoning = replayContent.some((c) => c.type === "reasoning");
+        const shouldEmitPlaceholder = hasOrphanedToolCalls || hasAnyReasoning || hasAbnormalFinish;
 
-        if (!wouldEmitAssistantMessage && (hasReasoningOrAbnormalFinish || hasOrphanedToolCalls)) {
-          const placeholderText = hasOrphanedToolCalls
-            ? ORPHANED_TOOL_CALLS_MARKER
-            : (TRUNCATION_MARKERS[llmResp.finishReason ?? "other"] ?? TRUNCATION_MARKERS.other!);
-          const reasoningRoundTrips =
-            !hasOrphanedToolCalls &&
-            reasoningContent.some((r) => "providerOptions" in r && r.providerOptions != null);
-          const placeholderContent = reasoningRoundTrips
-            ? reasoningContent
-            : [{ type: "text" as const, text: placeholderText }];
-          const assistantMsg: StoredMessage = {
-            role: "assistant",
-            content: placeholderContent,
-            timestamp: llmResp.ts,
-            metadata: baseMetadata(),
-          };
-          messages.push(assistantMsg);
-        }
+        if (!shouldEmitPlaceholder) continue;
+
+        const placeholderText = hasOrphanedToolCalls
+          ? ORPHANED_TOOL_CALLS_MARKER
+          : (TRUNCATION_MARKERS[llmResp.finishReason ?? "other"] ?? TRUNCATION_MARKERS.other!);
+        const reasoningRoundTrips = !hasOrphanedToolCalls && reasoningWithMeta.length > 0;
+        const placeholderContent: LanguageModelV3Content[] = reasoningRoundTrips
+          ? reasoningWithMeta
+          : [{ type: "text" as const, text: placeholderText }];
+
+        const assistantMsg = {
+          role: "assistant",
+          content: placeholderContent,
+          timestamp: llmResp.ts,
+          metadata: baseMetadata(),
+        } as StoredMessage;
+        messages.push(assistantMsg);
       }
 
       continue;

--- a/src/conversation/event-reconstructor.ts
+++ b/src/conversation/event-reconstructor.ts
@@ -330,6 +330,15 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
         // For the orphaned-tool-calls case we always use marker text:
         // the reasoning may end mid-tool-call-intent, and the marker is
         // the load-bearing signal to the model on retry.
+        //
+        // Behavior change vs. the pre-block-ordering reconstructor: when
+        // a turn has both signed and unsigned reasoning blocks, only the
+        // signed ones are kept in the placeholder. The old code kept all
+        // reasoning blocks as long as ANY had a signature; the unsigned
+        // blocks would then be silently dropped by the AI SDK provider on
+        // the next prompt with an "unsupported reasoning metadata" warning.
+        // Filtering up-front is more honest — the reconstructed message
+        // accurately reflects what the next call will actually send.
         const reasoningWithMeta = replayContent.filter(
           (c): c is LanguageModelV3Content & { type: "reasoning" } =>
             c.type === "reasoning" &&

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -9,6 +9,7 @@ import type {
 } from "@ai-sdk/provider";
 import { MAX_ITERATIONS, MAX_TOOL_RESULT_CHARS } from "../limits.ts";
 import { getProviderFromModel, supportsEnabledThinking } from "../model/catalog.ts";
+import { normalizeForReplay } from "../model/inbound-fit.ts";
 import { callModel, type StreamResult } from "../model/stream.ts";
 import { validateToolInput } from "../tools/validate-input.ts";
 import {
@@ -430,29 +431,11 @@ export class AgentEngine {
           break; // Model is done
         }
 
-        // 4. Append assistant message to history
-        // Stream content uses fields that don't always match the prompt-side
-        // shape — convert before pushing back as next-iteration history:
-        //   - tool-call: input is a JSON string in stream output, but the
-        //     prompt format expects a parsed object.
-        //   - reasoning: stream output uses `providerMetadata` (matches
-        //     LanguageModelV3Reasoning); the prompt-side ReasoningPart
-        //     reads `providerOptions`. The AI SDK Anthropic provider
-        //     drops reasoning blocks without `providerOptions.anthropic.
-        //     signature`, breaking multi-iteration replay.
-        const historyContent = response.content.map((part) => {
-          if (part.type === "tool-call" && typeof part.input === "string") {
-            try {
-              return { ...part, input: JSON.parse(part.input) };
-            } catch {
-              return { ...part, input: {} };
-            }
-          }
-          if (part.type === "reasoning" && part.providerMetadata) {
-            return { ...part, providerOptions: part.providerMetadata };
-          }
-          return part;
-        });
+        // 4. Append assistant message to history.
+        // `normalizeForReplay` handles the stream→prompt shape mismatches
+        // (tool-call input string→object, reasoning providerMetadata→
+        // providerOptions). See src/model/inbound-fit.ts.
+        const historyContent = normalizeForReplay(response.content);
         history.push({ role: "assistant", content: historyContent } as LanguageModelV3Message);
 
         // 5. Execute tools in PARALLEL (sync + task-augmented concurrently, §13)

--- a/src/model/inbound-fit.ts
+++ b/src/model/inbound-fit.ts
@@ -1,0 +1,43 @@
+/**
+ * Normalize provider response content for the next iteration's prompt.
+ *
+ * The Vercel AI SDK V3 has an asymmetric reasoning shape: provider metadata
+ * (e.g. Anthropic's thinking-block signature) arrives in `providerMetadata`
+ * on the way IN from `model.doStream()`, but the prompt-side converter that
+ * builds the next request reads `providerOptions`. Without the rename, the
+ * Anthropic provider drops the block as "unsupported reasoning metadata"
+ * and the API rejects the call — `messages.N.content.M: thinking blocks in
+ * the latest assistant message cannot be modified`.
+ *
+ * Tool-call blocks have a similar asymmetry: stream output carries `input`
+ * as a JSON string; the prompt format expects a parsed object.
+ *
+ * This module is the single source of truth for both renames. Both the
+ * engine (after `model.doStream()`) and the conversation event reconstructor
+ * (when rebuilding history from JSONL) call into it.
+ *
+ * Idempotent: applying twice produces the same result.
+ */
+
+import type { LanguageModelV3Content } from "@ai-sdk/provider";
+
+export function normalizeForReplay(
+  content: readonly LanguageModelV3Content[],
+): LanguageModelV3Content[] {
+  return content.map((part) => {
+    if (part.type === "tool-call" && typeof part.input === "string") {
+      try {
+        return { ...part, input: JSON.parse(part.input) };
+      } catch {
+        return { ...part, input: {} };
+      }
+    }
+    if (part.type === "reasoning" && part.providerMetadata) {
+      // Spread keeps `providerMetadata` AND adds `providerOptions`. The
+      // AI SDK reads the latter; preserving the former is harmless and
+      // keeps any downstream telemetry that introspects metadata working.
+      return { ...part, providerOptions: part.providerMetadata };
+    }
+    return part;
+  });
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -10,6 +10,7 @@ import { deriveServerName } from "../bundles/paths.ts";
 import type { AppInfo, BundleInstance } from "../bundles/types.ts";
 import { log } from "../cli/log.ts";
 import { isToolVisibleToRole, type ResolvedFeatures, resolveFeatures } from "../config/features.ts";
+import { deriveOverridePath } from "../config/overrides.ts";
 import { createPrivilegeHook, NoopConfirmationGate } from "../config/privilege.ts";
 import { generateTitle } from "../conversation/auto-title.ts";
 import { EventSourcedConversationStore } from "../conversation/event-sourced-store.ts";
@@ -263,6 +264,14 @@ export class Runtime {
 
   /** Create and start a runtime from config. */
   static async start(config: RuntimeConfig): Promise<Runtime> {
+    // Derive the override-file path when the caller supplied a configPath
+    // but not an explicit override path. The CLI's loadConfig already
+    // populates both; this fallback covers embedded callers (tests,
+    // library use) that build a RuntimeConfig directly.
+    if (config.configPath && !config.configOverridePath) {
+      config = { ...config, configOverridePath: deriveOverridePath(config.configPath) };
+    }
+
     const resolveModelFn = resolveModel(config);
 
     const telemetryManager = TelemetryManager.create({
@@ -1618,9 +1627,19 @@ export class Runtime {
     return mergeScopedSkills(orgPool, workspacePool, userPool);
   }
 
-  /** Get the path to the nimblebrain.json config file. */
+  /** Get the path to the nimblebrain.json config file (Helm-managed seed). */
   getConfigPath(): string | undefined {
     return this.config.configPath;
+  }
+
+  /**
+   * Get the path to nimblebrain.overrides.json — the user-managed override
+   * file written by `set_model_config` and preserved across deploys.
+   * Defaults to a sibling of `configPath`; absent only when no `configPath`
+   * is set (in-memory tests, embedded usage).
+   */
+  getConfigOverridePath(): string | undefined {
+    return this.config.configOverridePath;
   }
 
   /** Get current runtime config values (safe subset — no secrets). */

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -125,8 +125,17 @@ export interface RuntimeConfig {
   /** Confirmation gate for privileged operations and credential prompts. */
   confirmationGate?: ConfirmationGate;
 
-  /** Path to nimblebrain.json. Used for config persistence. */
+  /** Path to nimblebrain.json. The Helm-managed seed file. Overwritten on every deploy. */
   configPath?: string;
+
+  /**
+   * Path to nimblebrain.overrides.json. The user-managed override file written
+   * by `set_model_config`. Preserved across deploys (init container leaves it
+   * alone). Loaded by `loadConfig` and 1-level deep-merged over the seed —
+   * override values win. Defaults to a sibling of `configPath` (`<dir>/
+   * nimblebrain.overrides.json`).
+   */
+  configOverridePath?: string;
 
   /**
    * Working directory for all runtime state (conversations, skills, cache).

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -68,12 +68,15 @@ export interface RuntimeConfig {
    * provider option; non-Anthropic providers ignore it.
    *
    *   - `off`        — never request thinking. Cheapest; no reasoning content.
-   *   - `adaptive`   — model decides per call (Anthropic's recommended default
-   *                    for reasoning-capable models like Opus 4.7 / Sonnet 4.6).
+   *   - `adaptive`   — model decides per call.
    *   - `enabled`    — always think, with optional `thinkingBudgetTokens` cap.
    *
-   * If unset, the platform defaults to `adaptive` for catalog-flagged
-   * reasoning-capable models and `off` otherwise.
+   * If unset, the platform defaults to `enabled` (with a budget capped at
+   * roughly half of `maxOutputTokens`) for catalog-flagged reasoning-capable
+   * models and `off` otherwise. The default was changed from `adaptive`
+   * after production showed Opus 4.7 routinely consumed the entire output
+   * budget on internal reasoning, producing empty user-visible turns on
+   * long-context tasks.
    */
   thinking?: "off" | "adaptive" | "enabled";
 

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -134,9 +134,17 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
       },
     },
     {
+      // Atomic write (temp + rename) but NOT lock-protected against
+      // concurrent calls: two parallel set_model_config invocations both
+      // read the override file, both apply their patch to the read state,
+      // both write — last writer wins, first writer's patch is silently
+      // lost. Admin-only and rare in practice; documenting here so the
+      // next caller doesn't assume it's safe to fire many in parallel.
+      // If concurrency becomes a real concern, gate writes on a per-path
+      // mutex via async-mutex or similar.
       name: "set_model_config",
       description:
-        "Update model selection and runtime limits. Writes atomically to nimblebrain.json. Does not allow changing API keys or secrets.",
+        "Update model selection and runtime limits. Writes atomically to nimblebrain.overrides.json (preserved across deploys). Does not allow changing API keys or secrets.",
       inputSchema: {
         type: "object",
         properties: {
@@ -252,11 +260,33 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
           // a null in the enum — Gemini rejects enums on non-string types,
           // breaking every tool call on Google-only tenants. Booleans are
           // the LCD-clean way to expose the same semantic across providers.
+          //
+          // Note: this mutates the caller's `input` object so downstream
+          // branches read the normalized null. Safe today because each
+          // tool call has its own input. If we ever batch/replay tool
+          // calls, switch to a local copy.
           if (input.clearThinking === true) {
             if (input.thinking !== undefined && input.thinking !== null) {
               return {
                 content: textContent(
                   "Cannot set both `thinking` and `clearThinking`. Use one or the other.",
+                ),
+                isError: true,
+              };
+            }
+            // `clearThinking` clears BOTH thinking and the budget (a budget
+            // without a mode is meaningless). Setting `thinkingBudgetTokens`
+            // alongside `clearThinking` would produce an orphan budget on
+            // disk: the merge below deletes both fields when thinking is
+            // null, then re-sets the budget from the patch. Live runtime
+            // stays consistent (the handler's updateConfig call clears
+            // both) but disk diverges, surfacing at next restart. Reject
+            // the combination at the input boundary instead.
+            if (input.thinkingBudgetTokens !== undefined && input.thinkingBudgetTokens !== null) {
+              return {
+                content: textContent(
+                  "Cannot set `thinkingBudgetTokens` while clearing `thinking` — " +
+                    "clearing the mode also clears the budget. Drop one or the other.",
                 ),
                 isError: true,
               };

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -169,21 +169,31 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             description: "Max output tokens per LLM call (must be > 0).",
           },
           thinking: {
-            type: ["string", "null"],
-            enum: ["off", "adaptive", "enabled", null],
+            type: "string",
+            enum: ["off", "adaptive", "enabled"],
             description:
               "Extended-thinking mode for reasoning-capable models. " +
               "off: never reason. adaptive: model decides per call. " +
               "enabled: always reason (use thinkingBudgetTokens to cap). " +
-              "null: clear the operator override and revert to platform default " +
-              "(adaptive for catalog-flagged reasoning models, off otherwise).",
+              "Use clearThinking=true to revert to the platform default.",
+          },
+          clearThinking: {
+            type: "boolean",
+            description:
+              "If true, clears any persisted thinking override and reverts to the platform default. " +
+              "Mutually exclusive with `thinking`.",
           },
           thinkingBudgetTokens: {
-            type: ["number", "null"],
+            type: "number",
             description:
               "Token budget when thinking=enabled. Counts toward maxOutputTokens. " +
-              "Anthropic requires a minimum of 1,024. " +
-              "null: clear any persisted budget.",
+              "Anthropic requires a minimum of 1,024.",
+          },
+          clearThinkingBudget: {
+            type: "boolean",
+            description:
+              "If true, clears any persisted thinking budget. " +
+              "Mutually exclusive with `thinkingBudgetTokens`.",
           },
         },
       },
@@ -228,6 +238,35 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               content: textContent("No config file path available. Cannot persist changes."),
               isError: true,
             };
+          }
+
+          // Normalize the `clear*` booleans into the canonical null sentinel
+          // the merge logic below already understands. The schema previously
+          // expressed "revert to default" as `type: ["string","null"]` with
+          // a null in the enum — Gemini rejects enums on non-string types,
+          // breaking every tool call on Google-only tenants. Booleans are
+          // the LCD-clean way to expose the same semantic across providers.
+          if (input.clearThinking === true) {
+            if (input.thinking !== undefined && input.thinking !== null) {
+              return {
+                content: textContent(
+                  "Cannot set both `thinking` and `clearThinking`. Use one or the other.",
+                ),
+                isError: true,
+              };
+            }
+            input.thinking = null;
+          }
+          if (input.clearThinkingBudget === true) {
+            if (input.thinkingBudgetTokens !== undefined && input.thinkingBudgetTokens !== null) {
+              return {
+                content: textContent(
+                  "Cannot set both `thinkingBudgetTokens` and `clearThinkingBudget`. Use one or the other.",
+                ),
+                isError: true,
+              };
+            }
+            input.thinkingBudgetTokens = null;
           }
 
           // Validate inputs

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -232,10 +232,16 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             }
           }
 
-          const configPath = runtime.getConfigPath();
-          if (!configPath) {
+          // Writes go to the override file, NOT the Helm-managed seed.
+          // The init container overwrites the seed on every deploy, so any
+          // value written here would last only until the next rollout. The
+          // override file is a sibling on the PVC that the init container
+          // leaves alone, so user changes survive deploys. The runtime
+          // loader merges seed → override at startup; override values win.
+          const configOverridePath = runtime.getConfigOverridePath();
+          if (!configOverridePath) {
             return {
-              content: textContent("No config file path available. Cannot persist changes."),
+              content: textContent("No config override path available. Cannot persist changes."),
               isError: true,
             };
           }
@@ -358,37 +364,40 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             }
           }
 
-          // Read current config
+          // Read current override file (the one we'll patch and write back).
+          // The seed file is read separately by the runtime loader; we only
+          // touch overrides here.
           let existing: Record<string, unknown> = {};
           try {
-            const raw = await readFile(configPath, "utf-8");
+            const raw = await readFile(configOverridePath, "utf-8");
             existing = JSON.parse(raw);
           } catch {
-            // File doesn't exist or invalid — start fresh
+            // Override file doesn't exist yet (fresh deploy / first call) —
+            // start with empty overrides.
           }
 
           // Cross-field validation: thinking="enabled" requires a budget,
-          // either from this patch or already in the persisted config.
-          // Without one, the Anthropic SDK silently downgrades to its
-          // 1,024-token minimum — almost certainly not the operator's
-          // intent. Force the explicit choice.
+          // either from this patch or already in the *effective* config
+          // (seed + overrides). Without one, the Anthropic SDK silently
+          // downgrades to its 1,024-token minimum — almost certainly not
+          // the operator's intent. Force the explicit choice.
           //
-          // Important edge case: when the patch is *clearing* the budget
+          // Edge case: when the patch is *clearing* the budget
           // (thinkingBudgetTokens=null), the merge below deletes the
-          // existing budget. The validator must mirror that — treating
-          // existingBudget as gone — so a patch like
-          //   { thinking: "enabled", thinkingBudgetTokens: null }
-          // can't slip past by relying on a budget the merge will drop.
+          // override-side budget. After clear, the effective budget falls
+          // back to the seed's budget (if any). The validator must mirror
+          // that — read the merged effective state from the runtime, not
+          // just the override file.
           if (input.thinking === "enabled") {
             const clearingBudget = input.thinkingBudgetTokens === null;
             const patchBudget =
               !clearingBudget && input.thinkingBudgetTokens !== undefined
                 ? Number(input.thinkingBudgetTokens)
                 : undefined;
-            const existingBudget = clearingBudget
+            const effectiveBudget = clearingBudget
               ? undefined
-              : (existing.thinkingBudgetTokens as number | undefined);
-            if (patchBudget == null && existingBudget == null) {
+              : runtime.getRuntimeConfig().thinkingBudgetTokens;
+            if (patchBudget == null && effectiveBudget == null) {
               return {
                 content: textContent(
                   'thinking="enabled" requires thinkingBudgetTokens (≥ 1024). ' +
@@ -431,10 +440,10 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
           } else if (input.thinkingBudgetTokens !== undefined) {
             existing.thinkingBudgetTokens = Number(input.thinkingBudgetTokens);
           }
-          // Atomic write: write to temp file, then rename
-          const tmpPath = `${configPath}.tmp.${Date.now()}`;
+          // Atomic write of the override file: write to temp file, then rename.
+          const tmpPath = `${configOverridePath}.tmp.${Date.now()}`;
           await writeFile(tmpPath, `${JSON.stringify(existing, null, 2)}\n`, "utf-8");
-          await rename(tmpPath, configPath);
+          await rename(tmpPath, configOverridePath);
 
           // Apply changes to live runtime config
           const modelsPatch =

--- a/test/integration/core-source.test.ts
+++ b/test/integration/core-source.test.ts
@@ -385,6 +385,45 @@ describe("Core Source", () => {
 		}
 	});
 
+	it("nb__set_model_config rejects clearThinking=true + thinkingBudgetTokens together (would orphan the budget on disk)", async () => {
+		// Without this guard, the disk-side merge:
+		//   - L430: input.thinking === null → delete existing.thinking + budget
+		//   - L441: input.thinkingBudgetTokens !== undefined/null → re-set budget
+		// produced { thinkingBudgetTokens: 4096 } with no thinking — an orphan
+		// budget on disk. Live runtime stayed clean (handler passes both as
+		// null to updateConfig when input.thinking === null), so the divergence
+		// surfaces only on next restart. Reject the combination at the input
+		// boundary instead.
+		const workDir = join(testDir, `work-clear-orphan-${Date.now()}`);
+		mkdirSync(workDir, { recursive: true });
+		const configPath = join(workDir, "nimblebrain.json");
+		const overridePath = deriveOverridePath(configPath);
+		writeFileSync(configPath, JSON.stringify({ version: "1" }));
+
+		const runtime = await Runtime.start({
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			configPath,
+			logging: { disabled: true },
+		});
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
+			const result = await source.execute("set_model_config", {
+				clearThinking: true,
+				thinkingBudgetTokens: 4096,
+			});
+			expect(result.isError).toBe(true);
+			expect(extractText(result.content)).toContain(
+				"Cannot set `thinkingBudgetTokens` while clearing `thinking`",
+			);
+			// Override file untouched on validation failure.
+			expect(existsSync(overridePath)).toBe(false);
+		} finally {
+			await runtime.shutdown();
+		}
+	});
+
 	it("nb__set_model_config rejects ambiguous thinking + clearThinking together", async () => {
 		const workDir = join(testDir, `work-clear-ambiguous-${Date.now()}`);
 		mkdirSync(workDir, { recursive: true });

--- a/test/integration/core-source.test.ts
+++ b/test/integration/core-source.test.ts
@@ -267,7 +267,7 @@ describe("Core Source", () => {
 		}
 	});
 
-	it("nb__set_model_config rejects thinking='enabled' + budget=null even with an existing budget", async () => {
+	it("nb__set_model_config rejects thinking='enabled' + clearThinkingBudget=true even with an existing budget", async () => {
 		// The existing budget would survive validation if the validator
 		// only checked disk state, but the merge then deletes it — leaving
 		// thinking=enabled with no budget, the silent-downgrade trap.
@@ -290,7 +290,7 @@ describe("Core Source", () => {
 			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
 			const result = await source.execute("set_model_config", {
 				thinking: "enabled",
-				thinkingBudgetTokens: null,
+				clearThinkingBudget: true,
 			});
 			expect(result.isError).toBe(true);
 			expect(extractText(result.content)).toContain("requires thinkingBudgetTokens");
@@ -303,11 +303,14 @@ describe("Core Source", () => {
 		}
 	});
 
-	it("nb__set_model_config thinking=null clears the override (and budget)", async () => {
-		const workDir = join(testDir, `work-thinking-clear-${Date.now()}`);
+	it("nb__set_model_config clearThinking=true clears the override and the budget", async () => {
+		// The schema-clean replacement for the legacy `thinking: null` sentinel.
+		// The handler still understands null internally — see the normalize step
+		// at the top of the handler — but the public surface is the boolean flag
+		// because Gemini rejects enums on non-string types.
+		const workDir = join(testDir, `work-clear-thinking-${Date.now()}`);
 		mkdirSync(workDir, { recursive: true });
 		const configPath = join(workDir, "nimblebrain.json");
-		// Pre-existing operator override
 		writeFileSync(
 			configPath,
 			JSON.stringify({ thinking: "enabled", thinkingBudgetTokens: 8192 }),
@@ -323,13 +326,94 @@ describe("Core Source", () => {
 		try {
 			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
 			const result = await source.execute("set_model_config", {
-				thinking: null,
+				clearThinking: true,
 			});
 			expect(result.isError).toBe(false);
 			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
 			expect(raw.thinking).toBeUndefined();
 			// Budget is cleared together — a budget without a mode is meaningless.
 			expect(raw.thinkingBudgetTokens).toBeUndefined();
+		} finally {
+			await runtime.shutdown();
+		}
+	});
+
+	it("nb__set_model_config clearThinkingBudget=true clears just the budget", async () => {
+		const workDir = join(testDir, `work-clear-budget-${Date.now()}`);
+		mkdirSync(workDir, { recursive: true });
+		const configPath = join(workDir, "nimblebrain.json");
+		// Start in adaptive with an inherited budget that should disappear.
+		writeFileSync(
+			configPath,
+			JSON.stringify({ thinking: "adaptive", thinkingBudgetTokens: 8192 }),
+		);
+
+		const runtime = await Runtime.start({
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			configPath,
+			logging: { disabled: true },
+		});
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
+			const result = await source.execute("set_model_config", {
+				clearThinkingBudget: true,
+			});
+			expect(result.isError).toBe(false);
+			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+			expect(raw.thinking).toBe("adaptive");
+			expect(raw.thinkingBudgetTokens).toBeUndefined();
+		} finally {
+			await runtime.shutdown();
+		}
+	});
+
+	it("nb__set_model_config rejects ambiguous thinking + clearThinking together", async () => {
+		const workDir = join(testDir, `work-clear-ambiguous-${Date.now()}`);
+		mkdirSync(workDir, { recursive: true });
+		const configPath = join(workDir, "nimblebrain.json");
+		writeFileSync(configPath, JSON.stringify({}));
+
+		const runtime = await Runtime.start({
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			configPath,
+			logging: { disabled: true },
+		});
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
+			const result = await source.execute("set_model_config", {
+				thinking: "off",
+				clearThinking: true,
+			});
+			expect(result.isError).toBe(true);
+			expect(extractText(result.content)).toContain("Cannot set both");
+		} finally {
+			await runtime.shutdown();
+		}
+	});
+
+	it("nb__set_model_config schema declares thinking as plain string + boolean clear flags (Gemini-compatible)", async () => {
+		// Regression guard: any future schema change that puts `enum` on a
+		// non-string type, or uses union types, will break Google-only tenants
+		// because Gemini rejects the entire request. Lock the LCD shape.
+		const runtime = await makeRuntime();
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
+			const tools = await source.tools();
+			const setModelConfig = tools.find((t) => t.name === "nb__set_model_config");
+			expect(setModelConfig).toBeDefined();
+			const props = (setModelConfig?.inputSchema as { properties: Record<string, unknown> })
+				.properties;
+			const thinking = props.thinking as { type: unknown; enum: unknown };
+			expect(thinking.type).toBe("string");
+			expect(thinking.enum).toEqual(["off", "adaptive", "enabled"]);
+			const budget = props.thinkingBudgetTokens as { type: unknown };
+			expect(budget.type).toBe("number");
+			expect((props.clearThinking as { type: unknown }).type).toBe("boolean");
+			expect((props.clearThinkingBudget as { type: unknown }).type).toBe("boolean");
 		} finally {
 			await runtime.shutdown();
 		}

--- a/test/integration/core-source.test.ts
+++ b/test/integration/core-source.test.ts
@@ -8,6 +8,8 @@ import { createEchoModel } from "../helpers/echo-model.ts";
 import { createCoreToolDefs } from "../../src/tools/core-source.ts";
 import { makeInProcessSource } from "../helpers/in-process-source.ts";
 import { extractText } from "../../src/engine/content-helpers.ts";
+import { loadConfig } from "../../src/cli/config.ts";
+import { deriveOverridePath } from "../../src/config/overrides.ts";
 import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
 
 const testDir = join(tmpdir(), `nimblebrain-core-source-${Date.now()}`);
@@ -123,9 +125,9 @@ describe("Core Source", () => {
 			const data = result.structuredContent as Record<string, unknown>;
 			expect(data.success).toBe(true);
 
-			// Verify file was written
+			// Verify the override file (NOT the seed) was written.
 			const raw = JSON.parse(
-				require("node:fs").readFileSync(configPath, "utf-8"),
+				require("node:fs").readFileSync(deriveOverridePath(configPath), "utf-8"),
 			);
 			expect(raw.defaultModel).toBe("claude-haiku-4-5-20251001");
 		} finally {
@@ -202,13 +204,18 @@ describe("Core Source", () => {
 				maxOutputTokens: 8192,
 			});
 
-			// File must be valid JSON and preserve existing fields
-			const raw = JSON.parse(
+			// Override file must be valid JSON with only the field we wrote.
+			// The seed file is NOT touched — it stays Helm-managed.
+			const overrideRaw = JSON.parse(
+				require("node:fs").readFileSync(deriveOverridePath(configPath), "utf-8"),
+			);
+			expect(overrideRaw.maxOutputTokens).toBe(8192);
+			const seedRaw = JSON.parse(
 				require("node:fs").readFileSync(configPath, "utf-8"),
 			);
-			expect(raw.version).toBe("1");
-			expect(raw.maxIterations).toBe(5);
-			expect(raw.maxOutputTokens).toBe(8192);
+			expect(seedRaw.version).toBe("1");
+			expect(seedRaw.maxIterations).toBe(5);
+			expect(seedRaw.maxOutputTokens).toBeUndefined();
 		} finally {
 			await runtime.shutdown();
 		}
@@ -259,7 +266,9 @@ describe("Core Source", () => {
 				thinkingBudgetTokens: 8192,
 			});
 			expect(result.isError).toBe(false);
-			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+			const raw = JSON.parse(
+				require("node:fs").readFileSync(deriveOverridePath(configPath), "utf-8"),
+			);
 			expect(raw.thinking).toBe("enabled");
 			expect(raw.thinkingBudgetTokens).toBe(8192);
 		} finally {
@@ -274,8 +283,11 @@ describe("Core Source", () => {
 		const workDir = join(testDir, `work-thinking-clearbudget-${Date.now()}`);
 		mkdirSync(workDir, { recursive: true });
 		const configPath = join(workDir, "nimblebrain.json");
+		const overridePath = deriveOverridePath(configPath);
+		writeFileSync(configPath, JSON.stringify({ version: "1" }));
+		// Pre-existing user override (representing prior set_model_config state).
 		writeFileSync(
-			configPath,
+			overridePath,
 			JSON.stringify({ thinking: "enabled", thinkingBudgetTokens: 8192 }),
 		);
 
@@ -294,8 +306,8 @@ describe("Core Source", () => {
 			});
 			expect(result.isError).toBe(true);
 			expect(extractText(result.content)).toContain("requires thinkingBudgetTokens");
-			// Disk untouched
-			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+			// Override file untouched on validation failure.
+			const raw = JSON.parse(require("node:fs").readFileSync(overridePath, "utf-8"));
 			expect(raw.thinking).toBe("enabled");
 			expect(raw.thinkingBudgetTokens).toBe(8192);
 		} finally {
@@ -311,8 +323,10 @@ describe("Core Source", () => {
 		const workDir = join(testDir, `work-clear-thinking-${Date.now()}`);
 		mkdirSync(workDir, { recursive: true });
 		const configPath = join(workDir, "nimblebrain.json");
+		const overridePath = deriveOverridePath(configPath);
+		writeFileSync(configPath, JSON.stringify({ version: "1" }));
 		writeFileSync(
-			configPath,
+			overridePath,
 			JSON.stringify({ thinking: "enabled", thinkingBudgetTokens: 8192 }),
 		);
 
@@ -329,7 +343,7 @@ describe("Core Source", () => {
 				clearThinking: true,
 			});
 			expect(result.isError).toBe(false);
-			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+			const raw = JSON.parse(require("node:fs").readFileSync(overridePath, "utf-8"));
 			expect(raw.thinking).toBeUndefined();
 			// Budget is cleared together — a budget without a mode is meaningless.
 			expect(raw.thinkingBudgetTokens).toBeUndefined();
@@ -342,9 +356,11 @@ describe("Core Source", () => {
 		const workDir = join(testDir, `work-clear-budget-${Date.now()}`);
 		mkdirSync(workDir, { recursive: true });
 		const configPath = join(workDir, "nimblebrain.json");
+		const overridePath = deriveOverridePath(configPath);
+		writeFileSync(configPath, JSON.stringify({ version: "1" }));
 		// Start in adaptive with an inherited budget that should disappear.
 		writeFileSync(
-			configPath,
+			overridePath,
 			JSON.stringify({ thinking: "adaptive", thinkingBudgetTokens: 8192 }),
 		);
 
@@ -361,7 +377,7 @@ describe("Core Source", () => {
 				clearThinkingBudget: true,
 			});
 			expect(result.isError).toBe(false);
-			const raw = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+			const raw = JSON.parse(require("node:fs").readFileSync(overridePath, "utf-8"));
 			expect(raw.thinking).toBe("adaptive");
 			expect(raw.thinkingBudgetTokens).toBeUndefined();
 		} finally {
@@ -392,6 +408,70 @@ describe("Core Source", () => {
 			expect(extractText(result.content)).toContain("Cannot set both");
 		} finally {
 			await runtime.shutdown();
+		}
+	});
+
+	it("set_model_config writes survive a runtime restart (layered seed + override)", async () => {
+		// Regression guard for the deploy-replay scenario: an operator runs
+		// set_model_config to pin defaultModel and thinking, then the pod
+		// restarts. The init container overwrites the seed (simulated by us
+		// keeping the seed file unchanged) but the override file on the PVC
+		// survives, and the runtime should boot with the user's last values.
+		const workDir = join(testDir, `work-layered-restart-${Date.now()}`);
+		mkdirSync(workDir, { recursive: true });
+		const configPath = join(workDir, "nimblebrain.json");
+		const overridePath = deriveOverridePath(configPath);
+		writeFileSync(
+			configPath,
+			JSON.stringify({ version: "1", defaultModel: "claude-opus-4-7", maxIterations: 10 }),
+		);
+
+		// First runtime: simulate the operator changing config.
+		const r1 = await Runtime.start({
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			configPath,
+			logging: { disabled: true },
+		});
+		try {
+			const source = await makeInProcessSource("nb", createCoreToolDefs(r1));
+			const result = await source.execute("set_model_config", {
+				defaultModel: "claude-haiku-4-5-20251001",
+				thinking: "off",
+			});
+			expect(result.isError).toBe(false);
+		} finally {
+			await r1.shutdown();
+		}
+
+		// Override file written, seed file untouched.
+		const overrideAfterWrite = JSON.parse(
+			require("node:fs").readFileSync(overridePath, "utf-8"),
+		);
+		expect(overrideAfterWrite.defaultModel).toBe("claude-haiku-4-5-20251001");
+		expect(overrideAfterWrite.thinking).toBe("off");
+		const seedAfterWrite = JSON.parse(require("node:fs").readFileSync(configPath, "utf-8"));
+		expect(seedAfterWrite.defaultModel).toBe("claude-opus-4-7"); // unchanged
+		expect(seedAfterWrite.thinking).toBeUndefined();
+
+		// Second runtime: load via loadConfig (the production path that
+		// reads seed + override). Effective config should reflect the
+		// override, not the seed — that's the whole point.
+		const loaded = loadConfig({ config: configPath });
+		const r2 = await Runtime.start({
+			...loaded,
+			model: { provider: "custom", adapter: createEchoModel() },
+			noDefaultBundles: true,
+			workDir,
+			logging: { disabled: true },
+		});
+		try {
+			const cfg = r2.getRuntimeConfig();
+			expect(cfg.defaultModel).toBe("claude-haiku-4-5-20251001");
+			expect(cfg.thinking).toBe("off");
+		} finally {
+			await r2.shutdown();
 		}
 	});
 
@@ -427,7 +507,7 @@ describe("Core Source", () => {
 				maxIterations: 5,
 			});
 			expect(result.isError).toBe(true);
-			expect(extractText(result.content)).toContain("No config file path");
+			expect(extractText(result.content)).toContain("No config override path");
 		} finally {
 			await runtime.shutdown();
 		}

--- a/test/unit/event-reconstructor.test.ts
+++ b/test/unit/event-reconstructor.test.ts
@@ -406,6 +406,61 @@ describe("reconstructMessages", () => {
     expect(text?.text).toContain("cut off");
   });
 
+  it("preserves original block ordering within an llm.response (Anthropic latest-message invariant)", () => {
+    // Regression guard for the HQ replay bug: Anthropic validates the
+    // LATEST assistant message byte-for-byte and rejects any modification
+    // of thinking blocks. Anthropic returns content like
+    //   [reasoning_A, tool_call_1, reasoning_B, tool_call_2]
+    // and the reconstructed assistant message MUST preserve that order.
+    // The previous categorical-bucketing implementation hoisted all
+    // reasoning to the front (`[A, B, T1, T2]`) and 400'd on replay.
+    const interleavedTurn: LlmResponseEvent = {
+      ...llmText("run-1", ""),
+      content: [
+        {
+          type: "reasoning",
+          text: "Plan: search then fetch.",
+          providerMetadata: { anthropic: { signature: "sig-A" } },
+        },
+        { type: "tool-call", toolCallId: "tc-1", toolName: "search", input: { q: "x" } },
+        {
+          type: "reasoning",
+          text: "Now fetch the top result.",
+          providerMetadata: { anthropic: { signature: "sig-B" } },
+        },
+        { type: "tool-call", toolCallId: "tc-2", toolName: "fetch", input: { id: 1 } },
+      ],
+    };
+    const events: ConversationEvent[] = [
+      userMessage("research x"),
+      runStart("run-1"),
+      interleavedTurn,
+      toolStart("run-1", "tc-1", "search"),
+      toolDone("run-1", "tc-1", "search"),
+      toolStart("run-1", "tc-2", "fetch"),
+      toolDone("run-1", "tc-2", "fetch"),
+      runDone("run-1"),
+    ];
+    const messages = reconstructMessages(events);
+    const assistant = messages.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+
+    // Block types must come back in original interleaved order — NOT
+    // grouped (reasoning, reasoning, tool-call, tool-call).
+    const types = assistant!.content.map((c) => c.type);
+    expect(types).toEqual(["reasoning", "tool-call", "reasoning", "tool-call"]);
+
+    // Both signatures must round-trip via providerOptions so the AI SDK
+    // Anthropic provider re-emits both thinking blocks on the next call.
+    const reasonings = assistant!.content.filter(
+      (c): c is { type: "reasoning"; text: string; providerOptions?: unknown } =>
+        c.type === "reasoning",
+    );
+    expect(reasonings).toHaveLength(2);
+    expect(reasonings[0]!.providerOptions).toEqual({ anthropic: { signature: "sig-A" } });
+    expect(reasonings[1]!.providerOptions).toEqual({ anthropic: { signature: "sig-B" } });
+  });
+
   it("preserves Anthropic signature on reasoning blocks across reconstruction", () => {
     // Verifies the multi-iteration round-trip path: stream captures
     // signature → JSONL persists it → reconstructor copies into

--- a/web/src/pages/settings/ModelTab.tsx
+++ b/web/src/pages/settings/ModelTab.tsx
@@ -111,12 +111,12 @@ export function ModelTab() {
     setSaving(true);
     setFeedback(null);
     try {
-      // null → clear operator override (revert to platform default policy)
+      // clearThinking → revert to platform default policy (drops persisted override + budget)
       // string mode → set explicit override
       // budget only sent for "enabled"; "off"/"adaptive" don't need it
       const thinkingPatch =
         thinking === THINKING_DEFAULT
-          ? { thinking: null, thinkingBudgetTokens: null }
+          ? { clearThinking: true, clearThinkingBudget: true }
           : thinking === "enabled"
             ? { thinking, thinkingBudgetTokens }
             : { thinking };


### PR DESCRIPTION
## Summary

Three related fixes that surfaced during the ipsdi (Gemini-only) and HQ (Anthropic) tenant incidents this week. Each commit stands alone and reviews independently.

### 1. `4313a4a` — LCD-narrow `set_model_config` schema for Gemini compatibility

`set_model_config`'s `thinking` and `thinkingBudgetTokens` properties used JSON-Schema union types with `null` in the enum (`type: ["string","null"]`, `enum: [...,null]`). Gemini rejects `enum` on non-string types, blowing up **every** tool call on Google-only tenants — including the call that would let an operator fix it. Self-locking bug.

Narrowed the schema to LCD-clean shapes (`type: "string"` with a string-only enum, `type: "number"`) and exposed the clear semantic via two new boolean inputs: `clearThinking` and `clearThinkingBudget`. Handler normalizes the booleans into the existing null-sentinel logic; downstream merge code is unchanged.

Also fixes a stale JSDoc in `runtime/types.ts` claiming the platform default for reasoning models is `adaptive` — has been `enabled` since the cost incident at `resolve-thinking.ts:108-119`.

### 2. `dbcdf06` — Preserve content block ordering on history replay

Anthropic validates the latest assistant message byte-for-byte and rejects any modification of thinking blocks. The conversation event reconstructor was splitting each `llm.response` into separate messages by category — one assistant message per (reasoning, tool-call, text) bucket — which hoisted reasoning blocks to the front and reordered tool-calls relative to text. With extended thinking enabled, multi-iteration runs 400'd on the second user message:

```
messages.N.content.M: thinking blocks in the latest assistant message cannot be modified
```

The reconstructor now emits **one** assistant message per `llm.response`, preserving the provider's original block order. Orphaned tool-calls (no matching `tool.done`) are still filtered. Placeholder/role-alternation logic for empty turns and abandoned runs unchanged.

The chat UI consumes its own projection from `src/bundles/conversations/src/jsonl-reader.ts`; nothing here affects display.

This commit also lifts the `providerMetadata`→`providerOptions` and tool-call-input-parse logic out of the engine and the reconstructor into a shared `src/model/inbound-fit.ts` module — single source of truth for provider response normalization, idempotent, used at both the in-memory iteration boundary (engine) and the disk-replay boundary (reconstructor).

New canary test asserts interleaved `[reasoning, tool-call, reasoning, tool-call]` returns in the same order with both signatures preserved.

### 3. `21cfea0` — Layered config: seed + overrides so `set_model_config` survives deploys

The init container overwrites `/data/nimblebrain.json` on every pod start to keep Helm values authoritative. That meant any change made via the UI or chat (`set_model_config`) silently reverted on the next rollout — operator pinned `thinking: off`, deploy ran, runtime came back on the seed default. Bad UX, hard to debug.

Split the file into two:

```
/data/nimblebrain.json            seed, Helm-managed, overwrite on deploy
/data/nimblebrain.overrides.json  user, written by set_model_config,
                                  PVC-resident, untouched by deploys
```

The loader (`cli/config.ts::loadConfig`) reads both and 1-level deep-merges override over seed. Override wins per-key. `set_model_config` writes only to the override file and reads the merged effective state (via `runtime.getRuntimeConfig()`) for cross-field validation. Existing clear-flag semantics work unchanged — they delete keys from the override file, which lets the seed value take over on the next runtime reload.

Startup log line surfaces divergence:
```
[config] Applied N runtime override(s) from <path>: <keys>
```

Bonus fix: `thinking` and `thinkingBudgetTokens` are now propagated from the file config into `RuntimeConfig` (they were silently dropped before). Pre-existing gap, surfaced by the new round-trip test.

New canary test simulates the deploy-replay scenario: operator pins config, runtime restarts, effective config still reflects the override. This is the test that would have caught the original HQ regression.

A companion docs change (`deployments/nimblebrain/CLAUDE.md`) describing the new architecture is on a separate branch in the deployments repo and will follow.

## Test plan

- [x] `bun run verify:static` — clean (1 unrelated pre-existing IPv4 lint warning)
- [x] `bun run verify:test-unit` — 2195 unit + 213 web pass, 0 fail
- [x] `bun run test:integration` — 457 pass, 6 skip, 0 fail
- [x] New canary tests for each commit:
  - `nb__set_model_config schema declares thinking as plain string + boolean clear flags`
  - `preserves original block ordering within an llm.response`
  - `set_model_config writes survive a runtime restart (layered seed + override)`
- [ ] Manual: deploy to ipsdi staging, run `set_model_config { thinking: "off" }` against Gemini, confirm no 400 and value persists
- [ ] Manual: deploy to HQ staging with `thinking: "enabled"`, run a multi-iteration tool-using conversation, confirm no Anthropic 400 on iteration 2+
- [ ] Manual: deploy to either tenant, run `set_model_config`, redeploy, confirm value still in effect

## Commit-by-commit review notes

The three commits are independent and can be reviewed in order. Phase 1 unblocks ipsdi standalone; Phases 2 and 3 fix HQ standalone; Phase 4 prevents the regression class going forward.