### PR TITLE
fix(engine): normalize MCP tool schemas at LLM boundary; add Dropbox

### DIFF
--- a/src/connectors/catalog.yaml
+++ b/src/connectors/catalog.yaml
@@ -94,6 +94,38 @@ servers:
         auth: dcr
         tags: [infra, devops]
 
+  # Dropbox advertises DCR but only honors it for a curated partner
+  # allowlist (Claude Desktop, Cursor, ChatGPT) — `/register` rejects
+  # everyone else with "Dynamic client registration is not supported."
+  # Wired here as `auth: static` so operators can bring their own
+  # OAuth app from the Dropbox App Console. Drop back to `auth: dcr`
+  # once #200 outreach lands.
+  - name: com.dropbox/mcp
+    title: Dropbox
+    description: Files, folders, and shared links
+    version: "1.0.0"
+    icons:
+      - src: https://static.nimblebrain.ai/icons/dropbox.png
+        sizes: ["any"]
+    remotes:
+      - type: streamable-http
+        url: https://mcp.dropbox.com/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        defaultScope: workspace
+        auth: static
+        requiredScopes:
+          - files.metadata.read
+          - files.content.read
+          - files.content.write
+          - sharing.write
+          - account_info.read
+        operatorSetup:
+          portalUrl: https://www.dropbox.com/developers/apps
+          hint: Create a Scoped Access app in the Dropbox App Console, enable the listed scopes, add the NimbleBrain redirect URI, then paste App key + App secret here
+          clientSecretKey: dropbox.client_secret
+        tags: [storage, files]
+
   # com.intercom/mcp: dropped pending vendor host allowlisting.
   # Intercom rejects DCR /register itself with "Redirect URI ... is
   # not in the allowlist, reach out to Intercom Customer Support if

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -22,6 +22,7 @@ import {
   textContent,
 } from "./content-helpers.ts";
 import { withRetry } from "./retry.ts";
+import { toolSchemaForLlm } from "./tool-schema-for-llm.ts";
 import type {
   EngineConfig,
   EngineResult,
@@ -330,7 +331,7 @@ export class AgentEngine {
           type: "function" as const,
           name: t.name,
           description: t.description,
-          inputSchema: t.inputSchema as JSONSchema7,
+          inputSchema: toolSchemaForLlm(t.inputSchema) as JSONSchema7,
         }));
 
         const toolSchemaMap = new Map<string, ToolSchema>();

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -331,7 +331,7 @@ export class AgentEngine {
           type: "function" as const,
           name: t.name,
           description: t.description,
-          inputSchema: toolSchemaForLlm(t.inputSchema) as JSONSchema7,
+          inputSchema: toolSchemaForLlm(t.inputSchema, t.name) as JSONSchema7,
         }));
 
         const toolSchemaMap = new Map<string, ToolSchema>();

--- a/src/engine/tool-schema-for-llm.ts
+++ b/src/engine/tool-schema-for-llm.ts
@@ -25,37 +25,44 @@ import { log } from "../cli/log.ts";
  * pass-through of the vendor-emitted schema; downstream consumers
  * (validation, audit, debugging) see the original.
  *
- *   - `oneOf` / `anyOf` at root → **union-merge** branch properties;
- *     intersect required arrays. The LLM sees every reachable field
- *     across all branches but is told to require only what every branch
- *     requires (i.e., nothing branch-specific).
+ * ### `oneOf` / `anyOf` at root → **first branch wins** (lossy, but only
+ * representable choice).
  *
- *     This is safe because the engine validates the LLM's emitted args
- *     against the *original* schema (see `engine.ts` call to
- *     `validateToolInput` — the schema map holds pre-transform Tools).
- *     Ajv compiles `oneOf` correctly: a payload matching 0 or >1 branches
- *     is rejected before the tool runs, the error is fed back, and the
- *     model self-corrects on the next iteration. So an invalid
- *     mix-and-match costs at most one wasted LLM turn — strictly better
- *     than picking a single branch and rendering the others unreachable
- *     (e.g. Dropbox `list_folder`'s `shared_link` branch).
+ * An earlier iteration tried union-merge ("show the LLM every reachable
+ * field; let Ajv-over-original reject invalid combos") on the theory that
+ * post-hoc validation would let the model self-correct. Empirically that
+ * fails — observed with Dropbox `list_folder` (which uses oneOf to model
+ * `path` vs `cursor` continuation): the model emits both fields together,
+ * Ajv rejects with `must NOT have additional properties; must match
+ * exactly one schema in oneOf`, and that error message gives the model
+ * no signal about *which* field to drop or *which* branch was nearest.
+ * The model loops with cosmetic variations until it hits the iteration
+ * cap.
  *
- *   - `allOf` at root → union-merge branch properties; **union** required
- *     arrays. `allOf` means all branches hold simultaneously, so anything
- *     required in any branch is universally required.
+ * The lesson: post-hoc validation only constitutes a recovery loop when
+ * its error messages are recoverable. JSON Schema `oneOf` errors are not.
  *
- *   - On property-key collision across branches: **last branch wins**.
- *     A vendor that reuses the same property name with different shapes
- *     across branches is already malformed; predictable spread-style
- *     last-wins beats inventing a property-level oneOf. The MCP server's
- *     own validation still gates the actual call.
+ * First-branch is the closest representable approximation we can hand
+ * the LLM: a schema it can satisfy on the first call. Alternative
+ * branches become unreachable; that loss is real but bounded (vendors
+ * order branches by canonical use — `path` is the 99% case for Dropbox).
+ * Operators are warned via `log.warn` so the loss is visible. The
+ * permanent fix lives upstream — vendor MCP servers should flatten
+ * top-level composition, since no LLM provider supports it.
  *
- *   - `enum` / `not` at root → stripped. Neither has a flat-object
- *     representation and the MCP spec doesn't anticipate them as root
- *     schemas for tool inputs.
+ * ### `allOf` at root → union-merge (semantically faithful).
  *
- *   - After all rewrites, `type: "object"` and a plain-object
- *     `properties` are guaranteed to exist.
+ * `allOf` means every branch holds simultaneously, so merging properties
+ * across branches and unioning required arrays is the truthful
+ * representation. No information is lost; the LLM sees the full schema.
+ *
+ * ### `enum` / `not` at root → stripped.
+ *
+ * Neither has a flat-object representation and the MCP spec doesn't
+ * anticipate them as root schemas for tool inputs.
+ *
+ * After all rewrites, `type: "object"` and a plain-object `properties`
+ * are guaranteed to exist.
  *
  * ## Input contract
  *
@@ -83,11 +90,11 @@ export function toolSchemaForLlm(raw: unknown, toolName?: string): Record<string
   let schema: Record<string, unknown> = { ...(raw as Record<string, unknown>) };
 
   if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
-    schema = mergeRootComposition(schema, "oneOf");
+    schema = collapseToFirstBranch(schema, "oneOf", toolName);
   } else if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
-    schema = mergeRootComposition(schema, "anyOf");
+    schema = collapseToFirstBranch(schema, "anyOf", toolName);
   } else if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
