### PR TITLE
feat(api): SessionRegistry abstraction + Redis provider + classified session-miss

### DIFF
--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -3,6 +3,35 @@
  *
  * External MCP clients (Claude Code, Open WebUI, etc.) connect to /mcp and
  * access all installed tools through the standard MCP protocol.
+ *
+ * Two-layer state architecture:
+ *
+ *   1. **Transport map** (per-process, in-memory, never abstracted) — owns
+ *      the live `WebStandardStreamableHTTPServerTransport`, the SDK `Server`
+ *      instance with its registered handlers, and any in-flight JSON-RPC
+ *      state. Process-bound: holds open response streams and JS object
+ *      references that cannot be serialized or moved.
+ *
+ *   2. **SessionRegistry** (pluggable; see `./session-store/`) — cluster-
+ *      shared metadata. Tells us whether a session exists, when it was last
+ *      touched, and which workspace + identity it's bound to. Deliberately
+ *      deployment-vocabulary-free — no pod, no instance, no ownership.
+ *      Routing requests to the process that owns a session's transport is
+ *      the load balancer's job (cookie stickiness, header-hash), not the
+ *      registry's.
+ *
+ * On a request whose sessionId we don't have a local transport for:
+ *
+ *   - Registry says nothing exists → `not_found`. Session evicted or never
+ *     created.
+ *   - Registry says it exists      → `unavailable`. The live transport isn't
+ *     on this process. Could be: process restart, sticky-routing miss,
+ *     local transport closed, anything. Client's correct action is the
+ *     same in either case: re-initialize.
+ *
+ * Both return 404 with a JSON-RPC envelope; `error.data.reason` lets
+ * operators correlate logs without the registry having to know what an
+ * "instance" is.
  */
 
 import { readFileSync } from "node:fs";
@@ -33,6 +62,7 @@ import {
   type OwnerContext,
   type TaskAwareSource,
 } from "./mcp-task-store.ts";
+import type { SessionRegistry } from "./session-store/index.ts";
 
 /**
  * JSON-RPC error code for "resource not found".
@@ -50,28 +80,27 @@ const mcpPkg = JSON.parse(readFileSync(mcpPkgPath, "utf-8")) as {
 // Prefer the build-time-injected git tag; fall back to package.json for local dev.
 const MCP_SERVER_VERSION = process.env.NB_VERSION || mcpPkg.version;
 
-/* ── Session limits (configurable via env) ──
+/* ── Capacity limit (configurable via env) ──
  *
- * TTL default is 8h: long enough that a connector left open during a working
- * day never expires mid-use. Sessions are evicted on idle, not absolute age,
- * so an actively-used connection survives indefinitely (each request bumps
- * `lastAccessedAt`). Override via `MCP_SESSION_TTL_SECONDS` for tighter
- * limits. The internal sweep math is in milliseconds (matches `Date.now()`)
- * but the operator-facing knob is in seconds — operators don't think in ms.
+ * Sessions are evicted on idle TTL (managed by the injected SessionRegistry,
+ * not by this module). The cap below is a memory ceiling on the local
+ * transport map: a misbehaving client that re-inits on every request can't
+ * blow the heap by allocating transports faster than the registry's TTL
+ * reclaims them. Override via `MCP_MAX_SESSIONS`.
  *
- * `parsePositiveIntEnv` rejects non-positive and non-integer values. The
- * previous `parseInt(env, 10)` left two failure modes open: a typo like
- * `8h` parsed to `8` (an 8-second TTL that evicted every session on the
- * next sweep) and `foo` parsed to `NaN` (silently disabled eviction
- * because every comparison against NaN is false). Both surface as runaway
- * capacity-cap 429s. The helper rejects either shape with a warning and
- * uses the in-code default.
+ * The TTL knob (`MCP_SESSION_TTL_SECONDS` / `sessionStore.ttlSeconds`) is
+ * applied in `Runtime.getSessionStoreTtlMs()` — it shapes the registry,
+ * not this map.
  */
 const MAX_MCP_SESSIONS = parsePositiveIntEnv("MCP_MAX_SESSIONS", 100);
-const SESSION_TTL_SECONDS = parsePositiveIntEnv("MCP_SESSION_TTL_SECONDS", 8 * 60 * 60);
-const SESSION_TTL_MS = SESSION_TTL_SECONDS * 1000;
 
-/** Exported for unit testing. */
+/**
+ * Validate a positive-integer env var. Rejects NaN / non-positive values
+ * (e.g. `8h` typo) and falls back loudly so silent eviction-disabled state
+ * can't ship to prod undetected.
+ *
+ * Exported for unit testing.
+ */
 export function parsePositiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw === "") return fallback;
@@ -83,45 +112,10 @@ export function parsePositiveIntEnv(name: string, fallback: number): number {
   return parsed;
 }
 
