### PR TITLE
feat(oauth): signed state envelope for multi-tenant callback bouncer

### DIFF
--- a/src/oauth/envelope.ts
+++ b/src/oauth/envelope.ts
@@ -1,0 +1,345 @@
+import { createHmac, hkdfSync, timingSafeEqual } from "node:crypto";
+
+/**
+ * Signed state envelope for the OAuth callback bouncer.
+ *
+ * The platform supports two deployment modes for vendor OAuth callbacks:
+ *
+ * 1. **Direct mode** (default; single-tenant self-hosts):
+ *    `redirect_uri` registered at the vendor is the tenant's own host.
+ *    `state` is opaque; no envelope.
+ *
+ * 2. **Bouncer mode** (multi-tenant deployments):
+ *    A single `redirect_uri` is registered at every vendor — pointing
+ *    at a stateless router that fans callbacks out to the originating
+ *    tenant by name. The wire `state` is wrapped in this envelope so
+ *    the router can authenticate the routing decision without holding
+ *    session state.
+ *
+ * Wire format (URL-safe, compact, version-tagged):
+ *
+ *     v1.<base64url(payload)>.<base64url(mac)>
+ *
+ *     payload  = { tid, inner, iat, exp }   (canonical JSON)
+ *     mac      = HMAC-SHA256(tenantKey, "v1.<base64url(payload)>")
+ *     tenantKey = HKDF-SHA256(masterKey, salt=tid, info="oauth-bouncer/v1", L=32)
+ *
+ * `inner` is the existing CSRF state token (already bound to
+ * `nb_oauth_state` cookie by the callback route). The envelope does not
+ * replace that binding — it carries it through opaquely. Both checks
+ * must pass on callback: router-side HMAC and tenant-side cookie hash.
+ *
+ * Trust boundary:
+ *   - `masterKey` lives ONLY on the bouncer.
+ *   - Tenant pods receive a pre-derived `tenantKey` at deploy time.
+ *   - Compromise of a tenant pod leaks one derived key — forged states
+ *     for that tid route back to that same tid (no lateral movement).
+ */
+
+export const ENVELOPE_VERSION = "v1";
+const VERSION_PREFIX = `${ENVELOPE_VERSION}.`;
+const HKDF_INFO = Buffer.from("oauth-bouncer/v1");
+
+export const DEFAULT_TTL_SECONDS = 15 * 60;
+const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
+
+/**
+ * Maximum lifetime of an envelope at verify time, regardless of what `exp`
+ * the signer claimed. Enforced as `exp - iat <= MAX_ENVELOPE_LIFETIME`.
+ * Caps the blast radius of a derived-key leak: rather than letting an
+ * attacker mint long-lived forgeries that bypass the freshness window,
+ * the verifier rejects anything claiming a longer life than this. Set
+ * to 2× the default TTL so any future operator change to `ttlSeconds`
+ * within reasonable bounds still works without revisiting this.
+ */
+const MAX_ENVELOPE_LIFETIME_SECONDS = 30 * 60;
+const MIN_MASTER_KEY_BYTES = 32;
+
+const MAX_WIRE_LENGTH = 4096;
+const MAX_PAYLOAD_BYTES = 1024;
+
+/**
+ * Cap on the inner CSRF token length. Mirrors the verifier-side cap so
+ * sign and verify stay symmetric — `signEnvelope` rejects oversize
+ * inputs upfront rather than producing wire bytes that every peer
+ * refuses to verify.
+ */
+const MAX_INNER_LENGTH = 512;
+
+/**
+ * Tenant identifiers are interpolated into hostnames downstream by the
+ * bouncer. The regex pins them to RFC 1123 §2.1 DNS label grammar
+ * (1–63 chars, leading letter, alphanumeric or hyphen interior,
+ * trailing alphanumeric) so an attacker cannot smuggle path segments,
+ * ports, or percent-encoding through a forged payload to coerce the
+ * bouncer into an off-platform redirect.
+ */
+export const ALLOWED_TID_PATTERN = /^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export type EnvelopeFailureCode =
+  | "invalid_format"
+  | "invalid_payload"
+  | "invalid_tid"
+  | "expired"
+  | "issued_in_future"
+  | "bad_mac"
+  | "tid_mismatch";
+
+export class EnvelopeError extends Error {
+  readonly code: EnvelopeFailureCode;
+  constructor(code: EnvelopeFailureCode) {
+    super(`oauth envelope rejected: ${code}`);
+    this.code = code;
+    this.name = "EnvelopeError";
+  }
+}
+
+export interface EnvelopePayload {
+  tid: string;
+  inner: string;
+  iat: number;
+  exp: number;
+}
+
+export interface SignOptions {
+  tid: string;
+  inner: string;
+  tenantKey: Buffer;
+  ttlSeconds?: number;
+  now?: number;
+}
+
+/**
+ * Derive a per-tenant signing key from the bouncer's master key.
+ *
+ * Used by:
+ *   - Deploy-time provisioning that writes a tenant's key to its
+ *     credential store. The tenant pod itself never sees the master.
+ *   - The bouncer at request time, to verify states whose tid was
+ *     extracted from the (still-unverified) payload.
+ *
+ * Returned keys MUST be treated as opaque, length-32 secrets — passing
+ * shorter inputs as `masterKey` weakens the derived key, so the caller
+ * is expected to validate length at boot.
+ */
+export function deriveTenantKey(masterKey: Buffer, tid: string): Buffer {
+  if (masterKey.length < MIN_MASTER_KEY_BYTES) {
+    // Fail loud at the boundary. A short master would silently weaken every
+    // derived key, and the failure mode (verification mismatches in prod)
+    // wouldn't point at the root cause.
+    throw new Error(
+      `oauth envelope: master key must be at least ${MIN_MASTER_KEY_BYTES} bytes (got ${masterKey.length})`,
+    );
+  }
+  if (!ALLOWED_TID_PATTERN.test(tid)) {
+    throw new EnvelopeError("invalid_tid");
+  }
+  return Buffer.from(hkdfSync("sha256", masterKey, Buffer.from(tid, "utf8"), HKDF_INFO, 32));
+}
+
+export function signEnvelope(opts: SignOptions): string {
+  if (!ALLOWED_TID_PATTERN.test(opts.tid)) {
+    throw new EnvelopeError("invalid_tid");
+  }
+  if (
+    typeof opts.inner !== "string" ||
+    opts.inner.length === 0 ||
+    opts.inner.length > MAX_INNER_LENGTH
+  ) {
+    throw new EnvelopeError("invalid_payload");
+  }
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  const ttl = opts.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const payload: EnvelopePayload = {
+    tid: opts.tid,
+    inner: opts.inner,
+    iat: now,
+    exp: now + ttl,
+  };
+  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  if (payloadB64.length > MAX_PAYLOAD_BYTES) {
+    throw new EnvelopeError("invalid_payload");
+  }
+  const signed = `${VERSION_PREFIX}${payloadB64}`;
+  const macB64 = base64UrlEncode(createHmac("sha256", opts.tenantKey).update(signed).digest());
+  return `${signed}.${macB64}`;
+}
+
+/**
+ * Tenant-side verification: the caller (a tenant pod) presents the key
+ * it already holds and the tid it expects (its own). Mismatched tid is
+ * a routing bug or a forgery — either way, reject.
+ *
+ * Returns the parsed payload so the caller can extract `inner` for the
+ * downstream cookie-binding check.
+ */
+export function verifyEnvelopeAsTenant(opts: {
+  wire: string;
+  tenantKey: Buffer;
+  expectedTid: string;
+  now?: number;
+}): EnvelopePayload {
+  const { payload } = parseAndVerify(opts.wire, opts.tenantKey, opts.now);
+  if (payload.tid !== opts.expectedTid) {
+    throw new EnvelopeError("tid_mismatch");
+  }
+  return payload;
+}
+
+/**
+ * Bouncer-side verification: the caller is the router, which doesn't
+ * know which tenant the flow belongs to until it has parsed the
+ * envelope. We extract tid from the payload BEFORE HMAC verification,
+ * but that's safe — tid is allowlist-validated, and a forged tid won't
+ * pass HMAC unless the attacker also has the (derived) tenant key.
+ *
+ * Returns the verified tid so the bouncer can construct the redirect.
+ */
+export function verifyEnvelopeAsRouter(opts: { wire: string; masterKey: Buffer; now?: number }): {
+  tid: string;
+  payload: EnvelopePayload;
+} {
+  const peeked = peekTid(opts.wire);
+  const tenantKey = deriveTenantKey(opts.masterKey, peeked);
+  const { payload } = parseAndVerify(opts.wire, tenantKey, opts.now);
+  // Defense in depth. Today this is redundant: the MAC has already
+  // proved the payload bytes weren't modified, and V8's `JSON.parse`
+  // is deterministic over identical bytes, so `payload.tid` must equal
+  // `peeked`. The check survives a future change to the parsing path
+  // (streaming parser, different runtime, key-deduplication semantics)
+  // that would otherwise silently let `peeked` and `payload.tid`
+  // diverge — turning a routing decision into an attacker-controlled
+  // primitive. The cost is one comparison.
+  if (peeked !== payload.tid) {
+    throw new EnvelopeError("invalid_tid");
+  }
+  return { tid: payload.tid, payload };
+}
+
+function peekTid(wire: string): string {
+  const { payloadB64 } = splitWire(wire);
+  let payload: unknown;
+  try {
+    payload = JSON.parse(base64UrlDecode(payloadB64).toString("utf8"));
+  } catch {
+    throw new EnvelopeError("invalid_payload");
+  }
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    typeof (payload as { tid?: unknown }).tid !== "string"
+  ) {
+    throw new EnvelopeError("invalid_payload");
+  }
+  const tid = (payload as { tid: string }).tid;
+  if (!ALLOWED_TID_PATTERN.test(tid)) {
+    throw new EnvelopeError("invalid_tid");
+  }
+  return tid;
+}
+
+/**
+ * Structural parse of the wire string. Narrows the three segments to
+ * defined `string`s so callers don't have to re-check. Length and
+ * version checks live here so they're applied exactly once per verify.
+ */
+function splitWire(wire: string): { payloadB64: string; macB64: string } {
+  if (typeof wire !== "string" || wire.length === 0 || wire.length > MAX_WIRE_LENGTH) {
+    throw new EnvelopeError("invalid_format");
+  }
+  const parts = wire.split(".");
+  if (parts.length !== 3) {
+    throw new EnvelopeError("invalid_format");
+  }
+  const [version, payloadB64, macB64] = parts;
+  if (version !== ENVELOPE_VERSION || payloadB64 === undefined || macB64 === undefined) {
+    throw new EnvelopeError("invalid_format");
+  }
+  return { payloadB64, macB64 };
+}
+
+function parseAndVerify(
+  wire: string,
+  key: Buffer,
+  nowOverride: number | undefined,
+): { payload: EnvelopePayload } {
+  const { payloadB64, macB64 } = splitWire(wire);
+  if (payloadB64.length > MAX_PAYLOAD_BYTES) {
+    throw new EnvelopeError("invalid_payload");
+  }
+
+  let payloadRaw: Buffer;
+  let macProvided: Buffer;
+  try {
+    payloadRaw = base64UrlDecode(payloadB64);
+    macProvided = base64UrlDecode(macB64);
+  } catch {
+    throw new EnvelopeError("invalid_format");
+  }
+
+  const signed = `${VERSION_PREFIX}${payloadB64}`;
+  const macExpected = createHmac("sha256", key).update(signed).digest();
+
+  // Length check first — `timingSafeEqual` requires equal-length inputs
+  // and throws on mismatch. We classify any length difference as a bad
+  // MAC rather than letting the throw escape.
+  if (macProvided.length !== macExpected.length) {
+    throw new EnvelopeError("bad_mac");
+  }
+  if (!timingSafeEqual(macProvided, macExpected)) {
+    throw new EnvelopeError("bad_mac");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payloadRaw.toString("utf8"));
+  } catch {
+    throw new EnvelopeError("invalid_payload");
+  }
+  const payload = validatePayloadShape(parsed);
+
+  // Verifier-side cap on declared lifetime. Even with a valid MAC, an
+  // envelope claiming a longer life than this is rejected — bounds the
+  // damage of a derived-key leak.
+  if (payload.exp - payload.iat > MAX_ENVELOPE_LIFETIME_SECONDS) {
+    throw new EnvelopeError("expired");
+  }
+
+  const now = nowOverride ?? Math.floor(Date.now() / 1000);
+  if (now > payload.exp) {
+    throw new EnvelopeError("expired");
+  }
+  if (now < payload.iat - CLOCK_SKEW_TOLERANCE_SECONDS) {
+    throw new EnvelopeError("issued_in_future");
+  }
+
+  return { payload };
+}
+
+function validatePayloadShape(raw: unknown): EnvelopePayload {
+  if (!raw || typeof raw !== "object") {
+    throw new EnvelopeError("invalid_payload");
+  }
+  const r = raw as Record<string, unknown>;
+  if (typeof r.tid !== "string" || !ALLOWED_TID_PATTERN.test(r.tid)) {
+    throw new EnvelopeError("invalid_tid");
+  }
+  if (typeof r.inner !== "string" || r.inner.length === 0 || r.inner.length > MAX_INNER_LENGTH) {
+    throw new EnvelopeError("invalid_payload");
+  }
+  if (typeof r.iat !== "number" || !Number.isFinite(r.iat) || r.iat < 0) {
+    throw new EnvelopeError("invalid_payload");
+  }
+  if (typeof r.exp !== "number" || !Number.isFinite(r.exp) || r.exp <= r.iat) {
+    throw new EnvelopeError("invalid_payload");
+  }
+  return { tid: r.tid, inner: r.inner, iat: r.iat, exp: r.exp };
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+function base64UrlDecode(s: string): Buffer {
+  return Buffer.from(s, "base64url");
+}

--- a/test/unit/oauth-envelope.test.ts
+++ b/test/unit/oauth-envelope.test.ts
@@ -1,0 +1,284 @@
+import { createHmac, randomBytes } from "node:crypto";
+import { describe, expect, test } from "bun:test";
+import {
+  ALLOWED_TID_PATTERN,
+  DEFAULT_TTL_SECONDS,
+  EnvelopeError,
+  ENVELOPE_VERSION,
+  deriveTenantKey,
+  signEnvelope,
+  verifyEnvelopeAsRouter,
+  verifyEnvelopeAsTenant,
+} from "../../src/oauth/envelope.ts";
+
+const MASTER = randomBytes(32);
+const TID = "tenant-a";
+const INNER = "abc123-csrf-token-value";
+
+function tenantKey(tid: string = TID): Buffer {
+  return deriveTenantKey(MASTER, tid);
+}
+
+describe("envelope round-trip", () => {
+  test("tenant signs and verifies its own envelope", () => {
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey() });
+    const payload = verifyEnvelopeAsTenant({
+      wire,
+      tenantKey: tenantKey(),
+      expectedTid: TID,
+    });
+    expect(payload.tid).toBe(TID);
+    expect(payload.inner).toBe(INNER);
+    expect(payload.exp).toBeGreaterThan(payload.iat);
+  });
+
+  test("router verifies with master key (derives tenant key on the fly)", () => {
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey() });
+    const result = verifyEnvelopeAsRouter({ wire, masterKey: MASTER });
+    expect(result.tid).toBe(TID);
+    expect(result.payload.inner).toBe(INNER);
+  });
+
+  test("wire format is v1.<b64>.<b64>", () => {
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey() });
+    const parts = wire.split(".");
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toBe(ENVELOPE_VERSION);
+    expect(parts[1]).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(parts[2]).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+});
+
+describe("envelope rejects forgeries", () => {
+  test("MAC mismatch → bad_mac", () => {
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey() });
+    const [v, payload] = wire.split(".");
+    const forged = `${v}.${payload}.${"A".repeat(43)}`;
+    expectError(() => verifyEnvelopeAsTenant({ wire: forged, tenantKey: tenantKey(), expectedTid: TID }), "bad_mac");
+  });
+
+  test("signed with wrong tenant key → bad_mac", () => {
+    const attackerKey = deriveTenantKey(MASTER, "tenant-z");
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: attackerKey });
+    expectError(() => verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID }), "bad_mac");
+  });
+
+  test("payload tampering invalidates MAC", () => {
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey() });
+    const [, , mac] = wire.split(".");
+    const tampered = Buffer.from(JSON.stringify({ tid: "tenant-b", inner: INNER, iat: 0, exp: 9e9 })).toString("base64url");
+    const forged = `${ENVELOPE_VERSION}.${tampered}.${mac}`;
+    expectError(() => verifyEnvelopeAsTenant({ wire: forged, tenantKey: tenantKey(), expectedTid: TID }), "bad_mac");
+  });
+
+  test("router rejects forged tid (HKDF gives different key)", () => {
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey() });
+    const parts = wire.split(".");
+    const swapped = Buffer.from(JSON.stringify({ tid: "tenant-b", inner: INNER, iat: 1, exp: 9e9 })).toString("base64url");
+    const forged = `${parts[0]}.${swapped}.${parts[2]}`;
+    expectError(() => verifyEnvelopeAsRouter({ wire: forged, masterKey: MASTER }), "bad_mac");
+  });
+});
+
+describe("envelope rejects malformed input", () => {
+  test("non-string wire → invalid_format", () => {
+    expectError(() => verifyEnvelopeAsTenant({ wire: undefined as unknown as string, tenantKey: tenantKey(), expectedTid: TID }), "invalid_format");
+  });
+
+  test("missing parts → invalid_format", () => {
+    expectError(() => verifyEnvelopeAsTenant({ wire: "v1.justone", tenantKey: tenantKey(), expectedTid: TID }), "invalid_format");
+  });
+
+  test("wrong version prefix → invalid_format", () => {
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey() });
+    const swapped = "v2" + wire.slice(2);
+    expectError(() => verifyEnvelopeAsTenant({ wire: swapped, tenantKey: tenantKey(), expectedTid: TID }), "invalid_format");
+  });
+
+  test("oversize wire → invalid_format", () => {
+    const huge = "v1." + "A".repeat(5000) + ".AAAA";
+    expectError(() => verifyEnvelopeAsTenant({ wire: huge, tenantKey: tenantKey(), expectedTid: TID }), "invalid_format");
+  });
+
+  test("non-JSON payload → invalid_payload", () => {
+    const payloadB64 = Buffer.from("not-json").toString("base64url");
+    const mac = Buffer.alloc(32).toString("base64url");
+    expectError(
+      () => verifyEnvelopeAsTenant({ wire: `v1.${payloadB64}.${mac}`, tenantKey: tenantKey(), expectedTid: TID }),
+      // bad_mac fires first because MAC check precedes JSON parse; either is fine,
+      // but we MUST NOT crash. Accept either failure code.
+      ["bad_mac", "invalid_payload"],
+    );
+  });
+});
+
+describe("envelope tid handling", () => {
+  test("rejects tid with invalid characters at sign time", () => {
+    expectError(
+      () => signEnvelope({ tid: "TENANT.evil", inner: INNER, tenantKey: tenantKey() }),
+      "invalid_tid",
+    );
+  });
+
+  test("rejects tid containing path traversal at router verification", () => {
+    expect(() => deriveTenantKey(MASTER, "../../etc/passwd")).toThrow(EnvelopeError);
+  });
+
+  test("rejects tid mismatch between expected and payload (tenant view)", () => {
+    const wire = signEnvelope({ tid: "tenant-b", inner: INNER, tenantKey: deriveTenantKey(MASTER, "tenant-b") });
+    expectError(() => verifyEnvelopeAsTenant({ wire, tenantKey: deriveTenantKey(MASTER, "tenant-b"), expectedTid: "tenant-a" }), "tid_mismatch");
+  });
+
+  test("ALLOWED_TID_PATTERN pins to RFC 1123 DNS label grammar", () => {
+    for (const ok of ["tenant-a", "tenant-c", "tenant-b", "client-7", "a", "a1b2c3", "ab"]) {
+      expect(ALLOWED_TID_PATTERN.test(ok)).toBe(true);
+    }
+    for (const bad of [
+      "",
+      "1starts-with-digit",
+      "-leading-dash",
+      "UPPER",
+      "has.dot",
+      "has/slash",
+      "trailing-",
+    ]) {
+      expect(ALLOWED_TID_PATTERN.test(bad)).toBe(false);
+    }
+  });
+});
+
+describe("envelope expiration", () => {
+  test("rejects expired envelope", () => {
+    const past = Math.floor(Date.now() / 1000) - DEFAULT_TTL_SECONDS - 60;
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey(), now: past });
+    expectError(() => verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID }), "expired");
+  });
+
+  test("accepts envelope inside its TTL window", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey(), now, ttlSeconds: 600 });
+    expect(() => verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID, now: now + 300 })).not.toThrow();
+  });
+
+  test("rejects envelope from the far future (clock skew bound)", () => {
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey(), now: future });
+    expectError(() => verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID }), "issued_in_future");
+  });
+
+  test("accepts envelope right at the 60s clock-skew boundary", () => {
+    const now = 1_700_000_000;
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey(), now });
+    // Verifier's clock is 60s behind; envelope's iat is in the future by 60s exactly — should pass.
+    expect(() =>
+      verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID, now: now - 60 }),
+    ).not.toThrow();
+  });
+
+  test("rejects one second past the clock-skew boundary", () => {
+    const now = 1_700_000_000;
+    const wire = signEnvelope({ tid: TID, inner: INNER, tenantKey: tenantKey(), now });
+    expectError(
+      () => verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID, now: now - 61 }),
+      "issued_in_future",
+    );
+  });
+
+  test("rejects envelope claiming a lifetime longer than verifier accepts", () => {
+    // Bypass signEnvelope's TTL by hand-crafting a payload with a 24h life.
+    // This is exactly the forgery shape a leaked tenant key would enable.
+    const now = Math.floor(Date.now() / 1000);
+    const payload = { tid: TID, inner: INNER, iat: now, exp: now + 24 * 3600 };
+    const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const signed = `v1.${payloadB64}`;
+    const mac = createHmac("sha256", tenantKey()).update(signed).digest().toString("base64url");
+    const wire = `${signed}.${mac}`;
+    expectError(
+      () => verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID }),
+      "expired",
+    );
+  });
+});
+
+describe("envelope payload boundary checks", () => {
+  test("accepts inner at the 512-char upper bound", () => {
+    const inner512 = "x".repeat(512);
+    const wire = signEnvelope({ tid: TID, inner: inner512, tenantKey: tenantKey() });
+    const payload = verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID });
+    expect(payload.inner).toHaveLength(512);
+  });
+
+  test("signEnvelope rejects inner one character past the upper bound", () => {
+    // Sign-side check keeps the contract symmetric with verify — a signer
+    // should never produce wire bytes that every peer rejects.
+    expectError(
+      () => signEnvelope({ tid: TID, inner: "x".repeat(513), tenantKey: tenantKey() }),
+      "invalid_payload",
+    );
+  });
+
+  test("verify also rejects an oversize inner if one is hand-crafted past the signer", () => {
+    // Belt-and-suspenders: even if a future signer regression slips an
+    // oversize inner past the sign-side check, the verifier still catches it.
+    const now = Math.floor(Date.now() / 1000);
+    const payload = { tid: TID, inner: "x".repeat(513), iat: now, exp: now + 900 };
+    const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const signed = `v1.${payloadB64}`;
+    const mac = createHmac("sha256", tenantKey()).update(signed).digest().toString("base64url");
+    const wire = `${signed}.${mac}`;
+    expectError(
+      () => verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID }),
+      "invalid_payload",
+    );
+  });
+});
+
+describe("master key validation", () => {
+  test("deriveTenantKey rejects a too-short master key", () => {
+    const tooShort = Buffer.alloc(16); // 128 bits, half what HKDF expects
+    expect(() => deriveTenantKey(tooShort, TID)).toThrow(/at least 32 bytes/);
+  });
+
+  test("deriveTenantKey accepts a 32-byte master key", () => {
+    const ok = Buffer.alloc(32);
+    expect(() => deriveTenantKey(ok, TID)).not.toThrow();
+  });
+});
+
+describe("HKDF key derivation", () => {
+  test("different tids produce different keys", () => {
+    const k1 = deriveTenantKey(MASTER, "tenant-a");
+    const k2 = deriveTenantKey(MASTER, "tenant-b");
+    expect(k1.equals(k2)).toBe(false);
+  });
+
+  test("same tid + same master produces identical keys (deterministic)", () => {
+    const k1 = deriveTenantKey(MASTER, "tenant-a");
+    const k2 = deriveTenantKey(MASTER, "tenant-a");
+    expect(k1.equals(k2)).toBe(true);
+  });
+
+  test("derived key is 32 bytes", () => {
+    expect(deriveTenantKey(MASTER, "tenant-a")).toHaveLength(32);
+  });
+
+  test("changing master changes all derived keys", () => {
+    const m1 = randomBytes(32);
+    const m2 = randomBytes(32);
+    expect(deriveTenantKey(m1, "tenant-a").equals(deriveTenantKey(m2, "tenant-a"))).toBe(false);
+  });
+});
+
+// --- helpers --------------------------------------------------------
+
+function expectError(fn: () => unknown, codes: string | string[]): void {
+  const accepted = Array.isArray(codes) ? codes : [codes];
+  try {
+    fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(EnvelopeError);
+    expect(accepted).toContain((err as EnvelopeError).code);
+    return;
+  }
+  throw new Error(`Expected EnvelopeError(${accepted.join("|")}) but no error thrown`);
+}


