### PR TITLE
Fix cost formatting and add Precise Cost toggle

### DIFF
--- a/src/bundles/usage/ui/src/App.tsx
+++ b/src/bundles/usage/ui/src/App.tsx
@@ -54,11 +54,7 @@ type GroupBy = "day" | "model" | "conversation";
 /* ---------- formatters ---------- */
 
 function fmtCost(n: number): string {
-  return n < 0.01 ? `$${(n * 100).toFixed(2)}c` : `$${n.toFixed(2)}`;
-}
-
-function fmtCostP(n: number): string {
-  return `$${n.toFixed(4)}`;
+  return n < 0.01 ? `${(n * 100).toFixed(2)}¢` : `$${n.toFixed(2)}`;
 }
 
 function fmtTok(n: number): string {
@@ -158,19 +154,19 @@ function Dashboard() {
           <div className="stat-detail">
             <div className="row">
               <span>Input</span>
-              <span>{fmtCostP(cost.input || 0)}</span>
+              <span>{fmtCost(cost.input || 0)}</span>
             </div>
             <div className="row">
               <span>Output</span>
-              <span>{fmtCostP(cost.output || 0)}</span>
+              <span>{fmtCost(cost.output || 0)}</span>
             </div>
             <div className="row">
               <span>Cache read</span>
-              <span>{fmtCostP(cost.cacheRead || 0)}</span>
+              <span>{fmtCost(cost.cacheRead || 0)}</span>
             </div>
             <div className="row">
               <span>Cache write</span>
-              <span>{fmtCostP(cost.cacheWrite || 0)}</span>
+              <span>{fmtCost(cost.cacheWrite || 0)}</span>
             </div>
           </div>
         </div>
@@ -232,7 +228,7 @@ function Dashboard() {
                       (m.tokens.input || 0) + (m.tokens.output || 0) + (m.tokens.cacheRead || 0),
                     )}
                   </td>
-                  <td className="right">{fmtCostP(m.cost.total)}</td>
+                  <td className="right">{fmtCost(m.cost.total)}</td>
                   <td className="right">{m.llmCalls}</td>
                 </tr>
               ))
@@ -268,7 +264,7 @@ function Dashboard() {
                   <td className="right">{fmtTok(d.tokens.input)}</td>
                   <td className="right">{fmtTok(d.tokens.output)}</td>
                   <td className="right">{fmtTok(d.tokens.cacheRead)}</td>
-                  <td className="right">{fmtCostP(d.cost.total)}</td>
+                  <td className="right">{fmtCost(d.cost.total)}</td>
                   <td className="right">{d.llmCalls}</td>
                 </tr>
               ))

--- a/src/tools/core-resources/scripts/usage-bar.ts
+++ b/src/tools/core-resources/scripts/usage-bar.ts
@@ -5,7 +5,7 @@ export const USAGE_BAR_SCRIPT =
   `
 const app = document.getElementById("app");
 
-function fmtCost(n) { return n < 0.01 ? "$" + (n * 100).toFixed(2) + "c" : "$" + n.toFixed(2); }
+function fmtCost(n) { return n < 0.01 ? (n * 100).toFixed(2) + "¢" : "$" + n.toFixed(2); }
 function fmtTokens(n) {
   if (n >= 1000000) return (n / 1000000).toFixed(1) + "M";
   if (n >= 1000) return Math.round(n / 1000) + "K";

--- a/src/tools/core-resources/scripts/usage-dashboard.ts
+++ b/src/tools/core-resources/scripts/usage-dashboard.ts
@@ -5,8 +5,7 @@ export const USAGE_DASHBOARD_SCRIPT =
   `
 const app = document.getElementById("app");
 
