### PR TITLE
docs(agents): add MCP session architecture section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,29 @@ The platform serves three audiences with three protocol surfaces. They are not t
 
 `/v1/tools/call` and `/v1/resources/read` are NOT being deprecated. They are the platform's first-party API and stay alive indefinitely.
 
+## MCP Session Architecture
+
+Two-layer state model for `/mcp`. Don't merge them.
+
+- **Transport map** (`McpServerHost.transports`): per-process `Map<sessionId, transport>`. Owns the live `WebStandardStreamableHTTPServerTransport`, the SDK `Server` instance, and in-flight JSON-RPC state. Process-bound — never serialize, never share across processes.
+- **`SessionRegistry`** (`src/api/session-store/`): pluggable cluster-shared metadata. Stores `{sessionId, identityId, workspaceId, createdAt, lastAccessedAt}` only. **No pod / instance / owner fields** — adding any would leak deployment vocabulary into a metadata interface. Implementations: `InMemorySessionRegistry` (default) and `RedisSessionRegistry`.
+
+Routing requests to the process owning a session's transport is the **load balancer's** job (ALB `lb_cookie` stickiness or header-hash on `Mcp-Session-Id`). The registry doesn't route; it can't move transports.
+
+**Session-miss `error.data.reason`** has exactly two values:
+
+- `not_found` — registry has no entry (idle-TTL eviction or never created).
+- `unavailable` — registry has an entry; this process doesn't have the transport. Don't try to distinguish process-restart from sticky-miss in the response — operators do that via deploy timing + `transport-count vs registry-size` divergence.
+
+**Prerequisites for `platform.replicas > 1`** (all four required):
+
+1. RWX storage or workspace data moved off the PVC. RWO PVC + `RollingUpdate` deadlocks on attach.
+2. Routing keyed on `Mcp-Session-Id`. ALB `lb_cookie` stickiness on the platform target group, or NGINX/Envoy header-hash routing.
+3. `sessionStore.type: "redis"`. Each tenant gets its own Redis instance in its own namespace (see `infra/CLAUDE.md` per-tenant Redis pattern). Default `nb:mcp:session:` keyPrefix is correct under that model.
+4. `platform.strategy.type: RollingUpdate`. Only after (1).
+
+**TTL units: seconds at the surface, ms internally.** Operator-facing: `MCP_SESSION_TTL_SECONDS` env (highest priority) > `sessionStore.ttlSeconds` config > 8h default. Conversion to ms happens in `Runtime.getSessionStoreTtlMs()` only — registry constructors and sweep math take ms. Don't add mixed-unit code elsewhere.
+
 ## MCP App Bridge Rules
 
 These cause production bugs if violated:


### PR DESCRIPTION
## Summary

Codifies the design that landed across #161, #162, and #164 so future contributors don't re-derive it (or unwittingly break it). Pure docs change in `AGENTS.md` — no code, no behavior.

The full design discussion that produced these decisions covered ground that's not obvious from reading the code alone: why the `SessionRegistry` interface is deployment-vocabulary-free, why three miss-reasons collapsed to two, why routing belongs to the load balancer, and what the four prerequisites for `replicas > 1` actually are. This section keeps that orientation in-tree where contributors will find it.

## Added

A new `## MCP Session Architecture` section between `API Surfaces — Three Audiences` and `MCP App Bridge Rules`, covering:

- The two-layer split: transport map (process-bound, in-memory) vs `SessionRegistry` (pluggable, cluster-shared metadata).
- Why the registry stays deployment-vocabulary-free (no pod / instance / owner concept).
- Why routing is the load balancer's job, not the registry's.
- The 2-reason `error.data.reason` taxonomy (`not_found` / `unavailable`) and what operators look at to disambiguate the second.
- The four prerequisites for `platform.replicas > 1`, in dependency order.
- Per-tenant Redis is the deploy model (cross-references `infra/CLAUDE.md`).
- Operator surface is seconds; internal API is ms; conversion lives in `Runtime.getSessionStoreTtlMs` only.

## Why now

The user-facing config docs landed in [nimblebrain-docs#11](https://github.com/NimbleBrainInc/nimblebrain-docs/pull/11). This PR is the contributor-facing companion — the kind of orientation that doesn't belong on `docs.nimblebrain.ai` because it's about how to NOT break the implementation.

## Test plan

- [x] No code, no tests. Markdown-only.