### PR TITLE
fix(docker): install Node 22 from NodeSource so bundles can build Astro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 # inside the bundle raises FileNotFoundError(2) and the boot phase
 # fails with no clear cause.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl unzip nodejs npm git \
+    curl unzip git ca-certificates gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
     && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr bash \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

- Platform Dockerfile installed nodejs/npm from Debian apt, which on `python:3.13-slim` resolves to **Node 20.x**. Astro 5+ requires `>=22.12`, so any bundle running `astro build` (or other modern Node tooling) crashes inside the platform pod with `Node.js v20.x is not supported by Astro!`.
- Switch the platform image to NodeSource's `setup_22.x` repo. NodeSource's `nodejs` package bundles npm, so the explicit `npm` apt package is dropped; `ca-certificates` + `gnupg` are added since the NodeSource setup script needs them.
- Caught in production on the `hq` tenant. Same defect affects every tenant on the current image — `hq` just hit it first.

## Verification

Locally built `linux/amd64`:

```
$ docker run --rm --entrypoint node <image> --version
v22.22.2
$ docker run --rm --entrypoint npm <image> --version
10.9.7
```

All bundle UI Vite builds still pass during `RUN for ui in src/bundles/*/ui ...`.

## Follow-up

#147 tracks the bump from Node 22 → 24 (Active LTS as of October 2025). Keeping that as a separate change so this PR stays narrowly focused on unblocking the broken build.

## Test plan

- [ ] CI green (build + verify)
- [ ] After merge, `make push ENV=production` then `make deploy CLIENT=hq ENV=production`
- [ ] Re-run the failing Astro-using bundle on `hq`; confirm no `Node.js v20.x is not supported` error
- [ ] Roll remaining prod tenants via `make deploy-all ENV=production`