### PR TITLE
fix(engine): promote tools discovered by nb__search into the next iteration

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -225,6 +225,17 @@ function addCacheBreakpoint(messages: LanguageModelV3Message[]): LanguageModelV3
   return result;
 }
 
+const DISCOVERED_TOOL_NAME_RE = /^- \*\*([a-zA-Z0-9_-]+__[a-zA-Z0-9_-]+)\*\*:/gm;
+
+function extractDiscoveredToolNames(text: string): string[] {
+  const names = new Set<string>();
+  for (const match of text.matchAll(DISCOVERED_TOOL_NAME_RE)) {
+    const name = match[1];
+    if (name) names.add(name);
+  }
+  return [...names];
+}
+
 export class AgentEngine {
   constructor(
     private model: LanguageModelV3,
@@ -258,19 +269,13 @@ export class AgentEngine {
       if (t.annotations) toolAnnotations.set(t.name, t.annotations);
     }
 
-    // Translate ToolSchema[] to LanguageModelV3FunctionTool[] for the model call
-    const modelTools: LanguageModelV3FunctionTool[] = tools.map((t) => ({
-      type: "function" as const,
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema as JSONSchema7,
-    }));
-
-    // Build tool schema lookup for input validation (once per run, not per iteration)
-    const toolSchemaMap = new Map<string, ToolSchema>();
-    for (const t of tools) {
-      toolSchemaMap.set(t.name, t);
+    const allToolSchemaMap = new Map<string, ToolSchema>();
+    for (const t of allRouterTools) {
+      allToolSchemaMap.set(t.name, t);
     }
+
+    const directTools = [...tools];
+    const directToolNames = new Set(directTools.map((t) => t.name));
 
     this.events.emit({
       type: "run.start",
@@ -330,6 +335,18 @@ export class AgentEngine {
 
     try {
       while (iteration < maxIter) {
+        const modelTools: LanguageModelV3FunctionTool[] = directTools.map((t) => ({
+          type: "function" as const,
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema as JSONSchema7,
+        }));
+
+        const toolSchemaMap = new Map<string, ToolSchema>();
+        for (const t of directTools) {
+          toolSchemaMap.set(t.name, t);
+        }
+
         // 1. Apply context/prompt hooks and call LLM
         const windowed = config.hooks?.transformContext
           ? config.hooks.transformContext([...history])
@@ -459,6 +476,11 @@ export class AgentEngine {
             if (gatedCall === null) {
               return {
                 toolCall,
+                gatedCall: {
+                  id: toolCall.toolCallId,
+                  name: toolCall.toolName,
+                  input: parsedInput,
+                },
                 result: {
                   content: textContent("Tool call was denied by policy."),
                   isError: true,
@@ -570,7 +592,7 @@ export class AgentEngine {
               },
             });
 
-            return { toolCall, result: finalResult, ms, resourceUri, resourceLinks };
+            return { toolCall, gatedCall, result: finalResult, ms, resourceUri, resourceLinks };
           }),
         );
 
@@ -582,6 +604,7 @@ export class AgentEngine {
 
         for (const {
           toolCall,
+          gatedCall,
           result,
           ms,
           resourceUri: uri,
@@ -627,6 +650,21 @@ export class AgentEngine {
               ? { type: "error-text", value: llmText }
               : { type: "text", value: llmText },
           });
+
+          if (
+            gatedCall.name === "nb__search" &&
+            !result.isError &&
+            gatedCall.input.scope === "tools"
+          ) {
+            const discoveredNames = extractDiscoveredToolNames(llmText);
+            for (const name of discoveredNames) {
+              if (directToolNames.has(name)) continue;
+              const schema = allToolSchemaMap.get(name);
+              if (!schema) continue;
+              directTools.push(schema);
+              directToolNames.add(name);
+            }
+          }
         }
 
         // 6. Feed results back as tool message

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -225,17 +225,6 @@ function addCacheBreakpoint(messages: LanguageModelV3Message[]): LanguageModelV3
   return result;
 }
 
-const DISCOVERED_TOOL_NAME_RE = /^- \*\*([a-zA-Z0-9_-]+__[a-zA-Z0-9_-]+)\*\*:/gm;
-
-function extractDiscoveredToolNames(text: string): string[] {
-  const names = new Set<string>();
-  for (const match of text.matchAll(DISCOVERED_TOOL_NAME_RE)) {
-    const name = match[1];
-    if (name) names.add(name);
-  }
-  return [...names];
-}
-
 export class AgentEngine {
   constructor(
     private model: LanguageModelV3,
@@ -656,11 +645,15 @@ export class AgentEngine {
             !result.isError &&
             gatedCall.input.scope === "tools"
           ) {
-            const discoveredNames = extractDiscoveredToolNames(llmText);
-            for (const name of discoveredNames) {
+            const structured = result.structuredContent as
+              | { tools?: Array<{ name?: string }> }
+              | undefined;
+            for (const { name } of structured?.tools ?? []) {
+              if (!name) continue;
               if (directToolNames.has(name)) continue;
               const schema = allToolSchemaMap.get(name);
               if (!schema) continue;
+              if (schema.annotations?.["ai.nimblebrain/internal"]) continue;
               directTools.push(schema);
               directToolNames.add(name);
             }

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -911,5 +911,9 @@ function groupToolsBySource(all: Array<{ name: string; description: string }>): 
   for (const [source, names] of groups) {
     lines.push(`**${source}** (${names.length} tools): ${names.join(", ")}`);
   }
-  return { content: textContent(lines.join("\n")), isError: false };
+  return {
+    content: textContent(lines.join("\n")),
+    structuredContent: { tools: all.map((t) => ({ name: t.name })) },
+    isError: false,
+  };
 }

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -142,7 +142,9 @@ export async function createSystemTools(
 
         // scope === "tools" (default)
         const q = query.toLowerCase();
-        const all = await getRegistry().availableTools();
+        const all = (await getRegistry().availableTools()).filter(
+          (t) => !t.annotations?.["ai.nimblebrain/internal"],
+        );
         if (!q) return groupToolsBySource(all);
         const matches = all.filter(
           (t) => t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q),
@@ -151,7 +153,11 @@ export async function createSystemTools(
           return { content: textContent(`No tools matched "${query}".`), isError: false };
         const lines = [`Found ${matches.length} tool(s) for "${query}":\n`];
         for (const t of matches) lines.push(`- **${t.name}**: ${t.description}`);
-        return { content: textContent(lines.join("\n")), isError: false };
+        return {
+          content: textContent(lines.join("\n")),
+          structuredContent: { tools: matches.map((t) => ({ name: t.name })) },
+          isError: false,
+        };
       },
     },
     {

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -119,6 +119,96 @@ describe("AgentEngine", () => {
     expect(result.stopReason).toBe("complete");
   });
 
+  it("promotes tools discovered by nb__search for the next iteration", async () => {
+    let callCount = 0;
+    const seenToolLists: string[][] = [];
+    const model = createMockModel((options) => {
+      callCount++;
+      const toolNames = (options.tools ?? []).map((t) => t.name);
+      seenToolLists.push(toolNames);
+
+      if (callCount === 1) {
+        return {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_search",
+              toolName: "nb__search",
+              input: JSON.stringify({ scope: "tools", query: "newsapi" }),
+            },
+          ],
+          inputTokens: 10,
+          outputTokens: 5,
+        };
+      }
+
+      if (callCount === 2) {
+        expect(toolNames).toContain("newsapi__get_top_headlines");
+        return {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_news",
+              toolName: "newsapi__get_top_headlines",
+              input: JSON.stringify({ country: "us", category: "technology", page_size: 5 }),
+            },
+          ],
+          inputTokens: 10,
+          outputTokens: 5,
+        };
+      }
+
+      return {
+        content: [{ type: "text", text: "Done!" }],
+        inputTokens: 10,
+        outputTokens: 5,
+      };
+    });
+
+    const toolSchemas: ToolSchema[] = [
+      { name: "nb__search", description: "Search tools", inputSchema: { type: "object", properties: {} } },
+      {
+        name: "newsapi__get_top_headlines",
+        description: "Get top headlines",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+
+    const engine = new AgentEngine(
+      model,
+      new StaticToolRouter(toolSchemas, (call) => {
+        if (call.name === "nb__search") {
+          return {
+            content: textContent(
+              'Found 1 tool(s) for "newsapi":\n\n- **newsapi__get_top_headlines**: Get top news headlines by country and category.',
+            ),
+            isError: false,
+          };
+        }
+        if (call.name === "newsapi__get_top_headlines") {
+          return { content: textContent("headline results"), isError: false };
+        }
+        return { content: textContent(""), isError: false };
+      }),
+      new NoopEventSink(),
+    );
+
+    const result = await engine.run(
+      defaultConfig,
+      "",
+      [{ role: "user", content: [{ type: "text", text: "Get me tech news" }] }],
+      [toolSchemas[0]!],
+    );
+
+    expect(seenToolLists[0]).toEqual(["nb__search"]);
+    expect(seenToolLists[1]).toContain("newsapi__get_top_headlines");
+    expect(result.toolCalls.map((c) => c.name)).toEqual([
+      "nb__search",
+      "newsapi__get_top_headlines",
+    ]);
+    expect(result.output).toBe("Done!");
+  });
+
   it("includes resourceUri in tool events when tool has UI annotations", async () => {
     let callCount = 0;
     const model = createMockModel(() => {

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -182,6 +182,9 @@ describe("AgentEngine", () => {
             content: textContent(
               'Found 1 tool(s) for "newsapi":\n\n- **newsapi__get_top_headlines**: Get top news headlines by country and category.',
             ),
+            structuredContent: {
+              tools: [{ name: "newsapi__get_top_headlines" }],
+            },
             isError: false,
           };
         }

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -57,6 +57,10 @@ async function makeRegistry(): Promise<ToolRegistry> {
 	return registry;
 }
 
+function getStructured<T>(result: { structuredContent?: unknown }): T | undefined {
+	return result.structuredContent as T | undefined;
+}
+
 describe("System Tools", () => {
 	it("search with scope=tools returns matching tools by substring", async () => {
 		const registry = await makeRegistry();
@@ -67,6 +71,9 @@ describe("System Tools", () => {
 		});
 		expect(result.isError).toBe(false);
 		expect(extractText(result.content)).toContain("test__greet");
+		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toEqual([
+			{ name: "test__greet" },
+		]);
 	});
 
 	it("search with scope=tools and empty query returns all tools grouped", async () => {
@@ -87,6 +94,38 @@ describe("System Tools", () => {
 		});
 		expect(result.isError).toBe(false);
 		expect(extractText(result.content)).toContain('No tools matched "nonexistent"');
+	});
+
+	it("search with scope=tools excludes internal tools from results", async () => {
+		const registry = new ToolRegistry();
+		const source = await makeInProcessSource("test", [
+			{
+				name: "visible",
+				description: "Visible tool",
+				inputSchema: { type: "object", properties: {} },
+				handler: async () => ({ content: textContent("ok"), isError: false }),
+			},
+			{
+				name: "hidden",
+				description: "Hidden internal tool",
+				inputSchema: { type: "object", properties: {} },
+				handler: async () => ({ content: textContent("ok"), isError: false }),
+				annotations: { "ai.nimblebrain/internal": true },
+			},
+		]);
+		registry.addSource(source);
+		const systemTools = await createSystemTools(() => registry);
+		const result = await systemTools.execute("search", {
+			scope: "tools",
+			query: "tool",
+		});
+		expect(result.isError).toBe(false);
+		const text = extractText(result.content);
+		expect(text).toContain("test__visible");
+		expect(text).not.toContain("test__hidden");
+		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toEqual([
+			{ name: "test__visible" },
+		]);
 	});
 
 	// `search with scope=registry` lives in test/smoke/system-tools-registry.test.ts.

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -83,6 +83,12 @@ describe("System Tools", () => {
 		expect(result.isError).toBe(false);
 		expect(extractText(result.content)).toContain("test");
 		expect(extractText(result.content)).toContain("2 tools");
+		// Browse path must populate structuredContent so the engine can promote
+		// discovered tools into the direct callable set on the next iteration.
+		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toEqual([
+			{ name: "test__greet" },
+			{ name: "test__farewell" },
+		]);
 	});
 
 	it("search with scope=tools returns no-match message", async () => {


### PR DESCRIPTION
## Summary
- promote exact tool names discovered through `nb__search(scope="tools")` into the callable tool set for the next iteration of the same engine run
- add regression coverage for the discovery-to-execution flow
## Problem
In workspaces with enough tools to trigger tiered surfacing, app tools can be placed in the proxied/discoverable bucket instead of the direct/callable bucket.
In that state, the model can:
1. call `nb__search`
2. discover an app tool name such as `newsapi__get_top_headlines`
but it could not actually call that discovered tool in the next step, because the discovered tool was never promoted into the callable tool list for the run.
This was especially visible with OpenAI-backed agent runs, where the model would report that the tool existed but was not directly callable in the current tool set.
## Root Cause
The proxied-tool workflow had a missing bridge between:
1. discovery by name through `nb__search(scope="tools")`
2. execution of the discovered tool in a subsequent iteration
The engine preserved the original direct tool list across the run, so discovered proxied tools never became callable.
## Fix
- track tools discovered from successful `nb__search(scope="tools")` results during an engine run
- parse exact discovered tool names from the search result text
- promote those discovered tools into the direct callable tool set for the next iteration
- keep promotion scoped to the current run only
- do not change runtime tool surfacing policy globally
## Why This Approach
This keeps NimbleBrain's tiered surfacing design intact and fixes the actual gap in the proxied-tool flow, instead of broadening tool exposure for a whole provider.
It avoids provider-specific behavior and avoids exposing all tools directly just to work around the issue.
## Testing
Added regression coverage for:
- promoting a discovered tool after `nb__search`
- making that tool callable on the next iteration
- preserving normal behavior when no discovery occurs
Focused checks run:
```bash
bun test test/unit/engine.test.ts test/unit/tool-surfacing.test.ts
bun run verify
```
## Reproduction
One concrete reproduction was:
- workspace contains enough tools to exceed DEFAULT_MAX_DIRECT_TOOLS
- @nimblebraininc/newsapi is installed and healthy
- the agent asks for technology headlines in the US
- the model discovers newsapi__get_top_headlines via nb__search
- before this fix, the discovered tool remained non-callable for the run
- after this fix, the discovered tool becomes callable on the next iteration