### PR TITLE
fix(tools): coerce string-encoded nested args + reorder skill perm checks

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -12,6 +12,7 @@ import { RunInProgressError } from "../runtime/errors.ts";
 import { type RequestContext, runWithRequestContext } from "../runtime/request-context.ts";
 import type { Runtime } from "../runtime/runtime.ts";
 import type { ChatRequest } from "../runtime/types.ts";
+import { coerceInputForSchema } from "../tools/coerce-input.ts";
 import type { HealthMonitor } from "../tools/health-monitor.ts";
 import type { ResourceData } from "../tools/types.ts";
 import { validateToolInput } from "../tools/validate-input.ts";
@@ -524,6 +525,11 @@ export async function handleToolCall(
   // or bare (e.g., "briefing"). Normalize to full name.
   const toolName = tool.startsWith(`${server}__`) ? tool : `${server}__${tool}`;
 
+  // Coerced args flow through to registry.execute below — validation and
+  // execution must see the same shape. Defaults to the raw args; replaced
+  // with the schema-coerced version once we resolve the tool definition.
+  let coercedArgs: Record<string, unknown> = args ?? {};
+
   const source = registry.getSources().find((s) => s.name === server);
   if (source) {
     try {
@@ -536,9 +542,12 @@ export async function handleToolCall(
         });
       }
 
-      // Validate input against the tool's declared JSON Schema
+      // Validate input against the tool's declared JSON Schema. Coerce
+      // first to recover nested string-encoded object/array values — see
+      // src/tools/coerce-input.ts.
       if (toolDef.inputSchema) {
-        const validation = validateToolInput(args ?? {}, toolDef.inputSchema);
+        coercedArgs = coerceInputForSchema(coercedArgs, toolDef.inputSchema);
+        const validation = validateToolInput(coercedArgs, toolDef.inputSchema);
         if (!validation.valid) {
           return apiError(
             400,
@@ -603,7 +612,7 @@ export async function handleToolCall(
       registry.execute({
         id: callId,
         name: toolName,
-        input: args ?? {},
+        input: coercedArgs,
       }),
     );
   } catch (err) {

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -356,7 +356,6 @@ function createServer(
         } catch {
           // Resource not found on this source; keep trying the next one.
         }
-        continue;
       }
     }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -473,6 +473,11 @@ export class AgentEngine {
             const resourceUri =
               typeof uiMeta?.resourceUri === "string" ? uiMeta.resourceUri : undefined;
 
+            // tool.start fires with the *pre-coercion* input on purpose:
+            // audit/telemetry should see the raw model emission so we can
+            // observe when models string-encode nested objects (the very
+            // misbehavior coerceInputForSchema below recovers from). Do
+            // not move this emit after the coerce step.
             this.events.emit({
               type: "tool.start",
               data: {

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -11,6 +11,7 @@ import { MAX_ITERATIONS, MAX_TOOL_RESULT_CHARS } from "../limits.ts";
 import { getProviderFromModel, supportsEnabledThinking } from "../model/catalog.ts";
 import { normalizeForReplay } from "../model/inbound-fit.ts";
 import { callModel, type StreamResult } from "../model/stream.ts";
+import { coerceInputForSchema } from "../tools/coerce-input.ts";
 import { validateToolInput } from "../tools/validate-input.ts";
 import {
   estimateContentSize,
@@ -486,13 +487,16 @@ export class AgentEngine {
             const start = performance.now();
             let result: ToolResult | undefined;
 
-            // Validate tool input against declared schema before execution
+            // Validate tool input against declared schema before execution.
+            // Coerce first: models occasionally emit nested object/array
+            // values as JSON-encoded strings (`{ manifest: "{...}" }`).
+            // The coerce pass uses the schema as a parsing oracle to
+            // recover those one-level misencodings before validation.
             const toolSchema = toolSchemaMap.get(gatedCall.name);
             if (toolSchema?.inputSchema) {
-              const validation = validateToolInput(
-                gatedCall.input,
-                toolSchema.inputSchema as Record<string, unknown>,
-              );
+              const schema = toolSchema.inputSchema as Record<string, unknown>;
+              gatedCall.input = coerceInputForSchema(gatedCall.input, schema);
+              const validation = validateToolInput(gatedCall.input, schema);
               if (!validation.valid) {
                 result = {
                   content: textContent(`Invalid tool input: ${validation.error}`),

--- a/src/model/inbound-fit.ts
+++ b/src/model/inbound-fit.ts
@@ -101,7 +101,6 @@ export function normalizeForReplay(content: readonly LanguageModelV3Content[]): 
         ? { ...part, providerOptions: part.providerMetadata }
         : part;
       out.push(replay);
-      continue;
     }
 
     // Drop the rest:

--- a/src/tools/coerce-input.ts
+++ b/src/tools/coerce-input.ts
@@ -1,0 +1,140 @@
+/**
+ * Schema-aware input coercion. Runs before `validateToolInput` at every
+ * tool-call entry point.
+ *
+ * Why this exists: the wire format for streaming tool calls historically
+ * delivered `function_call.arguments` as a JSON-encoded string (OpenAI's
+ * legacy shape). Models trained against that convention sometimes
+ * overgeneralize and stringify *nested* object/array values too — emitting
+ * `{ manifest: "{\"name\":\"foo\"}" }` instead of `{ manifest: { name: "foo" }}`.
+ *
+ * The engine and `inbound-fit` already JSON-parse the *outer* `input` when
+ * it arrives as a string. This helper extends the same forgiveness one
+ * level deeper: schema-driven, not depth-limited. We use the schema as a
+ * parsing oracle — for any property declared as `object` or `array`, if
+ * the actual value is a string, attempt `JSON.parse` once and substitute
+ * the parsed value. Recurse into the parsed result so deeply nested
+ * misencodings unwind in one pass.
+ *
+ * Non-parseable strings (and strings where the schema didn't expect an
+ * object/array) pass through unchanged — the validator reports them with
+ * its content-aware error. Non-string values are untouched.
+ *
+ * Idempotent: a properly shaped input survives unchanged. Safe to call at
+ * multiple boundaries without amplification.
+ *
+ * Why not AJV's `coerceTypes`: AJV only coerces between scalar types
+ * (string ↔ number, etc.). It does not parse string-as-JSON into objects
+ * or arrays. This helper fills exactly that gap.
+ */
+
+type Schema = Record<string, unknown> | undefined;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** True iff the schema declares a single concrete type matching `target`. */
+function declaresType(schema: Schema, target: "object" | "array"): boolean {
+  if (!schema) return false;
+  const t = schema.type;
+  if (t === target) return true;
+  if (Array.isArray(t) && t.includes(target)) return true;
+  return false;
+}
+
+/** Try to parse a string as JSON; return undefined on failure. */
+function tryJsonParse(s: string): unknown {
+  // Cheap sniff: the model encodes objects as "{...}" and arrays as "[...]".
+  // Anything else (a plain string the schema rejects on its own merits) is
+  // not our responsibility to recover.
+  const trimmed = s.trim();
+  if (trimmed.length === 0) return undefined;
+  const first = trimmed[0];
+  if (first !== "{" && first !== "[") return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Coerce one value against one sub-schema. Recurses through nested objects,
+ * array items, and `oneOf`/`anyOf` alternatives. Returns the (possibly new)
+ * value — callers should rebind, not mutate.
+ */
+function coerceValue(value: unknown, schema: Schema): unknown {
+  if (!schema) return value;
+
+  // String → object/array recovery via schema-declared expected type.
+  if (typeof value === "string") {
+    const wantObject = declaresType(schema, "object");
+    const wantArray = declaresType(schema, "array");
+    if (wantObject || wantArray) {
+      const parsed = tryJsonParse(value);
+      if (parsed !== undefined) {
+        // Recurse so a nested misencoding inside the just-parsed value
+        // also unwinds. The `parsed` shape may itself need further
+        // coercion (object whose property is also string-encoded).
+        return coerceValue(parsed, schema);
+      }
+      // Parse failed — leave as string. Validator will surface the
+      // content-aware error ("must be object", "must be array").
+      return value;
+    }
+    return value;
+  }
+
+  // Walk into objects: coerce each declared property by its sub-schema.
+  if (isPlainObject(value) && declaresType(schema, "object")) {
+    const properties = schema.properties as Record<string, Schema> | undefined;
+    if (!properties) return value;
+    let mutated: Record<string, unknown> | undefined;
+    for (const key of Object.keys(value)) {
+      const subSchema = properties[key];
+      if (!subSchema) continue;
+      const coerced = coerceValue(value[key], subSchema);
+      if (coerced !== value[key]) {
+        if (!mutated) mutated = { ...value };
+        mutated[key] = coerced;
+      }
+    }
+    return mutated ?? value;
+  }
+
+  // Walk into arrays: coerce each element by `items`.
+  if (Array.isArray(value) && declaresType(schema, "array")) {
+    const items = schema.items as Schema;
+    if (!items) return value;
+    let mutated: unknown[] | undefined;
+    for (let i = 0; i < value.length; i++) {
+      const coerced = coerceValue(value[i], items);
+      if (coerced !== value[i]) {
+        if (!mutated) mutated = [...value];
+        mutated[i] = coerced;
+      }
+    }
+    return mutated ?? value;
+  }
+
+  return value;
+}
+
+/**
+ * Deep-coerce `input` against `schema` so nested string-encoded objects
+ * and arrays (a model misemission we've seen in production with both
+ * Sonnet and Opus 4.7) survive validation.
+ *
+ * Always returns a `Record<string, unknown>`. If the top-level coerce
+ * doesn't yield an object (input was something other than a string-
+ * encoded top-level object), returns the input unchanged — the validator
+ * decides what to do with it.
+ */
+export function coerceInputForSchema(
+  input: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const coerced = coerceValue(input, schema);
+  return isPlainObject(coerced) ? coerced : input;
+}

--- a/src/tools/coerce-input.ts
+++ b/src/tools/coerce-input.ts
@@ -60,9 +60,15 @@ function tryJsonParse(s: string): unknown {
 }
 
 /**
- * Coerce one value against one sub-schema. Recurses through nested objects,
- * array items, and `oneOf`/`anyOf` alternatives. Returns the (possibly new)
- * value — callers should rebind, not mutate.
+ * Coerce one value against one sub-schema. Recurses through nested objects
+ * (via `properties`) and array items (via `items`); union types declared
+ * as `type: ["object", "null"]` etc. are honored. `oneOf` / `anyOf` are
+ * NOT walked — first-party tools follow the strict-schema convention in
+ * `src/tools/platform/CLAUDE.md` § 1.2 and don't use them; if a bundle
+ * ever needs it, the fix is additive (treat each alternative as a
+ * candidate sub-schema and pick the one that produces a non-string value).
+ *
+ * Returns the (possibly new) value — callers should rebind, not mutate.
  */
 function coerceValue(value: unknown, schema: Schema): unknown {
   if (!schema) return value;

--- a/src/tools/in-process-app.ts
+++ b/src/tools/in-process-app.ts
@@ -13,6 +13,7 @@ import {
 import type { PlacementDeclaration } from "../bundles/types.ts";
 import type { EventSink, ToolResult } from "../engine/types.ts";
 import { bytesToBase64 } from "../util/base64.ts";
+import { coerceInputForSchema } from "./coerce-input.ts";
 import { McpSource } from "./mcp-source.ts";
 import { validateToolInput } from "./validate-input.ts";
 
@@ -218,7 +219,12 @@ export function defineInProcessApp(
             };
           }
 
-          const input = (request.params.arguments ?? {}) as Record<string, unknown>;
+          // Coerce nested string-encoded object/array values before
+          // validating — see src/tools/coerce-input.ts for rationale. The
+          // engine performs the same step, but external `/mcp` clients
+          // bypass the engine and enter directly here.
+          const rawInput = (request.params.arguments ?? {}) as Record<string, unknown>;
+          const input = coerceInputForSchema(rawInput, tool.inputSchema);
           const validation = validateToolInput(input, tool.inputSchema);
           if (!validation.valid) {
             return {

--- a/src/tools/platform/skills.ts
+++ b/src/tools/platform/skills.ts
@@ -285,6 +285,17 @@ export function createSkillsSource(runtime: Runtime, eventSink: EventSink): McpS
           // sends the agent down a hallucination loop trying to fix a
           // role instead of refreshing its path. (skill:// URIs skip
           // this — existence is checked inside readSkillById.)
+          //
+          // Trade-off: an authenticated tenant member can now distinguish
+          // "file exists but I lack permission" from "file doesn't exist"
+          // for paths in other workspaces — a thin filename-existence
+          // oracle. Severity is low in our threat model: skill filenames
+          // are not secrets, content is still gated by checkPathAccess,
+          // and the caller is already inside the tenant. If a future
+          // deployment needs to close this oracle, gate the existence
+          // check behind the same scope-allowance that `checkPathAccess`
+          // applies (e.g. only run existsSync for paths in the caller's
+          // own workspace / user dir / org).
           if (!isUri && !existsSync(id)) {
             return {
               content: textContent(

--- a/src/tools/platform/skills.ts
+++ b/src/tools/platform/skills.ts
@@ -278,16 +278,36 @@ export function createSkillsSource(runtime: Runtime, eventSink: EventSink): McpS
               isError: true,
             };
           }
+          // Existence before permission. A stale `id` (e.g. a path the
+          // agent cached before the skill was moved to a workspace dir)
+          // should report "not found" — telling the caller their file
+          // is gone. Reporting "permission denied" on a missing path
+          // sends the agent down a hallucination loop trying to fix a
+          // role instead of refreshing its path. (skill:// URIs skip
+          // this — existence is checked inside readSkillById.)
+          if (!isUri && !existsSync(id)) {
+            return {
+              content: textContent(
+                `Skill not found at "${id}". The file may have been moved or deleted — ` +
+                  `call skills__list to get current paths.`,
+              ),
+              isError: true,
+            };
+          }
           const permission = await checkPathAccess(runtime, id, scope, "read");
           if (!permission.allowed) {
-            return permissionDenied(permission.reason ?? "Permission denied");
+            return permissionDenied(permission.reason ?? "Permission denied", {
+              path: id,
+              scope,
+              role: currentRoleHint(runtime, scope),
+            });
           }
           // Symlink-boundary check (skipped for skill:// URIs which
           // dispatch to the resource handler, not the filesystem path).
           // Without this, a tenant member could symlink another
           // workspace's skill into their own dir and read its
           // contents via parseSkillFile (which follows symlinks).
-          if (!isUri && existsSync(id)) {
+          if (!isUri) {
             try {
               assertSymlinkBoundaryOrThrow(runtime, id, scope);
             } catch (err) {
@@ -1405,12 +1425,72 @@ async function reloadBootSkills(runtime: Runtime): Promise<void> {
   }
 }
 
-function permissionDenied(reason: string): ToolResult {
+/**
+ * Render a permission-denied error with causation. The bare reason from
+ * `checkPathAccess` ("Org-scope writes require org admin or owner") leaves
+ * the caller hypothesizing about why their path landed in that scope and
+ * what role they actually have — surfaced as a real problem in production
+ * when an agent looped trying to fix its role instead of fixing its `id`.
+ *
+ * Now appends:
+ *   - which scope was inferred and that it came from the path prefix
+ *   - the caller's current role (when known)
+ *   - what an alternate-scope path would look like
+ *
+ * Self-correctable signal for both LLM agents and human operators.
+ */
+function permissionDenied(
+  reason: string,
+  context?: {
+    path?: string;
+    scope?: WritableScope | "bundle";
+    role?: string;
+  },
+): ToolResult {
+  const lines: string[] = [reason];
+  if (context?.path && context.scope) {
+    lines.push(
+      `Path "${context.path}" classified as ${context.scope}-scope (derived from path prefix).`,
+    );
+    if (context.scope === "org") {
+      lines.push(
+        "If this skill should be workspace-scoped, the path would be " +
+          "/data/workspaces/<wsId>/skills/<file>. Run skills__list to refresh paths.",
+      );
+    } else if (context.scope === "workspace") {
+      lines.push(
+        "If this skill should be user-scoped, the path would be " +
+          "/data/users/<userId>/skills/<file>. Run skills__list to refresh paths.",
+      );
+    }
+  }
+  if (context?.role) {
+    lines.push(`Your current role: ${context.role}.`);
+  }
   return {
-    content: textContent(reason),
-    structuredContent: { error: reason, code: "permission_denied" },
+    content: textContent(lines.join("\n")),
+    structuredContent: {
+      error: reason,
+      code: "permission_denied",
+      ...(context?.path ? { path: context.path } : {}),
+      ...(context?.scope ? { scope: context.scope } : {}),
+      ...(context?.role ? { role: context.role } : {}),
+    },
     isError: true,
   };
+}
+
+/** Best-effort role lookup for permission-denied causation messages. */
+function currentRoleHint(runtime: Runtime, scope: WritableScope | "bundle"): string | undefined {
+  const identity = runtime.getCurrentIdentity();
+  if (!identity) return undefined;
+  if (scope === "workspace") {
+    // Workspace role lives on the membership record, not the identity —
+    // resolving it here would require the path's wsId and an async store
+    // read. The org role is informative enough for the message.
+    return `org=${identity.orgRole}`;
+  }
+  return identity.orgRole;
 }
 
 function bundleNotMutable(): ToolResult {
@@ -1500,7 +1580,13 @@ async function createSkill(
   }
   const target = join(dir, `${name}.md`);
   const permission = await checkPathAccess(runtime, target, scope, "write");
-  if (!permission.allowed) return permissionDenied(permission.reason ?? "Permission denied");
+  if (!permission.allowed) {
+    return permissionDenied(permission.reason ?? "Permission denied", {
+      path: target,
+      scope,
+      role: currentRoleHint(runtime, scope),
+    });
+  }
 
   if (existsSync(target)) {
     return errorResult(new Error(`Skill "${name}" already exists in ${scope} scope`));
@@ -1565,10 +1651,25 @@ async function updateSkillHandler(
   if (scope === "bundle") return bundleNotMutable();
   if (!scope) return errorResult(new Error(unrecognizedIdMessage(id)));
 
-  const permission = await checkPathAccess(runtime, id, scope, "write");
-  if (!permission.allowed) return permissionDenied(permission.reason ?? "Permission denied");
+  // Existence before permission — a stale `id` should report "not found",
+  // not "permission denied". See read handler for full rationale.
+  if (!existsSync(id)) {
+    return errorResult(
+      new Error(
+        `Skill not found at "${id}". The file may have been moved or deleted — ` +
+          `call skills__list to get current paths.`,
+      ),
+    );
+  }
 
-  if (!existsSync(id)) return errorResult(new Error(`Skill not found: ${id}`));
+  const permission = await checkPathAccess(runtime, id, scope, "write");
+  if (!permission.allowed) {
+    return permissionDenied(permission.reason ?? "Permission denied", {
+      path: id,
+      scope,
+      role: currentRoleHint(runtime, scope),
+    });
+  }
 
   // Defense-in-depth: realpath the target and verify the link doesn't
   // escape the declared scope/tenant. Catches three classes of attack:
@@ -1628,10 +1729,24 @@ async function deleteSkillHandler(
   if (scope === "bundle") return bundleNotMutable();
   if (!scope) return errorResult(new Error(unrecognizedIdMessage(id)));
 
-  const permission = await checkPathAccess(runtime, id, scope, "write");
-  if (!permission.allowed) return permissionDenied(permission.reason ?? "Permission denied");
+  // Existence before permission — see updateSkillHandler for rationale.
+  if (!existsSync(id)) {
+    return errorResult(
+      new Error(
+        `Skill not found at "${id}". The file may have been moved or deleted — ` +
+          `call skills__list to get current paths.`,
+      ),
+    );
+  }
 
-  if (!existsSync(id)) return errorResult(new Error(`Skill not found: ${id}`));
+  const permission = await checkPathAccess(runtime, id, scope, "write");
+  if (!permission.allowed) {
+    return permissionDenied(permission.reason ?? "Permission denied", {
+      path: id,
+      scope,
+      role: currentRoleHint(runtime, scope),
+    });
+  }
 
   // Symlink-boundary defense — see updateSkillHandler for rationale.
   try {

--- a/test/unit/tools/coerce-input.test.ts
+++ b/test/unit/tools/coerce-input.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import { coerceInputForSchema } from "../../../src/tools/coerce-input.ts";
+
+describe("coerceInputForSchema — nested object recovery", () => {
+  const schema = {
+    type: "object" as const,
+    properties: {
+      manifest: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          description: { type: "string" },
+        },
+      },
+      body: { type: "string" },
+    },
+    required: ["manifest", "body"],
+  };
+
+  it("parses a string-encoded nested object", () => {
+    const input = {
+      manifest: '{"name":"foo","description":"bar"}',
+      body: "x",
+    };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.manifest).toEqual({ name: "foo", description: "bar" });
+    expect(out.body).toBe("x");
+  });
+
+  it("leaves a properly shaped nested object untouched (idempotent)", () => {
+    const input = {
+      manifest: { name: "foo", description: "bar" },
+      body: "x",
+    };
+    const out = coerceInputForSchema(input, schema);
+    expect(out).toEqual(input);
+  });
+
+  it("leaves a non-JSON string untouched so the validator catches it", () => {
+    const input = {
+      manifest: "not json at all",
+      body: "x",
+    };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.manifest).toBe("not json at all");
+  });
+
+  it("does not coerce a string field whose schema declares type: string", () => {
+    const input = {
+      manifest: { name: "foo", description: "bar" },
+      body: '{"this":"would parse but is meant to stay a string"}',
+    };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.body).toBe('{"this":"would parse but is meant to stay a string"}');
+  });
+});
+
+describe("coerceInputForSchema — nested array recovery", () => {
+  const schema = {
+    type: "object" as const,
+    properties: {
+      edits: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            find: { type: "string" },
+            replace: { type: "string" },
+          },
+        },
+      },
+    },
+  };
+
+  it("parses a string-encoded array of objects", () => {
+    const input = {
+      edits: '[{"find":"a","replace":"b"},{"find":"c","replace":"d"}]',
+    };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.edits).toEqual([
+      { find: "a", replace: "b" },
+      { find: "c", replace: "d" },
+    ]);
+  });
+
+  it("leaves a properly shaped array untouched", () => {
+    const input = { edits: [{ find: "a", replace: "b" }] };
+    const out = coerceInputForSchema(input, schema);
+    expect(out).toEqual(input);
+  });
+
+  it("recovers per-element string-encoding inside a real array", () => {
+    // Array is fine, but each element was stringified individually — also
+    // a real shape we've seen models emit.
+    const input = {
+      edits: ['{"find":"a","replace":"b"}', '{"find":"c","replace":"d"}'],
+    };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.edits).toEqual([
+      { find: "a", replace: "b" },
+      { find: "c", replace: "d" },
+    ]);
+  });
+});
+
+describe("coerceInputForSchema — depth and edge cases", () => {
+  it("recovers a doubly-nested string-encoded object", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        outer: {
+          type: "object",
+          properties: {
+            inner: { type: "object", properties: { v: { type: "string" } } },
+          },
+        },
+      },
+    };
+    const input = { outer: '{"inner":"{\\"v\\":\\"hello\\"}"}' };
+    const out = coerceInputForSchema(input, schema);
+    expect(out).toEqual({ outer: { inner: { v: "hello" } } });
+  });
+
+  it("ignores unknown properties not declared in the schema", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { known: { type: "object" } },
+    };
+    const input = { known: '{"a":1}', unknown: '{"b":2}' };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.known).toEqual({ a: 1 });
+    // Unknown is left alone — the validator decides via additionalProperties.
+    expect(out.unknown).toBe('{"b":2}');
+  });
+
+  it("returns input unchanged when schema is empty", () => {
+    const input = { manifest: '{"a":1}' };
+    const out = coerceInputForSchema(input, {});
+    expect(out).toEqual(input);
+  });
+
+  it("does not attempt to parse a string that doesn't look like JSON", () => {
+    // Cheap sniff guard: only strings starting with { or [ are tried.
+    // Avoids JSON.parse on every string field for performance.
+    const schema = {
+      type: "object" as const,
+      properties: { manifest: { type: "object" } },
+    };
+    const input = { manifest: "hello world" };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.manifest).toBe("hello world");
+  });
+
+  it("handles a schema that allows multiple types (union)", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        edits: { type: ["array", "null"], items: { type: "object" } },
+      },
+    };
+    const input = { edits: '[{"find":"a"}]' };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.edits).toEqual([{ find: "a" }]);
+  });
+});

--- a/test/unit/tools/platform/skills-mutation.test.ts
+++ b/test/unit/tools/platform/skills-mutation.test.ts
@@ -375,6 +375,37 @@ describe("skills__update", () => {
   });
 });
 
