### PR TITLE
fix: use UTC date methods for usage page dates

### DIFF
--- a/src/conversation/usage-aggregator.ts
+++ b/src/conversation/usage-aggregator.ts
@@ -141,15 +141,15 @@ export function resolveDateRange(
     case "day":
       return { from: toDate, to: toDate };
     case "week": {
-      const d = new Date(toDate);
-      d.setDate(d.getDate() - 7);
+      const d = new Date(`${toDate}T00:00:00Z`);
+      d.setUTCDate(d.getUTCDate() - 7);
       return { from: d.toISOString().slice(0, 10), to: toDate };
     }
     case "all":
       return { from: "2020-01-01", to: toDate };
     default: {
-      const d = new Date(toDate);
-      d.setDate(1);
+      const d = new Date(`${toDate}T00:00:00Z`);
+      d.setUTCDate(1);
       return { from: d.toISOString().slice(0, 10), to: toDate };
     }
   }

--- a/test/unit/conversation/usage-aggregator.test.ts
+++ b/test/unit/conversation/usage-aggregator.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, it } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { aggregateUsage } from "../../../src/conversation/usage-aggregator.ts";
+import { aggregateUsage, resolveDateRange } from "../../../src/conversation/usage-aggregator.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -200,5 +200,69 @@ describe("usage-aggregator", () => {
 
     expect(report.totals.llmCalls).toBe(0);
     expect(report.totals.conversations).toBe(0);
