### PR TITLE
fix(connectors): DCR drift cleanup + chat tool-enumeration resilience

### DIFF
--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { log } from "../cli/log.ts";
@@ -441,6 +441,28 @@ export class BundleLifecycleManager {
         const msg = err instanceof Error ? err.message : String(err);
         process.stderr.write(
           `[lifecycle] Failed to clear credentials for ${instance.bundleName} in ${instance.wsId}: ${msg}\n`,
+        );
+      }
+      // Drop the OAuth state dir as defense-in-depth. URL bundles
+      // route through `disconnect` first (which now invalidates "all"
+      // including client.json) — but stdio bundles never had OAuth
+      // state, and any leftover from a partial earlier disconnect
+      // shouldn't survive an uninstall. Worst case the dir is already
+      // gone; rmSync with `force` is a no-op then.
+      try {
+        const oauthDir = join(
+          workDir,
+          "workspaces",
+          instance.wsId,
+          "credentials",
+          "mcp-oauth",
+          serverName,
+        );
+        rmSync(oauthDir, { recursive: true, force: true });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[lifecycle] Failed to clear OAuth state for ${serverName} in ${instance.wsId}: ${msg}\n`,
         );
       }
     }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,4 +1,5 @@
 import { WORKSPACE_PRINCIPAL_ID } from "../bundles/connection.ts";
+import { log } from "../cli/log.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolCall, ToolResult, ToolRouter, ToolSchema } from "../engine/types.ts";
 import type { PermissionStore } from "../permissions/permission-store.ts";
@@ -102,7 +103,27 @@ export class ToolRegistry implements ToolRouter {
   async availableTools(): Promise<ToolSchema[]> {
     const all: ToolSchema[] = [];
     for (const source of this.sources.values()) {
-      const tools = await source.tools();
+      // Per-source error containment. A connector in `starting` /
+      // `pending_auth` / `dead` state has `this.client === null` and
+      // throws `"<name>" not started` from McpSource.tools(). Without
+      // this guard, ONE stuck connector's enumeration error rejects
+      // the whole call and every chat turn fails — exactly the
+      // platform-level outage shape we don't want from one bad
+      // workspace source. Surface the failure in the source's own
+      // status (Configure page renders it from BundleInstance.state)
+      // and leave the chat usable.
+      let tools: Tool[];
+      try {
+        tools = await source.tools();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(
+          `[registry] availableTools: skipping source "${source.name}" — ${msg}. ` +
+            `The bundle's own state surface (Connectors page) reflects this; the chat list ` +
+            `omits its tools until the source recovers.`,
+        );
+        continue;
+      }
       for (const tool of tools) {
         all.push({
           name: tool.name,

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -574,13 +574,55 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
       };
       return info;
     }
-    if (this.cachedClientInfo) return this.cachedClientInfo;
+    if (this.cachedClientInfo) {
+      if (this.isClientInfoUsable(this.cachedClientInfo)) return this.cachedClientInfo;
+      // Cached entry has stale redirect_uri (e.g. NB_API_URL changed
+      // between registration and now). Drop it so we re-register fresh
+      // below, then on disk so future reads agree.
+      this.cachedClientInfo = null;
+      await this.unlinkIfExists(this.dataDir, "client.json");
+    }
     // DCR client info is workspace-shared regardless of scope — every
     // member of the workspace authenticates as the same NimbleBrain
     // OAuth client.
     const data = await this.readJson<OAuthClientInformationFull>(this.dataDir, "client.json");
-    if (data) this.cachedClientInfo = data;
-    return data ?? undefined;
+    if (!data) return undefined;
+    if (!this.isClientInfoUsable(data)) {
+      // Drift detection: the platform's redirect_uri (derived from
+      // NB_API_URL) doesn't match what was registered with the
+      // authorization server when this client was DCR'd. Returning the
+      // stale entry here means the next /authorize sends a redirect_uri
+      // the AS doesn't recognize, surfacing as `invalid_redirect_uri`
+      // long after the user has clicked Connect. Drop the entry and
+      // let the SDK trigger a fresh DCR call with the current URI.
+      log.warn(
+        `[oauth] ${this.serverName} cached DCR client redirect_uri drift detected (registered=${
+          data.redirect_uris?.[0] ?? "<none>"
+        }, current=${this.callbackUrl}) — discarding cached client.json so the next flow re-registers`,
+      );
+      await this.unlinkIfExists(this.dataDir, "client.json");
+      return undefined;
+    }
+    this.cachedClientInfo = data;
+    return data;
+  }
+
+  /**
+   * Drift check for a DCR `client.json`. Returns true when the
+   * registered `redirect_uris` includes the current callbackUrl —
+   * i.e. the AS will accept what we send at /authorize and /token.
+   * Returns false when the registration is stale (the canonical
+   * NB_API_URL-changed-between-deploys case), so callers know to
+   * re-register rather than serve a doomed flow.
+   *
+   * Conservative: a missing or non-array `redirect_uris` is treated
+   * as drift (force re-register). That handles broken on-disk state
+   * the same as known drift.
+   */
+  private isClientInfoUsable(info: OAuthClientInformationFull): boolean {
+    const uris = info.redirect_uris;
+    if (!Array.isArray(uris) || uris.length === 0) return false;
+    return uris.includes(this.callbackUrl);
   }
 
   async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
