### PR TITLE
fix(api): bump MCP session TTL default to 8h + log session-miss

### DIFF
--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -56,9 +56,26 @@ const MCP_SERVER_VERSION = process.env.NB_VERSION || mcpPkg.version;
  * day never expires mid-use. Sessions are evicted on idle, not absolute age,
  * so an actively-used connection survives indefinitely (each request bumps
  * `lastAccessedAt`). Override via `MCP_SESSION_TTL_MS` for tighter limits.
+ *
+ * `parsePositiveIntEnv` rejects `NaN` and non-positive values: a typo like
+ * `MCP_SESSION_TTL_MS=8h` would otherwise leave `SESSION_TTL_MS=NaN`, which
+ * silently disables eviction (NaN comparisons are always false) and the
+ * capacity cap eventually 429s every new client.
  */
-const MAX_MCP_SESSIONS = parseInt(process.env.MCP_MAX_SESSIONS ?? "100", 10);
-const SESSION_TTL_MS = parseInt(process.env.MCP_SESSION_TTL_MS ?? String(8 * 60 * 60 * 1000), 10);
+const MAX_MCP_SESSIONS = parsePositiveIntEnv("MCP_MAX_SESSIONS", 100);
+const SESSION_TTL_MS = parsePositiveIntEnv("MCP_SESSION_TTL_MS", 8 * 60 * 60 * 1000);
+
+/** Exported for unit testing. */
+export function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    log.warn(`[mcp] ignoring invalid ${name}="${raw}" (not a positive integer); using ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
 
 interface SessionEntry {
   transport: WebStandardStreamableHTTPServerTransport;

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -55,19 +55,21 @@ const MCP_SERVER_VERSION = process.env.NB_VERSION || mcpPkg.version;
  * TTL default is 8h: long enough that a connector left open during a working
  * day never expires mid-use. Sessions are evicted on idle, not absolute age,
  * so an actively-used connection survives indefinitely (each request bumps
- * `lastAccessedAt`). Override via `MCP_SESSION_TTL_MS` for tighter limits.
+ * `lastAccessedAt`). Override via `MCP_SESSION_TTL_SECONDS` for tighter
+ * limits. The internal sweep math is in milliseconds (matches `Date.now()`)
+ * but the operator-facing knob is in seconds — operators don't think in ms.
  *
- * `parsePositiveIntEnv` rejects non-positive and non-integer values to close
- * two failure modes the previous `parseInt(env, 10)` left open:
- *   - `MCP_SESSION_TTL_MS=8h` → `parseInt("8h", 10)` returned `8`, i.e. an
- *     8-millisecond TTL that evicted every session on the next sweep.
- *   - `MCP_SESSION_TTL_MS=foo` → `parseInt("foo", 10)` returned `NaN`, which
- *     silently disabled eviction (every comparison against NaN is false).
- * Both surface as runaway capacity-cap 429s. The new helper rejects either
- * shape with a warning and uses the in-code default.
+ * `parsePositiveIntEnv` rejects non-positive and non-integer values. The
+ * previous `parseInt(env, 10)` left two failure modes open: a typo like
+ * `8h` parsed to `8` (an 8-second TTL that evicted every session on the
+ * next sweep) and `foo` parsed to `NaN` (silently disabled eviction
+ * because every comparison against NaN is false). Both surface as runaway
+ * capacity-cap 429s. The helper rejects either shape with a warning and
+ * uses the in-code default.
  */
 const MAX_MCP_SESSIONS = parsePositiveIntEnv("MCP_MAX_SESSIONS", 100);
-const SESSION_TTL_MS = parsePositiveIntEnv("MCP_SESSION_TTL_MS", 8 * 60 * 60 * 1000);
+const SESSION_TTL_SECONDS = parsePositiveIntEnv("MCP_SESSION_TTL_SECONDS", 8 * 60 * 60);
+const SESSION_TTL_MS = SESSION_TTL_SECONDS * 1000;
 
 /** Exported for unit testing. */
 export function parsePositiveIntEnv(name: string, fallback: number): number {

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -21,6 +21,7 @@ import {
   type Resource,
   type ServerCapabilities,
 } from "@modelcontextprotocol/sdk/types.js";
+import { log } from "../cli/log.ts";
 import { isToolEnabled, isToolVisibleToRole, type ResolvedFeatures } from "../config/features.ts";
 import type { UserIdentity } from "../identity/provider.ts";
 import { type RequestContext, runWithRequestContext } from "../runtime/request-context.ts";
@@ -49,9 +50,15 @@ const mcpPkg = JSON.parse(readFileSync(mcpPkgPath, "utf-8")) as {
 // Prefer the build-time-injected git tag; fall back to package.json for local dev.
 const MCP_SERVER_VERSION = process.env.NB_VERSION || mcpPkg.version;
 
-/* ── Session limits (configurable via env) ── */
+/* ── Session limits (configurable via env) ──
+ *
+ * TTL default is 8h: long enough that a connector left open during a working
+ * day never expires mid-use. Sessions are evicted on idle, not absolute age,
+ * so an actively-used connection survives indefinitely (each request bumps
+ * `lastAccessedAt`). Override via `MCP_SESSION_TTL_MS` for tighter limits.
+ */
 const MAX_MCP_SESSIONS = parseInt(process.env.MCP_MAX_SESSIONS ?? "100", 10);
-const SESSION_TTL_MS = parseInt(process.env.MCP_SESSION_TTL_MS ?? String(30 * 60 * 1000), 10);
+const SESSION_TTL_MS = parseInt(process.env.MCP_SESSION_TTL_MS ?? String(8 * 60 * 60 * 1000), 10);
 
 interface SessionEntry {
   transport: WebStandardStreamableHTTPServerTransport;
@@ -428,6 +435,13 @@ async function handlePost(
   if (sessionId) {
     const entry = sessions.get(sessionId);
     if (!entry) {
+      // Surface session-not-found as a warning. The client is sending a real
+      // session ID we don't recognize — most often because the pod restarted,
+      // the session was swept on idle TTL, or (with future multi-replica) the
+      // request landed on a pod that doesn't own this session. Logging the
+      // prefix + identity + workspace lets us correlate with client reports
+      // without requiring NB_DEBUG.
+      log.warn(`[mcp] session miss ${fmtSessionContext(request, sessionId, workspaceCtx)}`);
       return new Response(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -457,6 +471,11 @@ async function handlePost(
   }
 
   if (!isInitializeRequest(body)) {
+    // Same diagnostic value as the 404 above: a non-init POST with no session
+    // ID typically means the client dropped its session ID without reinitializing.
+    log.warn(
+      `[mcp] non-init request without session id ${fmtSessionContext(request, null, workspaceCtx)}`,
+    );
     return new Response(
       JSON.stringify({
         jsonrpc: "2.0",
@@ -520,10 +539,31 @@ async function handleDelete(request: Request): Promise<Response> {
   }
   const entry = sessions.get(sessionId);
   if (!entry) {
+    // Routine: client closing a session we already reaped. Info-level so it
+    // shows up in correlation but doesn't trip alerting.
+    log.info(`[mcp] delete session miss ${fmtSessionContext(request, sessionId)}`);
     return new Response("Session not found", { status: 404 });
   }
   entry.lastAccessedAt = Date.now();
   return entry.transport.handleRequest(request);
+}
+
+/**
+ * Build a `key=value` log fragment with the request context that matters for
+ * session-miss diagnosis: a sessionId prefix (UUIDs are not sensitive but the
+ * prefix keeps lines greppable), workspace + identity (for cross-tenant
+ * correlation), and the client IP from `x-forwarded-for` (the ALB sets it).
+ */
+function fmtSessionContext(
+  request: Request,
+  sessionId: string | null,
+  workspaceCtx?: McpWorkspaceContext,
+): string {
+  const sidPrefix = sessionId ? sessionId.slice(0, 8) : "none";
+  const wsId = workspaceCtx?.workspaceId ?? "none";
+  const identityId = workspaceCtx?.identity?.id ?? "none";
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "direct";
+  return `sessionId=${sidPrefix} workspace=${wsId} identity=${identityId} ip=${ip}`;
 }
 
 /**

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -57,10 +57,14 @@ const MCP_SERVER_VERSION = process.env.NB_VERSION || mcpPkg.version;
  * so an actively-used connection survives indefinitely (each request bumps
  * `lastAccessedAt`). Override via `MCP_SESSION_TTL_MS` for tighter limits.
  *
- * `parsePositiveIntEnv` rejects `NaN` and non-positive values: a typo like
- * `MCP_SESSION_TTL_MS=8h` would otherwise leave `SESSION_TTL_MS=NaN`, which
- * silently disables eviction (NaN comparisons are always false) and the
- * capacity cap eventually 429s every new client.
+ * `parsePositiveIntEnv` rejects non-positive and non-integer values to close
+ * two failure modes the previous `parseInt(env, 10)` left open:
+ *   - `MCP_SESSION_TTL_MS=8h` → `parseInt("8h", 10)` returned `8`, i.e. an
+ *     8-millisecond TTL that evicted every session on the next sweep.
+ *   - `MCP_SESSION_TTL_MS=foo` → `parseInt("foo", 10)` returned `NaN`, which
+ *     silently disabled eviction (every comparison against NaN is false).
+ * Both surface as runaway capacity-cap 429s. The new helper rejects either
+ * shape with a warning and uses the in-code default.
  */
 const MAX_MCP_SESSIONS = parsePositiveIntEnv("MCP_MAX_SESSIONS", 100);
 const SESSION_TTL_MS = parsePositiveIntEnv("MCP_SESSION_TTL_MS", 8 * 60 * 60 * 1000);
@@ -431,7 +435,7 @@ export async function handleMcpRequest(
   }
 
   if (method === "DELETE") {
-    return handleDelete(request);
+    return handleDelete(request, workspaceCtx);
   }
 
   return new Response("Method Not Allowed", {
@@ -549,7 +553,10 @@ async function handlePost(
   return transport.handleRequest(request, { parsedBody: body });
 }
 
-async function handleDelete(request: Request): Promise<Response> {
+async function handleDelete(
+  request: Request,
+  workspaceCtx?: McpWorkspaceContext,
+): Promise<Response> {
   const sessionId = request.headers.get("mcp-session-id");
   if (!sessionId) {
     return new Response("Missing session ID", { status: 400 });
@@ -557,8 +564,10 @@ async function handleDelete(request: Request): Promise<Response> {
   const entry = sessions.get(sessionId);
   if (!entry) {
     // Routine: client closing a session we already reaped. Info-level so it
-    // shows up in correlation but doesn't trip alerting.
-    log.info(`[mcp] delete session miss ${fmtSessionContext(request, sessionId)}`);
+    // shows up in correlation but doesn't trip alerting. Thread the workspace
+    // context so the log line matches the format used by the POST 404 path —
+    // workspace + identity are exactly what cross-tenant correlation needs.
+    log.info(`[mcp] delete session miss ${fmtSessionContext(request, sessionId, workspaceCtx)}`);
     return new Response("Session not found", { status: 404 });
   }
   entry.lastAccessedAt = Date.now();

--- a/test/integration/mcp-server-endpoint.test.ts
+++ b/test/integration/mcp-server-endpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, afterAll, beforeAll } from "bun:test";
+import { describe, expect, it, afterAll, afterEach, beforeAll, beforeEach } from "bun:test";
 import { mkdirSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -7,12 +7,36 @@ import { createEchoModel } from "../helpers/echo-model.ts";
 import { createTestAuthAdapter } from "../helpers/test-auth-adapter.ts";
 import { startServer } from "../../src/api/server.ts";
 import type { ServerHandle } from "../../src/api/server.ts";
+import { log } from "../../src/cli/log.ts";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { ToolSource, Tool } from "../../src/tools/types.ts";
 import type { ToolResult } from "../../src/engine/types.ts";
 import { textContent } from "../../src/engine/content-helpers.ts";
 import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
+
+// ---------------------------------------------------------------------------
+// Log capture helper
+// ---------------------------------------------------------------------------
+//
+// The session-miss tests below assert on log content, not just status codes.
+// The whole reason this PR's logs exist is to make session-miss diagnoseable
+// in production — if a future refactor silently drops the `log.warn` calls,
+// status codes alone wouldn't catch it. Capturing also keeps stderr clean of
+// the yellow `[mcp] session miss` lines that the tests deliberately provoke.
+function captureLogs(): { lines: string[]; restore: () => void } {
+	const lines: string[] = [];
+	const orig = { warn: log.warn, info: log.info };
+	log.warn = (msg: string) => lines.push(`warn ${msg}`);
+	log.info = (msg: string) => lines.push(`info ${msg}`);
+	return {
+		lines,
+		restore: () => {
+			log.warn = orig.warn;
+			log.info = orig.info;
+		},
+	};
+}
 
 // ---------------------------------------------------------------------------
 // Fake tool source for testing
@@ -187,60 +211,99 @@ describe("MCP Server Endpoint (/mcp)", () => {
 	});
 
 	// Session-miss surface: a POST carrying an unknown session ID must return
-	// 404 with a JSON-RPC error envelope. This is the fault the client sees
-	// after a pod restart, an idle-TTL sweep, or (with future multi-replica)
-	// a misrouted request — exactly what `[mcp] session miss` is logged for.
-	it("returns 404 for POST /mcp with an unknown session id", async () => {
-		const res = await fetch(`${baseUrl}/mcp`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Accept: "application/json, text/event-stream",
-				"x-workspace-id": TEST_WORKSPACE_ID,
-				"mcp-session-id": "00000000-0000-0000-0000-000000000000",
-			},
-			body: JSON.stringify({
-				jsonrpc: "2.0",
-				method: "tools/list",
-				id: 1,
-			}),
+	// 404 with a JSON-RPC error envelope AND emit a structured log line.
+	// This is the fault the client sees after a pod restart, an idle-TTL
+	// sweep, or (with future multi-replica) a misrouted request — exactly
+	// what `[mcp] session miss` is logged for.
+	describe("session-miss logging", () => {
+		let capture: ReturnType<typeof captureLogs>;
+		beforeEach(() => {
+			capture = captureLogs();
 		});
-		expect(res.status).toBe(404);
-		const body = (await res.json()) as {
-			error?: { code: number; message: string };
-		};
-		expect(body.error?.code).toBe(-32000);
-		expect(body.error?.message).toBe("Session not found");
-	});
+		afterEach(() => {
+			capture.restore();
+		});
 
-	// Companion case: a non-init POST with no session id at all. Different
-	// code path (we never look in the map) but the same client confusion.
-	it("returns 400 for POST /mcp without a session id when method is not initialize", async () => {
-		const res = await fetch(`${baseUrl}/mcp`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Accept: "application/json, text/event-stream",
-				"x-workspace-id": TEST_WORKSPACE_ID,
-			},
-			body: JSON.stringify({
-				jsonrpc: "2.0",
-				method: "tools/list",
-				id: 1,
-			}),
-		});
-		expect(res.status).toBe(400);
-	});
+		it("returns 404 and warn-logs key=value context for POST with unknown session id", async () => {
+			const res = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Accept: "application/json, text/event-stream",
+					"x-workspace-id": TEST_WORKSPACE_ID,
+					"mcp-session-id": "00000000-0000-0000-0000-000000000000",
+				},
+				body: JSON.stringify({
+					jsonrpc: "2.0",
+					method: "tools/list",
+					id: 1,
+				}),
+			});
+			expect(res.status).toBe(404);
+			const body = (await res.json()) as {
+				error?: { code: number; message: string };
+			};
+			expect(body.error?.code).toBe(-32000);
+			expect(body.error?.message).toBe("Session not found");
 
-	it("returns 404 for DELETE /mcp with an unknown session id", async () => {
-		const res = await fetch(`${baseUrl}/mcp`, {
-			method: "DELETE",
-			headers: {
-				"x-workspace-id": TEST_WORKSPACE_ID,
-				"mcp-session-id": "00000000-0000-0000-0000-000000000000",
-			},
+			// The whole point of this PR: a structured log line we can grep
+			// for in prod. Asserting prefix + key=value shape rather than
+			// the exact string lets future tweaks to wording survive.
+			const line = capture.lines.find((l) => l.startsWith("warn [mcp] session miss"));
+			expect(line).toBeDefined();
+			expect(line).toContain("sessionId=00000000");
+			expect(line).toContain(`workspace=${TEST_WORKSPACE_ID}`);
+			expect(line).toMatch(/identity=\S+/);
+			expect(line).toMatch(/ip=\S+/);
 		});
-		expect(res.status).toBe(404);
+
+		// Companion case: a non-init POST with no session id at all. Different
+		// code path (we never look in the map) but the same client confusion.
+		it("returns 400 and warn-logs for non-init POST without a session id", async () => {
+			const res = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Accept: "application/json, text/event-stream",
+					"x-workspace-id": TEST_WORKSPACE_ID,
+				},
+				body: JSON.stringify({
+					jsonrpc: "2.0",
+					method: "tools/list",
+					id: 1,
+				}),
+			});
+			expect(res.status).toBe(400);
+
+			const line = capture.lines.find((l) =>
+				l.startsWith("warn [mcp] non-init request without session id"),
+			);
+			expect(line).toBeDefined();
+			expect(line).toContain("sessionId=none");
+			expect(line).toContain(`workspace=${TEST_WORKSPACE_ID}`);
+		});
+
+		it("returns 404 and info-logs context (incl. workspace) for DELETE with unknown session id", async () => {
+			const res = await fetch(`${baseUrl}/mcp`, {
+				method: "DELETE",
+				headers: {
+					"x-workspace-id": TEST_WORKSPACE_ID,
+					"mcp-session-id": "00000000-0000-0000-0000-000000000000",
+				},
+			});
+			expect(res.status).toBe(404);
+
+			// Regression guard: the workspace context must reach the DELETE
+			// log line, not just the POST ones. An earlier version of this
+			// PR dropped `workspaceCtx` at the route → handler boundary and
+			// the DELETE log emitted `workspace=none identity=none`, which
+			// defeated the cross-tenant correlation the PR exists to enable.
+			const line = capture.lines.find((l) => l.startsWith("info [mcp] delete session miss"));
+			expect(line).toBeDefined();
+			expect(line).toContain("sessionId=00000000");
+			expect(line).toContain(`workspace=${TEST_WORKSPACE_ID}`);
+			expect(line).toMatch(/identity=\S+/);
+		});
 	});
 });
 

--- a/test/integration/mcp-server-endpoint.test.ts
+++ b/test/integration/mcp-server-endpoint.test.ts
@@ -185,6 +185,63 @@ describe("MCP Server Endpoint (/mcp)", () => {
 		expect(res.headers.get("allow")).toBe("POST, DELETE");
 		await res.body?.cancel();
 	});
+
+	// Session-miss surface: a POST carrying an unknown session ID must return
+	// 404 with a JSON-RPC error envelope. This is the fault the client sees
+	// after a pod restart, an idle-TTL sweep, or (with future multi-replica)
+	// a misrouted request — exactly what `[mcp] session miss` is logged for.
+	it("returns 404 for POST /mcp with an unknown session id", async () => {
+		const res = await fetch(`${baseUrl}/mcp`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Accept: "application/json, text/event-stream",
+				"x-workspace-id": TEST_WORKSPACE_ID,
+				"mcp-session-id": "00000000-0000-0000-0000-000000000000",
+			},
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				method: "tools/list",
+				id: 1,
+			}),
+		});
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as {
+			error?: { code: number; message: string };
+		};
+		expect(body.error?.code).toBe(-32000);
+		expect(body.error?.message).toBe("Session not found");
+	});
+
+	// Companion case: a non-init POST with no session id at all. Different
+	// code path (we never look in the map) but the same client confusion.
+	it("returns 400 for POST /mcp without a session id when method is not initialize", async () => {
+		const res = await fetch(`${baseUrl}/mcp`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Accept: "application/json, text/event-stream",
+				"x-workspace-id": TEST_WORKSPACE_ID,
+			},
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				method: "tools/list",
+				id: 1,
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 404 for DELETE /mcp with an unknown session id", async () => {
+		const res = await fetch(`${baseUrl}/mcp`, {
+			method: "DELETE",
+			headers: {
+				"x-workspace-id": TEST_WORKSPACE_ID,
+				"mcp-session-id": "00000000-0000-0000-0000-000000000000",
+			},
+		});
+		expect(res.status).toBe(404);
+	});
 });
 
 describe("MCP Server Auth", () => {

--- a/test/unit/api/mcp-server-env.test.ts
+++ b/test/unit/api/mcp-server-env.test.ts
@@ -1,47 +1,76 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { parsePositiveIntEnv } from "../../../src/api/mcp-server.ts";
+import { log } from "../../../src/cli/log.ts";
 
 const ENV_NAME = "__MCP_TEST_PARSE_INT__";
 
 describe("parsePositiveIntEnv", () => {
+	// Failure cases deliberately exercise log.warn. Capture instead of letting
+	// the yellow lines stream to stderr — both to keep test output clean and to
+	// assert the warning actually fires when the input is rejected. Restore on
+	// each test so an early `expect` failure can't leak the patched log.warn
+	// into unrelated tests.
+	let warned: string[];
+	let originalWarn: typeof log.warn;
+
+	beforeEach(() => {
+		warned = [];
+		originalWarn = log.warn;
+		log.warn = (msg: string) => warned.push(msg);
+	});
+
 	afterEach(() => {
+		log.warn = originalWarn;
 		delete process.env[ENV_NAME];
 	});
 
 	it("returns the fallback when the env var is unset", () => {
 		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+		expect(warned).toEqual([]);
 	});
 
 	it("returns the fallback for an empty string", () => {
 		process.env[ENV_NAME] = "";
 		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+		expect(warned).toEqual([]);
 	});
 
 	it("parses a valid positive integer", () => {
 		process.env[ENV_NAME] = "1800000";
 		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(1_800_000);
+		expect(warned).toEqual([]);
 	});
 
-	// The footgun this guard exists for: a typo like `8h` parses as NaN under
-	// the previous parseInt path, which then silently disabled eviction
-	// because every comparison against NaN is false.
-	it("returns the fallback for non-numeric input", () => {
+	// The two failure modes this guard exists for:
+	//   - `parseInt("8h", 10)` previously returned `8` (an 8 ms TTL — every
+	//     session evicted on the next sweep).
+	//   - `Number("8h")` returns `NaN`, which silently disables eviction.
+	// Both are bad; both are now rejected with a warning + fallback.
+	it("rejects non-numeric input with a warning", () => {
 		process.env[ENV_NAME] = "8h";
 		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+		expect(warned).toHaveLength(1);
+		expect(warned[0]).toContain(`[mcp] ignoring invalid ${ENV_NAME}="8h"`);
 	});
 
-	it("returns the fallback for zero", () => {
+	it("rejects zero with a warning", () => {
 		process.env[ENV_NAME] = "0";
 		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+		expect(warned).toHaveLength(1);
+		expect(warned[0]).toContain(`[mcp] ignoring invalid ${ENV_NAME}="0"`);
 	});
 
-	it("returns the fallback for a negative integer", () => {
+	it("rejects a negative integer with a warning", () => {
 		process.env[ENV_NAME] = "-1";
 		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+		expect(warned).toHaveLength(1);
+		expect(warned[0]).toContain(`[mcp] ignoring invalid ${ENV_NAME}="-1"`);
 	});
 
-	it("returns the fallback for a decimal", () => {
+	it("rejects a decimal with a warning", () => {
 		process.env[ENV_NAME] = "1.5";
 		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+		expect(warned).toHaveLength(1);
+		expect(warned[0]).toContain(`[mcp] ignoring invalid ${ENV_NAME}="1.5"`);
 	});
 });

--- a/test/unit/api/mcp-server-env.test.ts
+++ b/test/unit/api/mcp-server-env.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { parsePositiveIntEnv } from "../../../src/api/mcp-server.ts";
+
+const ENV_NAME = "__MCP_TEST_PARSE_INT__";
+
+describe("parsePositiveIntEnv", () => {
+	afterEach(() => {
+		delete process.env[ENV_NAME];
+	});
+
+	it("returns the fallback when the env var is unset", () => {
+		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+	});
+
+	it("returns the fallback for an empty string", () => {
+		process.env[ENV_NAME] = "";
+		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+	});
+
+	it("parses a valid positive integer", () => {
+		process.env[ENV_NAME] = "1800000";
+		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(1_800_000);
+	});
+
+	// The footgun this guard exists for: a typo like `8h` parses as NaN under
+	// the previous parseInt path, which then silently disabled eviction
+	// because every comparison against NaN is false.
+	it("returns the fallback for non-numeric input", () => {
+		process.env[ENV_NAME] = "8h";
+		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+	});
+
+	it("returns the fallback for zero", () => {
+		process.env[ENV_NAME] = "0";
+		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+	});
+
+	it("returns the fallback for a negative integer", () => {
+		process.env[ENV_NAME] = "-1";
+		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+	});
+
+	it("returns the fallback for a decimal", () => {
+		process.env[ENV_NAME] = "1.5";
+		expect(parsePositiveIntEnv(ENV_NAME, 42)).toBe(42);
+	});
+});


### PR DESCRIPTION
## Summary

The 30-minute idle TTL on MCP sessions was sweeping connector sessions mid-workday — every sweep returns 404 to the next request, which surfaces as a "timeout" on the client. This is the immediate fix.

- **TTL default 30 min → 8 h.** Sessions are evicted on idle, not absolute age, so an actively-used connection survives indefinitely (each request bumps `lastAccessedAt`).
- **`MCP_SESSION_TTL_MS` env var renamed to `MCP_SESSION_TTL_SECONDS`** *(breaking)*. Operator-facing knobs should use the unit operators think in — nobody sets a sub-second timeout, and `28800000` is hostile to read when the actual value is 8 hours. Seconds also matches every adjacent abstraction (K8s timeouts, ALB `idle_timeout.timeout_seconds`, ALB `stickiness.lb_cookie.duration_seconds`, Redis EXPIRE). Internal sweep math stays in ms; conversion happens once at the env-parse boundary.
- **`parsePositiveIntEnv` guard** rejects non-positive and non-integer values. The previous `parseInt(env, 10)` left two failure modes open: `8h` parsed to `8` (an 8-second TTL that evicted every session on the next sweep), and `foo` parsed to `NaN` (silently disabled eviction). Both surfaced as runaway capacity-cap 429s.
- **Structured logging at the three session-confusion paths** so this class of issue is diagnoseable without `NB_DEBUG`:
  - POST `/mcp` with unknown session id → `warn`
  - POST `/mcp` non-init without session id → `warn`
  - DELETE `/mcp` with unknown session id → `info`

Each log line carries `sessionId=<8-char prefix> workspace=<id> identity=<id> ip=<x-forwarded-for>` for cross-tenant correlation.

This is the unblock-today fix. The architectural work (pluggable `SessionRegistry`, Redis provider, Helm `RollingUpdate` + ALB stickiness for horizontal scale) is in NimbleBrainInc/nimblebrain#162.

## Breaking changes

`MCP_SESSION_TTL_MS` → `MCP_SESSION_TTL_SECONDS`. **Any existing deployment setting the old env var will silently fall through to the new 8h default.** Mention in release notes; update operator docs (handled in the docs PR).

## Test plan

- [x] `bun run verify` (unit + integration + smoke; 2274+ tests).
- [x] New unit tests cover `parsePositiveIntEnv` for 7 input shapes (unset/empty/valid/non-numeric/zero/negative/decimal). Each rejection case asserts the warning fires.
- [x] New integration tests for the three log branches assert both status codes AND structured log fragments (`sessionId=`, `workspace=`, `identity=`, `ip=`) via a `captureLogs()` spy. The earlier QA review caught that workspace context wasn't reaching the DELETE path; the test now asserts it does.
- [x] Manual smoke test against running dev server.
- [x] Bootstrap endpoint loads cleanly in Chrome.