-interface SessionEntry {
+interface TransportEntry {
   transport: WebStandardStreamableHTTPServerTransport;
-  createdAt: number;
-  lastAccessedAt: number;
+  workspaceId: string;
 }
-
-/** Active sessions keyed by session ID. */
-const sessions = new Map<string, SessionEntry>();
-
-/** Periodic cleanup interval handle. */
-let cleanupInterval: ReturnType<typeof setInterval> | null = null;
-
-/** Close and delete sessions that have exceeded the TTL. */
-function sweepExpiredSessions(): void {
-  const now = Date.now();
-  for (const [sid, entry] of sessions) {
-    if (now - entry.lastAccessedAt > SESSION_TTL_MS) {
-      try {
-        entry.transport.close();
-      } catch {
-        // Ignore close errors during sweep
-      }
-      sessions.delete(sid);
-    }
-  }
-}
-
-/** Start the periodic session cleanup (60s interval). */
-function startSessionCleanup(): void {
-  if (cleanupInterval) return;
-  cleanupInterval = setInterval(sweepExpiredSessions, 60_000);
-  // Allow the process to exit even if the interval is active
-  if (cleanupInterval && typeof cleanupInterval === "object" && "unref" in cleanupInterval) {
-    cleanupInterval.unref();
-  }
-}
-
-// Start cleanup on module load
-startSessionCleanup();
 
 /** Workspace context captured at session creation time. */
 export interface McpWorkspaceContext {
@@ -144,6 +138,268 @@ const TASKS_CAPABILITY: NonNullable<ServerCapabilities["tasks"]> = {
   cancel: {},
   requests: { tools: { call: {} } },
 };
+
+/**
+ * Per-process MCP HTTP host. Owns the in-process transport map and delegates
+ * cluster-shared session metadata to the injected `SessionRegistry`.
+ *
+ * One instance per process. Constructed in `startServer`, threaded through
+ * `AppContext`, used by `routes/mcp.ts`.
+ */
+export class McpServerHost {
+  private readonly transports = new Map<string, TransportEntry>();
+  private readonly registry: SessionRegistry;
+
+  constructor(opts: { registry: SessionRegistry }) {
+    this.registry = opts.registry;
+  }
+
+  /**
+   * Handle an incoming HTTP request on the /mcp path.
+   *
+   * - POST: JSON-RPC messages (initialization or subsequent)
+   * - GET:  405 — see comment below
+   * - DELETE: Session termination
+   *
+   * GET /mcp is the spec's *optional* server→client SSE channel for
+   * notifications outside any in-flight request (broadcast notifications,
+   * sampling, elicitation). We don't push anything down it: tool responses
+   * and task progress flow on the POST that started them, and our own
+   * server→client signaling for the iframe app (data.changed, conversation
+   * events, heartbeats) goes through `/v1/events`, not MCP.
+   *
+   * Holding the connection open with nothing to write meant Bun's
+   * `idleTimeout` (max 255s) — and any L7 proxy in front of the API (Vite
+   * dev proxy, ALB's 60s default, nginx) — would silently kill the socket,
+   * surfacing as `socket hang up` upstream and triggering the SDK's
+   * limited reconnect loop (default `maxRetries: 2`).
+   *
+   * Returning 405 is the spec-blessed escape hatch: the SDK explicitly
+   * treats it as "server doesn't offer GET-style listening" and gracefully
+   * runs POST-only (`@modelcontextprotocol/sdk/.../client/streamableHttp.js`
+   * in `_startOrAuthSse`). If we ever start emitting standalone-stream
+   * notifications, switch this back to a real handler and add a heartbeat
+   * (see `src/api/sse-heartbeat.ts`).
+   */
+  async handle(
+    request: Request,
+    toolRegistry: ToolRegistry,
+    features: ResolvedFeatures,
+    workspaceCtx?: McpWorkspaceContext,
+  ): Promise<Response> {
+    const method = request.method;
+    if (method === "POST") return this.handlePost(request, toolRegistry, features, workspaceCtx);
+    if (method === "DELETE") return this.handleDelete(request, workspaceCtx);
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "POST, DELETE" },
+    });
+  }
+
+  /**
+   * Close every transport this pod owns and shut the registry down. Called
+   * during graceful server stop.
+   */
+  async shutdown(): Promise<void> {
+    for (const [sid, entry] of this.transports) {
+      try {
+        await entry.transport.close();
+      } catch {
+        // Ignore close errors during shutdown
+      }
+      this.transports.delete(sid);
+    }
+    await this.registry.shutdown();
+  }
+
+  /** Test-only: number of locally-held transports. */
+  transportCount(): number {
+    return this.transports.size;
+  }
+
+  // ─── private ──────────────────────────────────────────────────────
+
+  private async handlePost(
+    request: Request,
+    toolRegistry: ToolRegistry,
+    features: ResolvedFeatures,
+    workspaceCtx?: McpWorkspaceContext,
+  ): Promise<Response> {
+    const sessionId = request.headers.get("mcp-session-id");
+
+    if (sessionId) {
+      const local = this.transports.get(sessionId);
+      if (local) {
+        // Fast path: we own this transport. Best-effort registry touch
+        // keeps the cluster-shared TTL aligned without blocking the request.
+        this.registry.touch(sessionId, Date.now()).catch((err) => {
+          log.warn(`[mcp] registry touch failed: ${(err as Error).message}`);
+        });
+        return local.transport.handleRequest(request);
+      }
+      return this.localMissResponse(request, sessionId, workspaceCtx);
+    }
+
+    // No session id — must be an initialize.
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return jsonRpcError(400, -32700, "Parse error");
+    }
+
+    if (!isInitializeRequest(body)) {
+      log.warn(
+        `[mcp] non-init request without session id ${fmtSessionContext(request, null, workspaceCtx)}`,
+      );
+      return jsonRpcError(400, -32000, "Bad Request: No valid session ID provided");
+    }
+
+    if (this.transports.size >= MAX_MCP_SESSIONS) {
+      return jsonRpcError(429, -32000, "Too many active sessions");
+    }
+
+    return this.initializeSession(request, body, toolRegistry, features, workspaceCtx);
+  }
+
+  private async handleDelete(
+    request: Request,
+    workspaceCtx?: McpWorkspaceContext,
+  ): Promise<Response> {
+    const sessionId = request.headers.get("mcp-session-id");
+    if (!sessionId) return new Response("Missing session ID", { status: 400 });
+    const local = this.transports.get(sessionId);
+    if (!local) {
+      // Thread the workspace context so the log line carries `workspace=...`
+      // and `identity=...` — exactly the cross-tenant correlation context
+      // operators need to distinguish noisy clients from real eviction.
+      log.info(`[mcp] delete session miss ${fmtSessionContext(request, sessionId, workspaceCtx)}`);
+      // Mirror the POST cleanup: registry delete is best-effort so a stale
+      // entry doesn't linger after a client says "I'm done."
+      this.bestEffortDelete(sessionId);
+      return new Response("Session not found", { status: 404 });
+    }
+    return local.transport.handleRequest(request);
+  }
+
+  /**
+   * Build the 404 response when the local transport map doesn't contain the
+   * requested session ID. The `error.data.reason` distinguishes:
+   *
+   *   - `not_found` — the registry has no entry. Session evicted by TTL,
+   *     never existed, or already deleted.
+   *   - `unavailable` — the registry has an entry, but the live transport
+   *     isn't on this process. Could be a process restart (transport state
+   *     was lost) or a sticky-routing miss (the request landed on a process
+   *     that didn't initialize this session). Client should re-initialize
+   *     either way; operators distinguish via deploy timing, uptime, and
+   *     "registry size vs local transport count" signals.
+   */
+  private async localMissResponse(
+    request: Request,
+    sessionId: string,
+    workspaceCtx?: McpWorkspaceContext,
+  ): Promise<Response> {
+    const meta = await this.safeRegistryGet(sessionId);
+    const ctx = fmtSessionContext(request, sessionId, workspaceCtx);
+
+    const reason: "not_found" | "unavailable" = meta ? "unavailable" : "not_found";
+    log.warn(`[mcp] session miss reason=${reason} ${ctx}`);
+
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Session not found", data: { reason } },
+        id: null,
+      }),
+      { status: 404, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  /**
+   * Wrap `registry.get` so a registry outage degrades to "treat as missing"
+   * rather than killing the request. The local transport map already
+   * answered "I don't have it"; the worst case here is we report `not_found`
+   * instead of a more specific reason — still a useful 404.
+   */
+  private async safeRegistryGet(
+    sessionId: string,
+  ): Promise<Awaited<ReturnType<SessionRegistry["get"]>>> {
+    try {
+      return await this.registry.get(sessionId);
+    } catch (err) {
+      log.warn(`[mcp] registry get failed: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  private async initializeSession(
+    request: Request,
+    parsedBody: unknown,
+    toolRegistry: ToolRegistry,
+    features: ResolvedFeatures,
+    workspaceCtx: McpWorkspaceContext | undefined,
+  ): Promise<Response> {
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      onsessioninitialized: (sid: string) => {
+        const now = Date.now();
+        const wsId = workspaceCtx?.workspaceId;
+        if (!wsId) {
+          // Should never happen — `routes/mcp.ts` enforces workspace
+          // resolution before reaching the host. Fail loudly so a future
+          // refactor can't slip past this guarantee silently.
+          log.warn("[mcp] session init reached host without workspaceId — closing transport");
+          transport.close().catch(() => {});
+          return;
+        }
+
+        this.transports.set(sid, { transport, workspaceId: wsId });
+        // Fire-and-forget the registry write. The session is already live
+        // on this process; if the registry is down we still serve the client.
+        this.registry
+          .create({
+            sessionId: sid,
+            identityId: workspaceCtx?.identity?.id ?? null,
+            workspaceId: wsId,
+            createdAt: now,
+            lastAccessedAt: now,
+          })
+          .catch((err) => {
+            log.warn(`[mcp] registry create failed: ${(err as Error).message}`);
+          });
+      },
+      onsessionclosed: (sid: string) => {
+        this.transports.delete(sid);
+        this.bestEffortDelete(sid);
+      },
+    });
+
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        this.transports.delete(transport.sessionId);
+        this.bestEffortDelete(transport.sessionId);
+      }
+    };
+
+    const server = createServer(toolRegistry, features, workspaceCtx);
+    await server.connect(transport);
+    return transport.handleRequest(request, { parsedBody });
+  }
+
+  /**
+   * Best-effort registry delete on session teardown. Failures are not fatal
+   * (the local transport is already gone; the registry entry will TTL out)
+   * but we log them so a chronically-failing Redis surfaces in the same
+   * observability stream as `session miss` warnings rather than vanishing
+   * into a silent `.catch`.
+   */
+  private bestEffortDelete(sessionId: string): void {
+    this.registry.delete(sessionId).catch((err) => {
+      log.warn(`[mcp] registry delete failed: ${(err as Error).message}`);
+    });
+  }
+}
 
 /**
  * Create a new MCP Server instance wired to the given ToolRegistry.
@@ -397,183 +653,16 @@ function createServer(
   return server;
 }
 
-/**
- * Handle an incoming HTTP request on the /mcp path.
- *
- * - POST: JSON-RPC messages (initialization or subsequent)
- * - GET:  405 — see comment below
- * - DELETE: Session termination
- *
- * GET /mcp is the spec's *optional* server→client SSE channel for
- * notifications outside any in-flight request (broadcast notifications,
- * sampling, elicitation). We don't push anything down it: tool responses
- * and task progress flow on the POST that started them, and our own
- * server→client signaling for the iframe app (data.changed, conversation
- * events, heartbeats) goes through `/v1/events`, not MCP.
- *
- * Holding the connection open with nothing to write meant Bun's
- * `idleTimeout` (max 255s) — and any L7 proxy in front of the API (Vite
- * dev proxy, ALB's 60s default, nginx) — would silently kill the socket,
- * surfacing as `socket hang up` upstream and triggering the SDK's
- * limited reconnect loop (default `maxRetries: 2`).
- *
- * Returning 405 is the spec-blessed escape hatch: the SDK explicitly
- * treats it as "server doesn't offer GET-style listening" and gracefully
- * runs POST-only (`@modelcontextprotocol/sdk/.../client/streamableHttp.js`
- * in `_startOrAuthSse`). If we ever start emitting standalone-stream
- * notifications, switch this back to a real handler and add a heartbeat
- * (see `src/api/sse-heartbeat.ts`).
- */
-export async function handleMcpRequest(
-  request: Request,
-  registry: ToolRegistry,
-  features: ResolvedFeatures,
-  workspaceCtx?: McpWorkspaceContext,
-): Promise<Response> {
-  const method = request.method;
-
-  if (method === "POST") {
-    return handlePost(request, registry, features, workspaceCtx);
-  }
-
-  if (method === "DELETE") {
-    return handleDelete(request, workspaceCtx);
-  }
-
-  return new Response("Method Not Allowed", {
-    status: 405,
-    headers: { Allow: "POST, DELETE" },
-  });
-}
-
-async function handlePost(
-  request: Request,
-  registry: ToolRegistry,
-  features: ResolvedFeatures,
-  workspaceCtx?: McpWorkspaceContext,
-): Promise<Response> {
-  const sessionId = request.headers.get("mcp-session-id");
-
-  // Existing session — reuse transport
-  if (sessionId) {
-    const entry = sessions.get(sessionId);
-    if (!entry) {
-      // Surface session-not-found as a warning. The client is sending a real
-      // session ID we don't recognize — most often because the pod restarted,
-      // the session was swept on idle TTL, or (with future multi-replica) the
-      // request landed on a pod that doesn't own this session. Logging the
-      // prefix + identity + workspace lets us correlate with client reports
-      // without requiring NB_DEBUG.
-      log.warn(`[mcp] session miss ${fmtSessionContext(request, sessionId, workspaceCtx)}`);
-      return new Response(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          error: { code: -32000, message: "Session not found" },
-          id: null,
-        }),
-        { status: 404, headers: { "Content-Type": "application/json" } },
-      );
-    }
-    entry.lastAccessedAt = Date.now();
-    return entry.transport.handleRequest(request);
-  }
-
-  // New session — check if this is an initialize request
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return new Response(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        error: { code: -32700, message: "Parse error" },
-        id: null,
-      }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
-  }
-
-  if (!isInitializeRequest(body)) {
-    // Same diagnostic value as the 404 above: a non-init POST with no session
-    // ID typically means the client dropped its session ID without reinitializing.
-    log.warn(
-      `[mcp] non-init request without session id ${fmtSessionContext(request, null, workspaceCtx)}`,
-    );
-    return new Response(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Bad Request: No valid session ID provided",
-        },
-        id: null,
-      }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
-  }
-
-  // Evict expired sessions and enforce capacity limit
-  sweepExpiredSessions();
-  if (sessions.size >= MAX_MCP_SESSIONS) {
-    return new Response(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Too many active sessions",
-        },
-        id: null,
-      }),
-      { status: 429, headers: { "Content-Type": "application/json" } },
-    );
-  }
-
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: () => crypto.randomUUID(),
-    onsessioninitialized: (sid: string) => {
-      const now = Date.now();
-      sessions.set(sid, {
-        transport,
-        createdAt: now,
-        lastAccessedAt: now,
-      });
-    },
-    onsessionclosed: (sid: string) => {
-      sessions.delete(sid);
-    },
-  });
-
-  transport.onclose = () => {
-    if (transport.sessionId) {
-      sessions.delete(transport.sessionId);
-    }
-  };
-
-  const server = createServer(registry, features, workspaceCtx);
-  await server.connect(transport);
-
-  return transport.handleRequest(request, { parsedBody: body });
-}
-
-async function handleDelete(
-  request: Request,
-  workspaceCtx?: McpWorkspaceContext,
-): Promise<Response> {
-  const sessionId = request.headers.get("mcp-session-id");
-  if (!sessionId) {
-    return new Response("Missing session ID", { status: 400 });
-  }
-  const entry = sessions.get(sessionId);
-  if (!entry) {
-    // Routine: client closing a session we already reaped. Info-level so it
-    // shows up in correlation but doesn't trip alerting. Thread the workspace
-    // context so the log line matches the format used by the POST 404 path —
-    // workspace + identity are exactly what cross-tenant correlation needs.
-    log.info(`[mcp] delete session miss ${fmtSessionContext(request, sessionId, workspaceCtx)}`);
-    return new Response("Session not found", { status: 404 });
-  }
-  entry.lastAccessedAt = Date.now();
-  return entry.transport.handleRequest(request);
+/** JSON-RPC error response with the proper headers. */
+function jsonRpcError(status: number, code: number, message: string): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code, message },
+      id: null,
+    }),
+    { status, headers: { "Content-Type": "application/json" } },
+  );
 }
 
 /**
@@ -592,22 +681,4 @@ function fmtSessionContext(
   const identityId = workspaceCtx?.identity?.id ?? "none";
   const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "direct";
   return `sessionId=${sidPrefix} workspace=${wsId} identity=${identityId} ip=${ip}`;
-}
-
-/**
- * Close all active MCP sessions and stop the cleanup timer. Called during server shutdown.
- */
-export async function closeAllMcpSessions(): Promise<void> {
-  if (cleanupInterval) {
-    clearInterval(cleanupInterval);
-    cleanupInterval = null;
-  }
-  for (const [sid, entry] of sessions) {
-    try {
-      await entry.transport.close();
-    } catch {
-      // Ignore close errors during shutdown
-    }
-    sessions.delete(sid);
-  }
 }

--- a/src/api/routes/mcp.ts
+++ b/src/api/routes/mcp.ts
@@ -8,7 +8,7 @@ import {
   resolveWorkspace,
   WorkspaceResolutionError,
 } from "../auth-middleware.ts";
-import { handleMcpRequest, type McpWorkspaceContext } from "../mcp-server.ts";
+import type { McpWorkspaceContext } from "../mcp-server.ts";
 import { bodyLimit } from "../middleware/body-limit.ts";
 import { type AppContext, type AuthEnv, apiError } from "../types.ts";
 
@@ -106,7 +106,7 @@ export function mcpRoutes(ctx: AppContext) {
       identity,
       workspaceId: wsId,
     };
-    return handleMcpRequest(c.req.raw, registry, features, mcpWorkspaceCtx);
+    return ctx.mcpHost.handle(c.req.raw, registry, features, mcpWorkspaceCtx);
   });
 
   return app;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -9,8 +9,9 @@ import { createApp } from "./app.ts";
 import { resolveAuthMode } from "./auth-middleware.ts";
 import { ConversationEventManager } from "./conversation-events.ts";
 import { SseEventManager } from "./events.ts";
-import { closeAllMcpSessions } from "./mcp-server.ts";
+import { McpServerHost } from "./mcp-server.ts";
 import { LoginRateLimiter, RequestRateLimiter } from "./rate-limiter.ts";
+import { InMemorySessionRegistry, type SessionRegistry } from "./session-store/index.ts";
 import type { AppContext } from "./types.ts";
 
 export interface ServerOptions {
@@ -18,6 +19,13 @@ export interface ServerOptions {
   port?: number;
   /** Pluggable identity provider. Falls back to DevIdentityProvider (no auth) when null. */
   provider?: IdentityProvider | null;
+  /**
+   * Pluggable cluster-shared session metadata store. When omitted, a process-
+   * local in-memory registry is constructed with the runtime's configured TTL
+   * — equivalent to legacy single-pod behavior. Multi-replica deploys must
+   * pass a Redis-backed registry built via `createSessionRegistry`.
+   */
+  sessionRegistry?: SessionRegistry;
 }
 
 export interface ServerHandle {
@@ -157,6 +165,15 @@ export function startServer(options: ServerOptions): ServerHandle {
   const authMode = resolveAuthMode(effectiveProvider);
   const authConfigured = authMode.type !== "dev";
 
+  // Construct the per-pod MCP host. The transport map lives here; the
+  // session-metadata registry is either supplied by the caller (production
+  // bootstrap building a Redis registry from config) or defaulted to an
+  // in-memory store using the runtime's configured TTL.
+  const sessionRegistry: SessionRegistry =
+    options.sessionRegistry ??
+    new InMemorySessionRegistry({ ttlMs: runtime.getSessionStoreTtlMs() });
+  const mcpHost = new McpServerHost({ registry: sessionRegistry });
+
   // Build shared context for all route groups
   const ctx: AppContext = {
     runtime,
@@ -174,6 +191,7 @@ export function startServer(options: ServerOptions): ServerHandle {
     isLocalhost: true, // Updated after Bun.serve starts
     appOrigin: allowedOrigins ? [...allowedOrigins][0] : undefined,
     internalToken,
+    mcpHost,
   };
 
   const app = createApp(ctx, authConfigured, allowedOrigins);
@@ -203,7 +221,7 @@ export function startServer(options: ServerOptions): ServerHandle {
       sseManager.stop();
       conversationEventManager.stop();
       healthMonitor.stop();
-      closeAllMcpSessions().catch(() => {});
+      mcpHost.shutdown().catch(() => {});
       server.stop(closeConnections);
     },
   };

--- a/src/api/session-store/factory.ts
+++ b/src/api/session-store/factory.ts
@@ -1,0 +1,160 @@
+/**
+ * Build a SessionRegistry from validated config. The single place that
+ * knows about all provider implementations — keeps `mcp-server.ts` and
+ * `server.ts` provider-agnostic.
+ */
+
+import { log } from "../../cli/log.ts";
+import { InMemorySessionRegistry } from "./memory.ts";
+import { RedisSessionRegistry } from "./redis.ts";
+import type { SessionRegistry } from "./types.ts";
+
+/**
+ * Resolved (post-defaults) session-store configuration.
+ *
+ * Operator-facing config (in `nimblebrain.json`) uses `ttlSeconds` because
+ * milliseconds are implementation-leakage — nobody sets a sub-second
+ * session timeout. The Resolved shape, however, carries `ttlMs` because
+ * that's the unit the providers consume (`Date.now()` is ms, sweep math
+ * is ms, `PEXPIRE` takes ms). The conversion happens once in
+ * `resolveSessionStoreConfig` so the rest of the runtime never has to
+ * think about units.
+ */
+export type ResolvedSessionStoreConfig =
+  | {
+      type: "memory";
+      ttlMs: number;
+    }
+  | {
+      type: "redis";
+      ttlMs: number;
+      redis: {
+        url: string;
+        keyPrefix: string;
+      };
+    };
+
+const DEFAULT_TTL_SECONDS = 8 * 60 * 60;
+
+/**
+ * Apply defaults to a partial session-store config and convert the
+ * operator-facing `ttlSeconds` to the internal `ttlMs` currency.
+ *
+ * - No config at all → in-memory, 8h TTL.
+ * - `type: "redis"` with no URL → throws; we won't silently fall back to
+ *   in-memory for production deploys, that would mask misconfiguration.
+ */
+export function resolveSessionStoreConfig(
+  raw: PartialSessionStoreConfig | undefined,
+): ResolvedSessionStoreConfig {
+  const ttlSeconds = raw?.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const ttlMs = ttlSeconds * 1000;
+
+  if (!raw || raw.type === undefined || raw.type === "memory") {
+    return { type: "memory", ttlMs };
+  }
+  if (raw.type === "redis") {
+    // ${VAR} expansion lets a Helm-rendered configmap carry a placeholder
+    // (`"url": "${REDIS_URL}"`) and have the URL fly in from an envFrom-
+    // mounted secret at process start. The expanded value is what the
+    // factory hands to `Bun.RedisClient`. We expand only this one field
+    // because the rest of `nimblebrain.json` is operator-controlled,
+    // non-secret, and shouldn't leak env into arbitrary config strings.
+    const url = expandEnvVars(raw.redis?.url ?? "").trim();
+    if (!url) {
+      throw new Error(
+        'sessionStore.type="redis" requires sessionStore.redis.url. ' +
+          "Set REDIS_URL (or the env var named in sessionStore.redis.url) in " +
+          "the deployment environment, or change type to 'memory'.",
+      );
+    }
+    return {
+      type: "redis",
+      ttlMs,
+      redis: {
+        url,
+        keyPrefix: raw.redis?.keyPrefix ?? "nb:mcp:session:",
+      },
+    };
+  }
+  // Exhaustiveness — TS will catch unhandled types if the union grows.
+  const _exhaustive: never = raw.type;
+  throw new Error(`Unknown sessionStore.type: ${String(_exhaustive)}`);
+}
+
+/** Loose, user-facing shape (every field optional). */
+export interface PartialSessionStoreConfig {
+  type?: "memory" | "redis";
+  /**
+   * Idle TTL in seconds. Sessions older than this on `lastAccessedAt` are
+   * evicted on the next sweep / TTL fire. Default: 28800 (8 h).
+   */
+  ttlSeconds?: number;
+  redis?: {
+    url?: string;
+    keyPrefix?: string;
+  };
+}
+
+/**
+ * Build the registry. For Redis, connects up front so misconfiguration
+ * fails the boot instead of every individual MCP request.
+ */
+export async function createSessionRegistry(
+  cfg: ResolvedSessionStoreConfig,
+): Promise<SessionRegistry> {
+  // Log lines surface seconds — the unit operators set in config — even
+  // though the providers themselves run on ms internally.
+  const ttlSec = cfg.ttlMs / 1000;
+  switch (cfg.type) {
+    case "memory":
+      log.info(`[mcp] session store: memory ttl=${ttlSec}s`);
+      return new InMemorySessionRegistry({ ttlMs: cfg.ttlMs });
+    case "redis": {
+      log.info(
+        `[mcp] session store: redis url=${redactUrl(cfg.redis.url)} ttl=${ttlSec}s keyPrefix=${cfg.redis.keyPrefix}`,
+      );
+      const registry = new RedisSessionRegistry({
+        url: cfg.redis.url,
+        ttlMs: cfg.ttlMs,
+        keyPrefix: cfg.redis.keyPrefix,
+      });
+      await registry.connect();
+      return registry;
+    }
+  }
+}
+
+/**
+ * Replace `${VAR}` placeholders in a string with `process.env[VAR]`. An
+ * undefined env var expands to empty (the trim+empty-check upstream then
+ * surfaces the misconfiguration as a thrown error, not a malformed URL).
+ *
+ * Names must match `[A-Z_][A-Z0-9_]*` — the standard K8s / shell convention.
+ * Lowercase placeholders like `${redis_url}` deliberately don't expand and
+ * will pass through into the URL, where the Redis client will reject them.
+ * If that surprises a caller, fix the env-var name to be uppercase rather
+ * than weakening this regex.
+ */
+function expandEnvVars(input: string): string {
+  return input.replace(/\$\{([A-Z_][A-Z0-9_]*)\}/g, (_match, name: string) => {
+    return process.env[name] ?? "";
+  });
+}
+
+/**
+ * Hide credentials in logged Redis URLs. `redis://user:pass@host:6379` →
+ * `redis://***@host:6379`.
+ */
+function redactUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.username || parsed.password) {
+      parsed.username = "***";
+      parsed.password = "";
+    }
+    return parsed.toString();
+  } catch {
+    return "<invalid-url>";
+  }
+}

--- a/src/api/session-store/index.ts
+++ b/src/api/session-store/index.ts
@@ -1,0 +1,9 @@
+export {
+  createSessionRegistry,
+  type PartialSessionStoreConfig,
+  type ResolvedSessionStoreConfig,
+  resolveSessionStoreConfig,
+} from "./factory.ts";
+export { InMemorySessionRegistry } from "./memory.ts";
+export { RedisSessionRegistry } from "./redis.ts";
+export type { SessionMeta, SessionRegistry } from "./types.ts";

--- a/src/api/session-store/memory.ts
+++ b/src/api/session-store/memory.ts
@@ -1,0 +1,85 @@
+/**
+ * In-memory session registry — process-local, no external dependencies.
+ *
+ * Default for dev, tests, and any single-replica deploy that doesn't need
+ * cluster-wide visibility. Drop-in equivalent to the bare `Map` the legacy
+ * `mcp-server.ts` carried, with the registry interface bolted on so the
+ * call sites match the Redis path exactly.
+ *
+ * TTL is enforced by a periodic sweep — no native expiry on `Map`. Sweep
+ * interval defaults to 60s, matching the legacy implementation. The
+ * interval is `unref`d so it never holds the process open during shutdown.
+ */
+
+import type { SessionMeta, SessionRegistry } from "./types.ts";
+
+export interface InMemorySessionRegistryOptions {
+  /** Idle TTL in milliseconds. Sessions older than this are evicted on sweep. */
+  ttlMs: number;
+  /** Sweep interval in milliseconds. Default: 60s. */
+  sweepIntervalMs?: number;
+}
+
+export class InMemorySessionRegistry implements SessionRegistry {
+  private readonly entries = new Map<string, SessionMeta>();
+  private readonly ttlMs: number;
+  private readonly sweepInterval: ReturnType<typeof setInterval>;
+
+  constructor(opts: InMemorySessionRegistryOptions) {
+    this.ttlMs = opts.ttlMs;
+    const interval = opts.sweepIntervalMs ?? 60_000;
+    this.sweepInterval = setInterval(() => {
+      this.sweepExpired(Date.now()).catch(() => {
+        // sweep is best-effort and synchronous internally; nothing to handle
+      });
+    }, interval);
+    // Don't pin the event loop open just because the registry is alive.
+    if (typeof this.sweepInterval === "object" && "unref" in this.sweepInterval) {
+      this.sweepInterval.unref();
+    }
+  }
+
+  async create(meta: SessionMeta): Promise<void> {
+    this.entries.set(meta.sessionId, { ...meta });
+  }
+
+  async get(sessionId: string): Promise<SessionMeta | null> {
+    const meta = this.entries.get(sessionId);
+    if (!meta) return null;
+    // TTL check on read so we never return a stale entry that the next
+    // sweep would have evicted.
+    if (Date.now() - meta.lastAccessedAt > this.ttlMs) {
+      this.entries.delete(sessionId);
+      return null;
+    }
+    return { ...meta };
+  }
+
+  async touch(sessionId: string, now: number): Promise<void> {
+    const meta = this.entries.get(sessionId);
+    if (!meta) return;
+    meta.lastAccessedAt = now;
+  }
+
+  async delete(sessionId: string): Promise<void> {
+    this.entries.delete(sessionId);
+  }
+
+  async sweepExpired(now: number): Promise<void> {
+    for (const [sid, meta] of this.entries) {
+      if (now - meta.lastAccessedAt > this.ttlMs) {
+        this.entries.delete(sid);
+      }
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    clearInterval(this.sweepInterval);
+    this.entries.clear();
+  }
+
+  /** Test-only: number of currently tracked sessions. */
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/api/session-store/redis.ts
+++ b/src/api/session-store/redis.ts
@@ -1,0 +1,186 @@
+/**
+ * Redis-backed session registry.
+ *
+ * Each session is a Redis hash at `${prefix}${sessionId}` with native TTL.
+ * Every `touch` re-applies the TTL via `PEXPIRE` so an actively-used session
+ * never expires; an idle session evicts itself when Redis' TTL fires (no
+ * sweep loop required, unlike the in-memory provider).
+ *
+ * Operations are best-effort from the caller's perspective: an unreachable
+ * Redis must not block the request path. We surface failures via thrown
+ * errors so the caller can decide policy (typically: log + fall back to the
+ * local transport map). We do NOT install a circuit breaker — the session
+ * map IS the gate, and ElastiCache local-AZ p99 is sub-ms.
+ *
+ * Connection lifecycle: the client is created at app startup and closed in
+ * `shutdown()`. We do NOT auto-reconnect on every command — Bun's client
+ * handles transient TCP blips internally; if it stays dead, requests fail
+ * loud and the session-miss log line tells operators what happened.
+ */
+
+import { log } from "../../cli/log.ts";
+import type { SessionMeta, SessionRegistry } from "./types.ts";
+
+export interface RedisSessionRegistryOptions {
+  /** Connection URL, e.g. `redis://host:6379` or `rediss://...`. */
+  url: string;
+  /** Idle TTL in milliseconds. Re-applied on every `touch`. */
+  ttlMs: number;
+  /** Hash key prefix. Default: `nb:mcp:session:`. */
+  keyPrefix?: string;
+  /**
+   * Override for tests: inject a pre-constructed client (e.g. an in-process
+   * fake). When omitted, a `Bun.RedisClient` is constructed from `url`.
+   */
+  client?: RedisLike;
+}
+
+/**
+ * Minimal subset of the Bun Redis API this module uses. Defined as a
+ * structural interface so tests can supply a fake without depending on
+ * the entire Bun.RedisClient surface (~150 methods).
+ */
+export interface RedisLike {
+  connect(): Promise<unknown>;
+  close(): unknown;
+  send(command: string, args: string[]): Promise<unknown>;
+}
+
+const DEFAULT_PREFIX = "nb:mcp:session:";
+
+export class RedisSessionRegistry implements SessionRegistry {
+  private readonly client: RedisLike;
+  private readonly ownsClient: boolean;
+  private readonly ttlMs: number;
+  private readonly prefix: string;
+
+  constructor(opts: RedisSessionRegistryOptions) {
+    this.ttlMs = opts.ttlMs;
+    this.prefix = opts.keyPrefix ?? DEFAULT_PREFIX;
+    if (opts.client) {
+      this.client = opts.client;
+      this.ownsClient = false;
+    } else {
+      // `Bun.RedisClient` exposes ~150 typed methods; we only ever call the
+      // three on `RedisLike` (`connect`, `close`, `send`). The cast widens
+      // the runtime instance down to the structural subset we depend on so
+      // tests can substitute a small fake without re-implementing the full
+      // surface. Mismatch risk is bounded: if Bun changes the shape of the
+      // three methods we use, compilation fails at the call sites below.
+      this.client = new Bun.RedisClient(opts.url) as unknown as RedisLike;
+      this.ownsClient = true;
+    }
+  }
+
+  /**
+   * Connect to Redis. Surfaces connection failures up front so a misconfigured
+   * cluster can't ship a half-broken pod through readiness probes.
+   */
+  async connect(): Promise<void> {
+    await this.client.connect();
+  }
+
+  async create(meta: SessionMeta): Promise<void> {
+    const key = this.key(meta.sessionId);
+    // Hash fields, then explicit TTL. Two commands instead of pipelining
+    // because Bun's RedisClient doesn't expose a public pipeline primitive
+    // and each call is sub-ms locally; the simplicity wins.
+    await this.client.send("HSET", [
+      key,
+      "sessionId",
+      meta.sessionId,
+      "identityId",
+      meta.identityId ?? "",
+      "workspaceId",
+      meta.workspaceId,
+      "createdAt",
+      String(meta.createdAt),
+      "lastAccessedAt",
+      String(meta.lastAccessedAt),
+    ]);
+    await this.client.send("PEXPIRE", [key, String(this.ttlMs)]);
+  }
+
+  async get(sessionId: string): Promise<SessionMeta | null> {
+    const key = this.key(sessionId);
+    const raw = (await this.client.send("HGETALL", [key])) as unknown;
+    return parseHash(sessionId, raw);
+  }
+
+  async touch(sessionId: string, now: number): Promise<void> {
+    const key = this.key(sessionId);
+    // HSET on a non-existent key creates it. We don't want to "resurrect"
+    // a session whose TTL already fired, so guard with EXISTS first.
+    // EXISTS returns the integer 1 / 0 — Bun returns it as a number.
+    const exists = (await this.client.send("EXISTS", [key])) as number;
+    if (exists !== 1) return;
+    await this.client.send("HSET", [key, "lastAccessedAt", String(now)]);
+    await this.client.send("PEXPIRE", [key, String(this.ttlMs)]);
+  }
+
+  async delete(sessionId: string): Promise<void> {
+    await this.client.send("DEL", [this.key(sessionId)]);
+  }
+
+  async sweepExpired(_now: number): Promise<void> {
+    // No-op: Redis evicts via native TTL. Method exists for interface parity.
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.ownsClient) return;
+    try {
+      this.client.close();
+    } catch (err) {
+      // close() is sync in Bun's API; surface unusual errors so failed
+      // shutdowns don't pass silently.
+      log.warn(`[mcp] redis registry close error: ${(err as Error).message}`);
+    }
+  }
+
+  private key(sessionId: string): string {
+    return `${this.prefix}${sessionId}`;
+  }
+}
+
+/**
+ * Parse the result of `HGETALL key`. Bun returns an object map for hashes;
+ * older clients sometimes return alternating-array form. Accept both so
+ * the registry isn't brittle to client version drift.
+ */
+function parseHash(sessionId: string, raw: unknown): SessionMeta | null {
+  if (raw === null || raw === undefined) return null;
+  const obj = toRecord(raw);
+  if (!obj || Object.keys(obj).length === 0) return null;
+
+  const workspaceId = obj.workspaceId;
+  const createdAt = Number(obj.createdAt);
+  const lastAccessedAt = Number(obj.lastAccessedAt);
+
+  if (!workspaceId || !Number.isFinite(createdAt) || !Number.isFinite(lastAccessedAt)) {
+    // Hash is corrupt or partial. Treat as missing.
+    return null;
+  }
+
+  return {
+    sessionId,
+    identityId: obj.identityId === "" ? null : (obj.identityId ?? null),
+    workspaceId,
+    createdAt,
+    lastAccessedAt,
+  };
+}
+
+function toRecord(raw: unknown): Record<string, string> | null {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, string>;
+  }
+  if (Array.isArray(raw)) {
+    if (raw.length % 2 !== 0) return null;
+    const out: Record<string, string> = {};
+    for (let i = 0; i < raw.length; i += 2) {
+      out[String(raw[i])] = String(raw[i + 1]);
+    }
+    return out;
+  }
+  return null;
+}

--- a/src/api/session-store/types.ts
+++ b/src/api/session-store/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Session metadata + cluster-shared registry for MCP HTTP sessions.
+ *
+ * Two layers cooperate to handle MCP Streamable-HTTP sessions:
+ *
+ *   1. **Transport map** — process-local `Map<sessionId, transport>` in
+ *      `mcp-server.ts`. Owns the live HTTP response handles, the SDK
+ *      `Server` instance with its registered handlers, and any in-flight
+ *      JSON-RPC state. Process-bound; cannot be serialized or moved.
+ *
+ *   2. **SessionRegistry** (this module) — pluggable metadata store. Knows
+ *      that a session exists, when it was last touched, and the workspace +
+ *      identity it's bound to. Used to:
+ *        - tell `not_found` ("session never existed / TTL'd") apart from
+ *          `unavailable` ("exists, but the live transport isn't on this
+ *          process") in 404 responses, so operators can correlate
+ *        - share TTL semantics across replicas via the underlying store
+ *        - observe in-flight sessions cluster-wide for ops/admin tooling
+ *
+ * The registry is **deliberately deployment-vocabulary-free**: no pod, no
+ * instance, no ownership. Routing live requests to the process that owns a
+ * given session's transport is the load balancer's job (sticky cookie, or
+ * header-hash on `Mcp-Session-Id`), not the registry's. Treating the
+ * registry as a router would either re-introduce process identity into
+ * the metadata schema or pull cross-process proxying into the application
+ * layer — both of which leak into a clean interface.
+ *
+ * Implementations: `InMemorySessionRegistry` (default; single-replica) and
+ * `RedisSessionRegistry` (multi-replica). The interface intentionally
+ * matches a TTL-keyed K/V — Redis maps natively, the in-memory version
+ * sweeps a `Map` on a periodic timer.
+ */
+
+export interface SessionMeta {
+  sessionId: string;
+  /** Identity that initialized the session (for cross-tenant correlation). */
+  identityId: string | null;
+  /** Workspace bound to the session (every MCP request must be ws-scoped). */
+  workspaceId: string;
+  createdAt: number;
+  lastAccessedAt: number;
+}
+
+/**
+ * Pluggable session metadata store.
+ *
+ * All operations are best-effort: failures must not block the request path.
+ * The transport map is the source of truth for "can I serve this session";
+ * the registry is supplementary metadata. Callers MUST tolerate registry
+ * outages (Redis down → log + continue with local map).
+ *
+ * Implementations are responsible for their own TTL semantics. In-memory
+ * runs a periodic sweep; Redis sets native TTLs and re-`EXPIRE`s on `touch`.
+ */
+export interface SessionRegistry {
+  /** Record a freshly-initialized session. */
+  create(meta: SessionMeta): Promise<void>;
+  /** Look up metadata. Returns null when the session is unknown or expired. */
+  get(sessionId: string): Promise<SessionMeta | null>;
+  /** Update `lastAccessedAt` and reset the TTL. No-op for unknown sessions. */
+  touch(sessionId: string, now: number): Promise<void>;
+  /** Remove the session from the registry. No-op for unknown sessions. */
+  delete(sessionId: string): Promise<void>;
+  /**
+   * Best-effort housekeeping. In-memory: scans the map.
+   * Redis: no-op (server-side TTL evicts).
+   */
+  sweepExpired(now: number): Promise<void>;
+  /** Stop background work, release connections. */
+  shutdown(): Promise<void>;
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -7,6 +7,7 @@ import type { WorkspaceStore } from "../workspace/workspace-store.ts";
 import type { AuthMiddlewareOptions } from "./auth-middleware.ts";
 import type { ConversationEventManager } from "./conversation-events.ts";
 import type { SseEventManager } from "./events.ts";
+import type { McpServerHost } from "./mcp-server.ts";
 import type { LoginRateLimiter, RequestRateLimiter } from "./rate-limiter.ts";
 
 // ---------------------------------------------------------------------------
@@ -76,4 +77,5 @@ export interface AppContext {
   isLocalhost: boolean;
   appOrigin: string | undefined;
   internalToken: string;
+  mcpHost: McpServerHost;
 }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 import { ConsoleEventSink } from "../../adapters/console-events.ts";
 import { DebugEventSink } from "../../adapters/debug-events.ts";
 import { startServerWithShutdown } from "../../api/server.ts";
+import { createSessionRegistry, resolveSessionStoreConfig } from "../../api/session-store/index.ts";
 import { Runtime } from "../../runtime/runtime.ts";
 import type { TelemetryManager } from "../../telemetry/manager.ts";
 import { loadConfig } from "../config.ts";
@@ -35,7 +36,14 @@ export function createServeCommand(telemetry: TelemetryManager): Command {
       });
       log.info("[nimblebrain] Runtime ready.");
 
+      // Build the MCP session metadata store from config. Defaults to in-
+      // memory; production deploys point this at Redis. Resolution + connect
+      // happens here (not in `startServer`) so misconfiguration fails the
+      // boot loudly instead of every individual MCP request.
+      const sessionStoreConfig = resolveSessionStoreConfig(runtime.getSessionStoreConfig());
+      const sessionRegistry = await createSessionRegistry(sessionStoreConfig);
+
       const port = Number(process.env.PORT) || Number(opts.port) || 27247;
-      await startServerWithShutdown({ runtime, port });
+      await startServerWithShutdown({ runtime, port, sessionRegistry });
     });
 }

