### PR TITLE
fix(web): route tryBootstrap through silent-refresh interceptor

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -102,7 +102,11 @@ function headers(extra?: Record<string, string>): Record<string, string> {
 // ---------------------------------------------------------------------------
 
 const refreshInterceptor = createFetchWithRefresh({
-  fetch: globalThis.fetch.bind(globalThis),
+  // Late-bind globalThis.fetch on each call so tests can swap in a mock; in
+  // production globalThis.fetch is stable so this is equivalent to .bind().
+  // Cast widens the call signature back to `typeof fetch` (the option type
+  // includes the static .preconnect method, which the interceptor never calls).
+  fetch: ((input, init) => globalThis.fetch(input, init)) as typeof fetch,
   refreshUrl: `${API_BASE}/v1/auth/refresh`,
   onAuthError: () => onAuthError?.(),
 });
@@ -516,6 +520,13 @@ export async function logout(): Promise<void> {
  * Try to bootstrap (unauthenticated-safe). Returns bootstrap data if
  * authenticated, null if 401 or network error. Used as the single auth check.
  *
+ * Routes through {@link fetchWithRefresh} so a returning user with an expired
+ * access-token cookie but a valid `nb_refresh` cookie is silently re-authed
+ * on cold load instead of being bounced to the login screen. `onAuthError`
+ * is null at this point in the App lifecycle (App.tsx wires it inside
+ * initFromBootstrap, after this call) so a failed refresh just leaves the
+ * 401 in place and we return null — same behavior as before.
+ *
  * `workspaceId` is the client's remembered last-active workspace — see
  * {@link getBootstrap} for the server-side contract.
  */
@@ -523,7 +534,7 @@ export async function tryBootstrap(workspaceId?: string): Promise<BootstrapRespo
   try {
     const extra: Record<string, string> = {};
     if (workspaceId) extra["X-Workspace-Id"] = workspaceId;
-    const res = await fetch(`${API_BASE}/v1/bootstrap`, {
+    const res = await fetchWithRefresh(`${API_BASE}/v1/bootstrap`, {
       credentials: "include",
       headers: {
         ...headers(),

--- a/web/src/api/try-bootstrap.test.ts
+++ b/web/src/api/try-bootstrap.test.ts
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------------------
+// api/client.ts — tryBootstrap silent-refresh contract
+//
+// tryBootstrap is the first auth-touching call the app makes on every page
+// load (App.tsx). It must route through fetchWithRefresh so that a returning
+// user with an expired access-token cookie but a valid `nb_refresh` cookie
+// is silently re-authed instead of being bounced to the login screen.
+//
+// Regression history: the original implementation used raw fetch and treated
+// any 401 as "show login," producing one forced re-login per (idle hour +
+// next page load). Multiple tenants reported "we get logged out several
+// times a day" until this was routed through the interceptor.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { setAuthToken, setOnAuthError, tryBootstrap } from "./client";
+
+interface CallLog {
+  bootstrap: number;
+  refresh: number;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const BOOTSTRAP_BODY = {
+  identity: { id: "u_1", email: "u@example.com", displayName: "U" },
+  workspaces: [{ id: "ws_1", name: "Personal" }],
+  activeWorkspace: "ws_1",
+  features: {},
+  version: "test",
+  buildSha: null,
+} as const;
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  // Reset module state that other tests may leave dangling.
+  setAuthToken(null);
+  setOnAuthError(null);
+});
+
+describe("tryBootstrap", () => {
+  test("returns parsed bootstrap when /v1/bootstrap returns 200 directly", async () => {
+    const calls: CallLog = { bootstrap: 0, refresh: 0 };
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/v1/auth/refresh")) {
+        calls.refresh++;
+        return new Response(null, { status: 200 });
+      }
+      if (url.endsWith("/v1/bootstrap")) {
+        calls.bootstrap++;
+        return jsonResponse(BOOTSTRAP_BODY);
+      }
+      throw new Error(`unexpected url: ${url}`);
+    }) as typeof fetch;
+
+    const result = await tryBootstrap();
+
+    expect(result).not.toBeNull();
+    expect(result?.activeWorkspace).toBe("ws_1");
+    expect(calls.bootstrap).toBe(1);
+    expect(calls.refresh).toBe(0);
+  });
+
+  test("silently refreshes on 401 and returns parsed bootstrap from the retry", async () => {
+    // The bug fix: returning user has expired access-token cookie but a
+    // valid `nb_refresh`. Bootstrap 401s, fetchWithRefresh hits /v1/auth/refresh,
+    // and retries the bootstrap. The user must NOT see a login screen.
+    const calls: CallLog = { bootstrap: 0, refresh: 0 };
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/v1/auth/refresh")) {
+        calls.refresh++;
+        return new Response(null, { status: 200 });
+      }
+      if (url.endsWith("/v1/bootstrap")) {
+        calls.bootstrap++;
+        return calls.bootstrap === 1
+          ? new Response(null, { status: 401 })
+          : jsonResponse(BOOTSTRAP_BODY);
+      }
+      throw new Error(`unexpected url: ${url}`);
+    }) as typeof fetch;
+
+    const result = await tryBootstrap();
+
+    expect(result).not.toBeNull();
+    expect(result?.activeWorkspace).toBe("ws_1");
+    expect(calls.bootstrap).toBe(2); // original 401 + retry after refresh
+    expect(calls.refresh).toBe(1);
+  });
+
+  test("returns null when bootstrap 401s and refresh also fails", async () => {
+    // Truly unauthenticated user (no `nb_refresh` cookie or it's invalid).
+    // Refresh fetch comes back 401; tryBootstrap should resolve to null
+    // so App.tsx renders the login screen.
+    const calls: CallLog = { bootstrap: 0, refresh: 0 };
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/v1/auth/refresh")) {
+        calls.refresh++;
+        return new Response(null, { status: 401 });
+      }
+      if (url.endsWith("/v1/bootstrap")) {
+        calls.bootstrap++;
+        return new Response(null, { status: 401 });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    }) as typeof fetch;
+
+    const result = await tryBootstrap();
+
+    expect(result).toBeNull();
+    expect(calls.refresh).toBe(1);
+  });
+
+  test("returns null on network error without throwing", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("Failed to fetch");
+    }) as typeof fetch;
+
+    const result = await tryBootstrap();
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- \`tryBootstrap\` (the first auth-touching call on every page load) used raw \`fetch\` and treated any 401 as "show login," so returning users with an expired access-token cookie but a valid \`nb_refresh\` cookie got bounced to the login screen on every cold load. Multiple tenants reported being logged out several times a day.
- Routed the call through \`fetchWithRefresh\`, the same silent-refresh interceptor every other authenticated REST call uses. On 401 it now hits \`/v1/auth/refresh\` and retries, exactly like the rest of the API surface.
- Late-bound \`globalThis.fetch\` inside the interceptor (was \`.bind()\`-at-load) so the new test can stub it. Production behavior is unchanged.

## Why bumping the WorkOS access-token TTL didn't fix this

Bumping access-token TTL from 5 min → 60 min reduces how often the JWT expires, but the bootstrap path never invoked the refresh interceptor in the first place — so any cold load after the JWT had expired (laptop slept, tab closed >TTL, etc.) still forced a re-login. This patch addresses the actual code path.

## Test plan

- [x] New \`web/src/api/try-bootstrap.test.ts\` covers four cases:
  - Direct 200 → returns parsed bootstrap, no refresh fired
  - 401 → refresh succeeds → retry returns parsed bootstrap (the bug fix)
  - 401 + refresh-also-401 → returns null (login screen path, unchanged)
  - Network error → returns null without throwing
- [x] \`bun run verify:static\` clean
- [x] \`bun run verify:test-unit\`: 2371 server + 238 web tests, 0 fail
- [ ] Smoke on bayze/hq after deploy: leave a tab idle past JWT expiry, refresh — should not see the login screen