### PR TITLE
fix(connectors): drop 3 allowlist-gated DCR entries; extend probe with auth step

### DIFF
--- a/scripts/check-catalog-dcr.ts
+++ b/scripts/check-catalog-dcr.ts
@@ -4,8 +4,7 @@
  *
  * Iterates `src/connectors/catalog.yaml`, picks every entry whose
  * `_meta["ai.nimblebrain/connector"].auth === "dcr"`, and runs the
- * same OAuth-discovery chain the production platform uses
- * (`src/tools/workspace-oauth-provider.ts`):
+ * full DCR flow end-to-end against each vendor:
  *
  *   1. Reachability — `HEAD <remotes[0].url>`. Anything non-network-error
  *      counts; vendors return 200 / 401 / 405 depending on auth state.
@@ -14,29 +13,58 @@
  *      .well-known/oauth-protected-resource`. Optional but preferred;
  *      yields the authorization-server origin(s).
  *   3. RFC 8414 authorization-server metadata — `GET <as-origin>/
- *      .well-known/oauth-authorization-server` against each candidate
- *      AS origin (RFC 9728 advertised, plus bundle origin as fallback).
- *      Must yield JSON with `registration_endpoint` (RFC 7591) for the
- *      catalog claim of `auth: "dcr"` to be truthful.
+ *      .well-known/oauth-authorization-server`. Must yield JSON with
+ *      `registration_endpoint` (RFC 7591) for the catalog claim of
+ *      `auth: "dcr"` to be truthful.
+ *   4. **DCR registration probe** — POST a synthetic client to the
+ *      `registration_endpoint` with a representative redirect URI.
+ *      Catches vendors that advertise DCR but reject our redirect-URI
+ *      host (Intercom, Vercel pattern: "redirect URI ... not in the
+ *      allowlist").
+ *   5. **Authorize probe** — GET the `authorization_endpoint` with the
+ *      client_id from step 4 and the same redirect URI. Catches
+ *      vendors that accept DCR registration but reject the redirect
+ *      URI at the authorize step (Canva pattern: "Invalid redirect
+ *      URI. It must be from an allowed host."). A successful authorize
+ *      probe responds with a redirect (302/303) to the vendor login
+ *      flow, or a 200 login page; a 4xx with a "redirect URI" error
+ *      string is the trapdoor.
  *
- * Each entry passes if at least one candidate AS yields a metadata
- * document with `registration_endpoint`. Per-entry pass/fail report;
- * exit 1 if any DCR entry fails.
+ * Steps 4 and 5 are what catch "DCR theater" — vendors that ship the
+ * RFC 7591 endpoints but enforce a parallel host allowlist that the
+ * spec is supposed to make obsolete. Pre-extension this script only
+ * verified step 3, and shipped #195 with three connectors (Canva,
+ * Intercom, Vercel) that broke at install time. See #200 for the
+ * vendor outreach to re-add them.
+ *
+ * Each entry passes only if all 5 steps succeed. Per-entry pass/fail
+ * report; exit 1 if any DCR entry fails.
  *
  * Network-dependent by design — NOT part of `bun run verify` (which is
  * offline). Run before merging catalog.yaml changes; CI runs it
- * automatically on PRs that touch the file (`.github/workflows/catalog-check.yml`).
+ * automatically on PRs that touch the file
+ * (`.github/workflows/catalog-check.yml`).
  *
- * Static-auth entries are skipped — they're operator-pre-registered and
- * don't use DCR. Their failure mode (operator hasn't set up the OAuth
- * app for the workspace) is workspace-state, not catalog-rot.
+ * Static-auth entries are skipped — they're operator-pre-registered
+ * and don't use DCR. Their failure mode (operator hasn't set up the
+ * OAuth app for the workspace) is workspace-state, not catalog-rot.
  */
 