--- a/src/config/nimblebrain-config.schema.json
+++ b/src/config/nimblebrain-config.schema.json
@@ -257,6 +257,41 @@
       "description": "Working directory for all runtime state. Defaults to ~/.nimblebrain.",
       "type": "string"
     },
+    "sessionStore": {
+      "description": "MCP session metadata store for /mcp. Tracks each Mcp-Session-Id and its idle TTL. Default: in-memory (process-local). Use 'redis' for multi-replica deploys; the same provider also gives single-replica deploys cluster-wide visibility for ops/admin tooling.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Provider. 'memory' is process-local (default). 'redis' is cluster-shared (required for platform.replicas > 1).",
+          "type": "string",
+          "enum": ["memory", "redis"],
+          "default": "memory"
+        },
+        "ttlSeconds": {
+          "description": "Idle TTL for sessions in seconds. Each request resets the clock — actively-used sessions never expire. Default: 28800 (8 h).",
+          "type": "integer",
+          "minimum": 1,
+          "default": 28800
+        },
+        "redis": {
+          "description": "Redis-specific options. Required when type='redis'.",
+          "type": "object",
+          "properties": {
+            "url": {
+              "description": "Redis connection URL (redis:// or rediss://). Typically injected via environment from a secret.",
+              "type": "string"
+            },
+            "keyPrefix": {
+              "description": "Hash key prefix for session entries. Default: 'nb:mcp:session:'.",
+              "type": "string",
+              "default": "nb:mcp:session:"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "telemetry": {
       "description": "Anonymous usage telemetry. Disable with telemetry.enabled: false, NB_TELEMETRY_DISABLED=1, or DO_NOT_TRACK=1.",
       "type": "object",

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1651,6 +1651,45 @@ export class Runtime {
   }
 
   /**
+   * Loose session-store config for the API host to resolve. The actual
+   * defaulting + validation lives in `api/session-store/factory.ts` so this
+   * returns whatever was put in `nimblebrain.json`, untouched.
+   */
+  getSessionStoreConfig(): RuntimeConfig["sessionStore"] {
+    return this.config.sessionStore;
+  }
+
+  /**
+   * Resolved idle TTL for sessions, in milliseconds. Two operator surfaces,
+   * one currency:
+   *
+   *   - `MCP_SESSION_TTL_SECONDS` env var (highest priority — env wins so
+   *     ops can flip TTL without redeploying the configmap)
+   *   - `sessionStore.ttlSeconds` in `nimblebrain.json`
+   *   - 8 h fallback
+   *
+   * Internal callers (registry constructors, sweep math) take ms; the
+   * conversion happens once here so the rest of the runtime never deals
+   * in mixed units. `parsePositiveIntEnv`-style validation lives in
+   * `mcp-server.ts`; this accessor only consumes the parsed env value.
+   */
+  getSessionStoreTtlMs(): number {
+    const envRaw = process.env.MCP_SESSION_TTL_SECONDS;
+    if (envRaw !== undefined && envRaw !== "") {
+      const parsed = Number(envRaw);
+      if (Number.isFinite(parsed) && parsed > 0 && Number.isInteger(parsed)) {
+        return parsed * 1000;
+      }
+      // Invalid env value — fall through to config / default. We don't
+      // log here because the chart-rendered config path is the typical
+      // source of truth; an unset/typo'd env should be a quiet fallback,
+      // not a noise generator on every cold start.
+    }
+    const seconds = this.config.sessionStore?.ttlSeconds ?? 8 * 60 * 60;
+    return seconds * 1000;
+  }
+
+  /**
    * Get the path to nimblebrain.overrides.json — the user-managed override
    * file written by `set_model_config` and preserved across deploys.
    * Defaults to a sibling of `configPath`; absent only when no `configPath`

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -125,6 +125,23 @@ export interface RuntimeConfig {
   /** Confirmation gate for privileged operations and credential prompts. */
   confirmationGate?: ConfirmationGate;
 
+  /**
+   * MCP session metadata store. Controls how sessions for `/mcp` are tracked
+   * across the cluster. Defaults to `memory` (process-local) — fine for any
+   * single-replica deploy. Set `type: "redis"` with a `redis.url` for
+   * multi-replica deploys; the registry shares session metadata across
+   * processes. See `src/api/session-store/`.
+   */
+  sessionStore?: {
+    type?: "memory" | "redis";
+    /** Idle TTL in seconds. Default: 28800 (8 h). */
+    ttlSeconds?: number;
+    redis?: {
+      url?: string;
+      keyPrefix?: string;
+    };
+  };
+
   /** Path to nimblebrain.json. The Helm-managed seed file. Overwritten on every deploy. */
   configPath?: string;
 

--- a/test/integration/mcp-server-endpoint.test.ts
+++ b/test/integration/mcp-server-endpoint.test.ts
@@ -211,10 +211,12 @@ describe("MCP Server Endpoint (/mcp)", () => {
 	});
 
 	// Session-miss surface: a POST carrying an unknown session ID must return
-	// 404 with a JSON-RPC error envelope AND emit a structured log line.
-	// This is the fault the client sees after a pod restart, an idle-TTL
-	// sweep, or (with future multi-replica) a misrouted request — exactly
-	// what `[mcp] session miss` is logged for.
+	// 404 with a JSON-RPC error envelope, the new `error.data.reason`
+	// classification (`not_found` for an unknown sessionId; `unavailable`
+	// when the registry has it but the local transport doesn't), AND emit a
+	// structured log line. This is the fault the client sees after a process
+	// restart, an idle-TTL sweep, or a sticky-routing miss — exactly what
+	// `[mcp] session miss` is logged for.
 	describe("session-miss logging", () => {
 		let capture: ReturnType<typeof captureLogs>;
 		beforeEach(() => {
@@ -224,7 +226,7 @@ describe("MCP Server Endpoint (/mcp)", () => {
 			capture.restore();
 		});
 
-		it("returns 404 and warn-logs key=value context for POST with unknown session id", async () => {
+		it("returns 404 with reason=not_found and warn-logs key=value context", async () => {
 			const res = await fetch(`${baseUrl}/mcp`, {
 				method: "POST",
 				headers: {
@@ -241,16 +243,19 @@ describe("MCP Server Endpoint (/mcp)", () => {
 			});
 			expect(res.status).toBe(404);
 			const body = (await res.json()) as {
-				error?: { code: number; message: string };
+				error?: { code: number; message: string; data?: { reason?: string } };
 			};
 			expect(body.error?.code).toBe(-32000);
 			expect(body.error?.message).toBe("Session not found");
+			// Default registry is in-memory and starts empty; an unknown
+			// sessionId necessarily lands on `not_found`, not `unavailable`.
+			expect(body.error?.data?.reason).toBe("not_found");
 
-			// The whole point of this PR: a structured log line we can grep
-			// for in prod. Asserting prefix + key=value shape rather than
-			// the exact string lets future tweaks to wording survive.
+			// Asserting prefix + key=value shape rather than the exact
+			// string lets future tweaks to wording survive.
 			const line = capture.lines.find((l) => l.startsWith("warn [mcp] session miss"));
 			expect(line).toBeDefined();
+			expect(line).toContain("reason=not_found");
 			expect(line).toContain("sessionId=00000000");
 			expect(line).toContain(`workspace=${TEST_WORKSPACE_ID}`);
 			expect(line).toMatch(/identity=\S+/);

--- a/test/unit/api/mcp-server-host.test.ts
+++ b/test/unit/api/mcp-server-host.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for `McpServerHost.handle`'s session-miss classification path.
+ *
+ * Covers the two reasons the host emits in `error.data.reason`:
+ *
+ *   - `not_found`   — registry has no entry for this session id.
+ *   - `unavailable` — registry has an entry, but the live transport isn't
+ *     on this process. Could be a process restart or a sticky-routing
+ *     miss; the host doesn't (and shouldn't) distinguish — the registry
+ *     is deployment-vocabulary-free.
+ *
+ * Constructed with a hand-populated `InMemorySessionRegistry` so tests are
+ * direct and don't need a real HTTP server.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { McpServerHost } from "../../../src/api/mcp-server.ts";
+import {
+	InMemorySessionRegistry,
+	type SessionRegistry,
+} from "../../../src/api/session-store/index.ts";
+import type { ResolvedFeatures } from "../../../src/config/features.ts";
+import { ToolRegistry } from "../../../src/tools/registry.ts";
+
+const FAKE_FEATURES = {} as ResolvedFeatures;
+const SAMPLE_SID = "11111111-2222-3333-4444-555555555555";
+
+function postRequest(sessionId: string): Request {
+	return new Request("http://test/mcp", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+			"mcp-session-id": sessionId,
+		},
+		body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+	});
+}
+
+describe("McpServerHost — session-miss classification", () => {
+	let registry: SessionRegistry;
+	let host: McpServerHost;
+	let toolRegistry: ToolRegistry;
+
+	beforeEach(() => {
+		registry = new InMemorySessionRegistry({ ttlMs: 60_000 });
+		host = new McpServerHost({ registry });
+		toolRegistry = new ToolRegistry();
+	});
+
+	afterEach(async () => {
+		await host.shutdown();
+	});
+
+	it("returns reason=not_found when the registry has no entry", async () => {
+		const res = await host.handle(postRequest(SAMPLE_SID), toolRegistry, FAKE_FEATURES, {
+			registry: toolRegistry,
+			identity: null,
+			workspaceId: "ws_test",
+		});
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as {
+			error: { data: { reason: string } };
+		};
+		expect(body.error.data.reason).toBe("not_found");
+	});
+
+	// Session exists in the registry but no live transport on this process.
+	// Could be a process restart (transport state lost) or a sticky-routing
+	// miss (request landed on a process that didn't handle the init). Host
+	// reports `unavailable` without trying to distinguish — the registry
+	// has no concept of which process owns what.
+	it("returns reason=unavailable when registry has the session but transport is missing", async () => {
+		await registry.create({
+			sessionId: SAMPLE_SID,
+			identityId: "usr_x",
+			workspaceId: "ws_test",
+			createdAt: Date.now(),
+			lastAccessedAt: Date.now(),
+		});
+
+		const res = await host.handle(postRequest(SAMPLE_SID), toolRegistry, FAKE_FEATURES, {
+			registry: toolRegistry,
+			identity: null,
+			workspaceId: "ws_test",
+		});
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as {
+			error: { data: { reason: string } };
+		};
+		expect(body.error.data.reason).toBe("unavailable");
+	});
+
+	// Registry outage degrades to `not_found`. We already know the local
+	// transport map doesn't have it, so falling back to "treat as missing"
+	// returns a useful 404 instead of a 500.
+	it("returns reason=not_found when registry.get throws", async () => {
+		const flakyRegistry: SessionRegistry = {
+			create: async () => {},
+			get: async () => {
+				throw new Error("redis down");
+			},
+			touch: async () => {},
+			delete: async () => {},
+			sweepExpired: async () => {},
+			shutdown: async () => {},
+		};
+		const flakyHost = new McpServerHost({ registry: flakyRegistry });
+
+		const res = await flakyHost.handle(postRequest(SAMPLE_SID), toolRegistry, FAKE_FEATURES, {
+			registry: toolRegistry,
+			identity: null,
+			workspaceId: "ws_test",
+		});
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as {
+			error: { data: { reason: string } };
+		};
+		expect(body.error.data.reason).toBe("not_found");
+		await flakyHost.shutdown();
+	});
+});

--- a/test/unit/api/session-store/conformance.ts
+++ b/test/unit/api/session-store/conformance.ts
@@ -1,0 +1,155 @@
+/**
+ * Provider-agnostic conformance suite for `SessionRegistry`. Both
+ * `InMemorySessionRegistry` and `RedisSessionRegistry` must pass it.
+ *
+ * Tests assert behavior, not implementation: what `get`/`touch`/`delete`
+ * return for a given sequence of operations. Callers wrap this in a
+ * `describe(...)` block of their own and pass a factory.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { SessionMeta, SessionRegistry } from "../../../../src/api/session-store/index.ts";
+
+export interface ConformanceFactoryOptions {
+  /** Idle TTL the registry should be configured with. */
+  ttlMs: number;
+  /** Sweep interval (in-memory only). Tests rely on short intervals to advance time. */
+  sweepIntervalMs?: number;
+}
+
+export type ConformanceFactory = (opts: ConformanceFactoryOptions) => Promise<SessionRegistry>;
+
+/**
+ * Run the full conformance suite against `factory`. Caller wraps in its
+ * own `describe(...)` so output groups by provider.
+ */
+export function registrySpec(factory: ConformanceFactory): void {
+  const sample = (overrides: Partial<SessionMeta> = {}): SessionMeta => {
+    const now = Date.now();
+    return {
+      sessionId: "11111111-2222-3333-4444-555555555555",
+      identityId: "usr_42",
+      workspaceId: "ws_test",
+      // Use real wall-clock time so providers that compare against `Date.now()`
+      // (the in-memory sweep, the Redis TTL) treat the entry as freshly-created.
+      createdAt: now,
+      lastAccessedAt: now,
+      ...overrides,
+    };
+  };
+
+  it("get returns null for an unknown session", async () => {
+    const reg = await factory({ ttlMs: 60_000 });
+    try {
+      expect(await reg.get("does-not-exist")).toBeNull();
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("create then get returns the same metadata", async () => {
+    const reg = await factory({ ttlMs: 60_000 });
+    try {
+      const meta = sample();
+      await reg.create(meta);
+      const got = await reg.get(meta.sessionId);
+      expect(got).not.toBeNull();
+      expect(got?.sessionId).toBe(meta.sessionId);
+      expect(got?.identityId).toBe(meta.identityId);
+      expect(got?.workspaceId).toBe(meta.workspaceId);
+      expect(got?.createdAt).toBe(meta.createdAt);
+      expect(got?.lastAccessedAt).toBe(meta.lastAccessedAt);
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("preserves identityId=null (anonymous sessions)", async () => {
+    const reg = await factory({ ttlMs: 60_000 });
+    try {
+      const meta = sample({ identityId: null });
+      await reg.create(meta);
+      const got = await reg.get(meta.sessionId);
+      expect(got?.identityId).toBeNull();
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("delete removes the entry", async () => {
+    const reg = await factory({ ttlMs: 60_000 });
+    try {
+      const meta = sample();
+      await reg.create(meta);
+      await reg.delete(meta.sessionId);
+      expect(await reg.get(meta.sessionId)).toBeNull();
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("delete is a no-op for an unknown session", async () => {
+    const reg = await factory({ ttlMs: 60_000 });
+    try {
+      await reg.delete("never-existed");
+      // No throw — interface contract.
+      expect(true).toBe(true);
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("touch is a no-op for an unknown session", async () => {
+    const reg = await factory({ ttlMs: 60_000 });
+    try {
+      await reg.touch("never-existed", Date.now());
+      expect(await reg.get("never-existed")).toBeNull();
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("get evicts entries older than ttl", async () => {
+    // Use a short TTL so the test doesn't race the wall clock.
+    const reg = await factory({ ttlMs: 25, sweepIntervalMs: 5 });
+    try {
+      const meta = sample();
+      await reg.create(meta);
+      // Wait past TTL.
+      await new Promise((r) => setTimeout(r, 40));
+      expect(await reg.get(meta.sessionId)).toBeNull();
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("touch refreshes ttl so an actively-used session survives", async () => {
+    // TTL=40ms; touch every 15ms; total elapsed > TTL but session must live.
+    const reg = await factory({ ttlMs: 40, sweepIntervalMs: 5 });
+    try {
+      const meta = sample();
+      await reg.create(meta);
+      for (let i = 0; i < 5; i++) {
+        await new Promise((r) => setTimeout(r, 15));
+        await reg.touch(meta.sessionId, Date.now());
+      }
+      const got = await reg.get(meta.sessionId);
+      expect(got).not.toBeNull();
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("create is idempotent — re-create overwrites", async () => {
+    const reg = await factory({ ttlMs: 60_000 });
+    try {
+      const sid = "re-init-test";
+      await reg.create(sample({ sessionId: sid, workspaceId: "ws_a" }));
+      await reg.create(sample({ sessionId: sid, workspaceId: "ws_b" }));
+      const got = await reg.get(sid);
+      expect(got?.workspaceId).toBe("ws_b");
+    } finally {
+      await reg.shutdown();
+    }
+  });
+}

--- a/test/unit/api/session-store/factory.test.ts
+++ b/test/unit/api/session-store/factory.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { resolveSessionStoreConfig } from "../../../../src/api/session-store/factory.ts";
+
+describe("resolveSessionStoreConfig", () => {
+  it("returns memory + 8h TTL (in ms) when input is undefined", () => {
+    const r = resolveSessionStoreConfig(undefined);
+    expect(r.type).toBe("memory");
+    expect(r.ttlMs).toBe(8 * 60 * 60 * 1000);
+  });
+
+  // Operator-facing knob is `ttlSeconds`; resolver multiplies once for the
+  // internal currency. Sanity-checking the conversion here, not in every test.
+  it("converts ttlSeconds → ttlMs at the resolver boundary", () => {
+    const r = resolveSessionStoreConfig({ ttlSeconds: 60 });
+    expect(r.type).toBe("memory");
+    expect(r.ttlMs).toBe(60_000);
+  });
+
+  it("returns memory when type='memory' is explicit", () => {
+    const r = resolveSessionStoreConfig({ type: "memory", ttlSeconds: 1 });
+    expect(r.type).toBe("memory");
+    expect(r.ttlMs).toBe(1000);
+  });
+
+  // Production-safety: silently falling back to in-memory when redis is
+  // requested but unconfigured would let a multi-replica deploy ship with a
+  // broken session store. Fail loud at boot.
+  it("throws when type='redis' and url is missing", () => {
+    expect(() => resolveSessionStoreConfig({ type: "redis" })).toThrow(
+      /requires sessionStore.redis.url/,
+    );
+  });
+
+  it("throws when type='redis' and url is whitespace", () => {
+    expect(() =>
+      resolveSessionStoreConfig({ type: "redis", redis: { url: "   " } }),
+    ).toThrow(/requires sessionStore.redis.url/);
+  });
+
+  it("returns redis with defaults applied when url is provided", () => {
+    const r = resolveSessionStoreConfig({
+      type: "redis",
+      redis: { url: "redis://example:6379" },
+    });
+    expect(r.type).toBe("redis");
+    if (r.type !== "redis") return;
+    expect(r.redis.url).toBe("redis://example:6379");
+    expect(r.redis.keyPrefix).toBe("nb:mcp:session:");
+    expect(r.ttlMs).toBe(8 * 60 * 60 * 1000);
+  });
+
+  it("honors explicit keyPrefix and ttlSeconds overrides", () => {
+    const r = resolveSessionStoreConfig({
+      type: "redis",
+      ttlSeconds: 1800,
+      redis: { url: "redis://example", keyPrefix: "custom:" },
+    });
+    if (r.type !== "redis") throw new Error("expected redis");
+    expect(r.ttlMs).toBe(1_800_000);
+    expect(r.redis.keyPrefix).toBe("custom:");
+  });
+
+  // Helm-driven deployment pattern: configmap renders a literal "${REDIS_URL}"
+  // placeholder; the actual URL flies in from an envFrom-mounted secret at
+  // process start. The factory must expand it before handing to RedisClient.
+  describe("env-var expansion in redis.url", () => {
+    const ENV = "__TEST_REDIS_URL__";
+
+    afterEach(() => {
+      delete process.env[ENV];
+    });
+
+    it("expands ${VAR} from process.env", () => {
+      process.env[ENV] = "redis://prod-cluster:6379";
+      const r = resolveSessionStoreConfig({
+        type: "redis",
+        redis: { url: `\${${ENV}}` },
+      });
+      if (r.type !== "redis") throw new Error("expected redis");
+      expect(r.redis.url).toBe("redis://prod-cluster:6379");
+    });
+
+    it("throws when ${VAR} expands to empty (undefined env)", () => {
+      // ENV deliberately unset.
+      expect(() =>
+        resolveSessionStoreConfig({
+          type: "redis",
+          redis: { url: `\${${ENV}}` },
+        }),
+      ).toThrow(/requires sessionStore.redis.url/);
+    });
+
+    it("leaves literal URLs untouched (no false-positive matches)", () => {
+      const literal = "redis://user:pass@host:6379/0";
+      const r = resolveSessionStoreConfig({
+        type: "redis",
+        redis: { url: literal },
+      });
+      if (r.type !== "redis") throw new Error("expected redis");
+      expect(r.redis.url).toBe(literal);
+    });
+  });
+});

--- a/test/unit/api/session-store/memory.test.ts
+++ b/test/unit/api/session-store/memory.test.ts
@@ -1,0 +1,7 @@
+import { describe } from "bun:test";
+import { InMemorySessionRegistry } from "../../../../src/api/session-store/memory.ts";
+import { registrySpec } from "./conformance.ts";
+
+describe("InMemorySessionRegistry — conformance", () => {
+	registrySpec(async (opts) => new InMemorySessionRegistry(opts));
+});

--- a/test/unit/api/session-store/redis.test.ts
+++ b/test/unit/api/session-store/redis.test.ts
@@ -1,0 +1,144 @@
+/**
+ * RedisSessionRegistry conformance test against an in-process fake.
+ *
+ * Why a fake instead of a real Redis: this is a unit test, no I/O. The
+ * fake implements just the commands `RedisSessionRegistry` actually sends
+ * (HSET, HGETALL, EXISTS, PEXPIRE, DEL) plus PEXPIRE-driven TTL eviction.
+ * If we ever add a Redis-roundtrip integration test, it goes in
+ * `test/integration/` and runs against `redis-server` from the host.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  type RedisLike,
+  RedisSessionRegistry,
+} from "../../../../src/api/session-store/redis.ts";
+import { registrySpec } from "./conformance.ts";
+
+class FakeRedis implements RedisLike {
+  private hashes = new Map<string, Map<string, string>>();
+  /** Wall-clock ms when the key expires; undefined = no expiry. */
+  private expiries = new Map<string, number>();
+
+  async connect(): Promise<unknown> {
+    return undefined;
+  }
+
+  close(): unknown {
+    this.hashes.clear();
+    this.expiries.clear();
+    return undefined;
+  }
+
+  async send(command: string, args: string[]): Promise<unknown> {
+    this.evictIfExpired(args[0] ?? "");
+
+    switch (command.toUpperCase()) {
+      case "HSET": {
+        const [key, ...pairs] = args;
+        if (!key) throw new Error("HSET requires key");
+        const hash = this.hashes.get(key) ?? new Map<string, string>();
+        for (let i = 0; i < pairs.length; i += 2) {
+          hash.set(pairs[i] ?? "", pairs[i + 1] ?? "");
+        }
+        this.hashes.set(key, hash);
+        return pairs.length / 2;
+      }
+      case "HGETALL": {
+        const [key] = args;
+        if (!key) return {};
+        const hash = this.hashes.get(key);
+        if (!hash) return {};
+        const out: Record<string, string> = {};
+        for (const [k, v] of hash) out[k] = v;
+        return out;
+      }
+      case "EXISTS": {
+        const [key] = args;
+        return key && this.hashes.has(key) ? 1 : 0;
+      }
+      case "PEXPIRE": {
+        const [key, ttl] = args;
+        if (!key || ttl === undefined) return 0;
+        if (!this.hashes.has(key)) return 0;
+        this.expiries.set(key, Date.now() + Number(ttl));
+        return 1;
+      }
+      case "DEL": {
+        const [key] = args;
+        if (!key) return 0;
+        const had = this.hashes.delete(key);
+        this.expiries.delete(key);
+        return had ? 1 : 0;
+      }
+      default:
+        throw new Error(`FakeRedis: unsupported command ${command}`);
+    }
+  }
+
+  /** Lazy expiry — Redis evicts on access; we simulate that here. */
+  private evictIfExpired(key: string): void {
+    const exp = this.expiries.get(key);
+    if (exp !== undefined && Date.now() >= exp) {
+      this.hashes.delete(key);
+      this.expiries.delete(key);
+    }
+  }
+}
+
+describe("RedisSessionRegistry — conformance (against in-process fake)", () => {
+  registrySpec(async (opts) => {
+    const client = new FakeRedis();
+    return new RedisSessionRegistry({
+      url: "redis://fake",
+      ttlMs: opts.ttlMs,
+      client,
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Redis-specific behavior not covered by the conformance suite
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("RedisSessionRegistry — provider specifics", () => {
+  it("touch only refreshes existing entries (no resurrection of expired keys)", async () => {
+    const client = new FakeRedis();
+    const reg = new RedisSessionRegistry({
+      url: "redis://fake",
+      ttlMs: 25,
+      client,
+    });
+    try {
+      await reg.create({
+        sessionId: "abc",
+        identityId: null,
+        workspaceId: "ws_x",
+        createdAt: 1,
+        lastAccessedAt: 1,
+      });
+      await new Promise((r) => setTimeout(r, 35));
+      // After TTL expiry, touch must not resurrect the key. HSET on a
+      // missing hash would create it; the EXISTS guard prevents that.
+      await reg.touch("abc", Date.now());
+      expect(await reg.get("abc")).toBeNull();
+    } finally {
+      await reg.shutdown();
+    }
+  });
+
+  it("redacts credentials before logging the connection URL", async () => {
+    // Smoke check on the URL redactor used in the factory boot log. We
+    // exercise via a live registry instance to confirm shape.
+    const client = new FakeRedis();
+    const reg = new RedisSessionRegistry({
+      url: "redis://user:secret@example.com:6379",
+      ttlMs: 1000,
+      client,
+    });
+    // No assertion on log content here — we just ensure construction
+    // doesn't throw with credentials in the URL.
+    await reg.shutdown();
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Architectural step that unblocks horizontal scaling of `/mcp`. Companion to NimbleBrainInc/nimblebrain#161 (immediate TTL fix).

**Two-layer session architecture:**

1. **Transport map** (per-process, in-memory, never abstracted) — owns the live `WebStandardStreamableHTTPServerTransport`, the SDK `Server` instance with its registered handlers, and any in-flight JSON-RPC state. Process-bound: holds open response streams and JS object references that cannot be serialized or moved.
2. **`SessionRegistry`** (pluggable) — cluster-shared metadata store. Tells us whether a session exists, when it was last touched, and which workspace + identity it's bound to. **Deliberately deployment-vocabulary-free** — no pod/instance/owner concept. Routing live requests to the process that owns a given session's transport is the load balancer's job (cookie stickiness, header-hash on `Mcp-Session-Id`), not the registry's.

**Two providers:**

- `InMemorySessionRegistry` — process-local `Map` + periodic TTL sweep. Default.
- `RedisSessionRegistry` — hash-per-session at `${prefix}${sessionId}` with native `PEXPIRE` TTL. No new npm dep — uses Bun's built-in `RedisClient`. Required when scaling `replicas > 1`. Also useful at single-replica for cluster-wide ops visibility into active sessions.

**`McpServerHost` class** replaces module-level globals in `mcp-server.ts`. Owns the transport map + injected `SessionRegistry`. One instance per process, constructed in `startServer`, threaded via `AppContext`, used by `routes/mcp.ts`.

**2-reason session-miss classification** — when a POST with a session-id has no local transport, the host reports via `error.data.reason`:

| reason | Meaning |
|--------|---------|
| `not_found` | Session store has no record. Idle-TTL eviction or session never existed. |
| `unavailable` | Session exists in the store, but the live transport isn't on this process. Could be a process restart, sticky-routing miss, or local transport closure — client's correct action is the same in either case: re-initialize. Operators distinguish via deploy timing, uptime, and "registry size vs local transport count" signals. |

**Best-effort registry semantics.** A Redis outage doesn't break sessions whose transports live on the local process — local map is the gate, registry is supplementary. Failed `touch` / `get` log a warning and degrade to "treat as missing", which is still a useful 404.

## Configuration

```json
{
  "sessionStore": {
    "type": "memory",                // or "redis"
    "ttlSeconds": 28800,             // 8h default
    "redis": {
      "url": "redis://...",          // typically `${REDIS_URL}` from a secret
      "keyPrefix": "nb:mcp:session:"
    }
  }
}
```

`resolveSessionStoreConfig` refuses to silently fall back to memory if `type: "redis"` is set without a URL — fail loud at boot rather than at every MCP request. The `redis.url` field expands `${VAR}` placeholders from `process.env` so Helm-rendered configmaps can carry the secret reference verbatim.

## Breaking changes

`sessionStore.ttlMs` → `sessionStore.ttlSeconds`. Anyone with `sessionStore.ttlMs` already in `nimblebrain.json` will get an AJV "unknown key" warning and silently fall through to the new 8h default. Operator-facing knobs use seconds because milliseconds are implementation-leakage — consistent with NimbleBrainInc/nimblebrain#161's env var rename and every adjacent abstraction (K8s timeouts, ALB cookie/idle annotations, Redis EXPIRE).

`McpServerHost` replaces the previous module-level `closeAllMcpSessions` and `handleMcpRequest` exports. Internal-only API; only updated within this PR.

## What's NOT in this PR

The operator-side pieces required to actually run multi-replica are tracked separately:
- Helm chart support for `config.sessionStore` and configurable `platform.strategy` (companion PR in internal infra repo)
- Per-tenant ALB stickiness annotation (companion PR in internal deployments repo)
- Redis instance provisioning + `REDIS_URL` ExternalSecret wiring (operator concern)
- Workspace storage off the RWO PVC (Postgres/S3 or RWX/EFS) — required before `RollingUpdate` can roll. Separate effort.

## Test plan

- [x] `bun run verify` — static (format/lint/types/cycles) clean; 451 integration tests pass; 17 smoke tests pass; new unit tests pass.
- [x] **Conformance suite** — same `registrySpec` runs against both providers (Redis via in-process fake). 9 conformance assertions × 2 providers + 2 redis-specific.
- [x] **Factory tests** — defaults, redis-without-url throws, `${VAR}` expansion (literal / from env / undefined-throws), `ttlSeconds` → `ttlMs` conversion, key-prefix override.
- [x] **Host classification tests** — `not_found` / `unavailable` / registry-outage paths via pre-populated registry.
- [x] **Integration test** — `error.data.reason: "not_found"` over the HTTP surface end-to-end.
- [x] **Manual smoke** against running dev server — session store boot log fires (`[mcp] session store: memory ttl=28800s`), full MCP init+list works, bogus sessionId returns classified 404.
- [x] Web bootstrap loads cleanly in Chrome.

## Adjudicated design decisions

| Question | Choice | Why |
|----------|--------|-----|
| Should `SessionMeta` carry instance identity? | No | Leaky deployment vocabulary in a clean metadata interface. Locality is the local transport map's job; routing is the LB's job. |
| 3 miss reasons or 2? | 2 | The orphaned/misrouted distinction required process identity in the registry. Operators distinguish via deploy timing, uptime, registry-vs-transport-count divergence — without polluting the type. |
| Bun's RedisClient or `ioredis`? | Bun built-in | Codebase is Bun-only. No new npm dep. |
| Eager Redis connect at boot, or lazy? | Eager | Fail-loud at boot beats failing every individual MCP request. Misconfiguration shouldn't pass readiness probes. |
| Cross-pod proxy on misroute? | No | Stickiness covers 99.9%. Streaming-response forwarding is a major project for the remaining 0.1%. Out of scope. |
| Persist transport state to Redis? | Impossible | Streamable HTTP transports own live response handles — not serializable. Registry tracks metadata only. |
| Test against real Redis? | Not in this PR | Unit tests use a structural `RedisLike` interface + in-process fake. A `testcontainers`-style integration test belongs in `test/integration/`; not blocking. |