+// ── read (regression: existence-first ordering) ──────────────────────────
+
+// Mirrors the update-side regression at line 305. The read handler picked
+// up the same existence-before-permission reorder; without a dedicated
+// test the read path could regress silently (cross-workspace tests cover
+// permission denial on extant files but not the stale-id case).
+describe("skills__read — stale-id regression", () => {
+  test("stale org-scope id (file moved away) returns 'not found', not 'permission denied'", async () => {
+    runtime.hasIdentityProvider = true;
+    runtime.identity = {
+      id: "u_member",
+      email: "m@ex.com",
+      displayName: "M",
+      orgRole: "member",
+      preferences: { timezone: "UTC", locale: "en-US", theme: "system" },
+    };
+    const src = await buildSource();
+    const client = src.getClient()!;
+    const result = await client.callTool({
+      name: "read",
+      arguments: { id: join(workDir, "skills", "moved-away.md") },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text).toMatch(/not found/i);
+    expect(text).toMatch(/skills__list/);
+    expect(text).not.toMatch(/permission denied/i);
+    expect(text).not.toMatch(/org admin/i);
+  });
+});
+
 // ── delete ───────────────────────────────────────────────────────────────
 
 describe("skills__delete", () => {

--- a/test/unit/tools/platform/skills-mutation.test.ts
+++ b/test/unit/tools/platform/skills-mutation.test.ts
@@ -295,6 +295,84 @@ describe("skills__update", () => {
     });
     expect(result.isError).toBe(true);
   });
+
+  // Regression: production bug where the agent passed a stale `id` (a path
+  // the skill used to live at, before being moved to a workspace dir). The
+  // old ordering ran the permission check first and returned "Org-scope
+  // writes require org admin or owner" — sending the agent down a
+  // hallucination loop trying to fix its role instead of refreshing its
+  // path. Existence-first surfaces the actual cause.
+  test("stale org-scope id (file moved away) returns 'not found', not 'permission denied'", async () => {
+    runtime.hasIdentityProvider = true;
+    runtime.identity = {
+      id: "u_member",
+      email: "m@ex.com",
+      displayName: "M",
+      orgRole: "member",
+      preferences: { timezone: "UTC", locale: "en-US", theme: "system" },
+    };
+    const src = await buildSource();
+    const client = src.getClient()!;
+    const result = await client.callTool({
+      name: "update",
+      arguments: { id: join(workDir, "skills", "moved-away.md"), body: "x" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text).toMatch(/not found/i);
+    expect(text).toMatch(/skills__list/);
+    // Must NOT lead with the role/permission narrative for a missing file.
+    expect(text).not.toMatch(/permission denied/i);
+    expect(text).not.toMatch(/org admin/i);
+  });
+
+  test("permission-denied error carries scope + role causation", async () => {
+    runtime.hasIdentityProvider = true;
+    runtime.identity = {
+      id: "u_member",
+      email: "m@ex.com",
+      displayName: "M",
+      orgRole: "member",
+      preferences: { timezone: "UTC", locale: "en-US", theme: "system" },
+    };
+    // Pre-stage an org-scope skill on disk so existence-check passes and
+    // permission becomes the real failure.
+    const orgDir = join(workDir, "skills");
+    mkdirSync(orgDir, { recursive: true });
+    const id = join(orgDir, "org-skill.md");
+    writeFileSync(
+      id,
+      [
+        "---",
+        "name: org-skill",
+        'description: "x"',
+        'version: "1.0.0"',
+        "type: skill",
+        "priority: 50",
+        "---",
+        "body",
+        "",
+      ].join("\n"),
+    );
+
+    const src = await buildSource();
+    const client = src.getClient()!;
+    const result = await client.callTool({
+      name: "update",
+      arguments: { id, body: "tampered" },
+    });
+    expect(result.isError).toBe(true);
+    const sc = (
+      result as { structuredContent?: { code?: string; scope?: string; role?: string } }
+    ).structuredContent;
+    expect(sc?.code).toBe("permission_denied");
+    expect(sc?.scope).toBe("org");
+    expect(sc?.role).toBe("member");
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text).toMatch(/org-scope/);
+    expect(text).toMatch(/workspace-scoped/); // alternate-scope hint
+    expect(text).toMatch(/member/);
+  });
 });
 
 // ── delete ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two production bugs surfaced while debugging the hq tenant on `ws_nimblebrain_shared`. Independent root causes; shipped together because they hit on the same conversation.

