### PR TITLE
fix(inbound-fit): preserve Gemini thoughtSignature on tool-call replay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # NimbleBrain
 
+> This file is read by agents. Keep edits terse, imperative, token-aware. No long-form prose; bullets with concrete triggers and examples.
+
 Self-hosted platform for MCP Apps and agent automations, built on Bun. Agentic loop + MCP bundle management + interactive UI host + cron-scheduled automations + skill-driven prompt composition + HTTP API + web client.
 
 ## Build & Verify
@@ -36,6 +38,7 @@ bun run build:bundles      # Rebuild every src/bundles/*/ui (vite single-file)
 - **Module system:** ESM only. All imports use `.ts` extensions.
 - **Linting:** Biome (not ESLint/Prettier). Run `bun run lint`.
 - **Type checking:** `bunx tsc --noEmit`. Strict mode enabled.
+- **Prefer typed-safe paths over `as unknown as T`.** When TS errors, find the input/output type matching runtime shape (e.g. stream-side vs prompt-side) before widening. Cast escape hatches require a comment naming the mismatch. Example: `src/model/inbound-fit.ts`.
 - **HTTP framework:** Hono for routing and middleware. Typed context via `AppEnv`/`AuthEnv`.
 - **Model types:** Use Vercel AI SDK V3 types (`LanguageModelV3`, `LanguageModelV3Message`, etc.) from `@ai-sdk/provider`. The engine calls `model.doStream()` directly.
 - **No classes for data** — plain interfaces + factory functions preferred.

--- a/src/conversation/event-reconstructor.ts
+++ b/src/conversation/event-reconstructor.ts
@@ -6,7 +6,7 @@
  * builder, and the web client.
  */
 
-import type { LanguageModelV3Content } from "@ai-sdk/provider";
+import type { LanguageModelV3Content, LanguageModelV3ReasoningPart } from "@ai-sdk/provider";
 import { estimateCost } from "../engine/cost.ts";
 import { normalizeForReplay } from "../model/inbound-fit.ts";
 import type { ConversationEvent, LlmResponseEvent, StoredMessage, ToolDoneEvent } from "./types.ts";
@@ -272,14 +272,7 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
           // Orphaned tool-calls (if any) were already filtered out of
           // replayContent — text alongside them survives as the visible
           // assistant turn, no placeholder needed.
-          //
-          // Cast: stream-side `LanguageModelV3Content` is wider than the
-          // assistant-role content union (it includes tool-result/source
-          // which only appear on tool/system messages). The data IS
-          // assistant-valid by construction — orphan filter is the only
-          // mutation — but TS can't prove it without a runtime type guard
-          // on every block. Same cast used by engine.ts after doStream.
-          const assistantMsg = {
+          const assistantMsg: StoredMessage = {
             role: "assistant",
             content: replayContent,
             timestamp: llmResp.ts,
@@ -287,7 +280,7 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
               ...baseMetadata(),
               ...(toolCallsMeta.length > 0 ? { toolCalls: toolCallsMeta } : {}),
             },
-          } as StoredMessage;
+          };
           messages.push(assistantMsg);
 
           // Tool-result message per executed tool-call (one per result so
@@ -340,10 +333,8 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
         // Filtering up-front is more honest — the reconstructed message
         // accurately reflects what the next call will actually send.
         const reasoningWithMeta = replayContent.filter(
-          (c): c is LanguageModelV3Content & { type: "reasoning" } =>
-            c.type === "reasoning" &&
-            "providerOptions" in c &&
-            (c as { providerOptions?: unknown }).providerOptions != null,
+          (c): c is LanguageModelV3ReasoningPart =>
+            c.type === "reasoning" && c.providerOptions != null,
         );
         const hasAbnormalFinish = llmResp.finishReason != null && llmResp.finishReason !== "stop";
         const hasAnyReasoning = replayContent.some((c) => c.type === "reasoning");
@@ -355,16 +346,20 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
           ? ORPHANED_TOOL_CALLS_MARKER
           : (TRUNCATION_MARKERS[llmResp.finishReason ?? "other"] ?? TRUNCATION_MARKERS.other!);
         const reasoningRoundTrips = !hasOrphanedToolCalls && reasoningWithMeta.length > 0;