+  });
+
+  it("zero-fills missing days in bounded period", async () => {
+    const dir = makeTmpDir();
+    writeFileSync(
+      join(dir, "sparse.jsonl"),
+      buildJsonl({ id: "sp", updatedAt: "2026-04-12T10:00:00Z" }, [
+        llmEvent({ ts: "2026-04-10T08:00:00Z", inputTokens: 100, outputTokens: 50 }),
+        llmEvent({ ts: "2026-04-12T10:00:00Z", inputTokens: 200, outputTokens: 100 }),
+      ]),
+    );
+
+    const report = await aggregateUsage(dir, "week", "day", "2026-04-10", "2026-04-12");
+
+    expect(report.breakdown).toHaveLength(3);
+    expect(report.breakdown[0].key).toBe("2026-04-10");
+    expect(report.breakdown[1].key).toBe("2026-04-11");
+    expect(report.breakdown[1].llmCalls).toBe(0);
+    expect(report.breakdown[2].key).toBe("2026-04-12");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDateRange — timezone safety
+// ---------------------------------------------------------------------------
+
+describe("resolveDateRange", () => {
+  it("'month' range starts on the 1st regardless of timezone", () => {
+    // Bug: new Date("2026-04-30") in PDT = April 29 local.
+    // setDate(1) then gives March 1 local → "2026-03-02" UTC.
+    // Correct: from should always be "2026-04-01".
+    const range = resolveDateRange("month", undefined, "2026-04-30");
+    expect(range.from).toBe("2026-04-01");
+    expect(range.to).toBe("2026-04-30");
+  });
+
+  it("'month' range correct for January (no year rollback)", () => {
+    const range = resolveDateRange("month", undefined, "2026-01-15");
+    expect(range.from).toBe("2026-01-01");
+    expect(range.to).toBe("2026-01-15");
+  });
+
+  it("'week' range subtracts exactly 7 days", () => {
+    const range = resolveDateRange("week", undefined, "2026-04-30");
+    expect(range.from).toBe("2026-04-23");
+    expect(range.to).toBe("2026-04-30");
+  });
+
+  it("'week' range across month boundary", () => {
+    const range = resolveDateRange("week", undefined, "2026-05-03");
+    expect(range.from).toBe("2026-04-26");
+    expect(range.to).toBe("2026-05-03");
+  });
+
+  it("'day' range returns same date for from and to", () => {
+    const range = resolveDateRange("day", undefined, "2026-04-30");
+    expect(range.from).toBe("2026-04-30");
+    expect(range.to).toBe("2026-04-30");
+  });
+
+  it("explicit from/to passed through unchanged", () => {
+    const range = resolveDateRange("month", "2026-03-01", "2026-04-30");
+    expect(range.from).toBe("2026-03-01");
+    expect(range.to).toBe("2026-04-30");
   });
 });

--- a/web/src/components/charts/CostChart.tsx
+++ b/web/src/components/charts/CostChart.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { formatShortDate } from "../../lib/format";
 
 interface CostBreakdown {
   input: number;
@@ -32,11 +33,6 @@ const LABELS: Record<string, string> = {
   cacheRead: "Cache read",
   cacheCreation: "Cache write",
 };
-
-function formatShortDate(iso: string): string {
-  const d = new Date(iso);
-  return `${d.getMonth() + 1}/${d.getDate()}`;
-}
 
 function formatUsd(n: number): string {
   if (n < 0.01 && n > 0) return `$${(n * 100).toFixed(2)}c`;

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,3 +1,21 @@
+/**
+ * Format a UTC date-only string (YYYY-MM-DD) as short "M/D".
+ * Input is always a UTC date key from the server — never local.
+ */
+export function formatShortDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
+/**
+ * Format a UTC date-only string (YYYY-MM-DD) for table display.
+ * Input is always a UTC date key from the server — never local.
+ */
+export function formatDateLabel(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return d.toLocaleDateString(undefined, { timeZone: "UTC" });
+}
+
 /** Strip the MCP server prefix from a tool name (e.g. "server__tool" → "tool") */
 export function stripServerPrefix(name: string): string {
   const idx = name.indexOf("__");

--- a/web/src/pages/settings/UsageTab.tsx
+++ b/web/src/pages/settings/UsageTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { callTool } from "../../api/client";
 import { parseToolResult } from "../../api/tool-result";
 import { CostChart } from "../../components/charts/CostChart";
+import { formatDateLabel } from "../../lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { Select } from "../../components/ui/select";
 import {
@@ -74,10 +75,6 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
   return String(n);
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
 }
 
 function shortModel(m: string): string {
@@ -278,7 +275,7 @@ function UsageBody({ report }: { report: UsageReport }) {
             <TableBody>
               {report.breakdown.map((row) => (
                 <TableRow key={row.key}>
-                  <TableCell>{formatDate(row.key)}</TableCell>
+                  <TableCell>{formatDateLabel(row.key)}</TableCell>
                   <TableCell className="text-right">{formatTokens(row.tokens.input)}</TableCell>
                   <TableCell className="text-right">{formatTokens(row.tokens.output)}</TableCell>
                   <TableCell className="text-right">{formatTokens(row.tokens.cacheRead)}</TableCell>

--- a/web/test/format.test.ts
+++ b/web/test/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { formatDuration, stripServerPrefix } from "../src/lib/format";
+import { formatDateLabel, formatDuration, formatShortDate, stripServerPrefix } from "../src/lib/format";
 
 describe("formatDuration", () => {
   it("renders <1ms for sub-millisecond values that round to 0", () => {
@@ -47,5 +47,42 @@ describe("stripServerPrefix", () => {
 
   it("only strips the first __ boundary (preserves the rest)", () => {
     expect(stripServerPrefix("a__b__c")).toBe("b__c");
+  });
+});
+
+describe("formatShortDate", () => {
+  it("formats UTC date-only string as M/D using UTC day", () => {
+    // "2026-04-30" is UTC midnight. In PDT (UTC-7), getDate() returns 29.
+    // Correct behavior: always show 4/30.
+    expect(formatShortDate("2026-04-30")).toBe("4/30");
+  });
+
+  it("formats first of month correctly", () => {
+    expect(formatShortDate("2026-01-01")).toBe("1/1");
+  });
+
+  it("formats December 31 correctly", () => {
+    expect(formatShortDate("2026-12-31")).toBe("12/31");
+  });
+
+  it("handles month boundary (UTC date differs from local in west-of-UTC TZ)", () => {
+    // "2026-05-01" UTC midnight = April 30 in PDT
+    expect(formatShortDate("2026-05-01")).toBe("5/1");
+  });
+});
+
+describe("formatDateLabel", () => {
+  it("preserves UTC date, not local interpretation", () => {
+    // "2026-04-30" should always format as April 30, never April 29.
+    const result = formatDateLabel("2026-04-30");
+    expect(result).toContain("30");
+    expect(result).not.toContain("29");
+  });
+
+  it("handles year boundary", () => {
+    const result = formatDateLabel("2026-01-01");
+    expect(result).toContain("1");
+    // Should not roll back to December 31
+    expect(result).not.toContain("31");
   });
 });


### PR DESCRIPTION
## Summary

- Fix all usage page dates showing one day behind for users west of UTC
- Fix server-side "This month" range dropping the 1st of the month
- Extract shared `formatShortDate`/`formatDateLabel` into `web/src/lib/format.ts`
- Harden "week" range computation against latent timezone bug

## Root Cause

Date-only strings (`"YYYY-MM-DD"`) parse as UTC midnight per JS spec, but all four call sites used local-timezone `Date` methods (`getMonth`, `getDate`, `setDate`, `toLocaleDateString`). For any timezone west of UTC, UTC midnight rolls back to the previous local day.

## Changes

| File | What |
|------|------|
| `src/conversation/usage-aggregator.ts` | `setDate` → `setUTCDate`, explicit `T00:00:00Z` suffix |
| `web/src/lib/format.ts` | New `formatShortDate` and `formatDateLabel` using UTC methods |
| `web/src/components/charts/CostChart.tsx` | Use shared `formatShortDate` instead of inline |
| `web/src/pages/settings/UsageTab.tsx` | Use shared `formatDateLabel` instead of inline `formatDate` |

## Test plan

- [x] Added 6 `resolveDateRange` tests (month start, January, week, week across month boundary, day, explicit range)
- [x] Added 6 `formatShortDate`/`formatDateLabel` tests (UTC correctness, month boundaries, year boundary)
- [x] All tests verified passing in `TZ=America/Los_Angeles` (PDT), `TZ=UTC`, and `TZ=Asia/Tokyo` (JST)
- [x] 2201 unit tests pass, 219 web tests pass, 0 failures
- [ ] Manual verification: open Usage page in a west-of-UTC timezone and confirm chart/table dates match today

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)