- **Bug A — tool-arg deserialization.** Opus 4.7 occasionally emits nested object/array values as JSON-encoded strings (`{ manifest: \"{...}\" }`). Outer parsing exists in the engine; nested values weren't recovered. New schema-aware coerce pass walks the JSON Schema and parses string values where an object/array was declared, before validation. Wired at all three tool-call entry points (engine, in-process MCP, REST).
- **Bug B — skill permission error masked stale paths.** When skills were moved from `/data/skills/` to `/data/workspaces/<ws>/skills/`, the agent kept calling `skills__update` with old org-prefix paths. `scopeOfPath` is prefix-only and inferred `org`, the role check fired first, and the agent got `Org-scope writes require org admin or owner` — sending it into a hallucination spiral about its role. Reorder to existence-before-permission in read/update/delete; permission denials now carry path + scope + role causation.

See the commit message for the full per-bug breakdown and reasoning.

## Files

- New: `src/tools/coerce-input.ts`, `test/unit/tools/coerce-input.test.ts`
- Wired: `src/engine/engine.ts`, `src/tools/in-process-app.ts`, `src/api/handlers.ts`
- Reordered + richer errors: `src/tools/platform/skills.ts`
- Regression tests: `test/unit/tools/platform/skills-mutation.test.ts`
- Incidental (Biome auto-fix on import reorder): two redundant `continue` removed in `src/api/mcp-server.ts` and `src/model/inbound-fit.ts`