-import { readStaticServers } from "../src/registries/static-source.ts";
-import { BUNDLED_STATIC_CATALOG_PATH } from "../src/registries/registry-store.ts";
 import { getNimbleBrainConnectorMeta, type ServerDetail } from "../src/connectors/server-detail.ts";
+import { BUNDLED_STATIC_CATALOG_PATH } from "../src/registries/registry-store.ts";
+import { readStaticServers } from "../src/registries/static-source.ts";
 
 const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Synthetic redirect URI for the probe. Real prod tenants live at
+ * `https://<tenant>.platform.nimblebrain.ai/v1/mcp-auth/callback`;
+ * this representative form catches host-allowlist policies that
+ * accept the wildcard but not arbitrary hosts. Vendors that allowlist
+ * the wildcard pattern pass; vendors with per-tenant pinning still
+ * need outreach (the prod wildcard captures the common case).
+ */
+const PROBE_REDIRECT_URI = "https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback";
 
 interface CheckResult {
   name: string;
@@ -44,7 +72,7 @@ interface CheckResult {
   pass: boolean;
   reachability: { ok: boolean; status?: number; error?: string };
   registrationEndpoint?: string;
-  metadataAttempts: Array<{ url: string; ok: boolean; status?: number; error?: string }>;
+  authorizationEndpoint?: string;
   failureReason?: string;
 }
 
@@ -63,7 +91,9 @@ async function main(): Promise<void> {
     return;
   }
 
-  console.log(`Probing ${dcrEntries.length} DCR catalog entries…\n`);
+  console.log(
+    `Probing ${dcrEntries.length} DCR catalog entries (reachability + DCR registration + authorize)…\n`,
+  );
 
   const results = await Promise.all(dcrEntries.map(checkEntry));
 
@@ -77,7 +107,7 @@ async function main(): Promise<void> {
   for (const r of results) {
     const icon = r.pass ? "✓" : "✗";
     const status = r.pass
-      ? `${icon} ok (registration_endpoint=${r.registrationEndpoint})`
+      ? `${icon} ok (DCR + authorize end-to-end)`
       : `${icon} FAIL — ${r.failureReason}`;
     console.log(`${pad(r.name, colName)}  ${pad(r.url, colUrl)}  ${status}`);
   }
@@ -88,10 +118,7 @@ async function main(): Promise<void> {
     console.log(`✗ ${failed.length}/${results.length} DCR entries failed.\n`);
     for (const r of failed) {
       console.log(`  ${r.name} (${r.url}):`);
-      console.log(`    reachability: ${r.reachability.ok ? "ok" : `failed — ${r.reachability.error ?? r.reachability.status}`}`);
-      for (const m of r.metadataAttempts) {
-        console.log(`    metadata ${m.url}: ${m.ok ? "ok" : `failed — ${m.error ?? m.status}`}`);
-      }
+      console.log(`    ${r.failureReason}`);
     }
     process.exit(1);
   }
@@ -105,10 +132,9 @@ async function checkEntry(s: ServerDetail): Promise<CheckResult> {
     url,
     pass: false,
     reachability: { ok: false },
-    metadataAttempts: [],
   };
 
-  // 1. Reachability — any non-network-error response counts.
+  // 1. Reachability.
   result.reachability = await probeReachable(url);
   if (!result.reachability.ok) {
     result.failureReason = `unreachable (${result.reachability.error ?? `HTTP ${result.reachability.status}`})`;
@@ -116,25 +142,50 @@ async function checkEntry(s: ServerDetail): Promise<CheckResult> {
   }
 
   // 2 + 3. OAuth metadata discovery — same chain as
-  // workspace-oauth-provider.discoverAuthorizationServerOrigins:
-  // try RFC 9728 first to find advertised AS origin(s), always fall
-  // back to the bundle origin.
+  // workspace-oauth-provider.discoverAuthorizationServerOrigins.
   const bundleOrigin = new URL(url).origin;
   const asOrigins = await discoverAuthorizationServerOrigins(bundleOrigin);
 
+  let asMetadata: { registration_endpoint: string; authorization_endpoint?: string } | null = null;
   for (const asOrigin of asOrigins) {
-    const metaUrl = `${asOrigin}/.well-known/oauth-authorization-server`;
-    const attempt = await probeMetadata(metaUrl);
-    result.metadataAttempts.push(attempt);
-    if (attempt.ok && attempt.registrationEndpoint) {
-      result.pass = true;
-      result.registrationEndpoint = attempt.registrationEndpoint;
-      return result;
+    const m = await fetchAsMetadata(`${asOrigin}/.well-known/oauth-authorization-server`);
+    if (m) {
+      asMetadata = m;
+      break;
     }
   }
+  if (!asMetadata) {
+    result.failureReason = "no AS metadata advertised registration_endpoint (RFC 7591)";
+    return result;
+  }
+  result.registrationEndpoint = asMetadata.registration_endpoint;
+  if (asMetadata.authorization_endpoint) {
+    result.authorizationEndpoint = asMetadata.authorization_endpoint;
+  }
 
-  result.failureReason =
-    "no AS metadata advertised registration_endpoint (RFC 7591)";
+  // 4. DCR registration probe — catches vendors that reject the
+  // redirect URI at the registration step (Intercom, Vercel pattern).
+  const regResult = await probeDcrRegistration(asMetadata.registration_endpoint);
+  if (!regResult.ok) {
+    result.failureReason = `DCR /register rejected our redirect URI: ${regResult.message}`;
+    return result;
+  }
+
+  // 5. Authorize probe — catches vendors that accept DCR registration
+  // but reject the redirect URI at the authorize step (Canva pattern).
+  if (!asMetadata.authorization_endpoint) {
+    // Without an authorize endpoint we can't probe step 5. Mark pass
+    // since DCR + the rest succeeded; flag for follow-up.
+    result.pass = true;
+    return result;
+  }
+  const authResult = await probeAuthorize(asMetadata.authorization_endpoint, regResult.clientId);
+  if (!authResult.ok) {
+    result.failureReason = `/authorize rejected our redirect URI: ${authResult.message}`;
+    return result;
+  }
+
+  result.pass = true;
   return result;
 }
 
@@ -147,15 +198,11 @@ async function probeReachable(
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       redirect: "manual",
     });
-    // 2xx, 3xx, 4xx all mean the URL is responding. 5xx = vendor down.
     if (res.status >= 500) {
       return { ok: false, status: res.status };
     }
     return { ok: true, status: res.status };
-  } catch (err) {
-    // Some servers reject HEAD with a transport error. Retry with GET
-    // before giving up — this catches CDNs that 405 HEAD and Bun-side
-    // protocol mismatches that look like network errors.
+  } catch {
     try {
       const res = await fetch(url, {
         method: "GET",
@@ -197,33 +244,110 @@ async function discoverAuthorizationServerOrigins(bundleOrigin: string): Promise
   return [...origins];
 }
 
-async function probeMetadata(metaUrl: string): Promise<{
-  url: string;
-  ok: boolean;
-  status?: number;
-  error?: string;
-  registrationEndpoint?: string;
-}> {
+async function fetchAsMetadata(
+  metaUrl: string,
+): Promise<{ registration_endpoint: string; authorization_endpoint?: string } | null> {
   try {
     const res = await fetch(metaUrl, {
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
-    if (!res.ok) return { url: metaUrl, ok: false, status: res.status };
-    const body = (await res.json()) as { registration_endpoint?: unknown };
-    if (typeof body.registration_endpoint !== "string") {
-      return { url: metaUrl, ok: false, status: res.status, error: "no registration_endpoint" };
-    }
-    return {
-      url: metaUrl,
-      ok: true,
-      status: res.status,
-      registrationEndpoint: body.registration_endpoint,
+    if (!res.ok) return null;
+    const body = (await res.json()) as {
+      registration_endpoint?: unknown;
+      authorization_endpoint?: unknown;
     };
+    if (typeof body.registration_endpoint !== "string") return null;
+    return {
+      registration_endpoint: body.registration_endpoint,
+      authorization_endpoint:
+        typeof body.authorization_endpoint === "string" ? body.authorization_endpoint : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * POST a synthetic DCR client to the registration endpoint. Returns
+ * `{ ok: true, clientId }` on success or `{ ok: false, message }` on
+ * vendor-side rejection (typically host-allowlist failures).
+ */
+async function probeDcrRegistration(
+  registrationEndpoint: string,
+): Promise<{ ok: true; clientId: string } | { ok: false; message: string }> {
+  try {
+    const res = await fetch(registrationEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_name: "NimbleBrain catalog probe",
+        redirect_uris: [PROBE_REDIRECT_URI],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      // Try to surface the vendor's structured error_description if any.
+      let detail = text.slice(0, 200);
+      try {
+        const body = JSON.parse(text) as { error?: string; error_description?: string };
+        detail = body.error_description ?? body.error ?? detail;
+      } catch {
+        // not JSON; keep raw
+      }
+      return { ok: false, message: `HTTP ${res.status}: ${detail}` };
+    }
+    const body = JSON.parse(text) as { client_id?: unknown };
+    if (typeof body.client_id !== "string") {
+      return { ok: false, message: "registration response missing client_id" };
+    }
+    return { ok: true, clientId: body.client_id };
   } catch (err) {
     return {
-      url: metaUrl,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * GET the authorization endpoint with a synthetic state + PKCE pair.
+ * A spec-compliant vendor will redirect us to a login page (302/303)
+ * or render one inline (200). A vendor with a parallel host
+ * allowlist returns 4xx with a "redirect URI ... not allowed" body.
+ */
+async function probeAuthorize(
+  authorizationEndpoint: string,
+  clientId: string,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  // PKCE challenge — `code_challenge_method=S256` of an arbitrary
+  // verifier. Some vendors require it; supplying it never hurts.
+  const url = new URL(authorizationEndpoint);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", PROBE_REDIRECT_URI);
+  url.searchParams.set("scope", "");
+  url.searchParams.set("state", "probe");
+  url.searchParams.set("code_challenge", "Wph4LpxPDcXGKQQjkmFwIyMu5ZKLXEUW2Bn7sV3vqYU");
+  url.searchParams.set("code_challenge_method", "S256");
+
+  try {
+    const res = await fetch(url.toString(), {
+      method: "GET",
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      redirect: "manual",
+    });
+    // 2xx (login page) or 3xx (redirect to vendor login) = pass.
+    if (res.status < 400) return { ok: true };
+    const body = (await res.text()).slice(0, 200).replace(/\s+/g, " ").trim();
+    return { ok: false, message: `HTTP ${res.status}: ${body}` };
+  } catch (err) {
+    return {
+      ok: false,
+      message: err instanceof Error ? err.message : String(err),
     };
   }
 }

--- a/src/connectors/catalog.yaml
+++ b/src/connectors/catalog.yaml
@@ -72,21 +72,11 @@ servers:
         auth: dcr
         tags: [issues, project-mgmt]
 
-  - name: com.canva/mcp
-    title: Canva
-    description: Design files and brand assets
-    version: "1.0.0"
-    icons:
-      - src: https://static.nimblebrain.ai/icons/canva.png
-        sizes: ["any"]
-    remotes:
-      - type: streamable-http
-        url: https://mcp.canva.com/mcp
-    _meta:
-      ai.nimblebrain/connector:
-        defaultScope: workspace
-        auth: dcr
-        tags: [design, creative]
+  # com.canva/mcp: dropped pending vendor host allowlisting. Canva's
+  # /authorize independently rejects non-allowlisted redirect URIs
+  # (DCR /register accepts but install fails at the browser redirect
+  # with "Invalid redirect URI. It must be from an allowed host.").
+  # Re-add once #200 outreach lands.
 
   - name: com.cloudflare/mcp
     title: Cloudflare
@@ -104,21 +94,10 @@ servers:
         auth: dcr
         tags: [infra, devops]
 
-  - name: com.intercom/mcp
-    title: Intercom
-    description: Customer conversations and support tickets
-    version: "1.0.0"
-    icons:
-      - src: https://static.nimblebrain.ai/icons/intercom.png
-        sizes: ["any"]
-    remotes:
-      - type: streamable-http
-        url: https://mcp.intercom.com/mcp
-    _meta:
-      ai.nimblebrain/connector:
-        defaultScope: workspace
-        auth: dcr
-        tags: [support, messaging]
+  # com.intercom/mcp: dropped pending vendor host allowlisting.
+  # Intercom rejects DCR /register itself with "Redirect URI ... is
+  # not in the allowlist, reach out to Intercom Customer Support if
+  # you believe we should support it." Re-add once #200 lands.
 
   - name: com.mercury/mcp
     title: Mercury
@@ -206,21 +185,10 @@ servers:
   # only honors the well-known root today — install would fail. Re-add
   # once issue #196 lands the WWW-Authenticate fallback.
 
-  - name: com.vercel/mcp
-    title: Vercel
-    description: Deployments, projects, and environment variables
-    version: "1.0.0"
-    icons:
-      - src: https://static.nimblebrain.ai/icons/vercel.png
-        sizes: ["any"]
-    remotes:
-      - type: streamable-http
-        url: https://mcp.vercel.com
-    _meta:
-      ai.nimblebrain/connector:
-        defaultScope: workspace
-        auth: dcr
-        tags: [hosting, devops]
+  # com.vercel/mcp: dropped pending vendor host allowlisting. Vercel
+  # rejects DCR /register with "The provided redirect URIs are not
+  # approved for use by this authorization server." Re-add once #200
+  # lands.
 
   - name: com.webflow/mcp
     title: Webflow


### PR DESCRIPTION
Closes #200 once vendor outreach completes (this PR drops; #200 tracks re-add).

## Summary

- Drop `com.canva/mcp`, `com.intercom/mcp`, `com.vercel/mcp` from `catalog.yaml`. All three advertise compliant DCR but enforce a parallel host allowlist that blocks installs against tenant hosts (`*.platform.nimblebrain.ai`). Surfaced when Canva install was attempted on `tenant-hq` after #195's deploy.
- Extend `scripts/check-catalog-dcr.ts` from a 3-step probe (reachability + RFC 9728 + RFC 8414 metadata) to a 5-step probe (also: DCR `/register` + `/authorize`). The new steps catch the "DCR theater" class of failure that was invisible before — vendor compliance with RFC 7591 is necessary but not sufficient for an install to actually work.

## Failure matrix (probed against `https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback`)

| Vendor | Failure point | Vendor message |
|---|---|---|
| Canva | `/authorize` | `Invalid redirect URI. It must be from an allowed host.` |
| Intercom | `/register` | `Redirect URI ... is not in the allowlist, reach out to Intercom Customer Support if you believe we should support it` |
| Vercel | `/register` | `The provided redirect URIs are not approved for use by this authorization server.` |

11/11 remaining DCR entries (Notion, Linear, Cloudflare, Mercury, Neon, PayPal, Sentry, Stripe, Webflow, Wix, Granola) pass the extended probe.

## Test plan

- [x] `bun run verify` — green
- [x] `bun run check:catalog` — 11/11 pass with the extended probe
- [ ] Manual: install one of the remaining DCR entries on `tenant-hq` end-to-end as smoke confirmation

## Related

- #195 — original DCR adoption PR
- #200 — vendor outreach tracking issue (re-add criteria + per-vendor contact channels)