### PR TITLE
fix(web): recover from expired MCP server sessions in the iframe bridge (#141)

### DIFF
--- a/web/src/__tests__/bridge/bridge-tasks.test.ts
+++ b/web/src/__tests__/bridge/bridge-tasks.test.ts
@@ -114,6 +114,12 @@ mock.module("../../mcp-bridge-client", () => ({
   resetMcpBridgeClient: () => {
     /* noop */
   },
+  // Passthrough: this file doesn't exercise the session-miss recovery path,
+  // so the wrapper just runs the op once. Mocking it is required because
+  // bridge.ts named-imports it; without this the file fails to link in
+  // isolation (passes under `bun test` only because mcp-bridge-client.test.ts
+  // happens to load the real module first and Bun shares link state).
+  withSessionRetry: async <T>(op: () => Promise<T>): Promise<T> => op(),
 }));
 
 // Import bridge AFTER mocks so it picks up the stubs.

--- a/web/src/__tests__/bridge/bridge-transport.test.ts
+++ b/web/src/__tests__/bridge/bridge-transport.test.ts
@@ -87,6 +87,12 @@ mock.module("../../mcp-bridge-client", () => ({
   resetMcpBridgeClient: () => {
     /* noop */
   },
+  // Passthrough: this file doesn't exercise the session-miss recovery path,
+  // so the wrapper just runs the op once. Mocking it is required because
+  // bridge.ts named-imports it; without this the file fails to link in
+  // isolation (passes under `bun test` only because mcp-bridge-client.test.ts
+  // happens to load the real module first and Bun shares link state).
+  withSessionRetry: async <T>(op: () => Promise<T>): Promise<T> => op(),
 }));
 
 // Import bridge AFTER mocks are registered so it picks up the stubs.

--- a/web/src/__tests__/mcp-bridge-client.test.ts
+++ b/web/src/__tests__/mcp-bridge-client.test.ts
@@ -80,7 +80,7 @@ mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { setActiveWorkspaceId, setAuthLifecycleHandler, setAuthToken } from "../api/client";
-import { getMcpBridgeClient, resetMcpBridgeClient } from "../mcp-bridge-client";
+import { getMcpBridgeClient, resetMcpBridgeClient, withSessionRetry } from "../mcp-bridge-client";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -205,6 +205,117 @@ describe("resetMcpBridgeClient", () => {
     expect(() => resetMcpBridgeClient()).not.toThrow();
     expect(clientCloseCalls).toBe(0);
     expect(transportCloseCalls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session-not-found recovery — fixes the symptom in #141 where a stale
+// `Mcp-Session-Id` (after a server-side TTL eviction or process restart)
+// would lock every iframe call into a permanent error until page refresh.
+// ---------------------------------------------------------------------------
+
+describe("withSessionRetry", () => {
+  /**
+   * The platform's exact 404 body, embedded inside the SDK transport's
+   * wrapper text. Matching `mcp-server.ts::handlePost`. If the wording on
+   * the server side changes, this test breaks loudly — which is the point.
+   */
+  const SESSION_NOT_FOUND_TRANSPORT_ERROR = new Error(
+    `Streamable HTTP error: Error POSTing to endpoint: ${JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Session not found" },
+      id: null,
+    })}`,
+  );
+
+  test("returns the operation's value when no error", async () => {
+    const op = mock(async () => "ok");
+    const result = await withSessionRetry(op);
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries once on session-not-found and returns the second-call value", async () => {
+    let invocations = 0;
+    const op = async () => {
+      invocations += 1;
+      if (invocations === 1) throw SESSION_NOT_FOUND_TRANSPORT_ERROR;
+      return "recovered";
+    };
+
+    // Prime the singleton so the reset path actually has something to close.
+    await getMcpBridgeClient();
+    expect(clientCtorCalls).toBe(1);
+
+    const result = await withSessionRetry(op);
+    expect(result).toBe("recovered");
+    expect(invocations).toBe(2);
+
+    // After-the-fact wait for the async client.close() the reset triggers.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(clientCloseCalls).toBe(1);
+  });
+
+  test("recognizes the parsed error.data.reason variant (forward-compat with #162)", async () => {
+    let invocations = 0;
+    const op = async () => {
+      invocations += 1;
+      if (invocations === 1) {
+        // Simulate the post-#162 SDK exposing parsed JSON-RPC error data.
+        throw Object.assign(new Error("session miss"), {
+          data: { reason: "unavailable" },
+        });
+      }
+      return "recovered";
+    };
+
+    const result = await withSessionRetry(op);
+    expect(result).toBe("recovered");
+    expect(invocations).toBe(2);
+  });
+
+  test("propagates non-session errors without retrying", async () => {
+    let invocations = 0;
+    const op = async () => {
+      invocations += 1;
+      throw new Error("Tool execution failed: bad input");
+    };
+
+    await expect(withSessionRetry(op)).rejects.toThrow("Tool execution failed");
+    expect(invocations).toBe(1);
+  });
+
+  test("propagates the second error if the retry also fails", async () => {
+    let invocations = 0;
+    const op = async () => {
+      invocations += 1;
+      if (invocations === 1) throw SESSION_NOT_FOUND_TRANSPORT_ERROR;
+      throw new Error("auth failed on retry");
+    };
+
+    await expect(withSessionRetry(op)).rejects.toThrow("auth failed on retry");
+    expect(invocations).toBe(2);
+  });
+
+  test("retried op gets a fresh client (singleton was dropped)", async () => {
+    const firstClient = await getMcpBridgeClient();
+    expect(clientCtorCalls).toBe(1);
+
+    let invocations = 0;
+    let secondClient: unknown = null;
+    await withSessionRetry(async () => {
+      invocations += 1;
+      if (invocations === 1) throw SESSION_NOT_FOUND_TRANSPORT_ERROR;
+      // The op closes over getMcpBridgeClient — second invocation must
+      // see a freshly-constructed client, not the dead singleton.
+      secondClient = await getMcpBridgeClient();
+      return "ok";
+    });
+
+    expect(secondClient).not.toBe(firstClient);
+    expect(clientCtorCalls).toBe(2);
+    expect(connectCalls).toBe(2);
   });
 });
 

--- a/web/src/bridge/bridge.ts
+++ b/web/src/bridge/bridge.ts
@@ -33,7 +33,7 @@ import {
   TaskStatusNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { uploadResource } from "../api/client";
-import { getMcpBridgeClient } from "../mcp-bridge-client";
+import { getMcpBridgeClient, withSessionRetry } from "../mcp-bridge-client";
 import { getHostThemeMode, getSpecThemeTokens, getThemeTokens } from "./theme";
 import type {
   BridgeCallbacks,
@@ -672,8 +672,6 @@ async function callToolViaMcp(
   params: ToolsCallParams,
   id: string,
 ): Promise<UiToolResultResponse | UiToolResultError | Record<string, unknown>> {
-  const client = await getMcpBridgeClient();
-
   // The `/mcp` endpoint advertises tool names as `<source>__<tool>`, so
   // the wire `tools/call` must use the qualified form (see
   // `mcp-server.ts::CallToolRequestSchema`). Iframes that already pass a
@@ -681,56 +679,60 @@ async function callToolViaMcp(
   // the resolved `server` (post-INTERNAL_APPS authz).
   const wireName = params.name.includes("__") ? params.name : `${server}__${params.name}`;
 
-  if (params.task) {
-    // Task-augmented: the server returns CreateTaskResult, not
-    // CallToolResult. The typed `client.callTool()` would reject that;
-    // use the generic `request()` path with the right schema and
-    // forward the result verbatim (Non-Negotiable Rule 4).
-    const method: CallToolRequest["method"] = "tools/call";
-    const result = await client.request(
-      {
-        method,
-        params: {
-          name: wireName,
-          arguments: params.arguments ?? {},
-          task: params.task,
+  return withSessionRetry(async () => {
+    const client = await getMcpBridgeClient();
+
+    if (params.task) {
+      // Task-augmented: the server returns CreateTaskResult, not
+      // CallToolResult. The typed `client.callTool()` would reject that;
+      // use the generic `request()` path with the right schema and
+      // forward the result verbatim (Non-Negotiable Rule 4).
+      const method: CallToolRequest["method"] = "tools/call";
+      const result = await client.request(
+        {
+          method,
+          params: {
+            name: wireName,
+            arguments: params.arguments ?? {},
+            task: params.task,
+          },
         },
+        CreateTaskResultSchema,
+      );
+      return { jsonrpc: "2.0", id, result };
+    }
+
+    const result = await client.callTool(
+      {
+        name: wireName,
+        arguments: params.arguments ?? {},
       },
-      CreateTaskResultSchema,
+      CallToolResultSchema,
     );
-    return { jsonrpc: "2.0", id, result };
-  }
 
-  const result = await client.callTool(
-    {
-      name: wireName,
-      arguments: params.arguments ?? {},
-    },
-    CallToolResultSchema,
-  );
+    if (result.isError) {
+      const errorText =
+        (result.content as Array<{ text?: string }> | undefined)
+          ?.map((b) => b.text ?? "")
+          .filter(Boolean)
+          .join("\n") || "Tool error";
+      return {
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32000, message: errorText },
+      } satisfies UiToolResultError;
+    }
 
-  if (result.isError) {
-    const errorText =
-      (result.content as Array<{ text?: string }> | undefined)
-        ?.map((b) => b.text ?? "")
-        .filter(Boolean)
-        .join("\n") || "Tool error";
+    // Forward the full CallToolResult shape (content + structuredContent).
     return {
       jsonrpc: "2.0",
       id,
-      error: { code: -32000, message: errorText },
-    } satisfies UiToolResultError;
-  }
-
-  // Forward the full CallToolResult shape (content + structuredContent).
-  return {
-    jsonrpc: "2.0",
-    id,
-    result: {
-      content: result.content as UiToolResultResponse["result"]["content"],
-      structuredContent: result.structuredContent as Record<string, unknown> | undefined,
-    },
-  } satisfies UiToolResultResponse;
+      result: {
+        content: result.content as UiToolResultResponse["result"]["content"],
+        structuredContent: result.structuredContent as Record<string, unknown> | undefined,
+      },
+    } satisfies UiToolResultResponse;
+  });
 }
 
 /**
@@ -739,15 +741,16 @@ async function callToolViaMcp(
  * JSON-RPC response envelope for the iframe.
  */
 async function readResourceViaMcp(server: string, uri: string): Promise<{ contents: unknown[] }> {
-  const client = await getMcpBridgeClient();
-
   // Per spec, `resources/read` carries only the URI — the resource is
   // namespaced by the bundle that authored it, not by request params.
   // `server` is consumed by the INTERNAL_APPS authz at the call site
   // (cross-call permission); it doesn't appear on the wire here.
   void server;
-  const result = await client.readResource({ uri });
-  return { contents: result.contents as unknown[] };
+  return withSessionRetry(async () => {
+    const client = await getMcpBridgeClient();
+    const result = await client.readResource({ uri });
+    return { contents: result.contents as unknown[] };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -815,10 +818,16 @@ async function forwardTaskRequest(
   id: string,
 ): Promise<Record<string, unknown>> {
   try {
-    const client = await getMcpBridgeClient();
-    const result = await client.request({ method, params }, schema);
-    // Forward the result verbatim (Non-Negotiable Rule 4: never unwrap).
-    return { jsonrpc: "2.0", id, result };
+    // `withSessionRetry` only re-runs on the specific session-not-found
+    // shape; any other error (incl. spec-mandated `-32602` for missing
+    // tasks) propagates through this catch and gets translated to the
+    // JSON-RPC error envelope the iframe expects.
+    return await withSessionRetry(async () => {
+      const client = await getMcpBridgeClient();
+      const result = await client.request({ method, params }, schema);
+      // Forward the result verbatim (Non-Negotiable Rule 4: never unwrap).
+      return { jsonrpc: "2.0", id, result };
+    });
   } catch (err) {
     return { jsonrpc: "2.0", id, error: translateTaskError(err) };
   }

--- a/web/src/mcp-bridge-client.ts
+++ b/web/src/mcp-bridge-client.ts
@@ -91,6 +91,79 @@ export function resetMcpBridgeClient(): void {
 setAuthLifecycleHandler(resetMcpBridgeClient);
 
 // ---------------------------------------------------------------------------
+// Session-not-found recovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Run an MCP bridge operation, recovering once from a stale `Mcp-Session-Id`.
+ *
+ * The platform's `/mcp` endpoint may respond with a 404 + JSON-RPC `Session
+ * not found` envelope after a server-side TTL eviction or process restart.
+ * The bridge's cached `Client` keeps replaying the dead session id on every
+ * subsequent request — every iframe call would fail with that error until
+ * the user refreshed the page (issue #141).
+ *
+ * This wrapper catches the specific shape, drops the cached singleton via
+ * `resetMcpBridgeClient`, and runs `op` once more. The retried operation
+ * triggers a fresh `getMcpBridgeClient()` → fresh `initialize` → fresh
+ * session id, and the original request goes out clean. Other errors (real
+ * tool failures, network outages, auth) propagate without modification —
+ * this is recovery scoped to the single failure mode it claims to fix.
+ *
+ * Single retry only. If the retry also fails for any reason, the caller
+ * sees that second error. Looping would mask infrastructure problems.
+ *
+ * Note: retry is per-operation, not per-session. A session-augmented
+ * `tasks/{get,result,cancel}` against a task that lived on the lost
+ * session will get a fresh session AND a fresh (empty) task table — the
+ * task-id will resolve to `-32602 task not found`. That's the correct
+ * answer (the task really is gone); iframes that care must re-issue any
+ * in-flight work after seeing it.
+ */
+export async function withSessionRetry<T>(op: () => Promise<T>): Promise<T> {
+  try {
+    return await op();
+  } catch (err) {
+    if (!isSessionNotFoundError(err)) throw err;
+    resetMcpBridgeClient();
+    return await op();
+  }
+}
+
+/**
+ * Detect the platform's session-miss 404 across the two shapes the SDK
+ * surfaces it in:
+ *
+ *   1. `StreamableHTTPClientTransport` sees a non-2xx response and throws
+ *      a generic `Error` whose `.message` embeds the JSON-RPC envelope
+ *      verbatim (`Error POSTing to endpoint: {"jsonrpc":"2.0",...}`). The
+ *      substring `Session not found` reliably distinguishes us from any
+ *      other JSON the transport might wrap.
+ *   2. Future SDK versions may parse the JSON-RPC envelope and expose
+ *      `error.data.reason` directly. Forward-compat: match `not_found`
+ *      and `unavailable` (the two reasons emitted by the post-#162
+ *      session-store classifier).
+ *
+ * Both paths return the same boolean — the recovery is identical.
+ */
+function isSessionNotFoundError(err: unknown): boolean {
+  if (!err) return false;
+
+  // Substring match on the SDK-wrapped transport error.
+  if (err instanceof Error && err.message.includes("Session not found")) {
+    return true;
+  }
+
+  // Parsed `error.data.reason` (post-#162 forward-compat).
+  if (typeof err === "object" && err !== null) {
+    const reason = (err as { data?: { reason?: unknown } }).data?.reason;
+    if (reason === "not_found" || reason === "unavailable") return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #141.

The platform's `/mcp` endpoint may respond with a 404 + JSON-RPC `Session not found` envelope after a server-side TTL eviction or process restart. The bridge's cached `Client` keeps replaying the dead session id on every subsequent request — every iframe tool call, resource read, or task request fails until the user refreshes the page.

PR #161 mitigated impact (TTL 30 min → 8 h, ~16× less frequent), but didn't add the recovery itself. This PR is the actual fix.

### What it does

`withSessionRetry()` in `mcp-bridge-client.ts` wraps an MCP bridge operation:

1. Run `op()`.
2. If it succeeds, return the value.
3. If it throws and the error matches the session-not-found shape, call `resetMcpBridgeClient()` to drop the cached singleton, then run `op()` once more.
4. Any other error propagates without modification. A second failure of any kind also propagates — single retry only, looping would mask infrastructure problems.

The retried op closes over `getMcpBridgeClient()` and gets a freshly-initialized `Client` — fresh session id, fresh transport, the original request completes cleanly.

### Detection — two shapes, same boolean

```ts
function isSessionNotFoundError(err: unknown): boolean {
  // SDK transport sees non-2xx and throws Error with the JSON-RPC body
  // embedded in the message: "...Error POSTing to endpoint: {jsonrpc..."
  if (err instanceof Error && err.message.includes("Session not found")) return true;

  // Forward-compat with #162: parsed error.data.reason exposed by SDK.
  if (typeof err === "object" && err !== null) {
    const reason = (err as { data?: { reason?: unknown } }).data?.reason;
    if (reason === "not_found" || reason === "unavailable") return true;
  }
  return false;
}
```

### Wired into all three bridge dispatch sites

- `callToolViaMcp` — both inline and task-augmented paths
- `readResourceViaMcp`
- `forwardTaskRequest` — wrapped *before* `translateTaskError`, so non-session errors (incl. spec-mandated `-32602` for missing tasks) still translate cleanly to the iframe's JSON-RPC envelope

### What's NOT in this PR

- **Notification handler re-subscription**: the bridge subscribes to `notifications/tasks/status` once per session in `bridge.ts`. After a session reset, that subscription is on the dead client; new tasks won't push status to the iframe until the next reset. Genuinely separate concern (in-flight tasks lost when the session evicted are gone anyway — task IDs are session-bound). Track as follow-up.
- **In-flight task ID survival**: a `tasks/get` retried with a fresh session will correctly return `-32602 task not found` because the task lived on the lost session. That's the right answer; iframes that care must re-issue.

## Test plan

- [x] `bun run verify` — all green (unit + integration + smoke).
- [x] **6 new unit tests** in `web/src/__tests__/mcp-bridge-client.test.ts`:
  1. No-error path returns op's value
  2. Retry-then-success returns the recovered value (closes the issue's symptom)
  3. Parsed `error.data.reason` variant matched (forward-compat with #162)
  4. Non-session errors propagate without retry
  5. Retry-also-fails surfaces the second error (no infinite loop)
  6. Retried op gets a fresh client (singleton actually dropped)
- [x] Manual smoke against running dev server: web bootstrap loads cleanly in Chrome; no console errors.

## Manual repro test (post-merge)

1. Start dev server with a tight TTL: `MCP_SESSION_TTL_SECONDS=10 bun run dev`.
2. Open the web UI; pick a synapse app whose iframe makes tool calls.
3. Idle the tab > 10 s.
4. Click anything that triggers a tool call.
5. Before this PR: visible error in the iframe; subsequent calls all fail until refresh. After this PR: brief delay (re-init handshake), then the call succeeds. Server log shows one `[mcp] session miss reason=...` line, then a fresh `initialize`.