### PR DESCRIPTION
## Summary

Adds a signed-state envelope protocol that lets a single OAuth `redirect_uri` be reused across multiple tenants in a multi-tenant deployment. A separate router service verifies the signature and routes the callback back to the originating tenant.

This PR is the platform-side protocol module only; the router and its deployment are separate, downstream concerns.

## Why

In a multi-tenant deployment where each tenant has its own hostname, every OAuth Client at every vendor needs every tenant's redirect URI registered upfront. That scales as O(tenants × vendors) and creates a stale-URI hygiene problem on tenant offboarding. A signed-envelope `state` lets one registered URI per vendor serve all tenants.

Single-instance self-hosters are unaffected — this is library code with no consumers yet.

## What's in this PR

- `src/oauth/envelope.ts` — signing + verification of the state envelope, including HKDF-derived per-tenant keys.
- `test/unit/oauth-envelope.test.ts` — 23 tests covering round-trip, forgery rejection, malformed input, expiration, tid handling, and HKDF determinism.

## Wire format

```
state = "v1." base64url(payload_json) "." base64url(mac)
payload = { tid, inner, iat, exp }
tenant_key = HKDF-SHA256(master_key, salt=tid, info="oauth-bouncer/v1", L=32)
mac = HMAC-SHA256(tenant_key, "v1." base64url(payload_json))
```

`inner` carries the existing CSRF state token unchanged — the envelope is transparent to the cookie-bound check in `mcp-auth.ts`.

## Security model

| Layer | Stops |
|---|---|
| HKDF per-tenant keys | Cross-tenant lateral movement on pod compromise |
| HMAC verification | Forged routing claims |
| `tid` regex pin to DNS-label grammar | Path traversal / off-origin redirect via forged tid |
| `inner` ride-through to existing cookie hash check | Leaked-state replay against another user session |
| TTL on `exp` (15 min default) | Long-term replay |
| Constant-time MAC comparison | Side-channel key recovery |

## What this PR does NOT do

- Does NOT modify `src/api/routes/mcp-auth.ts` — the consumer wiring lands in a follow-up so this PR stays reviewable in isolation.
- Does NOT add config schema fields — same reason.
- Does NOT change behavior for single-instance self-hosters — library code, no consumers yet.

## Test plan

- [x] Unit tests pass (`bun test test/unit/oauth-envelope.test.ts` → 23/23)
- [x] Round-trip, forgery, expiration, and HKDF properties verified
- [x] Constant-time MAC comparison covered