### PR TITLE
fix(bridge): make `id` optional on `ui/update-model-context`

### DIFF
--- a/test/unit/sdk-envelope-parity.test.ts
+++ b/test/unit/sdk-envelope-parity.test.ts
@@ -205,6 +205,54 @@ describe("Synapse SDK ⇄ host bridge schema parity", () => {
     expect(v.ok, `tools/call: ${v.reason}`).toBe(true);
   });
 
+  it("synapse.setVisibleState emits a schema-valid notification (no id)", async () => {
+    // Regression: the host previously required `id` on
+    // `ui/update-model-context`, dropping every `useVisibleState` push from
+    // every synapse-app. The SDK sends this as a JSON-RPC notification via
+    // `transport.send(...)` — no `id` field. Schema must admit that shape.
+    const { createSynapse } = await import("@nimblebrain/synapse");
+    const synapse = createSynapse({ name: "test-app", version: "1.0.0" });
+    await Promise.resolve();
+    completeHandshake();
+    await synapse.ready;
+
+    synapse.setVisibleState({ foo: "bar" }, "summary text");
+    // setVisibleState debounces by 250ms before flushing the envelope.
+    await new Promise((r) => setTimeout(r, 300));
+
+    const env = lastEnvelopeWithMethod("ui/update-model-context");
+    expect(env, "SDK must emit ui/update-model-context after setVisibleState").toBeDefined();
+    // Confirm the SDK is in fact sending the notification shape (no id).
+    expect("id" in (env as Record<string, unknown>)).toBe(false);
+    const v = validateAppToHostMessage(env);
+    expect(v.ok, `ui/update-model-context (notification): ${v.reason}`).toBe(true);
+  });
+
+  it("ui/update-model-context validates in both notification and request shapes", () => {
+    // Direct schema check: notification (no id) AND request (with id) both
+    // pass. The schema is intentionally broader than the SDK's current
+    // emission to avoid breaking any caller that opts to use the request
+    // form and await a response.
+    const baseParams = { structuredContent: { foo: "bar" } };
+
+    const notification = {
+      jsonrpc: "2.0",
+      method: "ui/update-model-context",
+      params: baseParams,
+    };
+    const notifResult = validateAppToHostMessage(notification);
+    expect(notifResult.ok, `notification: ${notifResult.reason}`).toBe(true);
+
+    const request = {
+      jsonrpc: "2.0",
+      id: "abc",
+      method: "ui/update-model-context",
+      params: baseParams,
+    };
+    const reqResult = validateAppToHostMessage(request);
+    expect(reqResult.ok, `request: ${reqResult.reason}`).toBe(true);
+  });
+
   it("synapse.action emits a schema-valid synapse/action envelope", async () => {
     const { createSynapse } = await import("@nimblebrain/synapse");
     const synapse = createSynapse({ name: "test-app", version: "1.0.0" });

--- a/web/src/bridge/schemas.ts
+++ b/web/src/bridge/schemas.ts
@@ -134,7 +134,14 @@ export type UiSizeChangedMessage = Static<typeof UiSizeChangedMessage>;
 
 export const UiUpdateModelContextMessage = Type.Object({
   jsonrpc: JsonRpcVersion,
-  id: RequestId,
+  // `id` is optional. The @nimblebrain/synapse SDK emits this message via
+  // the JSON-RPC notification path (`transport.send`, no `id`) from
+  // `setVisibleState` in core.ts, so requiring `id` here drops every
+  // visible-state push from every synapse-app. Some callers may still send
+  // it as a request (with `id`) and expect a response — both shapes are
+  // valid. The dispatcher in `bridge.ts` already echoes `id` only when
+  // present, so the request shape continues to work.
+  id: Type.Optional(RequestId),
   method: Type.Literal("ui/update-model-context"),
   params: Type.Object({
     content: Type.Optional(


### PR DESCRIPTION
## Summary

The bridge schema declared `id: RequestId` as **required** on `UiUpdateModelContextMessage`. But `@nimblebrain/synapse` emits this message via the JSON-RPC **notification** path — `transport.send(...)` in `packages/synapse/src/core.ts:319`, called from `setVisibleState` — with no `id` field.

Result: every `useVisibleState` push from every synapse-app was being dropped by the bridge with:

```
[bridge] dropping malformed ui/update-model-context envelope from app
  "<name>": /id: Expected required property
```

The agent never received any of the structured context apps were pushing — the "what is the user looking at" channel was silently broken platform-wide. Confirmed in synapse-crm during the recent uplift work; the same warning fires for `synapse-todo-board`, `synapse-collateral`, etc.

## Change

One line in the schema:

```diff
 export const UiUpdateModelContextMessage = Type.Object({
   jsonrpc: JsonRpcVersion,
-  id: RequestId,
+  id: Type.Optional(RequestId),
```

Plus an explanatory comment naming the SDK call site.

The change is **strictly broader** — both the notification shape (no `id`) and the request shape (with `id`, for callers that want a response) validate. The dispatcher in `bridge.ts:401-415` already handles the no-id path (it only echoes `id` on the response if one was provided), so no dispatcher change is needed.

## Tests

Added two cases in `test/unit/sdk-envelope-parity.test.ts`:

- `synapse.setVisibleState emits a schema-valid notification (no id)` — drives the actual SDK through `setVisibleState`, captures the emitted envelope, asserts it has no `id` field, and that it validates. This is the regression guard.
- `ui/update-model-context validates in both notification and request shapes` — direct schema check for both shapes; pins the contract independently of any SDK behavior.

## Test plan

- [x] `bun test test/unit/sdk-envelope-parity.test.ts` — 7/7 pass (5 existing + 2 new)
- [x] `bun run verify` — full CI parity clean (format, lint, tsc, unit, integration, smoke)
- [x] After merge, console in the running platform should show **zero** `[bridge] dropping malformed ui/update-model-context` warnings during normal synapse-app use

## Companion

Companion PR in synapse-crm: https://github.com/NimbleBrainInc/synapse-crm/pull/4 — the visible-state payload there is extended with `openPanel` / `panelDepth` so the agent can see what panel the user is exploring. That payload was always being dropped pre-fix; this PR is the unblock.