-function fmtCost(n) { return n < 0.01 ? "$" + (n * 100).toFixed(2) + "c" : "$" + n.toFixed(2); }
-function fmtCostPrecise(n) { return "$" + n.toFixed(4); }
+function fmtCost(n) { return n < 0.01 ? (n * 100).toFixed(2) + "¢" : "$" + n.toFixed(2); }
 function fmtTokens(n) {
   if (n >= 1000000) return (n / 1000000).toFixed(1) + "M";
   if (n >= 1000) return Math.round(n / 1000) + "K";
@@ -26,7 +25,7 @@ function render(data) {
 
   var modelRows = models.map(function(m) {
     return '<tr><td>' + shortModel(m.model) + '</td>'
-      + '<td class="right">' + fmtCostPrecise(m.cost.total) + '</td>'
+      + '<td class="right">' + fmtCost(m.cost.total) + '</td>'
       + '<td class="right">' + m.llmCalls + '</td></tr>';
   }).join("") || '<tr><td colspan="3" class="empty">No data</td></tr>';
 
@@ -35,7 +34,7 @@ function render(data) {
       + '<td class="right">' + fmtTokens(d.tokens.input) + '</td>'
       + '<td class="right">' + fmtTokens(d.tokens.output) + '</td>'
       + '<td class="right">' + fmtTokens(d.tokens.cacheRead) + '</td>'
-      + '<td class="right">' + fmtCostPrecise(d.cost.total) + '</td>'
+      + '<td class="right">' + fmtCost(d.cost.total) + '</td>'
       + '<td class="right">' + d.llmCalls + '</td></tr>';
   }).join("") || '<tr><td colspan="6" class="empty">No data for this period</td></tr>';
 
@@ -49,9 +48,9 @@ function render(data) {
     '<div class="stats-grid">' +
     '<div class="stat"><div class="stat-value">' + fmtCost(cost.total || 0) + '</div><div class="stat-label">Cost</div>' +
     '<div class="stat-detail">' +
-    '<div class="row"><span class="label">Input</span><span>' + fmtCostPrecise(cost.input || 0) + '</span></div>' +
-    '<div class="row"><span class="label">Output</span><span>' + fmtCostPrecise(cost.output || 0) + '</span></div>' +
-    '<div class="row"><span class="label">Cache</span><span>' + fmtCostPrecise(cost.cacheRead || 0) + '</span></div>' +
+    '<div class="row"><span class="label">Input</span><span>' + fmtCost(cost.input || 0) + '</span></div>' +
+    '<div class="row"><span class="label">Output</span><span>' + fmtCost(cost.output || 0) + '</span></div>' +
+    '<div class="row"><span class="label">Cache</span><span>' + fmtCost(cost.cacheRead || 0) + '</span></div>' +
     '</div></div>' +
     '<div class="stat"><div class="stat-value">' + fmtTokens(totalTokens) + '</div><div class="stat-label">Tokens</div></div>' +
     '<div class="stat"><div class="stat-value">' + (t.llmCalls || 0) + '</div><div class="stat-label">LLM Calls</div></div>' +

--- a/src/usage/cost.ts
+++ b/src/usage/cost.ts
@@ -98,7 +98,7 @@ export function estimateCost(modelString: string, usage: TokenUsage): number {
 
 /** Format USD cost for display. Sub-penny values shown as cents. */
 export function formatCost(usd: number): string {
-  if (usd < 0.01) return `$${(usd * 100).toFixed(2)}c`;
+  if (usd < 0.01) return `${(usd * 100).toFixed(2)}¢`;
   return `$${usd.toFixed(2)}`;
 }
 

--- a/src/usage/cost.ts
+++ b/src/usage/cost.ts
@@ -96,9 +96,9 @@ export function estimateCost(modelString: string, usage: TokenUsage): number {
   return costBreakdown(modelString, usage).total;
 }
 
-/** Format USD cost for display. Sub-penny values shown as cents. */
+/** Format USD cost for display. Sub-penny non-zero values shown as cents; zero is "$0.00". */
 export function formatCost(usd: number): string {
-  if (usd < 0.01) return `${(usd * 100).toFixed(2)}¢`;
+  if (usd > 0 && usd < 0.01) return `${(usd * 100).toFixed(2)}¢`;
   return `$${usd.toFixed(2)}`;
 }
 

--- a/test/unit/cost-format.test.ts
+++ b/test/unit/cost-format.test.ts
@@ -3,11 +3,11 @@ import { formatCost, formatTokenCount } from "../../src/usage/cost.ts";
 
 describe("formatCost", () => {
   it("formats sub-penny values as cents", () => {
-    expect(formatCost(0.005)).toBe("$0.50c");
+    expect(formatCost(0.005)).toBe("0.50¢");
   });
 
   it("formats zero as cents", () => {
-    expect(formatCost(0)).toBe("$0.00c");
+    expect(formatCost(0)).toBe("0.00¢");
   });
 
   it("formats dollar values with two decimals", () => {

--- a/test/unit/cost-format.test.ts
+++ b/test/unit/cost-format.test.ts
@@ -6,8 +6,8 @@ describe("formatCost", () => {
     expect(formatCost(0.005)).toBe("0.50¢");
   });
 
-  it("formats zero as cents", () => {
-    expect(formatCost(0)).toBe("0.00¢");
+  it("formats zero as $0.00 (no activity, not 'zero cents')", () => {
+    expect(formatCost(0)).toBe("$0.00");
   });
 
   it("formats dollar values with two decimals", () => {

--- a/web/src/components/charts/CostChart.tsx
+++ b/web/src/components/charts/CostChart.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { formatShortDate } from "../../lib/format";
+import { formatShortDate, formatUsd } from "../../lib/format";
 
 interface CostBreakdown {
   input: number;
@@ -33,11 +33,6 @@ const LABELS: Record<string, string> = {
   cacheRead: "Cache read",
   cacheWrite: "Cache write",
 };
-
-function formatUsd(n: number): string {
-  if (n < 0.01 && n > 0) return `$${(n * 100).toFixed(2)}c`;
-  return `$${n.toFixed(4)}`;
-}
 
 export function CostChart({ data }: CostChartProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
@@ -114,7 +109,7 @@ export function CostChart({ data }: CostChartProps) {
                 className="fill-muted-foreground"
                 style={{ fontSize: 10 }}
               >
-                ${value < 0.01 ? value.toFixed(3) : value.toFixed(2)}
+                {formatUsd(value)}
               </text>
             </g>
           );

--- a/web/src/components/charts/CostChart.tsx
+++ b/web/src/components/charts/CostChart.tsx
@@ -60,9 +60,14 @@ export function CostChart({ data }: CostChartProps) {
   const barWidth = Math.min(Math.floor(chartWidth / data.length) - 2, 40);
   const gap = (chartWidth - barWidth * data.length) / (data.length + 1);
 
-  // Y-axis ticks
+  // Y-axis ticks. Pick the unit once per axis based on maxCost so all ticks
+  // share a unit — formatUsd decides per-value, which would mix $ and ¢ on
+  // the same axis when the scale is sub-penny.
   const yTicks = 4;
   const yStep = maxCost / yTicks;
+  const axisInCents = maxCost < 0.01;
+  const formatTick = (value: number) =>
+    axisInCents ? `${(value * 100).toFixed(2)}¢` : `$${value.toFixed(2)}`;
 
   const segments: Array<{ key: keyof typeof COLORS; field: keyof CostBreakdown }> = [
     { key: "cacheWrite", field: "cacheWrite" },
@@ -109,7 +114,7 @@ export function CostChart({ data }: CostChartProps) {
                 className="fill-muted-foreground"
                 style={{ fontSize: 10 }}
               >
-                {formatUsd(value)}
+                {formatTick(value)}
               </text>
             </g>
           );

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,3 +1,16 @@
+/** Format USD cost. Sub-penny → cents with ¢ symbol; otherwise 2 decimal places. */
+export function formatUsd(n: number): string {
+  if (n < 0.01 && n > 0) return `${(n * 100).toFixed(2)}¢`;
+  return `$${n.toFixed(2)}`;
+}
+
+/** Format token count: >=1M → "2.5M", >=1K → "512K", else raw number. */
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return String(n);
+}
+
 /**
  * Format a UTC date-only string (YYYY-MM-DD) as short "M/D".
  * Input is always a UTC date key from the server — never local.

--- a/web/src/pages/settings/UsageTab.tsx
+++ b/web/src/pages/settings/UsageTab.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from "react";
 import { callTool } from "../../api/client";
 import { parseToolResult } from "../../api/tool-result";
 import { CostChart } from "../../components/charts/CostChart";
-import { formatDateLabel } from "../../lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { Select } from "../../components/ui/select";
 import {
@@ -13,6 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from "../../components/ui/table";
+import { formatDateLabel, formatTokens, formatUsd } from "../../lib/format";
 import { RequireActiveWorkspace, Section, SettingsDashboardPage } from "./components";
 
 interface TokenBreakdown {
@@ -61,21 +61,6 @@ type Period = "day" | "week" | "month" | "all";
 
 function formatNumber(n: number): string {
   return n.toLocaleString();
-}
-
-function formatUsd(n: number): string {
-  if (n < 0.01 && n > 0) return `$${(n * 100).toFixed(2)}c`;
-  return `$${n.toFixed(2)}`;
-}
-
-function formatUsdPrecise(n: number): string {
-  return `$${n.toFixed(4)}`;
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
-  return String(n);
 }
 
 function shortModel(m: string): string {
@@ -186,10 +171,10 @@ function UsageBody({ report }: { report: UsageReport }) {
           <CardContent>
             <p className="text-2xl font-semibold">{formatUsd(cost.total)}</p>
             <div className="mt-2 space-y-0.5 text-xs text-muted-foreground">
-              <CostRow label="Input" value={formatUsdPrecise(cost.input)} />
-              <CostRow label="Output" value={formatUsdPrecise(cost.output)} />
-              <CostRow label="Cache read" value={formatUsdPrecise(cost.cacheRead)} />
-              <CostRow label="Cache write" value={formatUsdPrecise(cost.cacheWrite)} />
+              <CostRow label="Input" value={formatUsd(cost.input)} />
+              <CostRow label="Output" value={formatUsd(cost.output)} />
+              <CostRow label="Cache read" value={formatUsd(cost.cacheRead)} />
+              <CostRow label="Cache write" value={formatUsd(cost.cacheWrite)} />
             </div>
           </CardContent>
         </Card>
@@ -256,7 +241,7 @@ function UsageBody({ report }: { report: UsageReport }) {
                       m.tokens.input + m.tokens.output + m.tokens.cacheRead + m.tokens.cacheWrite,
                     )}
                   </TableCell>
-                  <TableCell className="text-right">{formatUsdPrecise(m.cost.total)}</TableCell>
+                  <TableCell className="text-right">{formatUsd(m.cost.total)}</TableCell>
                   <TableCell className="text-right">{formatNumber(m.llmCalls)}</TableCell>
                 </TableRow>
               ))}
@@ -289,7 +274,7 @@ function UsageBody({ report }: { report: UsageReport }) {
                   <TableCell className="text-right">
                     {formatTokens(row.tokens.cacheRead + row.tokens.cacheWrite)}
                   </TableCell>
-                  <TableCell className="text-right">{formatUsdPrecise(row.cost.total)}</TableCell>
+                  <TableCell className="text-right">{formatUsd(row.cost.total)}</TableCell>
                   <TableCell className="text-right">{formatNumber(row.llmCalls)}</TableCell>
                 </TableRow>
               ))}

--- a/web/test/format.test.ts
+++ b/web/test/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { formatDateLabel, formatDuration, formatShortDate, stripServerPrefix } from "../src/lib/format";
+import {
+  formatDateLabel,
+  formatDuration,
+  formatShortDate,
+  formatTokens,
+  formatUsd,
+  stripServerPrefix,
+} from "../src/lib/format";
 
 describe("formatDuration", () => {
   it("renders <1ms for sub-millisecond values that round to 0", () => {
@@ -47,6 +54,41 @@ describe("stripServerPrefix", () => {
 
   it("only strips the first __ boundary (preserves the rest)", () => {
     expect(stripServerPrefix("a__b__c")).toBe("b__c");
+  });
+});
+
+describe("formatUsd", () => {
+  it("formats sub-penny values as cents with ¢ symbol", () => {
+    expect(formatUsd(0.005)).toBe("0.50¢");
+    expect(formatUsd(0.001)).toBe("0.10¢");
+    expect(formatUsd(0.0099)).toBe("0.99¢");
+  });
+
+  it("formats dollar values with two decimal places", () => {
+    expect(formatUsd(0.01)).toBe("$0.01");
+    expect(formatUsd(0.02)).toBe("$0.02");
+    expect(formatUsd(42.08)).toBe("$42.08");
+    expect(formatUsd(12.456)).toBe("$12.46");
+  });
+
+  it("formats zero as $0.00", () => {
+    expect(formatUsd(0)).toBe("$0.00");
+  });
+});
+
+describe("formatTokens", () => {
+  it("formats millions", () => {
+    expect(formatTokens(2_500_000)).toBe("2.5M");
+  });
+
+  it("formats thousands", () => {
+    expect(formatTokens(512_000)).toBe("512K");
+    expect(formatTokens(1_000)).toBe("1K");
+  });
+
+  it("formats small numbers as-is", () => {
+    expect(formatTokens(453)).toBe("453");
+    expect(formatTokens(0)).toBe("0");
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix `$0.30c` display → `0.30¢` across every `fmtCost` site (engine `formatCost`, usage bundle React UI, embedded usage-bar/usage-dashboard scripts, web client `formatUsd`)
- Consolidate web client cost formatting into shared `formatUsd` / `formatTokens` in `web/src/lib/format.ts`, removing duplicate local copies from `UsageTab.tsx` and `CostChart.tsx`
- `formatCost(0)` and `formatUsd(0)` both return `$0.00` (no activity reads as `$0.00`, not "zero cents")
- `CostChart` y-axis picks one unit (¢ or $) per scale based on `maxCost`, instead of mixing units on the same axis when the scale is sub-penny

Closes #153

## Test plan

- [ ] Sub-penny totals render as `0.50¢` on the usage page, chart tooltips, usage bar, and the bundle dashboard
- [ ] Dollar amounts render as `$X.XX` (2 decimals)
- [ ] Empty periods render as `$0.00` everywhere (engine + web)
- [ ] CostChart y-axis ticks all share one unit (all `$X.XX` or all `X.XX¢`) regardless of dataset scale
- [ ] `bun run test:unit` and `bun run test:web` pass