### PR TITLE
feat(dev): add dev:worktree for isolated per-worktree dev runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # local dev runtime state (conversations, logs, skills)
 .nimblebrain
 
+# per-worktree isolated workdir created by `bun run dev:worktree`
+.nimblebrain-worktree
+
 # environment fixture runtime state — config files are tracked, generated state is not
 .environments/*/conversations/
 .environments/*/logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Self-hosted platform for MCP Apps and agent automations, built on Bun. Agentic l
 ```bash
 bun install                # Install dependencies
 bun run dev                # API (:27247) + Web (:27246) with watch/HMR
+bun run dev:worktree       # Run from any worktree against an isolated workdir on alt ports — see "Worktree dev" below
 bun run dev:api            # API only with auto-restart
 bun run verify             # Full CI parity — runs every subscript below
 bun run verify:static      # format:check + lint + check + check:cycles
@@ -31,6 +32,20 @@ bun run build:bundles      # Rebuild every src/bundles/*/ui (vite single-file)
 **`bun run dev` does NOT rebuild bundles.** The API serves each bundle from its pre-built `src/bundles/<name>/ui/dist/index.html`. After editing any file under `src/bundles/*/ui/src/`, run `bun run build:bundles` and restart the dev server (the API reads dist on iframe mount; it doesn't watch the file). Forgetting this means the iframe loads stale code while your changes look "live" in the source tree — a high-confusion failure mode.
 
 **Before opening a PR, run `bun run verify`.** It is the single command that mirrors CI, enforced by construction: `.github/workflows/ci.yml` invokes only `verify:*` subscripts (plus `test:integration` and `smoke`) — no inline check steps. To add or change a check, edit the matching subscript in `package.json`; CI picks it up automatically. If CI ever catches something `verify` didn't, the fix is to update the subscript, not the checklist. Tool-level parity is the gate; discipline-level rules are not.
+
+### Worktree dev
+
+`bun run dev:worktree` runs the platform from any git worktree against a worktree-local workdir, on alt ports, with no auth gate — for QA on a feature branch without disturbing your primary `~/.nimblebrain` dev or another worktree's state.
+
+| Setting | Value |
+|---|---|
+| Workdir | `<worktree>/.nimblebrain-worktree/` (auto-seeded; gitignored) |
+| Config | `<worktree>/.nimblebrain-worktree/nimblebrain.json` (auto-seeded on first run) |
+| API / Web ports | 27271 / 27270 (override via `NB_API_PORT` / `NB_WEB_PORT`) |
+| Auth | none (dev mode — no `instance.json`) |
+| LLM keys | `ANTHROPIC_API_KEY` (and friends) read from your shell environment |
+
+Each worktree gets its own isolated state, so two worktrees can run side-by-side without colliding. Reset with `rm -rf .nimblebrain-worktree && bun run dev:worktree`. Share state across worktrees with `NB_WORK_DIR=/abs/path bun run dev:worktree`. Suitable for Chrome DevTools-driven E2E tests against `/v1/*` (no login dance).
 
 ## Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Added
 
+- `bun run dev:worktree` — runs the platform from any git worktree against a worktree-local `.nimblebrain-worktree/` workdir on alt ports (27271 API / 27270 web), in dev mode with no auth. For smoke-testing a feature branch without disturbing your primary dev or another worktree's state; suitable for Chrome DevTools E2E. See `AGENTS.md` § Worktree dev.
 - `compose__effective_context` debug tool — single-call answer to "what's in the system prompt for this conversation, with provenance per layer." Live mode returns the full traced composition; historical mode (`run_id` set) reads the recorded `skills.loaded` event for that run and verifies each layer-3 skill's `contentHash` against current source, with `_versions/` snapshot recovery on drift. Bundle filter narrows to one app's contributions ([#119](https://github.com/NimbleBrainInc/nimblebrain/issues/119)).
 - `skills.loaded` events now carry a `contentHash` (SHA-256 hex) per skill — telemetry foundation for the `compose__effective_context` debug tool. ~64 bytes per skill per turn.
 - Extended-thinking config (`thinking: off | adaptive | enabled` + `thinkingBudgetTokens`) in runtime config and Settings → Model; defaults to `adaptive` for catalog-flagged reasoning models, `off` otherwise ([#109](https://github.com/NimbleBrainInc/nimblebrain/pull/109)).

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dev:empty": "NB_API_PORT=27249 NB_WEB_PORT=27248 bun run src/cli/index.ts dev --port 27249 --config .environments/empty/nimblebrain.json",
     "dev:minimal": "NB_API_PORT=27251 NB_WEB_PORT=27250 bun run src/cli/index.ts dev --port 27251 --config .environments/minimal/nimblebrain.json",
     "dev:docs-demo": "NB_DEV_DISPLAY_NAME='Sarah Chen' NB_DEV_EMAIL='sarah@acme.co' NB_API_PORT=27253 NB_WEB_PORT=27252 bun run src/cli/index.ts dev --port 27253 --config .environments/docs-demo/nimblebrain.json",
+    "dev:worktree": "bun run scripts/dev-worktree.ts",
     "dev:api": "bun --watch src/cli/index.ts serve -c .nimblebrain/nimblebrain.json",
     "dev:web": "cd web && bun run dev",
     "dev:tui": "bun run src/cli/index.ts -c .nimblebrain/nimblebrain.json",

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+/**
+ * Run the platform from a worktree against an isolated workdir.
+ *
+ * Use case: smoke-test or QA against a feature branch without colliding
+ * with a primary `~/.nimblebrain` dev or another worktree's state. Runs
+ * in dev mode (no `instance.json` → no auth gate), so it's suitable for
+ * Chrome DevTools-driven E2E against `/v1/*` endpoints with no login
+ * dance.
+ *
+ * Convention (per worktree root):
+ *   - Workdir: `<cwd>/.nimblebrain-worktree/`
+ *   - Config:  `<cwd>/.nimblebrain-worktree/nimblebrain.json` (auto-seeded on first run)
+ *   - Ports:   API 27271, Web 27270 (override via `NB_API_PORT` / `NB_WEB_PORT`)
+ *   - Auth:    none (dev mode — no `instance.json`)
+ *
+ * Set `ANTHROPIC_API_KEY` (or other provider keys) in your shell to
+ * unlock real LLM calls. Without them, everything but model invocation
+ * still works — uploads, MCP resources, tool calls, conversation log.
+ *
+ * Reset state:  `rm -rf .nimblebrain-worktree && bun run dev:worktree`
+ * Share state across worktrees:  `NB_WORK_DIR=/abs/path bun run dev:worktree`
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const WORKDIR_NAME = ".nimblebrain-worktree";
+const WORKDIR = process.env.NB_WORK_DIR ?? join(process.cwd(), WORKDIR_NAME);
+const CONFIG_PATH = join(WORKDIR, "nimblebrain.json");
+const API_PORT = process.env.NB_API_PORT ?? "27271";
+const WEB_PORT = process.env.NB_WEB_PORT ?? "27270";
+
+function seedConfigIfMissing(): void {
+  if (existsSync(CONFIG_PATH)) return;
+  mkdirSync(WORKDIR, { recursive: true });
+  const seed = {
+    $schema: "https://schemas.nimblebrain.ai/v1/nimblebrain-config.schema.json",
+    version: "1",
+    // `workDir` is relative to the config file; using the basename keeps the
+    // workdir co-located with this config (matches the `.environments/*`
+    // pattern). `NB_WORK_DIR` overrides at runtime regardless.
+    workDir: WORKDIR === join(process.cwd(), WORKDIR_NAME) ? WORKDIR_NAME : WORKDIR,
+    bundles: [],
+    models: {
+      default: "anthropic:claude-sonnet-4-6",
+      fast: "anthropic:claude-haiku-4-5-20251001",
+      reasoning: "anthropic:claude-sonnet-4-6",
+    },
+  };
+  writeFileSync(CONFIG_PATH, `${JSON.stringify(seed, null, 2)}\n`);
+  console.log(`[dev:worktree] Seeded ${CONFIG_PATH}`);
+}
+
+seedConfigIfMissing();
+
+console.log("[dev:worktree] Starting");
+console.log(`[dev:worktree]   Worktree: ${process.cwd()}`);
+console.log(`[dev:worktree]   Workdir:  ${WORKDIR}`);
+console.log(`[dev:worktree]   API:      http://localhost:${API_PORT}`);
+console.log(`[dev:worktree]   Web:      http://localhost:${WEB_PORT}`);
+console.log("[dev:worktree]   Auth:     none (dev mode)");
+
+const child = spawn(
+  "bun",
+  ["run", "src/cli/index.ts", "dev", "--port", API_PORT, "--config", CONFIG_PATH],
+  {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      NB_API_PORT: API_PORT,
+      NB_WEB_PORT: WEB_PORT,
+      NB_WORK_DIR: WORKDIR,
+    },
+  },
+);
+
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -24,13 +24,21 @@
 
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
+// Anchor the worktree root from the script's location, not `process.cwd()`,
+// so `bun run scripts/dev-worktree.ts` from a subdirectory still resolves
+// the right place. The script lives at `<worktree>/scripts/dev-worktree.ts`,
+// so the parent of its containing directory is the worktree root.
+const WORKTREE_ROOT = dirname(import.meta.dir);
 const WORKDIR_NAME = ".nimblebrain-worktree";
-const WORKDIR = process.env.NB_WORK_DIR ?? join(process.cwd(), WORKDIR_NAME);
+// `||` (not `??`) so an accidentally-exported empty `NB_WORK_DIR=""` from a
+// misconfigured shell or direnv doesn't slip through and produce nonsense
+// paths. Same for the port vars below.
+const WORKDIR = process.env.NB_WORK_DIR || join(WORKTREE_ROOT, WORKDIR_NAME);
 const CONFIG_PATH = join(WORKDIR, "nimblebrain.json");
-const API_PORT = process.env.NB_API_PORT ?? "27271";
-const WEB_PORT = process.env.NB_WEB_PORT ?? "27270";
+const API_PORT = process.env.NB_API_PORT || "27271";
+const WEB_PORT = process.env.NB_WEB_PORT || "27270";
 
 function seedConfigIfMissing(): void {
   if (existsSync(CONFIG_PATH)) return;
@@ -41,12 +49,15 @@ function seedConfigIfMissing(): void {
     // `workDir` is relative to the config file; using the basename keeps the
     // workdir co-located with this config (matches the `.environments/*`
     // pattern). `NB_WORK_DIR` overrides at runtime regardless.
-    workDir: WORKDIR === join(process.cwd(), WORKDIR_NAME) ? WORKDIR_NAME : WORKDIR,
+    workDir: WORKDIR === join(WORKTREE_ROOT, WORKDIR_NAME) ? WORKDIR_NAME : WORKDIR,
     bundles: [],
+    // Defaults mirror the documented values in `AGENTS.md` § Defaults so
+    // dev:worktree starts in the same shape the rest of the platform's dev
+    // environments use.
     models: {
       default: "anthropic:claude-sonnet-4-6",
       fast: "anthropic:claude-haiku-4-5-20251001",
-      reasoning: "anthropic:claude-sonnet-4-6",
+      reasoning: "anthropic:claude-opus-4-6",
     },
   };
   writeFileSync(CONFIG_PATH, `${JSON.stringify(seed, null, 2)}\n`);
@@ -56,7 +67,7 @@ function seedConfigIfMissing(): void {
 seedConfigIfMissing();
 
 console.log("[dev:worktree] Starting");
-console.log(`[dev:worktree]   Worktree: ${process.cwd()}`);
+console.log(`[dev:worktree]   Worktree: ${WORKTREE_ROOT}`);
 console.log(`[dev:worktree]   Workdir:  ${WORKDIR}`);
 console.log(`[dev:worktree]   API:      http://localhost:${API_PORT}`);
 console.log(`[dev:worktree]   Web:      http://localhost:${WEB_PORT}`);
@@ -67,6 +78,7 @@ const child = spawn(
   ["run", "src/cli/index.ts", "dev", "--port", API_PORT, "--config", CONFIG_PATH],
   {
     stdio: "inherit",
+    cwd: WORKTREE_ROOT,
     env: {
       ...process.env,
       NB_API_PORT: API_PORT,
@@ -75,5 +87,10 @@ const child = spawn(
     },
   },
 );
+
+child.on("error", (err) => {
+  console.error(`[dev:worktree] Failed to spawn bun: ${err.message}`);
+  process.exit(1);
+});
 
 child.on("exit", (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Summary

- `bun run dev:worktree` runs the platform from any git worktree against a worktree-local `.nimblebrain-worktree/` workdir on alt ports (27271 API / 27270 web), in dev mode with no auth gate.
- Each worktree gets its own isolated state, so smoke-testing a feature branch doesn't disturb your primary \`~/.nimblebrain\` dev or another worktree's run.
- Suitable for Chrome DevTools-driven E2E tests against \`/v1/*\` (no login dance, no auth headers).

## Why

Smoke-testing a worktree against the same workdir as your main dev is a corruption hazard — two platform processes appending to the same JSONL conversation logs and spawning the same bundle subprocesses. The existing \`dev:empty\` / \`dev:minimal\` / \`dev:docs-demo\` patterns are env-fixture-specific; they don't generalize to "isolated dev for whichever branch I happen to be working on right now."

## How

- **`scripts/dev-worktree.ts`** — small bun script. Seeds \`<cwd>/.nimblebrain-worktree/nimblebrain.json\` on first run with the standard model defaults (no secrets — LLM keys come from the shell environment), then spawns \`nb dev\` with \`NB_WORK_DIR\` + \`NB_API_PORT\` + \`NB_WEB_PORT\` set.
- **\`package.json\`** — \`dev:worktree\` npm alias.
- **\`.gitignore\`** — ignore \`.nimblebrain-worktree/\` (per-worktree, never committed).
- **\`AGENTS.md\`** — new \`### Worktree dev\` section with the convention table and reset/share commands.
- **\`CHANGELOG.md\`** — entry under Unreleased > Added.

## Conventions

| Setting | Value |
|---|---|
| Workdir | \`<worktree>/.nimblebrain-worktree/\` (auto-seeded; gitignored) |
| Config | \`<worktree>/.nimblebrain-worktree/nimblebrain.json\` (auto-seeded on first run) |
| API / Web ports | 27271 / 27270 (override via \`NB_API_PORT\` / \`NB_WEB_PORT\`) |
| Auth | none (dev mode — no \`instance.json\`) |
| LLM keys | \`ANTHROPIC_API_KEY\` (and friends) read from your shell environment |

Reset state: \`rm -rf .nimblebrain-worktree && bun run dev:worktree\`
Share state across worktrees: \`NB_WORK_DIR=/abs/path bun run dev:worktree\`

## Test plan

- [x] \`bun run verify:static\` — green
- [x] \`bun run test:unit\` — green (no source touched; 2,490 baseline)
- [x] Manual: ran \`bun run dev:worktree\` from a fresh worktree; confirmed workdir is auto-created at \`<worktree>/.nimblebrain-worktree/\`, API responds on :27271, web on :27270, \`/v1/bootstrap\` returns the expected dev-mode user (\`usr_default\`) and workspace (\`ws_usr_default\`) without an auth header.
- [x] Worktree-local state — confirmed no leakage into \`~/.nimblebrain\` or the parent submodule's \`.nimblebrain/\`.

## Notes

- This change is independent of #188 (the vision/resource_link work), but #188 is the immediate use case it unblocks: smoke-testing a feature branch end-to-end against Chrome DevTools without disturbing primary dev.