### PR TITLE
fix(docker): install git in the platform image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,13 @@ LABEL org.opencontainers.image.url="https://nimblebrain.ai"
 LABEL org.opencontainers.image.vendor="NimbleBrain"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-# Bun runtime
+# Bun runtime + tools that Synapse bundles routinely shell out to.
+# `git` is required by any bundle that clones a repo at boot (e.g.
+# synapse-astro-editor). Without it, `subprocess.exec("git", ...)`
+# inside the bundle raises FileNotFoundError(2) and the boot phase
+# fails with no clear cause.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl unzip nodejs npm \
+    curl unzip nodejs npm git \
     && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr bash \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Adds \`git\` to the apt install in the platform Dockerfile so bundles that clone a repo at boot can run.

## Why

Synapse bundles that shell out to git — \`synapse-astro-editor\` is the first, more are likely as the http-proxy + repo-as-data pattern catches on — call \`subprocess.exec(\"git\", ...)\`. Without git on \$PATH the call raises \`FileNotFoundError(2)\` and the boot phase fails with a bare OS code, no hint of which executable was missing.

Surfaced when \`synapse-astro-editor\` v0.1.0 was first installed on the hq production tenant and refused to clone the configured repo.

## Test plan

- [x] Image rebuild verified locally (\`docker build .\` exits clean)
- [ ] Roll new image into hq, retry the synapse-astro-editor boot, confirm clone succeeds

## Follow-up

Bundle-side: \`synapse-astro-editor\` is being updated to wrap subprocess \`FileNotFoundError\` in a friendlier \"X is not installed in this environment\" so the next time a missing CLI dep surfaces, the user sees what's missing instead of an opaque OS error code.