## QA round 2 (commit `f2871f5`)

- coerce-input doc corrected: `coerceValue` doesn't walk `oneOf`/`anyOf` (and doesn't need to per first-party convention); doc no longer claims it.
- skills.ts existence-first ordering carries an inline trade-off comment: thin filename-existence oracle for cross-workspace probes vs. stale-id recovery in the agent loop. Threat-model judgement, documented for the next security pass.
- engine.ts `tool.start` emit annotated as deliberately pre-coercion so audit/telemetry see raw model emission. Prevents future "fix" attempts.
- New `skills__read` stale-id regression test, mirroring the update-side test.

## Test plan

- [x] `bun run verify` green (2240 unit + 216 web + 455 integration + 17 smoke; 0 fail)
- [x] New unit tests in `coerce-input.test.ts` cover: nested object recovery, nested array recovery, per-element array string recovery, doubly-nested, non-JSON pass-through, schema-declared string fields untouched, union types, empty schema, idempotence
- [x] Regression tests in `skills-mutation.test.ts`: stale id returns "not found" with `skills__list` hint (not "permission denied") for both `update` and `read`; permission denial carries `scope=org` + `role=member` causation
- [ ] Smoke on staging: agent retries `skills__update` with a stale path → sees "not found" not "permission denied"
- [ ] Smoke on staging: agent emits string-encoded `manifest` to `skills__create` → coerce pass recovers, write succeeds

## Follow-ups (not in this PR)

- Bundle-side parity: declare `Annotated[Union[str, list[...]]]` on FastMCP tools (e.g. `synapse-collateral` `patch_source(edits=...)`) so the existing in-body `json.loads` becomes reachable.
- Role source-of-truth cleanup: `users__update_user` writes to local UserStore, but role gates read from WorkOS. Either route role mutations through WorkOS (and call `invalidateUserCache`) or have the LLM-facing tool refuse role changes in WorkOS-backed deployments. Lower urgency — wasn't the cause of the prod incident, but a latent foot-gun.
- `skills__read` body visibility (Bug C from triage): body lives in `structuredContent`, only summary in `content[]`. Anthropic's tool-use API surfaces `content[]` to the model. Mirror body into `content` for read-style tools whose payload is the agent's actual artifact. Held intentionally per request.
- `coerceInputForSchema` does not recurse into schemas that declare only `additionalProperties` (no `properties` map). First-party tools never hit this per the strict-schema convention; third-party MCP bundles loaded via `/mcp` could. Acceptable scope-of-fix limitation for now — implement when a bundle author files a real bug rather than speculatively.