-    schema = mergeRootComposition(schema, "allOf");
+    schema = mergeAllOf(schema);
   }
 
   if ("enum" in schema) delete schema.enum;
@@ -108,19 +115,85 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Merge a root-level `oneOf` / `anyOf` / `allOf` into a single object
- * schema. Properties union across branches (last-wins on collision);
- * `required` semantics differ per keyword (see top-level docstring).
+ * Replace the schema with branches[0]. Root-level keys that the branch
+ * doesn't define (description, title, $defs, etc.) are preserved; branch
+ * values win on conflict (branch is the source of truth for shape, root
+ * for documentation).
  *
- * Branches that aren't plain objects are skipped — JSON Schema permits
- * boolean schemas (`true`/`false`) as branches, but for tool input use
- * cases they carry no merge information.
+ * Surfaces the loss to operators when branches beyond the first carry
+ * properties the LLM will never see — that's the architectural cost of
+ * first-branch and they should be able to spot it in logs.
  */
-function mergeRootComposition(
+function collapseToFirstBranch(
   schema: Record<string, unknown>,
-  key: "oneOf" | "anyOf" | "allOf",
+  key: "oneOf" | "anyOf",
+  toolName?: string,
 ): Record<string, unknown> {
   const branches = (schema[key] as unknown[]).filter(isPlainObject);
+  if (branches.length === 0) {
+    const copy = { ...schema };
+    delete copy[key];
+    return copy;
+  }
+
+  if (branches.length > 1) {
+    warnDroppedBranches(branches, key, toolName);
+  }
+
+  const rootRest = { ...schema };
+  delete rootRest[key];
+  return { ...rootRest, ...branches[0] };
+}
+
+/**
+ * Emit one log line per tool listing properties that exist in dropped
+ * branches but not in the kept one — those are the fields no LLM call
+ * via this tool can ever set. If the dropped branches add no novel
+ * properties (e.g. they only re-shape kept ones with different types),
+ * the warning still fires but with an empty list, because the kept
+ * branch's shape still misrepresents the alternatives semantically.
+ */
+function warnDroppedBranches(
+  branches: Array<Record<string, unknown>>,
+  key: "oneOf" | "anyOf",
+  toolName?: string,
+): void {
+  const keptProps = isPlainObject(branches[0]?.properties)
+    ? new Set(Object.keys(branches[0].properties as Record<string, unknown>))
+    : new Set<string>();
+  const lostProps = new Set<string>();
+  for (let i = 1; i < branches.length; i++) {
+    const b = branches[i];
+    if (b && isPlainObject(b.properties)) {
+      for (const p of Object.keys(b.properties)) {
+        if (!keptProps.has(p)) lostProps.add(p);
+      }
+    }
+  }
+  const lostList =
+    lostProps.size > 0 ? [...lostProps].join(", ") : "(none — branches reshape kept properties)";
+  log.warn(
+    `[engine] toolSchemaForLlm: tool ${toolName ? `"${toolName}"` : "<unknown>"} ` +
+      `has a top-level ${key} with ${branches.length} branches; LLM providers don't ` +
+      `support top-level composition, so only the first branch is exposed. ` +
+      `Properties unreachable in dropped branches: ${lostList}. ` +
+      "The permanent fix is for the MCP source to flatten its tool schema.",
+  );
+}
+
+/**
+ * Merge every `allOf` branch into a single object schema. Properties union
+ * (last-wins on collision); required is the union of root + every
+ * branch's required. Semantically faithful — `allOf` means every branch
+ * must hold simultaneously, so anything required anywhere is universally
+ * required.
+ *
+ * Branches that aren't plain objects are skipped — JSON Schema permits
+ * boolean schemas (`true`/`false`) as branches but they carry no
+ * mergeable shape information for tool inputs.
+ */
+function mergeAllOf(schema: Record<string, unknown>): Record<string, unknown> {
+  const branches = (schema.allOf as unknown[]).filter(isPlainObject);
 
   const mergedProperties: Record<string, unknown> = {
     ...((schema.properties as Record<string, unknown> | undefined) ?? {}),
@@ -131,44 +204,21 @@ function mergeRootComposition(
     }
   }
 
-  const required = mergeRequired(schema, branches, key);
+  const rootRequired = readStringArray(schema.required);
+  const required = new Set(rootRequired);
+  for (const branch of branches) {
+    for (const r of readStringArray(branch.required)) required.add(r);
+  }
 
   const out = { ...schema };
-  delete out[key];
+  delete out.allOf;
   out.properties = mergedProperties;
-  if (required.length > 0) {
-    out.required = required;
+  if (required.size > 0) {
+    out.required = [...required];
   } else {
     delete out.required;
   }
   return out;
-}
-
-/**
- * `allOf`: every branch holds → required = root ∪ (∪ branch.required).
- * `oneOf` / `anyOf`: exactly one branch holds → a field is universally
- * required only if every branch requires it → root ∪ (∩ branch.required).
- */
-function mergeRequired(
-  schema: Record<string, unknown>,
-  branches: Array<Record<string, unknown>>,
-  key: "oneOf" | "anyOf" | "allOf",
-): string[] {
-  const rootRequired = readStringArray(schema.required);
-  const branchRequireds = branches.map((b) => readStringArray(b.required));
-
-  if (key === "allOf") {
-    const merged = new Set(rootRequired);
-    for (const r of branchRequireds) for (const f of r) merged.add(f);
-    return [...merged];
-  }
-
-  if (branchRequireds.length === 0) return rootRequired;
-  const intersected = branchRequireds.reduce<string[]>(
-    (acc, cur) => acc.filter((f) => cur.includes(f)),
-    branchRequireds[0] ?? [],
-  );
-  return [...new Set([...rootRequired, ...intersected])];
 }
 
 function readStringArray(value: unknown): string[] {

--- a/src/engine/tool-schema-for-llm.ts
+++ b/src/engine/tool-schema-for-llm.ts
@@ -1,120 +1,177 @@
+import { log } from "../cli/log.ts";
+
 /**
- * The single transform that maps an MCP-spec tool inputSchema into the
- * narrower shape every major LLM provider's tool-schema validator accepts.
+ * Translate an MCP-spec tool inputSchema into the narrower shape every
+ * major LLM provider's tool-validator accepts.
  *
- * The constraint set, derived from the OpenAI Chat Completions / Responses
- * and Anthropic Messages APIs (both reject identical shapes with identical
- * messages):
+ * ## The constraint
+ *
+ * Verified against OpenAI (Chat Completions + Responses) and Anthropic
+ * Messages as of 2026-05-12 — both reject identical shapes with identical
+ * messages:
  *
  *   1. Root must be `type: "object"` with an explicit `properties` field.
  *   2. Root must NOT contain `oneOf` / `anyOf` / `allOf` / `enum` / `not`.
  *
- * Anywhere deeper than the root, every keyword is allowed — the providers
- * only enforce the constraint at the top level. We mirror that scope: this
- * function rewrites root keywords only and never walks into properties,
- * preserving every bit of vendor information that wasn't blocking the call.
+ * Anywhere deeper than the root, every JSON Schema keyword is allowed —
+ * the providers only enforce the constraint at the top level, so this
+ * transform never walks into properties. Revisit if a provider API
+ * version bump tightens the rules.
  *
- * Transformation rules:
+ * ## Strategy
  *
- *   - `oneOf` / `anyOf` at root → take the FIRST branch. A oneOf says
- *     "exactly one of these shapes"; any valid call already satisfies
- *     exactly one. Picking branch[0] yields a schema that, when satisfied,
- *     IS a valid tool input. Synthesizing a union (merging all branches)
- *     would invite mix-and-match payloads that match no real branch — a
- *     strictly worse failure mode than losing access to alternative branches.
- *     Vendors typically order branches by canonical use.
+ * Single transform at the one boundary every tool crosses (engine.ts →
+ * LanguageModelV3FunctionTool). The MCP source layer remains a faithful
+ * pass-through of the vendor-emitted schema; downstream consumers
+ * (validation, audit, debugging) see the original.
  *
- *   - `allOf` at root → merge every branch. `allOf` means "all must hold
- *     simultaneously", so combining their properties and unioning required
- *     is semantically faithful, not lossy.
+ *   - `oneOf` / `anyOf` at root → **union-merge** branch properties;
+ *     intersect required arrays. The LLM sees every reachable field
+ *     across all branches but is told to require only what every branch
+ *     requires (i.e., nothing branch-specific).
  *
- *   - `enum` / `not` at root → drop. Neither has a meaningful flat-object
- *     representation, and the MCP spec doesn't suggest vendors should
- *     declare entire tool inputs as enums.
+ *     This is safe because the engine validates the LLM's emitted args
+ *     against the *original* schema (see `engine.ts` call to
+ *     `validateToolInput` — the schema map holds pre-transform Tools).
+ *     Ajv compiles `oneOf` correctly: a payload matching 0 or >1 branches
+ *     is rejected before the tool runs, the error is fed back, and the
+ *     model self-corrects on the next iteration. So an invalid
+ *     mix-and-match costs at most one wasted LLM turn — strictly better
+ *     than picking a single branch and rendering the others unreachable
+ *     (e.g. Dropbox `list_folder`'s `shared_link` branch).
  *
- *   - After transformation, `type: "object"` and `properties: {}` are
- *     guaranteed to exist.
+ *   - `allOf` at root → union-merge branch properties; **union** required
+ *     arrays. `allOf` means all branches hold simultaneously, so anything
+ *     required in any branch is universally required.
  *
- * The MCP server itself still enforces strict semantics on the actual call,
- * so any invalid combo the LLM emits surfaces as a tool error and the
- * agent self-corrects.
+ *   - On property-key collision across branches: **last branch wins**.
+ *     A vendor that reuses the same property name with different shapes
+ *     across branches is already malformed; predictable spread-style
+ *     last-wins beats inventing a property-level oneOf. The MCP server's
+ *     own validation still gates the actual call.
+ *
+ *   - `enum` / `not` at root → stripped. Neither has a flat-object
+ *     representation and the MCP spec doesn't anticipate them as root
+ *     schemas for tool inputs.
+ *
+ *   - After all rewrites, `type: "object"` and a plain-object
+ *     `properties` are guaranteed to exist.
+ *
+ * ## Input contract
+ *
+ * `raw: unknown` — defensive by design. `null`/`undefined` is treated as
+ * "tool declares no input" (legitimate); any other non-object is treated
+ * as an upstream bug and logged via `log.warn` with the tool name so the
+ * source can be fixed. Both cases coerce to an empty object schema so
+ * the agent loop keeps running.
  */
-export function toolSchemaForLlm(raw: unknown): Record<string, unknown> {
-  if (raw === null || typeof raw !== "object") {
-    return { type: "object", properties: {} };
+export function toolSchemaForLlm(raw: unknown, toolName?: string): Record<string, unknown> {
+  if (raw === null || raw === undefined) {
+    return emptyObjectSchema();
   }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    const actual = Array.isArray(raw) ? "array" : typeof raw;
+    log.warn(
+      `[engine] toolSchemaForLlm: non-object inputSchema for tool ${
+        toolName ? `"${toolName}"` : "<unknown>"
+      } (got ${actual}); coercing to empty object schema. ` +
+        "This indicates an upstream bug in the tool source.",
+    );
+    return emptyObjectSchema();
+  }
+
   let schema: Record<string, unknown> = { ...(raw as Record<string, unknown>) };
 
   if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
-    schema = collapseToFirstBranch(schema, "oneOf");
+    schema = mergeRootComposition(schema, "oneOf");
   } else if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
-    schema = collapseToFirstBranch(schema, "anyOf");
+    schema = mergeRootComposition(schema, "anyOf");
   } else if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
-    schema = mergeAllOf(schema);
+    schema = mergeRootComposition(schema, "allOf");
   }
 
   if ("enum" in schema) delete schema.enum;
   if ("not" in schema) delete schema.not;
 
   if (schema.type !== "object") schema.type = "object";
-  if (schema.properties === undefined) schema.properties = {};
+  if (!isPlainObject(schema.properties)) schema.properties = {};
 
   return schema;
 }
 
-/**
- * Replace the schema with branches[0], preserving any root-level keys
- * that the branch doesn't define (description, title, $defs, etc.).
- * Branch values win on conflict — the branch is the source of truth
- * for shape, the root for documentation.
- */
-function collapseToFirstBranch(
-  schema: Record<string, unknown>,
-  key: "oneOf" | "anyOf",
-): Record<string, unknown> {
-  const branches = schema[key] as unknown[];
-  const first = branches[0];
-  if (first === null || typeof first !== "object") {
-    const copy = { ...schema };
-    delete copy[key];
-    return copy;
-  }
-  const branch = first as Record<string, unknown>;
-  const rootRest = { ...schema };
-  delete rootRest[key];
-  return { ...rootRest, ...branch };
+function emptyObjectSchema(): Record<string, unknown> {
+  return { type: "object", properties: {} };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 /**
- * Merge every allOf branch into a single object schema. Properties union;
- * required unions (deduped); branch values win over root on conflict.
+ * Merge a root-level `oneOf` / `anyOf` / `allOf` into a single object
+ * schema. Properties union across branches (last-wins on collision);
+ * `required` semantics differ per keyword (see top-level docstring).
+ *
+ * Branches that aren't plain objects are skipped — JSON Schema permits
+ * boolean schemas (`true`/`false`) as branches, but for tool input use
+ * cases they carry no merge information.
  */
-function mergeAllOf(schema: Record<string, unknown>): Record<string, unknown> {
-  const branches = (schema.allOf as unknown[]).filter(
-    (b): b is Record<string, unknown> => b !== null && typeof b === "object",
-  );
+function mergeRootComposition(
+  schema: Record<string, unknown>,
+  key: "oneOf" | "anyOf" | "allOf",
+): Record<string, unknown> {
+  const branches = (schema[key] as unknown[]).filter(isPlainObject);
+
   const mergedProperties: Record<string, unknown> = {
-    ...((schema.properties as Record<string, unknown>) ?? {}),
+    ...((schema.properties as Record<string, unknown> | undefined) ?? {}),
   };
-  const mergedRequired = new Set<string>(
-    Array.isArray(schema.required)
-      ? (schema.required as unknown[]).filter((r): r is string => typeof r === "string")
-      : [],
-  );
   for (const branch of branches) {
-    const branchProps = branch.properties;
-    if (branchProps !== null && typeof branchProps === "object") {
-      Object.assign(mergedProperties, branchProps as Record<string, unknown>);
-    }
-    if (Array.isArray(branch.required)) {
-      for (const r of branch.required) {
-        if (typeof r === "string") mergedRequired.add(r);
-      }
+    if (isPlainObject(branch.properties)) {
+      Object.assign(mergedProperties, branch.properties);
     }
   }
+
+  const required = mergeRequired(schema, branches, key);
+
   const out = { ...schema };
-  delete out.allOf;
+  delete out[key];
   out.properties = mergedProperties;
-  if (mergedRequired.size > 0) out.required = Array.from(mergedRequired);
+  if (required.length > 0) {
+    out.required = required;
+  } else {
+    delete out.required;
+  }
   return out;
+}
+
+/**
+ * `allOf`: every branch holds → required = root ∪ (∪ branch.required).
+ * `oneOf` / `anyOf`: exactly one branch holds → a field is universally
+ * required only if every branch requires it → root ∪ (∩ branch.required).
+ */
+function mergeRequired(
+  schema: Record<string, unknown>,
+  branches: Array<Record<string, unknown>>,
+  key: "oneOf" | "anyOf" | "allOf",
+): string[] {
+  const rootRequired = readStringArray(schema.required);
+  const branchRequireds = branches.map((b) => readStringArray(b.required));
+
+  if (key === "allOf") {
+    const merged = new Set(rootRequired);
+    for (const r of branchRequireds) for (const f of r) merged.add(f);
+    return [...merged];
+  }
+
+  if (branchRequireds.length === 0) return rootRequired;
+  const intersected = branchRequireds.reduce<string[]>(
+    (acc, cur) => acc.filter((f) => cur.includes(f)),
+    branchRequireds[0] ?? [],
+  );
+  return [...new Set([...rootRequired, ...intersected])];
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
 }

--- a/src/engine/tool-schema-for-llm.ts
+++ b/src/engine/tool-schema-for-llm.ts
@@ -1,0 +1,120 @@
+/**
+ * The single transform that maps an MCP-spec tool inputSchema into the
+ * narrower shape every major LLM provider's tool-schema validator accepts.
+ *
+ * The constraint set, derived from the OpenAI Chat Completions / Responses
+ * and Anthropic Messages APIs (both reject identical shapes with identical
+ * messages):
+ *
+ *   1. Root must be `type: "object"` with an explicit `properties` field.
+ *   2. Root must NOT contain `oneOf` / `anyOf` / `allOf` / `enum` / `not`.
+ *
+ * Anywhere deeper than the root, every keyword is allowed — the providers
+ * only enforce the constraint at the top level. We mirror that scope: this
+ * function rewrites root keywords only and never walks into properties,
+ * preserving every bit of vendor information that wasn't blocking the call.
+ *
+ * Transformation rules:
+ *
+ *   - `oneOf` / `anyOf` at root → take the FIRST branch. A oneOf says
+ *     "exactly one of these shapes"; any valid call already satisfies
+ *     exactly one. Picking branch[0] yields a schema that, when satisfied,
+ *     IS a valid tool input. Synthesizing a union (merging all branches)
+ *     would invite mix-and-match payloads that match no real branch — a
+ *     strictly worse failure mode than losing access to alternative branches.
+ *     Vendors typically order branches by canonical use.
+ *
+ *   - `allOf` at root → merge every branch. `allOf` means "all must hold
+ *     simultaneously", so combining their properties and unioning required
+ *     is semantically faithful, not lossy.
+ *
+ *   - `enum` / `not` at root → drop. Neither has a meaningful flat-object
+ *     representation, and the MCP spec doesn't suggest vendors should
+ *     declare entire tool inputs as enums.
+ *
+ *   - After transformation, `type: "object"` and `properties: {}` are
+ *     guaranteed to exist.
+ *
+ * The MCP server itself still enforces strict semantics on the actual call,
+ * so any invalid combo the LLM emits surfaces as a tool error and the
+ * agent self-corrects.
+ */
+export function toolSchemaForLlm(raw: unknown): Record<string, unknown> {
+  if (raw === null || typeof raw !== "object") {
+    return { type: "object", properties: {} };
+  }
+  let schema: Record<string, unknown> = { ...(raw as Record<string, unknown>) };
+
+  if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
+    schema = collapseToFirstBranch(schema, "oneOf");
+  } else if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
+    schema = collapseToFirstBranch(schema, "anyOf");
+  } else if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
+    schema = mergeAllOf(schema);
+  }
+
+  if ("enum" in schema) delete schema.enum;
+  if ("not" in schema) delete schema.not;
+
+  if (schema.type !== "object") schema.type = "object";
+  if (schema.properties === undefined) schema.properties = {};
+
+  return schema;
+}
+
+/**
+ * Replace the schema with branches[0], preserving any root-level keys
+ * that the branch doesn't define (description, title, $defs, etc.).
+ * Branch values win on conflict — the branch is the source of truth
+ * for shape, the root for documentation.
+ */
+function collapseToFirstBranch(
+  schema: Record<string, unknown>,
+  key: "oneOf" | "anyOf",
+): Record<string, unknown> {
+  const branches = schema[key] as unknown[];
+  const first = branches[0];
+  if (first === null || typeof first !== "object") {
+    const copy = { ...schema };
+    delete copy[key];
+    return copy;
+  }
+  const branch = first as Record<string, unknown>;
+  const rootRest = { ...schema };
+  delete rootRest[key];
+  return { ...rootRest, ...branch };
+}
+
+/**
+ * Merge every allOf branch into a single object schema. Properties union;
+ * required unions (deduped); branch values win over root on conflict.
+ */
+function mergeAllOf(schema: Record<string, unknown>): Record<string, unknown> {
+  const branches = (schema.allOf as unknown[]).filter(
+    (b): b is Record<string, unknown> => b !== null && typeof b === "object",
+  );
+  const mergedProperties: Record<string, unknown> = {
+    ...((schema.properties as Record<string, unknown>) ?? {}),
+  };
+  const mergedRequired = new Set<string>(
+    Array.isArray(schema.required)
+      ? (schema.required as unknown[]).filter((r): r is string => typeof r === "string")
+      : [],
+  );
+  for (const branch of branches) {
+    const branchProps = branch.properties;
+    if (branchProps !== null && typeof branchProps === "object") {
+      Object.assign(mergedProperties, branchProps as Record<string, unknown>);
+    }
+    if (Array.isArray(branch.required)) {
+      for (const r of branch.required) {
+        if (typeof r === "string") mergedRequired.add(r);
+      }
+    }
+  }
+  const out = { ...schema };
+  delete out.allOf;
+  out.properties = mergedProperties;
+  if (mergedRequired.size > 0) out.required = Array.from(mergedRequired);
+  return out;
+}

--- a/test/unit/tool-schema-for-llm.test.ts
+++ b/test/unit/tool-schema-for-llm.test.ts
@@ -8,10 +8,11 @@ import { toolSchemaForLlm } from "../../src/engine/tool-schema-for-llm.ts";
  * root `type: "object"` with explicit `properties`, no top-level
  * composition (oneOf / anyOf / allOf / enum / not).
  *
- * MCP servers routinely emit shapes the spec allows but providers reject.
- * The transform absorbs the contract gap at one place; downstream
- * validation (Ajv over the original schema) backs every actual call, so
- * the merge strategy can be permissive without compromising safety.
+ * Strategy summary (see docstring on the implementation for rationale):
+ *   - oneOf / anyOf → first-branch wins (lossy but recoverable for the LLM)
+ *   - allOf → union-merge (semantically faithful)
+ *   - enum / not → strip
+ *   - Always emit type: "object" with a plain-object properties block
  */
 describe("toolSchemaForLlm", () => {
   describe("base shape", () => {
@@ -108,11 +109,19 @@ describe("toolSchemaForLlm", () => {
     });
   });
 
-  describe("top-level oneOf — union-merge with intersected required", () => {
-    it("unions properties across branches", () => {
-      // Dropbox `list_folder`-style: model 'path' or 'shared_link' as
-      // mutually-exclusive branches. We want the LLM to be able to call
-      // either; Ajv over the original schema gates the actual call.
+  describe("top-level oneOf — first-branch wins", () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+    beforeEach(() => {
+      warnSpy = spyOn(log, "warn").mockImplementation(() => {});
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("collapses a top-level oneOf to its first branch", () => {
+      // Dropbox `list_folder`-style: model 'path' vs 'cursor' continuation
+      // as mutually-exclusive branches. We pick the first; the LLM gets a
+      // schema it can satisfy in one shot.
       const result = toolSchemaForLlm({
         oneOf: [
           {
@@ -122,103 +131,94 @@ describe("toolSchemaForLlm", () => {
           },
           {
             type: "object",
-            properties: { shared_link: { type: "string" } },
-            required: ["shared_link"],
+            properties: { cursor: { type: "string" } },
+            required: ["cursor"],
           },
         ],
       });
-      expect(result.type).toBe("object");
+      expect(result).toEqual({
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      });
       expect((result as Record<string, unknown>).oneOf).toBeUndefined();
-      expect(result.properties).toEqual({
-        path: { type: "string" },
-        shared_link: { type: "string" },
-      });
-      // Intersection of [path] and [shared_link] is empty → no root required.
-      expect(result.required).toBeUndefined();
     });
 
-    it("intersects required across oneOf branches", () => {
-      const result = toolSchemaForLlm({
-        oneOf: [
-          {
-            type: "object",
-            properties: { path: { type: "string" }, mode: { type: "string" } },
-            required: ["path", "mode"],
-          },
-          {
-            type: "object",
-            properties: { path: { type: "string" }, recursive: { type: "boolean" } },
-            required: ["path"],
-          },
-        ],
-      });
-      // path is required in BOTH branches → required.
-      // mode is required in only one branch → not universally required.
-      expect(result.required).toEqual(["path"]);
-    });
-
-    it("last branch wins on property-key collision", () => {
-      const result = toolSchemaForLlm({
-        oneOf: [
-          { type: "object", properties: { x: { type: "string" } } },
-          { type: "object", properties: { x: { type: "number" } } },
-        ],
-      });
-      expect(result.properties).toEqual({ x: { type: "number" } });
-    });
-
-    it("preserves root-level metadata (description, etc.)", () => {
+    it("preserves root metadata (description, etc.) when collapsing", () => {
       const result = toolSchemaForLlm({
         description: "Pick exactly one path style",
         oneOf: [
-          { type: "object", properties: { a: { type: "string" } } },
-          { type: "object", properties: { b: { type: "string" } } },
+          { type: "object", properties: { token: { type: "string" } }, required: ["token"] },
+          { type: "object", properties: { key: { type: "string" } } },
         ],
       });
       expect(result.description).toBe("Pick exactly one path style");
-      expect(result.properties).toEqual({
-        a: { type: "string" },
-        b: { type: "string" },
-      });
+      expect(result.properties).toEqual({ token: { type: "string" } });
+      expect(result.required).toEqual(["token"]);
     });
 
-    it("merges root-level properties with branch properties", () => {
-      const result = toolSchemaForLlm({
-        type: "object",
-        properties: { common: { type: "string" } },
+    it("does NOT warn when oneOf has only one branch (no loss)", () => {
+      toolSchemaForLlm({
+        oneOf: [{ type: "object", properties: { x: { type: "string" } } }],
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("warns when oneOf has multiple branches, listing dropped property names", () => {
+      toolSchemaForLlm(
+        {
+          oneOf: [
+            { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+            { type: "object", properties: { cursor: { type: "string" } }, required: ["cursor"] },
+            { type: "object", properties: { shared_link: { type: "string" } } },
+          ],
+        },
+        "com-dropbox-mcp__list_folder",
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = warnSpy.mock.calls[0]?.[0] as string;
+      expect(msg).toContain('"com-dropbox-mcp__list_folder"');
+      expect(msg).toContain("3 branches");
+      expect(msg).toContain("cursor");
+      expect(msg).toContain("shared_link");
+      // The kept branch's property (path) should NOT appear in the lost list.
+      // (Substring check is fine; "path" isn't in cursor / shared_link.)
+      expect(msg).not.toMatch(/unreachable.*\bpath\b/);
+    });
+
+    it("warns with a placeholder when no novel properties exist in dropped branches", () => {
+      toolSchemaForLlm({
         oneOf: [
-          { properties: { a: { type: "string" } } },
-          { properties: { b: { type: "string" } } },
+          { type: "object", properties: { x: { type: "string" } } },
+          { type: "object", properties: { x: { type: "number" } } }, // same name, different shape
         ],
       });
-      expect(result.properties).toEqual({
-        common: { type: "string" },
-        a: { type: "string" },
-        b: { type: "string" },
-      });
+      const msg = warnSpy.mock.calls[0]?.[0] as string;
+      expect(msg).toContain("(none — branches reshape kept properties)");
     });
   });
 
-  describe("top-level anyOf — union-merge with intersected required", () => {
-    it("merges anyOf identically to oneOf", () => {
+  describe("top-level anyOf — first-branch wins (identical to oneOf)", () => {
+    it("collapses anyOf to its first branch", () => {
+      const warnSpy = spyOn(log, "warn").mockImplementation(() => {});
       const result = toolSchemaForLlm({
         anyOf: [
           { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
           { type: "object", properties: { b: { type: "string" } } },
         ],
       });
-      expect(result.properties).toEqual({
-        a: { type: "string" },
-        b: { type: "string" },
+      expect(result).toEqual({
+        type: "object",
+        properties: { a: { type: "string" } },
+        required: ["a"],
       });
-      // Intersection of [a] and [] is empty.
-      expect(result.required).toBeUndefined();
       expect((result as Record<string, unknown>).anyOf).toBeUndefined();
+      warnSpy.mockRestore();
     });
   });
 
   describe("top-level allOf — union-merge with unioned required", () => {
-    it("unions both properties AND required (allOf means all hold)", () => {
+    it("unions properties AND required (allOf means all hold simultaneously)", () => {
       const result = toolSchemaForLlm({
         allOf: [
           { type: "object", properties: { a: { type: "string" } }, required: ["a"] },

--- a/test/unit/tool-schema-for-llm.test.ts
+++ b/test/unit/tool-schema-for-llm.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "bun:test";
+import { toolSchemaForLlm } from "../../src/engine/tool-schema-for-llm.ts";
+
+/**
+ * `toolSchemaForLlm` is the single boundary where MCP-spec JSON Schema
+ * gets transformed into the narrower shape that OpenAI and Anthropic
+ * both accept for tool input schemas:
+ *
+ *   1. Root must be `type: "object"` with an explicit `properties` key.
+ *   2. Root must NOT contain `oneOf` / `anyOf` / `allOf` / `enum` / `not`.
+ *
+ * MCP servers (Dropbox, etc.) routinely emit schemas that violate (1) or
+ * (2). Anthropic's `tools.N.custom.input_schema` and OpenAI's
+ * `tools[N].function.parameters` validators both reject them with the
+ * same constraint set, so this is a universal LLM-tool-boundary concern,
+ * not a per-provider quirk.
+ */
+describe("toolSchemaForLlm", () => {
+  describe("base shape", () => {
+    it("returns an empty object schema for non-object input", () => {
+      expect(toolSchemaForLlm(undefined)).toEqual({ type: "object", properties: {} });
+      expect(toolSchemaForLlm(null)).toEqual({ type: "object", properties: {} });
+      expect(toolSchemaForLlm("nope")).toEqual({ type: "object", properties: {} });
+    });
+
+    it("fills properties: {} when an object schema omits it", () => {
+      // Dropbox `get_usage_and_quota` ships this shape.
+      expect(toolSchemaForLlm({ type: "object" })).toEqual({
+        type: "object",
+        properties: {},
+      });
+    });
+
+    it("preserves an existing valid object schema verbatim", () => {
+      const schema = {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      };
+      expect(toolSchemaForLlm(schema)).toEqual(schema);
+    });
+
+    it("coerces a missing root type to object", () => {
+      expect(toolSchemaForLlm({ properties: { x: { type: "string" } } })).toEqual({
+        type: "object",
+        properties: { x: { type: "string" } },
+      });
+    });
+
+    it("does not mutate the input object", () => {
+      const original: Record<string, unknown> = { type: "object" };
+      toolSchemaForLlm(original);
+      expect(original).toEqual({ type: "object" });
+    });
+  });
+
+  describe("top-level oneOf / anyOf — first-branch wins", () => {
+    it("collapses a top-level oneOf to its first branch", () => {
+      // Dropbox `list_folder`-style: model "either path or shared link"
+      // as a oneOf. Take the first branch — every valid call to the tool
+      // must satisfy ONE branch, and synthesizing a union schema would
+      // let the model emit invalid mix-and-match payloads.
+      const result = toolSchemaForLlm({
+        oneOf: [
+          {
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          },
+          {
+            type: "object",
+            properties: { shared_link: { type: "string" } },
+            required: ["shared_link"],
+          },
+        ],
+      });
+      expect(result).toEqual({
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      });
+      expect((result as Record<string, unknown>).oneOf).toBeUndefined();
+    });
+
+    it("collapses a top-level anyOf to its first branch", () => {
+      const result = toolSchemaForLlm({
+        anyOf: [
+          { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+          { type: "object", properties: { b: { type: "string" } } },
+        ],
+      });
+      expect(result).toEqual({
+        type: "object",
+        properties: { a: { type: "string" } },
+        required: ["a"],
+      });
+    });
+
+    it("preserves root-level description/title when collapsing oneOf", () => {
+      const result = toolSchemaForLlm({
+        description: "Pick exactly one auth style",
+        oneOf: [
+          { type: "object", properties: { token: { type: "string" } }, required: ["token"] },
+          { type: "object", properties: { key: { type: "string" } } },
+        ],
+      });
+      expect(result).toEqual({
+        type: "object",
+        description: "Pick exactly one auth style",
+        properties: { token: { type: "string" } },
+        required: ["token"],
+      });
+    });
+  });
+
+  describe("top-level allOf — deep merge", () => {
+    it("merges allOf branch properties into a single object", () => {
+      const result = toolSchemaForLlm({
+        allOf: [
+          { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+          { type: "object", properties: { b: { type: "number" } }, required: ["b"] },
+        ],
+      });
+      expect(result.type).toBe("object");
+      expect(result.properties).toEqual({
+        a: { type: "string" },
+        b: { type: "number" },
+      });
+      expect(result.required).toEqual(expect.arrayContaining(["a", "b"]));
+      expect((result as Record<string, unknown>).allOf).toBeUndefined();
+    });
+  });
+
+  describe("top-level enum / not — dropped", () => {
+    it("drops a top-level enum, coercing to type: object", () => {
+      const result = toolSchemaForLlm({ enum: ["a", "b", "c"] });
+      expect(result).toEqual({ type: "object", properties: {} });
+    });
+
+    it("drops a top-level not, coercing to type: object", () => {
+      const result = toolSchemaForLlm({ not: { type: "string" } });
+      expect(result).toEqual({ type: "object", properties: {} });
+    });
+  });
+
+  describe("composition inside properties is preserved", () => {
+    it("leaves nested oneOf inside a property untouched", () => {
+      // Anthropic's error message specifies "at the top level" — nested
+      // composition is fine and we must NOT walk into it (loses real info).
+      const nested = {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [{ type: "string" }, { type: "number" }],
+          },
+        },
+      };
+      expect(toolSchemaForLlm(nested)).toEqual(nested);
+    });
+  });
+});

--- a/test/unit/tool-schema-for-llm.test.ts
+++ b/test/unit/tool-schema-for-llm.test.ts
@@ -1,30 +1,29 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { log } from "../../src/cli/log.ts";
 import { toolSchemaForLlm } from "../../src/engine/tool-schema-for-llm.ts";
 
 /**
- * `toolSchemaForLlm` is the single boundary where MCP-spec JSON Schema
- * gets transformed into the narrower shape that OpenAI and Anthropic
- * both accept for tool input schemas:
+ * `toolSchemaForLlm` is the single boundary that translates MCP-spec
+ * tool inputSchemas into the shape OpenAI and Anthropic both accept:
+ * root `type: "object"` with explicit `properties`, no top-level
+ * composition (oneOf / anyOf / allOf / enum / not).
  *
- *   1. Root must be `type: "object"` with an explicit `properties` key.
- *   2. Root must NOT contain `oneOf` / `anyOf` / `allOf` / `enum` / `not`.
- *
- * MCP servers (Dropbox, etc.) routinely emit schemas that violate (1) or
- * (2). Anthropic's `tools.N.custom.input_schema` and OpenAI's
- * `tools[N].function.parameters` validators both reject them with the
- * same constraint set, so this is a universal LLM-tool-boundary concern,
- * not a per-provider quirk.
+ * MCP servers routinely emit shapes the spec allows but providers reject.
+ * The transform absorbs the contract gap at one place; downstream
+ * validation (Ajv over the original schema) backs every actual call, so
+ * the merge strategy can be permissive without compromising safety.
  */
 describe("toolSchemaForLlm", () => {
   describe("base shape", () => {
-    it("returns an empty object schema for non-object input", () => {
+    it("treats null/undefined as 'no input' (silent coerce)", () => {
+      const warnSpy = spyOn(log, "warn");
       expect(toolSchemaForLlm(undefined)).toEqual({ type: "object", properties: {} });
       expect(toolSchemaForLlm(null)).toEqual({ type: "object", properties: {} });
-      expect(toolSchemaForLlm("nope")).toEqual({ type: "object", properties: {} });
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
 
     it("fills properties: {} when an object schema omits it", () => {
-      // Dropbox `get_usage_and_quota` ships this shape.
       expect(toolSchemaForLlm({ type: "object" })).toEqual({
         type: "object",
         properties: {},
@@ -48,18 +47,72 @@ describe("toolSchemaForLlm", () => {
     });
 
     it("does not mutate the input object", () => {
-      const original: Record<string, unknown> = { type: "object" };
+      const original: Record<string, unknown> = {
+        type: "object",
+        oneOf: [{ properties: { a: { type: "string" } } }],
+      };
+      const snapshot = JSON.parse(JSON.stringify(original));
       toolSchemaForLlm(original);
-      expect(original).toEqual({ type: "object" });
+      expect(original).toEqual(snapshot);
     });
   });
 
-  describe("top-level oneOf / anyOf — first-branch wins", () => {
-    it("collapses a top-level oneOf to its first branch", () => {
-      // Dropbox `list_folder`-style: model "either path or shared link"
-      // as a oneOf. Take the first branch — every valid call to the tool
-      // must satisfy ONE branch, and synthesizing a union schema would
-      // let the model emit invalid mix-and-match payloads.
+  describe("defensive coercion for malformed input", () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+    beforeEach(() => {
+      warnSpy = spyOn(log, "warn").mockImplementation(() => {});
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("warns and coerces when input is a string", () => {
+      expect(toolSchemaForLlm("not-a-schema", "my_tool")).toEqual({
+        type: "object",
+        properties: {},
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = warnSpy.mock.calls[0]?.[0] as string;
+      expect(msg).toContain('"my_tool"');
+      expect(msg).toContain("string");
+    });
+
+    it("warns and coerces when input is an array", () => {
+      toolSchemaForLlm([], "list_tool");
+      const msg = warnSpy.mock.calls[0]?.[0] as string;
+      expect(msg).toContain("array");
+      expect(msg).toContain('"list_tool"');
+    });
+
+    it("warns and coerces when input is a number", () => {
+      toolSchemaForLlm(42);
+      const msg = warnSpy.mock.calls[0]?.[0] as string;
+      expect(msg).toContain("number");
+      expect(msg).toContain("<unknown>");
+    });
+
+    it("fixes properties: null defensively (no warning — schema itself is valid)", () => {
+      const result = toolSchemaForLlm({ type: "object", properties: null });
+      expect(result).toEqual({ type: "object", properties: {} });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("fixes properties: <non-object> defensively", () => {
+      const result = toolSchemaForLlm({ type: "object", properties: "nope" });
+      expect(result).toEqual({ type: "object", properties: {} });
+    });
+
+    it("fixes properties: <array> defensively", () => {
+      const result = toolSchemaForLlm({ type: "object", properties: [] });
+      expect(result).toEqual({ type: "object", properties: {} });
+    });
+  });
+
+  describe("top-level oneOf — union-merge with intersected required", () => {
+    it("unions properties across branches", () => {
+      // Dropbox `list_folder`-style: model 'path' or 'shared_link' as
+      // mutually-exclusive branches. We want the LLM to be able to call
+      // either; Ajv over the original schema gates the actual call.
       const result = toolSchemaForLlm({
         oneOf: [
           {
@@ -74,54 +127,104 @@ describe("toolSchemaForLlm", () => {
           },
         ],
       });
-      expect(result).toEqual({
-        type: "object",
-        properties: { path: { type: "string" } },
-        required: ["path"],
-      });
+      expect(result.type).toBe("object");
       expect((result as Record<string, unknown>).oneOf).toBeUndefined();
+      expect(result.properties).toEqual({
+        path: { type: "string" },
+        shared_link: { type: "string" },
+      });
+      // Intersection of [path] and [shared_link] is empty → no root required.
+      expect(result.required).toBeUndefined();
     });
 
-    it("collapses a top-level anyOf to its first branch", () => {
+    it("intersects required across oneOf branches", () => {
+      const result = toolSchemaForLlm({
+        oneOf: [
+          {
+            type: "object",
+            properties: { path: { type: "string" }, mode: { type: "string" } },
+            required: ["path", "mode"],
+          },
+          {
+            type: "object",
+            properties: { path: { type: "string" }, recursive: { type: "boolean" } },
+            required: ["path"],
+          },
+        ],
+      });
+      // path is required in BOTH branches → required.
+      // mode is required in only one branch → not universally required.
+      expect(result.required).toEqual(["path"]);
+    });
+
+    it("last branch wins on property-key collision", () => {
+      const result = toolSchemaForLlm({
+        oneOf: [
+          { type: "object", properties: { x: { type: "string" } } },
+          { type: "object", properties: { x: { type: "number" } } },
+        ],
+      });
+      expect(result.properties).toEqual({ x: { type: "number" } });
+    });
+
+    it("preserves root-level metadata (description, etc.)", () => {
+      const result = toolSchemaForLlm({
+        description: "Pick exactly one path style",
+        oneOf: [
+          { type: "object", properties: { a: { type: "string" } } },
+          { type: "object", properties: { b: { type: "string" } } },
+        ],
+      });
+      expect(result.description).toBe("Pick exactly one path style");
+      expect(result.properties).toEqual({
+        a: { type: "string" },
+        b: { type: "string" },
+      });
+    });
+
+    it("merges root-level properties with branch properties", () => {
+      const result = toolSchemaForLlm({
+        type: "object",
+        properties: { common: { type: "string" } },
+        oneOf: [
+          { properties: { a: { type: "string" } } },
+          { properties: { b: { type: "string" } } },
+        ],
+      });
+      expect(result.properties).toEqual({
+        common: { type: "string" },
+        a: { type: "string" },
+        b: { type: "string" },
+      });
+    });
+  });
+
+  describe("top-level anyOf — union-merge with intersected required", () => {
+    it("merges anyOf identically to oneOf", () => {
       const result = toolSchemaForLlm({
         anyOf: [
           { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
           { type: "object", properties: { b: { type: "string" } } },
         ],
       });
-      expect(result).toEqual({
-        type: "object",
-        properties: { a: { type: "string" } },
-        required: ["a"],
+      expect(result.properties).toEqual({
+        a: { type: "string" },
+        b: { type: "string" },
       });
-    });
-
-    it("preserves root-level description/title when collapsing oneOf", () => {
-      const result = toolSchemaForLlm({
-        description: "Pick exactly one auth style",
-        oneOf: [
-          { type: "object", properties: { token: { type: "string" } }, required: ["token"] },
-          { type: "object", properties: { key: { type: "string" } } },
-        ],
-      });
-      expect(result).toEqual({
-        type: "object",
-        description: "Pick exactly one auth style",
-        properties: { token: { type: "string" } },
-        required: ["token"],
-      });
+      // Intersection of [a] and [] is empty.
+      expect(result.required).toBeUndefined();
+      expect((result as Record<string, unknown>).anyOf).toBeUndefined();
     });
   });
 
-  describe("top-level allOf — deep merge", () => {
-    it("merges allOf branch properties into a single object", () => {
+  describe("top-level allOf — union-merge with unioned required", () => {
+    it("unions both properties AND required (allOf means all hold)", () => {
       const result = toolSchemaForLlm({
         allOf: [
           { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
           { type: "object", properties: { b: { type: "number" } }, required: ["b"] },
         ],
       });
-      expect(result.type).toBe("object");
       expect(result.properties).toEqual({
         a: { type: "string" },
         b: { type: "number" },
@@ -131,22 +234,26 @@ describe("toolSchemaForLlm", () => {
     });
   });
 
-  describe("top-level enum / not — dropped", () => {
+  describe("top-level enum / not — stripped", () => {
     it("drops a top-level enum, coercing to type: object", () => {
-      const result = toolSchemaForLlm({ enum: ["a", "b", "c"] });
-      expect(result).toEqual({ type: "object", properties: {} });
+      expect(toolSchemaForLlm({ enum: ["a", "b", "c"] })).toEqual({
+        type: "object",
+        properties: {},
+      });
     });
 
     it("drops a top-level not, coercing to type: object", () => {
-      const result = toolSchemaForLlm({ not: { type: "string" } });
-      expect(result).toEqual({ type: "object", properties: {} });
+      expect(toolSchemaForLlm({ not: { type: "string" } })).toEqual({
+        type: "object",
+        properties: {},
+      });
     });
   });
 
   describe("composition inside properties is preserved", () => {
     it("leaves nested oneOf inside a property untouched", () => {
-      // Anthropic's error message specifies "at the top level" — nested
-      // composition is fine and we must NOT walk into it (loses real info).
+      // Providers only restrict the top level; preserving nested
+      // composition is more informative than walking and flattening.
       const nested = {
         type: "object",
         properties: {


### PR DESCRIPTION
## Summary

- New `src/engine/tool-schema-for-llm.ts` at the engine→LLM boundary translates MCP-spec JSON Schema into the narrower shape OpenAI (Chat + Responses) and Anthropic Messages both require for tool input schemas. Single transform, single boundary — `mcp-source.ts` stays a faithful pass-through.
- Adds `com.dropbox/mcp` to the connector catalog as `auth: static`. Dropbox advertises DCR but only honors it for a curated partner allowlist (Claude Desktop, Cursor, ChatGPT); operators bring their own OAuth app from the Dropbox App Console until #200 outreach lands.

## Why

Both providers reject identical shapes that the MCP spec allows: top-level `oneOf` / `anyOf` / `allOf` / `enum` / `not`, and object schemas without an explicit `properties` field. Dropbox's `list_folder` (root-level `oneOf`) and `get_usage_and_quota` (bare `{type: "object"}`) trip both gates today; Notion / Linear / Sentry hit similar shapes in their long-tail tools. Translating at the LLM boundary fixes every current and future case in one place, rather than per-vendor patching.

## Translation rules

- Root `oneOf` / `anyOf` → take the **first branch**. Any valid call already satisfies exactly one branch; synthesizing a union schema would let the model emit mix-and-match payloads that match no real branch — strictly worse failure mode.
- Root `allOf` → deep-merge all branches (semantically faithful: \"all hold simultaneously\").
- Root `enum` / `not` → strip (no flat-object representation).
- Always emit `type: \"object\"` + `properties: {}` at root.
- **Nested composition (inside properties) is preserved** — providers only restrict the top level, so we keep every drop of vendor info we can.

## Test plan

- [x] 12 unit tests in `test/unit/tool-schema-for-llm.test.ts` cover base shape, top-level oneOf/anyOf/allOf, enum/not stripping, nested-composition preservation, and non-mutation of input
- [x] Full unit suite: 2592 pass / 0 fail
- [x] `bun run verify:static` clean (format, lint, tsc, cycles, bundle-transport, codegen)
- [ ] Manual: install Dropbox connector locally with a Dropbox App Console-registered OAuth app, verify `list_folder` is usable on both `claude-haiku-4-5` and `gpt-5.5`