-        const placeholderContent: LanguageModelV3Content[] = reasoningRoundTrips
+        // Inferred type: ReasoningPart[] | [{type:"text",text:string}].
+        // Both are assignable to the assistant variant's content union;
+        // an explicit `LanguageModelV3Content[]` annotation here is the
+        // wrong type (stream-side, doesn't include `providerOptions`).
+        const placeholderContent = reasoningRoundTrips
           ? reasoningWithMeta
           : [{ type: "text" as const, text: placeholderText }];
 
-        const assistantMsg = {
+        const assistantMsg: StoredMessage = {
           role: "assistant",
           content: placeholderContent,
           timestamp: llmResp.ts,
           metadata: baseMetadata(),
-        } as StoredMessage;
+        };
         messages.push(assistantMsg);
       }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -433,10 +433,10 @@ export class AgentEngine {
 
         // 4. Append assistant message to history.
         // `normalizeForReplay` handles the stream→prompt shape mismatches
-        // (tool-call input string→object, reasoning providerMetadata→
-        // providerOptions). See src/model/inbound-fit.ts.
+        // (tool-call input string→object, providerMetadata→providerOptions
+        // on every content type). See src/model/inbound-fit.ts.
         const historyContent = normalizeForReplay(response.content);
-        history.push({ role: "assistant", content: historyContent } as LanguageModelV3Message);
+        history.push({ role: "assistant", content: historyContent });
 
         // 5. Execute tools in PARALLEL (sync + task-augmented concurrently, §13)
         const toolResults = await Promise.all(

--- a/src/model/inbound-fit.ts
+++ b/src/model/inbound-fit.ts
@@ -1,43 +1,121 @@
 /**
  * Normalize provider response content for the next iteration's prompt.
  *
- * The Vercel AI SDK V3 has an asymmetric reasoning shape: provider metadata
- * (e.g. Anthropic's thinking-block signature) arrives in `providerMetadata`
- * on the way IN from `model.doStream()`, but the prompt-side converter that
- * builds the next request reads `providerOptions`. Without the rename, the
- * Anthropic provider drops the block as "unsupported reasoning metadata"
- * and the API rejects the call — `messages.N.content.M: thinking blocks in
- * the latest assistant message cannot be modified`.
+ * The Vercel AI SDK V3 has a field-name asymmetry: provider-specific
+ * metadata arrives on inbound (stream) parts as `providerMetadata`
+ * (Anthropic's thinking-block signature, Google's thoughtSignature, etc.),
+ * but the prompt-side converters that build the next request read from
+ * `providerOptions`. Without the rename, providers drop the metadata
+ * silently and the model API rejects the call:
  *
- * Tool-call blocks have a similar asymmetry: stream output carries `input`
- * as a JSON string; the prompt format expects a parsed object.
+ *   - Anthropic: `messages.N.content.M: thinking blocks in the latest
+ *     assistant message cannot be modified` (signature missing on
+ *     reasoning blocks).
+ *   - Google: `Function call is missing a thought_signature in
+ *     functionCall parts` (thoughtSignature missing on tool-call blocks).
  *
- * This module is the single source of truth for both renames. Both the
- * engine (after `model.doStream()`) and the conversation event reconstructor
- * (when rebuilding history from JSONL) call into it.
+ * The rename applies to **every** content type, not only reasoning.
+ * Google attaches `thoughtSignature` to text, reasoning, file, AND
+ * tool-call parts; Anthropic puts the signature only on reasoning today.
+ * A type-discriminated rename would have shipped a hidden gap (the
+ * `nb__status` Gemini failure that surfaced the issue post-PR-#142);
+ * uniform application is the defensive shape.
  *
- * Idempotent: applying twice produces the same result.
+ * Tool-call blocks have a separate asymmetry that's also handled here:
+ * stream output carries `input` as a JSON string, but the prompt format
+ * expects a parsed object.
+ *
+ * Single source of truth for both renames. Both the engine (after
+ * `model.doStream()`) and the conversation event reconstructor (when
+ * rebuilding history from JSONL) call into it.
+ *
+ * Idempotent: applying twice produces the same result. The spread keeps
+ * `providerMetadata` AND adds `providerOptions`; preserving the former
+ * is harmless and keeps any downstream telemetry that introspects
+ * inbound metadata working.
+ *
+ * Return type is the *prompt-side* part union (`LanguageModelV3*Part`)
+ * because that's what the function actually produces — the function
+ * literally translates stream-side content (`LanguageModelV3Content`,
+ * which lacks `providerOptions`) into the prompt-side shape the AI SDK
+ * converters consume. Typing it that way removes the need for unsafe
+ * casts when adding `providerOptions` to a part.
  */
 
-import type { LanguageModelV3Content } from "@ai-sdk/provider";
+import type {
+  LanguageModelV3Content,
+  LanguageModelV3FilePart,
+  LanguageModelV3ReasoningPart,
+  LanguageModelV3TextPart,
+  LanguageModelV3ToolCallPart,
+  LanguageModelV3ToolResultPart,
+} from "@ai-sdk/provider";
 
-export function normalizeForReplay(
-  content: readonly LanguageModelV3Content[],
-): LanguageModelV3Content[] {
-  return content.map((part) => {
-    if (part.type === "tool-call" && typeof part.input === "string") {
-      try {
-        return { ...part, input: JSON.parse(part.input) };
-      } catch {
-        return { ...part, input: {} };
-      }
+/** Prompt-side assistant-message content union — the shape the AI SDK
+ *  converters expect on the way out. Mirror of `LanguageModelV3Message`'s
+ *  content array element type. */
+export type ReplayContent =
+  | LanguageModelV3TextPart
+  | LanguageModelV3ReasoningPart
+  | LanguageModelV3FilePart
+  | LanguageModelV3ToolCallPart
+  | LanguageModelV3ToolResultPart;
+
+function safeJsonParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return {};
+  }
+}
+
+export function normalizeForReplay(content: readonly LanguageModelV3Content[]): ReplayContent[] {
+  const out: ReplayContent[] = [];
+  for (const part of content) {
+    if (part.type === "tool-call") {
+      // Spread keeps every field of the original (toolCallId, toolName,
+      // providerExecuted, providerMetadata, etc.); the explicit `input`
+      // overrides the stream-side string with the parsed object;
+      // `providerOptions` is added when there's metadata to surface.
+      // Inferred type is structurally assignable to ToolCallPart — we
+      // skip the explicit annotation so TS doesn't excess-property-check
+      // the carried-through `providerMetadata` (which is fine to keep
+      // for telemetry but not declared on the prompt-side part type).
+      const input = typeof part.input === "string" ? safeJsonParse(part.input) : part.input;
+      const replay = {
+        ...part,
+        input,
+        ...(part.providerMetadata && { providerOptions: part.providerMetadata }),
+      };
+      out.push(replay);
+      continue;
     }
-    if (part.type === "reasoning" && part.providerMetadata) {
-      // Spread keeps `providerMetadata` AND adds `providerOptions`. The
-      // AI SDK reads the latter; preserving the former is harmless and
-      // keeps any downstream telemetry that introspects metadata working.
-      return { ...part, providerOptions: part.providerMetadata };
+
+    if (part.type === "text" || part.type === "reasoning" || part.type === "file") {
+      // Stream-side and prompt-side have the same field shape for these
+      // three (type + payload + providerMetadata|providerOptions); spread
+      // keeps the payload, the conditional add lifts metadata→options.
+      const replay = part.providerMetadata
+        ? { ...part, providerOptions: part.providerMetadata }
+        : part;
+      out.push(replay);
+      continue;
     }
-    return part;
-  });
+
+    if (part.type === "tool-result") {
+      // Stream-side ToolResult (`result` field) and prompt-side
+      // ToolResultPart (`output` field) have divergent shapes. In this
+      // codebase tool-results are built by the runtime as `role: "tool"`
+      // messages, NOT pulled from `doStream()` content; this branch is
+      // defensive for provider-side tool execution (e.g. Anthropic
+      // `code_execution`, server tools). Skip rather than mis-shape —
+      // a wrong-shaped ToolResultPart would fail the SDK's prompt
+      // validation more confusingly than its absence.
+      continue;
+    }
+
+    // tool-approval-request and source: stream-side only, never appear
+    // in assistant prompt content. Drop.
+  }
+  return out;
 }

--- a/src/model/inbound-fit.ts
+++ b/src/model/inbound-fit.ts
@@ -53,8 +53,10 @@ import type {
 
 /** Prompt-side assistant-message content union — the shape the AI SDK
  *  converters expect on the way out. Mirror of `LanguageModelV3Message`'s
- *  content array element type. */
-export type ReplayContent =
+ *  assistant-role content array element type. Unexported because no
+ *  caller outside this module needs the name; callers receive the same
+ *  shape via `LanguageModelV3Message`'s assistant variant. */
+type ReplayContent =
   | LanguageModelV3TextPart
   | LanguageModelV3ReasoningPart
   | LanguageModelV3FilePart
@@ -102,20 +104,16 @@ export function normalizeForReplay(content: readonly LanguageModelV3Content[]): 
       continue;
     }
 
-    if (part.type === "tool-result") {
-      // Stream-side ToolResult (`result` field) and prompt-side
-      // ToolResultPart (`output` field) have divergent shapes. In this
-      // codebase tool-results are built by the runtime as `role: "tool"`
-      // messages, NOT pulled from `doStream()` content; this branch is
-      // defensive for provider-side tool execution (e.g. Anthropic
-      // `code_execution`, server tools). Skip rather than mis-shape —
-      // a wrong-shaped ToolResultPart would fail the SDK's prompt
-      // validation more confusingly than its absence.
-      continue;
-    }
-
-    // tool-approval-request and source: stream-side only, never appear
-    // in assistant prompt content. Drop.
+    // Drop the rest:
+    //  - tool-result: stream-side `result` field vs prompt-side `output`
+    //    field have divergent shapes. In this codebase tool-results are
+    //    built by the runtime as `role: "tool"` messages, NOT pulled from
+    //    `doStream()` content; this branch is defensive for provider-side
+    //    tool execution (e.g. Anthropic `code_execution`, server tools).
+    //    Skipping rather than mis-shaping — a wrong-shaped ToolResultPart
+    //    would fail the SDK's prompt validation more confusingly.
+    //  - tool-approval-request, source: stream-side only, never appear in
+    //    assistant prompt content.
   }
   return out;
 }

--- a/test/unit/inbound-fit.test.ts
+++ b/test/unit/inbound-fit.test.ts
@@ -121,8 +121,8 @@ describe("normalizeForReplay", () => {
 			toolName: "echo",
 			input: { x: 1 },
 		});
-		expect("providerOptions" in out[0]!).toBe(false);
-		expect("providerOptions" in out[1]!).toBe(false);
+		expect(out[0]).not.toHaveProperty("providerOptions");
+		expect(out[1]).not.toHaveProperty("providerOptions");
 	});
 
 	it("is idempotent — applying twice produces the same result", () => {
@@ -163,6 +163,47 @@ describe("normalizeForReplay", () => {
 			input: { verbose: true },
 			providerOptions: { google: { thoughtSignature: "sig-combined" } },
 		});
+	});
+
+	it("filters out tool-result, source, and tool-approval-request parts", () => {
+		// Behavior assertion: these stream-side content types do not pass
+		// through to the prompt. Tool-results in this codebase are emitted
+		// by the runtime as `role: "tool"` messages (separate path);
+		// source / tool-approval-request never appear in assistant prompt
+		// content. Prevents regression if anyone "simplifies" the function
+		// by removing the filter — they'd silently mis-shape ToolResultPart
+		// (stream `result` field vs prompt `output` field) and produce
+		// confusing SDK validation errors downstream.
+		const input: LanguageModelV3Content[] = [
+			{ type: "text", text: "kept" },
+			{
+				type: "tool-result",
+				toolCallId: "tc-1",
+				toolName: "search",
+				result: "dropped — wrong shape for prompt-side ToolResultPart",
+			},
+			{
+				type: "source",
+				id: "src-1",
+				sourceType: "url",
+				url: "https://example.com",
+			},
+			{
+				type: "tool-approval-request",
+				approvalId: "ar-1",
+				toolCallId: "tc-1",
+			},
+			{
+				type: "tool-call",
+				toolCallId: "tc-2",
+				toolName: "ping",
+				input: "{}",
+			},
+		];
+		const out = normalizeForReplay(input);
+		expect(out).toHaveLength(2);
+		expect(out[0]).toEqual({ type: "text", text: "kept" });
+		expect(out[1]).toMatchObject({ type: "tool-call", toolCallId: "tc-2" });
 	});
 
 	it("does not mutate the input array or its parts", () => {

--- a/test/unit/inbound-fit.test.ts
+++ b/test/unit/inbound-fit.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "bun:test";
+import type { LanguageModelV3Content } from "@ai-sdk/provider";
+import { normalizeForReplay } from "../../src/model/inbound-fit.ts";
+
+describe("normalizeForReplay", () => {
+	it("returns an empty array for empty input", () => {
+		expect(normalizeForReplay([])).toEqual([]);
+	});
+
+	it("parses string-encoded tool-call input into an object", () => {
+		const input: LanguageModelV3Content[] = [
+			{
+				type: "tool-call",
+				toolCallId: "tc-1",
+				toolName: "search",
+				input: '{"query":"cats"}',
+			},
+		];
+		const out = normalizeForReplay(input);
+		expect(out[0]).toEqual({
+			type: "tool-call",
+			toolCallId: "tc-1",
+			toolName: "search",
+			input: { query: "cats" },
+		});
+	});
+
+	it("falls back to empty object on unparseable tool-call input", () => {
+		const input: LanguageModelV3Content[] = [
+			{
+				type: "tool-call",
+				toolCallId: "tc-1",
+				toolName: "search",
+				input: "not-json",
+			},
+		];
+		const out = normalizeForReplay(input);
+		expect(out[0]).toMatchObject({
+			type: "tool-call",
+			input: {},
+		});
+	});
+
+	it("copies providerMetadata to providerOptions on reasoning blocks (Anthropic signature path)", () => {
+		const input: LanguageModelV3Content[] = [
+			{
+				type: "reasoning",
+				text: "Need to look this up.",
+				providerMetadata: { anthropic: { signature: "sig-abc" } },
+			},
+		];
+		const out = normalizeForReplay(input);
+		// Spread keeps providerMetadata; the rename adds providerOptions.
+		expect(out[0]).toMatchObject({
+			type: "reasoning",
+			text: "Need to look this up.",
+			providerMetadata: { anthropic: { signature: "sig-abc" } },
+			providerOptions: { anthropic: { signature: "sig-abc" } },
+		});
+	});
+
+	it("copies providerMetadata to providerOptions on tool-call blocks (Gemini thoughtSignature path)", () => {
+		// Regression guard for the Gemini `nb__status` failure: when a
+		// functionCall part carries `providerMetadata.google.thoughtSignature`
+		// from the inbound stream, replay must surface it on `providerOptions`
+		// so the prompt-side converter forwards it on the next call. Without
+		// this, Gemini 400s with "Function call is missing a thought_signature
+		// in functionCall parts."
+		const input: LanguageModelV3Content[] = [
+			{
+				type: "tool-call",
+				toolCallId: "tc-1",
+				toolName: "nb__status",
+				input: "{}",
+				providerMetadata: { google: { thoughtSignature: "sig-xyz" } },
+			},
+		];
+		const out = normalizeForReplay(input);
+		expect(out[0]).toMatchObject({
+			type: "tool-call",
+			toolCallId: "tc-1",
+			toolName: "nb__status",
+			input: {},
+			providerMetadata: { google: { thoughtSignature: "sig-xyz" } },
+			providerOptions: { google: { thoughtSignature: "sig-xyz" } },
+		});
+	});
+
+	it("copies providerMetadata to providerOptions on text blocks (Gemini thoughtSignature on text)", () => {
+		// Gemini also attaches thoughtSignature to text parts; same treatment
+		// keeps replay correct without a per-type branch.
+		const input: LanguageModelV3Content[] = [
+			{
+				type: "text",
+				text: "Result is 42.",
+				providerMetadata: { google: { thoughtSignature: "sig-text" } },
+			},
+		];
+		const out = normalizeForReplay(input);
+		expect(out[0]).toMatchObject({
+			type: "text",
+			providerOptions: { google: { thoughtSignature: "sig-text" } },
+		});
+	});
+
+	it("leaves parts without providerMetadata unchanged", () => {
+		const input: LanguageModelV3Content[] = [
+			{ type: "text", text: "plain" },
+			{
+				type: "tool-call",
+				toolCallId: "tc-1",
+				toolName: "echo",
+				input: { x: 1 }, // already an object — no parse needed
+			},
+		];
+		const out = normalizeForReplay(input);
+		expect(out[0]).toEqual({ type: "text", text: "plain" });
+		expect(out[1]).toEqual({
+			type: "tool-call",
+			toolCallId: "tc-1",
+			toolName: "echo",
+			input: { x: 1 },
+		});
+		expect("providerOptions" in out[0]!).toBe(false);
+		expect("providerOptions" in out[1]!).toBe(false);
+	});
+
+	it("is idempotent — applying twice produces the same result", () => {
+		const input: LanguageModelV3Content[] = [
+			{
+				type: "tool-call",
+				toolCallId: "tc-1",
+				toolName: "nb__status",
+				input: '{"k":"v"}',
+				providerMetadata: { google: { thoughtSignature: "sig" } },
+			},
+			{
+				type: "reasoning",
+				text: "thinking",
+				providerMetadata: { anthropic: { signature: "sig-r" } },
+			},
+		];
+		const once = normalizeForReplay(input);
+		const twice = normalizeForReplay(once);
+		expect(twice).toEqual(once);
+	});
+
+	it("handles tool-call with both string input AND providerMetadata in one pass", () => {
+		// The Gemini `nb__status` failure exercised exactly this shape:
+		// stream-encoded JSON-string input + thoughtSignature metadata.
+		// Both transformations must apply to the same part.
+		const input: LanguageModelV3Content[] = [
+			{
+				type: "tool-call",
+				toolCallId: "tc-1",
+				toolName: "nb__status",
+				input: '{"verbose":true}',
+				providerMetadata: { google: { thoughtSignature: "sig-combined" } },
+			},
+		];
+		const out = normalizeForReplay(input);
+		expect(out[0]).toMatchObject({
+			input: { verbose: true },
+			providerOptions: { google: { thoughtSignature: "sig-combined" } },
+		});
+	});
+
+	it("does not mutate the input array or its parts", () => {
+		const original: LanguageModelV3Content[] = [
+			{
+				type: "reasoning",
+				text: "thoughts",
+				providerMetadata: { anthropic: { signature: "sig" } },
+			},
+		];
+		const snapshot = JSON.parse(JSON.stringify(original));
+		normalizeForReplay(original);
+		expect(original).toEqual(snapshot);
+	});
+});


### PR DESCRIPTION
## Summary

Gemini 2.5+/3.x signs tool calls with a `thoughtSignature` (its analogue of Anthropic's thinking-block `signature`). After PR #142 generalized the inbound-fit module, the `providerMetadata → providerOptions` rename was applied **only** to reasoning blocks — but Google attaches `thoughtSignature` to tool-call, text, file, AND reasoning parts. Tool-call signatures got dropped on round-trip, and Gemini 400'd:

```
Function call is missing a thought_signature in functionCall parts.
Additional data, function call \`default_api:nb__status\`, position 6.
```

Generalizes the rename to apply uniformly across content types. A type-discriminated rename was the original gap; uniform application is the defensive shape.

## What changed

- `src/model/inbound-fit.ts` — `normalizeForReplay` now lifts `providerMetadata → providerOptions` for every content type that carries metadata, not just reasoning. Plus the existing tool-call input parsing.
- Return type changed from `LanguageModelV3Content[]` (stream-side, no `providerOptions`) to a new exported `ReplayContent[]` (prompt-side `LanguageModelV3*Part` union, has `providerOptions`). Stream→prompt is what the function actually does; typing it that way removes the cast cascade an earlier draft needed (no `as unknown as` anywhere).
- Tool-result / source / tool-approval-request: explicitly skipped (filtered) instead of falling through unchanged. Tool-results in this codebase are built by the runtime as `role: "tool"` messages, not pulled from `doStream`; source and approval-request are stream-side concepts that never appear in assistant prompt content. Documented in code.
- New `test/unit/inbound-fit.test.ts` with 10 cases: tool-call input parsing, Anthropic signature on reasoning, **Gemini thoughtSignature on tool-call (the regression case)**, Gemini thoughtSignature on text, parts without metadata pass through, idempotency, no input mutation, both transformations on a single tool-call.
- `AGENTS.md` convention: prefer typed-safe paths over `as unknown as T`; cast escape hatches require a naming-the-mismatch comment. Plus a one-line meta-note that `AGENTS.md` edits should be terse and token-aware (audience is agents, not humans).

## Test plan

- [x] `bun run verify:static` — clean
- [x] `bun run verify:test-unit` — 213 web + unit pass, 0 fail
- [x] `bun run test:integration` — 461 pass, 6 skip, 0 fail
- [x] New regression test for the Gemini thoughtSignature path
- [ ] Manual: ipsdi tenant — Gemini chat with a tool call (e.g., \`whats your model?\` → triggers \`nb__status\`), confirm no \`Function call is missing a thought_signature\` error

## Note on the AGENTS.md change

This PR's refactor pass demonstrated the rule. An earlier draft used `as unknown as LanguageModelV3Content` to paper over a stream-vs-prompt-side type mismatch. The fix was to type the function as stream→prompt, not to widen with `unknown`. Codifying the lesson plus a pointer to the worked example so the next agent on the codebase finds the typed path first.