@@ -1015,8 +1057,15 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
     }
 
     // Always clear local state regardless of upstream revocation result.
-    await this.invalidateCredentials("tokens");
-    await this.invalidateCredentials("verifier");
+    // `all` is broader than the literal "tokens" the method name implies,
+    // and intentional: leaving the cached DCR `client.json` behind across
+    // a disconnect/reconnect is the well-trodden bug path. If `NB_API_URL`
+    // changes between a disconnect and the next reconnect, the AS still
+    // has the old `redirect_uri` registered to the cached `client_id`,
+    // and the next /authorize comes back as `Invalid redirect_uri`.
+    // Re-registering on reconnect costs one DCR roundtrip — cheap insurance
+    // against a confusing prod failure mode.
+    await this.invalidateCredentials("all");
     result.deletedLocal = true;
     return result;
   }

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -1021,6 +1021,20 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
       );
     }
 
+    if (!clientInfo) {
+      // `clientInformation()` returned undefined despite tokens being
+      // present — the canonical cause is drift detection unlinking
+      // `client.json` on this very call. Without a client_id we can't
+      // authenticate the RFC 7009 POST, so we skip upstream revoke and
+      // fall through to local cleanup. AS-side tokens stay valid until
+      // their natural expiry. Logged so operators reading audit trails
+      // understand why a particular disconnect didn't revoke.
+      log.warn(
+        `[oauth] ${this.serverName} skipping upstream revoke — no client info available ` +
+          `(likely DCR redirect_uri drift just discarded client.json). Local tokens still cleaned.`,
+      );
+    }
+
     if (revocationEndpoint && clientInfo) {
       try {
         // Revoke both tokens in sequence. RFC 7009 doesn't define an

--- a/test/unit/registry-tool-enumeration-resilience.test.ts
+++ b/test/unit/registry-tool-enumeration-resilience.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { textContent } from "../../src/engine/content-helpers.ts";
+import type { ToolResult } from "../../src/engine/types.ts";
+import { ToolRegistry } from "../../src/tools/registry.ts";
+import type { Tool, ToolSource } from "../../src/tools/types.ts";
+
+/**
+ * Resilience guard around `ToolRegistry.availableTools()`. The agent
+ * loop calls this on every chat turn to assemble the tool list for the
+ * LLM. A single bad source (notably a remote OAuth bundle in
+ * `pending_auth` / `starting` state with `this.client === null` —
+ * `McpSource.tools()` throws `<name> not started` in that case) MUST
+ * NOT take down the whole list. Every other workspace tool stays
+ * usable; the broken connector's status is already surfaced on the
+ * Connectors / Configure page.
+ */
+
+class HealthySource implements ToolSource {
+  readonly name = "healthy";
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async tools(): Promise<Tool[]> {
+    return [
+      {
+        name: "healthy__ping",
+        description: "ping",
+        inputSchema: {},
+        source: this.name,
+      },
+      {
+        name: "healthy__pong",
+        description: "pong",
+        inputSchema: {},
+        source: this.name,
+      },
+    ];
+  }
+  async execute(toolName: string): Promise<ToolResult> {
+    return { content: textContent(`ok ${toolName}`), isError: false };
+  }
+}
+
+class BrokenSource implements ToolSource {
+  readonly name = "broken";
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async tools(): Promise<Tool[]> {
+    // Mirrors the production failure shape: McpSource throws this
+    // string when its SDK Client hasn't connected (pending OAuth,
+    // dead transport, etc.).
+    throw new Error(`McpSource "${this.name}" not started`);
+  }
+  async execute(): Promise<ToolResult> {
+    return { content: textContent("unreachable"), isError: true };
+  }
+}
+
+describe("ToolRegistry.availableTools — error containment", () => {
+  test("a source whose tools() throws is skipped, healthy tools survive", async () => {
+    const registry = new ToolRegistry();
+    registry.addSource(new HealthySource());
+    registry.addSource(new BrokenSource());
+
+    const tools = await registry.availableTools();
+
+    // Healthy source's two tools are present; broken source contributes nothing.
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(["healthy__ping", "healthy__pong"]);
+  });
+
+  test("a source whose tools() throws does not propagate the error", async () => {
+    const registry = new ToolRegistry();
+    registry.addSource(new BrokenSource());
+
+    // The whole call resolves rather than rejects — that's the
+    // chat-stays-up guarantee the agent loop relies on.
+    await expect(registry.availableTools()).resolves.toEqual([]);
+  });
+});

--- a/test/unit/workspace-oauth-provider.test.ts
+++ b/test/unit/workspace-oauth-provider.test.ts
@@ -87,6 +87,68 @@ describe("WorkspaceOAuthProvider — file I/O roundtrips", () => {
     expect(await p2.clientInformation()).toBeDefined();
   });
 
+  it("clientInformation discards a cached client whose redirect_uri doesn't match the current callback", async () => {
+    // Simulate the operational case: a DCR client was registered when
+    // NB_API_URL was the dev default (or wrong), then the operator set
+    // NB_API_URL on the deploy and the provider's callbackUrl flipped.
+    // Returning the stale client.json would send the AS a redirect_uri
+    // the registered client doesn't allow, surfacing as
+    // `Invalid redirect_uri for OAuth client` after the user has
+    // already clicked Connect.
+    const stalePath = "http://localhost:27247/v1/mcp-auth/callback";
+    const livePath = "https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback";
+
+    // Provider 1 writes a client with the stale redirect_uri.
+    const p1 = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "drift-srv",
+      workDir,
+      callbackUrl: stalePath,
+    });
+    await p1.saveClientInformation({ client_id: "cid-stale", redirect_uris: [stalePath] });
+    expect(await p1.clientInformation()).toBeDefined();
+
+    // Provider 2 (fresh process, current deploy) reads the same dir
+    // but with the live callback URL. The cached client is stale —
+    // expect undefined so the SDK re-registers.
+    const p2 = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "drift-srv",
+      workDir,
+      callbackUrl: livePath,
+    });
+    expect(await p2.clientInformation()).toBeUndefined();
+
+    // And the on-disk client.json should be gone — drift detection
+    // unlinks it so a subsequent saveClientInformation writes a fresh
+    // record matching the current redirect URI.
+    const p3 = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "drift-srv",
+      workDir,
+      callbackUrl: livePath,
+    });
+    expect(await p3.clientInformation()).toBeUndefined();
+  });
+
+  it("clientInformation accepts a cached client with multiple redirect_uris when one matches the current callback", async () => {
+    // Defensive — some authorization servers seed multiple URIs on a
+    // single client (test + prod). Don't false-positive drift when the
+    // current callback is on the list, just not first.
+    const cb = "https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback";
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "multi-uri",
+      workDir,
+      callbackUrl: cb,
+    });
+    await p.saveClientInformation({
+      client_id: "cid-multi",
+      redirect_uris: ["https://other.example.com/cb", cb],
+    });
+    expect(await p.clientInformation()).toBeDefined();
+  });
+
   it("files are written under <workDir>/workspaces/<wsId>/credentials/mcp-oauth/<serverName>/", async () => {
     const p = makeProvider(workDir, "my-server");
     const tokens: OAuthTokens = { access_token: "a", token_type: "Bearer" };
@@ -534,6 +596,10 @@ describe("WorkspaceOAuthProvider — revokeAndDeleteTokens", () => {
       callbackUrl: CALLBACK,
     });
     expect(await p2.tokens()).toBeUndefined();
+    // Disconnect MUST also drop the cached DCR client info — leaving
+    // it behind across a NB_API_URL change is the canonical
+    // `Invalid redirect_uri for OAuth client` foot-gun.
+    expect(await p2.clientInformation()).toBeUndefined();
   });
 
   it("captures OIDC id_token claims to identity.json on saveTokens", async () => {


### PR DESCRIPTION
## Summary

Two related connector bugs that combined to take down chat conversations when an OAuth connector got stuck.

**Bug 1 — DCR redirect_uri drift survives uninstall/reconnect.** When `NB_API_URL` changes between deploys, the cached `client.json` DCR registration retains the old `redirect_uri`. Notion (and any DCR AS that validates registered URIs at /token time) rejects `/authorize` as `Invalid redirect_uri for OAuth client` long after the user has clicked Connect — confusing because the consent screen displayed the new URL. Pre-fix, neither `disconnect` nor `uninstall` cleared `client.json`, so the cached stale registration kept causing failures across reinstall cycles.

**Bug 2 — One stuck source kills chat for the whole workspace.** `ToolRegistry.availableTools()` (called on every chat turn) iterated sources without per-source error handling. A connector stuck in `pending_auth` / `starting` (with `this.client === null`) made `McpSource.tools()` throw `<name> not started`, rejecting the whole call. Every chat turn surfaced the OAuth provider's error to the user in a chat-error popup.

Combined, the user-visible failure: install Notion → Connect → DCR drift fails the OAuth flow → connector stuck in `pending_auth` → every chat turn fails with `McpSource "notion-org" not started` until the user manually uninstalls.

## Fix

Three-layer defense for the OAuth state, plus per-source error containment in tool enumeration:

| Layer | File | Change |
|---|---|---|
| Drift detection | `workspace-oauth-provider.ts::clientInformation` | When the cached `redirect_uris` doesn't include the current `callbackUrl`, unlink `client.json` and return `undefined` so the SDK re-registers. Multi-URI registrations are tolerated (drift = "current callback isn't in the list", not "isn't first"). |
| Disconnect cleanup | `workspace-oauth-provider.ts::revokeAndDeleteTokens` | Invalidate `all` (tokens + verifier + client + identity). Re-registration on reconnect costs one DCR roundtrip. |
| Uninstall deep-clean | `lifecycle.ts::uninstall` | `rmSync` the entire `<workDir>/workspaces/<wsId>/credentials/mcp-oauth/<serverName>/` dir as defense-in-depth. |
| Chat resilience | `registry.ts::availableTools` | Per-source try/catch. A failing source's tools are skipped + logged; healthy sources still serve the chat. |

## Tests

- `workspace-oauth-provider.test.ts` — 3 new: drift detection, multi-URI tolerance, disconnect-clears-client.
- `registry-tool-enumeration-resilience.test.ts` — new file, 2 tests: healthy tools survive sibling source's throw; broken-only registry resolves to `[]`.

Full suite: 2548/2548 unit tests pass, lint + format + typecheck clean.

## Test plan

- [ ] CI green (verify-static + verify-test-unit + integration + smoke)
- [ ] On staging or prod tenant: change `NB_API_URL`, observe stale DCR client gets re-registered on next Connect (expected log line: `[oauth] <name> cached DCR client redirect_uri drift detected ...`)
- [ ] Install a connector that won't complete OAuth (close the auth tab); start a chat — confirm the turn succeeds without that connector's tools rather than failing with "not started"
- [ ] Uninstall an OAuth connector; verify `<workDir>/workspaces/<ws>/credentials/mcp-oauth/<name>/` is gone

## Operational notes

The user-facing recovery for a tenant currently stuck in this state (without the deploy) is still: uninstall the broken connector via the UI. Once this PR ships, the same scenario self-heals on the next Connect attempt.