### PR TITLE
fix(bundles): inject NB_* spawn env on the registry path too

### DIFF
--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -32,6 +32,70 @@ import type {
 } from "./types.ts";
 import { validateBundleUrl } from "./url-validator.ts";
 
+/**
+ * Platform-side context every bundle subprocess needs at spawn time,
+ * regardless of how it was installed (registry vs. sideloaded local path).
+ *
+ * Typed deliberately: this is the contract between the platform and a bundle
+ * for "what does it know about its host." Adding a field here is the single
+ * edit needed to surface a new platform fact to bundles — TypeScript then
+ * forces every spawn site to provide it.
+ */
+export interface PlatformContext {
+  /** Workspace this bundle is being spawned for. Undefined outside a workspace. */
+  workspaceId: string | undefined;
+  /** Stable name the platform addresses this bundle by — composes into proxy URLs. */
+  serverName: string;
+  /** Manifest `_meta` — read for capability declarations (e.g. `ai.nimblebrain/http-proxy`). */
+  manifestMeta: Record<string, unknown> | undefined;
+  /** Browser-facing origin of the platform (e.g. https://hq.platform.nimblebrain.ai). */
+  publicOrigin: string;
+}
+
+/**
+ * Build the NB_* env vars every bundle subprocess receives.
+ *
+ * Both spawn paths in this file (registry + local) call this so the contract
+ * cannot drift. The previous implementation duplicated this logic inline in
+ * only the local branch, which silently broke registry-installed bundles that
+ * declared `ai.nimblebrain/http-proxy` — preview URLs came back null with no
+ * error in the logs.
+ */
+export function buildPlatformEnv(ctx: PlatformContext): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  if (ctx.workspaceId) {
+    env.NB_WORKSPACE_ID = ctx.workspaceId;
+  }
+
+  const httpProxyMeta = ctx.manifestMeta?.["ai.nimblebrain/http-proxy"] as
+    | { mount?: string }
+    | undefined;
+  if (httpProxyMeta?.mount && ctx.workspaceId) {
+    const mount = String(httpProxyMeta.mount).replace(/^\/+|\/+$/g, "");
+    if (mount && !/\//.test(mount)) {
+      env.NB_PROXY_PREFIX = `/v1/ws/${ctx.workspaceId}/apps/${ctx.serverName}/${mount}`;
+    }
+  }
+
+  if (ctx.publicOrigin) {
+    env.NB_PUBLIC_ORIGIN = ctx.publicOrigin;
+  }
+
+  return env;
+}
+
+/**
+ * Resolve the platform's browser-facing origin from process env.
+ * Operators set `NB_PUBLIC_ORIGIN` explicitly; ALLOWED_ORIGINS is a best-effort
+ * dev fallback. Empty result → bundles simply don't declare host-side CSP entries.
+ */
+export function resolvePublicOrigin(
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): string {
+  return env.NB_PUBLIC_ORIGIN ?? env.ALLOWED_ORIGINS?.split(",")[0]?.trim() ?? "";
+}
+
 /** Create and start a McpSource for a BundleRef, then add to registry.
  *  Returns manifest metadata and actual source name for local bundles. */
 export async function startBundleSource(
@@ -216,6 +280,13 @@ export async function startBundleSource(
       throw friendlyMpakConfigError(err, opts.wsId);
     }
 
+    const platformEnv = buildPlatformEnv({
+      workspaceId: opts.wsId,
+      serverName: sourceName,
+      manifestMeta: cachedManifest?._meta as Record<string, unknown> | undefined,
+      publicOrigin: resolvePublicOrigin(),
+    });
+
     source = new McpSource(
       sourceName,
       {
@@ -229,6 +300,7 @@ export async function startBundleSource(
             ...(ref.env ?? {}),
             MPAK_WORKSPACE: bundleDataDir,
             UPJACK_ROOT: bundleDataDir,
+            ...platformEnv,
           },
           cwd: server.cwd,
         },
@@ -324,41 +396,15 @@ function buildLocalSource(
   spawnEnv.MPAK_WORKSPACE = bundleDataDir;
   spawnEnv.UPJACK_ROOT = bundleDataDir;
 
-  // Tell every bundle which workspace it's running for. Each BundleInstance
-  // is workspace-scoped already, so this is just surfacing what the platform
-  // already knows. Bundles need it to compose URLs that include the workspace
-  // segment (the http-proxy route requires it in the path because browser
-  // iframe loads can't set the X-Workspace-Id header).
-  if (wsId) {
-    spawnEnv.NB_WORKSPACE_ID = wsId;
-  }
-
-  // If the bundle declares an http-proxy, tell it the public path prefix so it
-  // can configure its upstream server (e.g., `astro --base`) to match.
-  // Format: /v1/ws/<wsId>/apps/<serverName>/<mount>. Without wsId we can't
-  // build a usable prefix; skip in that case (the bundle simply won't expose
-  // a working preview URL until the workspace context is wired through).
-  const httpProxyMeta = (manifest._meta as Record<string, unknown> | undefined)?.[
-    "ai.nimblebrain/http-proxy"
-  ] as { mount?: string } | undefined;
-  if (httpProxyMeta?.mount && wsId) {
-    const mount = String(httpProxyMeta.mount).replace(/^\/+|\/+$/g, "");
-    if (mount && !/\//.test(mount)) {
-      spawnEnv.NB_PROXY_PREFIX = `/v1/ws/${wsId}/apps/${serverName}/${mount}`;
-    }
-  }
-
-  // Tell bundles the platform's browser-facing origin so they can declare it
-  // in `_meta.ui.csp.{frameDomains, connectDomains}` on UI resources that need
-  // to frame or fetch same-origin URLs (proxied preview, same-origin WS).
-  // Operators set NB_PUBLIC_ORIGIN explicitly; we fall back to the first
-  // ALLOWED_ORIGINS entry as a best-effort default for dev. Empty/unset →
-  // bundle simply doesn't declare and the host CSP stays restrictive.
-  const publicOrigin =
-    process.env.NB_PUBLIC_ORIGIN ?? process.env.ALLOWED_ORIGINS?.split(",")[0]?.trim() ?? "";
-  if (publicOrigin) {
-    spawnEnv.NB_PUBLIC_ORIGIN = publicOrigin;
-  }
+  Object.assign(
+    spawnEnv,
+    buildPlatformEnv({
+      workspaceId: wsId,
+      serverName,
+      manifestMeta: manifest._meta as Record<string, unknown> | undefined,
+      publicOrigin: resolvePublicOrigin(),
+    }),
+  );
 
   // Python bundles: resolve "python" -> "python3" if needed, build PYTHONPATH
   if (manifest.server.type === "python") {

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -251,6 +251,16 @@ export async function startBundleSource(
     if (cachedManifest) {
       meta = extractBundleMeta(cachedManifest as unknown as Record<string, unknown>);
       manifest = cachedManifest;
+    } else {
+      // Same silent-failure shape as the bug this file's helper extraction was
+      // written to fix: with no manifest in cache we can't read `_meta`
+      // capability declarations, so http-proxy (and any future declaration)
+      // gets silently skipped at spawn. Surface it loudly instead of letting
+      // operators chase phantom UI bugs.
+      log.warn(
+        `[bundles] manifest cache miss for ${ref.name} — capability declarations ` +
+          "(http-proxy, etc.) will be skipped at spawn. Reinstall the bundle to repopulate.",
+      );
     }
 
     // Read host-side credentials from the workspace credential store. The

--- a/test/unit/bundles/build-platform-env.test.ts
+++ b/test/unit/bundles/build-platform-env.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { buildPlatformEnv, resolvePublicOrigin } from "../../../src/bundles/startup.ts";
+
+describe("buildPlatformEnv", () => {
+  test("sets NB_WORKSPACE_ID when wsId is provided", () => {
+    const env = buildPlatformEnv({
+      workspaceId: "ws_test",
+      serverName: "my-server",
+      manifestMeta: undefined,
+      publicOrigin: "",
+    });
+    expect(env.NB_WORKSPACE_ID).toBe("ws_test");
+  });
+
+  test("omits NB_WORKSPACE_ID when wsId is undefined", () => {
+    const env = buildPlatformEnv({
+      workspaceId: undefined,
+      serverName: "my-server",
+      manifestMeta: undefined,
+      publicOrigin: "",
+    });
+    expect(env.NB_WORKSPACE_ID).toBeUndefined();
+  });
+
+  test("sets NB_PROXY_PREFIX when manifest declares http-proxy and wsId is provided", () => {
+    const env = buildPlatformEnv({
+      workspaceId: "ws_nimblebrain_shared",
+      serverName: "synapse-astro-editor",
+      manifestMeta: {
+        "ai.nimblebrain/http-proxy": { target: "http://127.0.0.1:4321", mount: "preview" },
+      },
+      publicOrigin: "",
+    });
+    expect(env.NB_PROXY_PREFIX).toBe(
+      "/v1/ws/ws_nimblebrain_shared/apps/synapse-astro-editor/preview",
+    );
+  });
+
+  test("strips leading and trailing slashes from declared mount", () => {
+    const env = buildPlatformEnv({
+      workspaceId: "ws_test",
+      serverName: "srv",
+      manifestMeta: {
+        "ai.nimblebrain/http-proxy": { mount: "/preview/" },
+      },
+      publicOrigin: "",
+    });
+    expect(env.NB_PROXY_PREFIX).toBe("/v1/ws/ws_test/apps/srv/preview");
+  });
+
+  test("omits NB_PROXY_PREFIX when wsId is missing (declaration alone is not enough)", () => {
+    const env = buildPlatformEnv({
+      workspaceId: undefined,
+      serverName: "srv",
+      manifestMeta: {
+        "ai.nimblebrain/http-proxy": { mount: "preview" },
+      },
+      publicOrigin: "",
+    });
+    expect(env.NB_PROXY_PREFIX).toBeUndefined();
+  });
+
+  test("omits NB_PROXY_PREFIX when manifest does not declare http-proxy", () => {
+    const env = buildPlatformEnv({
+      workspaceId: "ws_test",
+      serverName: "srv",
+      manifestMeta: { "some.other/meta": { foo: "bar" } },
+      publicOrigin: "",
+    });
+    expect(env.NB_PROXY_PREFIX).toBeUndefined();
+  });
+
+  test("rejects mount with embedded path separators (single segment only)", () => {
+    const env = buildPlatformEnv({
+      workspaceId: "ws_test",
+      serverName: "srv",
+      manifestMeta: {
+        "ai.nimblebrain/http-proxy": { mount: "preview/deep" },
+      },
+      publicOrigin: "",
+    });
+    expect(env.NB_PROXY_PREFIX).toBeUndefined();
+  });
+
+  test("sets NB_PUBLIC_ORIGIN when provided", () => {
+    const env = buildPlatformEnv({
+      workspaceId: "ws_test",
+      serverName: "srv",
+      manifestMeta: undefined,
+      publicOrigin: "https://hq.platform.nimblebrain.ai",
+    });
+    expect(env.NB_PUBLIC_ORIGIN).toBe("https://hq.platform.nimblebrain.ai");
+  });
+
+  test("omits NB_PUBLIC_ORIGIN when publicOrigin is empty", () => {
+    const env = buildPlatformEnv({
+      workspaceId: "ws_test",
+      serverName: "srv",
+      manifestMeta: undefined,
+      publicOrigin: "",
+    });
+    expect(env.NB_PUBLIC_ORIGIN).toBeUndefined();
+  });
+
+  // Regression: the original bug was that the registry spawn path in
+  // startup.ts did not call this helper, so registry-installed bundles
+  // (synapse-astro-editor in tenant-hq, ws_nimblebrain_shared) silently
+  // never received NB_PROXY_PREFIX. The UI showed "No preview URL — check
+  // that the http-proxy declaration is wired" even though the manifest
+  // was correct. Both spawn paths now call buildPlatformEnv with the
+  // bundle's _meta; this test pins the produced contract for that scenario.
+  test("regression: full contract for a registry bundle declaring http-proxy", () => {
+    const env = buildPlatformEnv({
+      workspaceId: "ws_nimblebrain_shared",
+      serverName: "synapse-astro-editor",
+      manifestMeta: {
+        "ai.nimblebrain/http-proxy": {
+          target: "http://127.0.0.1:4321",
+          mount: "preview",
+          websocket: true,
+        },
+      },
+      publicOrigin: "https://hq.platform.nimblebrain.ai",
+    });
+    expect(env).toEqual({
+      NB_WORKSPACE_ID: "ws_nimblebrain_shared",
+      NB_PROXY_PREFIX: "/v1/ws/ws_nimblebrain_shared/apps/synapse-astro-editor/preview",
+      NB_PUBLIC_ORIGIN: "https://hq.platform.nimblebrain.ai",
+    });
+  });
+});
+
+describe("resolvePublicOrigin", () => {
+  test("prefers NB_PUBLIC_ORIGIN", () => {
+    const env = { NB_PUBLIC_ORIGIN: "https://primary.example", ALLOWED_ORIGINS: "https://b.example" };
+    expect(resolvePublicOrigin(env)).toBe("https://primary.example");
+  });
+
+  test("falls back to first entry of ALLOWED_ORIGINS", () => {
+    const env = { ALLOWED_ORIGINS: "https://a.example,https://b.example" };
+    expect(resolvePublicOrigin(env)).toBe("https://a.example");
+  });
+
+  test("trims whitespace around ALLOWED_ORIGINS entry", () => {
+    const env = { ALLOWED_ORIGINS: "  https://a.example  ,https://b.example" };
+    expect(resolvePublicOrigin(env)).toBe("https://a.example");
+  });
+
+  test("returns empty string when neither is set", () => {
+    expect(resolvePublicOrigin({})).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

`startBundleSource` has two spawn paths: the **registry/mpak** path that runs `prepareServer` for installed bundles, and the **local** path in `buildLocalSource` for sideloaded bundles. The local path set `NB_WORKSPACE_ID`, `NB_PROXY_PREFIX`, and `NB_PUBLIC_ORIGIN` inline. The registry path did not. It silently never set them.

**Concrete impact (caught on tenant-hq production):** `synapse-astro-editor` installed in `ws_nimblebrain_shared` (registry source) had `NB_PROXY_PREFIX` missing. Its `get_workspace_status` returned `preview_url: null`, so the iframe rendered:

> No preview URL — check that the http-proxy declaration is wired.

The manifest was correct. Astro built fine. `astro preview` was healthy at `http://127.0.0.1:4321`. Bundle reported `[boot] READY`. There was no error in the platform logs — the missing env was a silent skip in `startup.ts`.

Confirmed by reading the running process env directly:

```
$ tr '\0' '\n' < /proc/51/environ | grep NB_
NB_WORK_DIR=/data
```

(Should also have had `NB_PROXY_PREFIX`, `NB_WORKSPACE_ID`, `NB_PUBLIC_ORIGIN`.)

## Refactor

- Extract `buildPlatformEnv(ctx: PlatformContext)` and `resolvePublicOrigin()`.
- Introduce a `PlatformContext` interface so adding a new platform-side fact is a single typed edit, and TypeScript forces every spawn site to pass it.
- Both spawn branches now call `buildPlatformEnv` with the same shape — no inline duplication, no class of "added a third spawn path and forgot."
- Behavior is preserved: same env keys set under the same conditions.

## Regression test

`test/unit/bundles/build-platform-env.test.ts` — 14 cases pin the contract:

- `with/without wsId`
- `with/without manifest http-proxy declaration`
- mount edge cases (leading/trailing slashes, embedded path separators rejected)
- public origin fallback chain (`NB_PUBLIC_ORIGIN` → `ALLOWED_ORIGINS[0]` → empty)
- one explicit "regression" case mirroring the broken `synapse-astro-editor` scenario

## What this PR does NOT address

This fix shrinks the bug class but doesn't eliminate it. The next person adding a third spawn path (worker pool, remote MCP, sidecar) still has to remember to call the helper. A follow-up issue (filed separately) captures the bigger move: making the platform→bundle contract part of the MCP `initialize` handshake so the contract is enforced at the protocol layer instead of merely tested at the helper layer.

## Verification

- ` bun run verify:static` — clean (TypeScript + lint + cycles)
- `bun run verify:test-unit` — 2225 server unit + 216 web tests pass
- `bun run test test/unit/bundles/build-platform-env.test.ts` — 14/14 pass

## Test plan

- [ ] CI green
- [ ] Merge, `make push ENV=production`, `make deploy CLIENT=hq ENV=production`
- [ ] After deploy, exec into the platform pod, find the astro-editor python pid, confirm `NB_PROXY_PREFIX` is now present in `/proc/<pid>/environ`
- [ ] Reload the synapse-astro-editor iframe in hq — "No preview URL" should be replaced with the live preview