### PR TITLE
feat(oauth): consume state envelope on mcp-auth routes for bouncer mode

### DIFF
--- a/src/api/routes/mcp-auth.ts
+++ b/src/api/routes/mcp-auth.ts
@@ -2,6 +2,13 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { WORKSPACE_PRINCIPAL_ID } from "../../bundles/connection.ts";
 import { log } from "../../cli/log.ts";
+import { getBouncerMode } from "../../oauth/bouncer-config.ts";
+import {
+  ENVELOPE_VERSION,
+  EnvelopeError,
+  signEnvelope,
+  verifyEnvelopeAsTenant,
+} from "../../oauth/envelope.ts";
 import { resolveWithCode } from "../../tools/oauth-flow-registry.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import { requireWorkspace } from "../middleware/workspace.ts";
@@ -75,11 +82,25 @@ const SUCCESS_PAGE_CSP = `default-src 'none'; style-src 'sha256-${SUCCESS_PAGE_S
  * they leave to set up the OAuth app.
  */
 export function mcpAuthCallbackUrl(): string {
+  // In bouncer mode every vendor's OAuth Client is registered against
+  // the bouncer's single URL, not this tenant's host. The bouncer
+  // verifies the signed state envelope on the callback leg and 302s
+  // back to this tenant.
+  const bouncer = getBouncerMode();
+  if (bouncer) return bouncer.callbackUrl;
+
   const apiBase = process.env.NB_API_URL ?? "http://localhost:27247";
   return `${apiBase.replace(/\/+$/, "")}/v1/mcp-auth/callback`;
 }
 
 export function mcpAuthRoutes(ctx: AppContext) {
+  // Eagerly validate bouncer config (if any) so a misconfigured
+  // deployment fails at server startup with a precise error, rather
+  // than serving traffic until the first user clicks "connect" and
+  // hitting a generic 500. Idempotent: returns the cached value on
+  // subsequent calls in the route handlers below.
+  getBouncerMode();
+
   const app = new Hono<AppEnv>();
 
   // ── POST /v1/mcp-auth/initiate ────────────────────────────────────
@@ -178,6 +199,34 @@ export function mcpAuthRoutes(ctx: AppContext) {
         );
       }
 
+      // In bouncer mode, wrap the SDK-generated state in a signed
+      // envelope so the bouncer can route the callback back to this
+      // tenant. The inner state is what's bound to the cookie and what
+      // `oauth-flow-registry` is keyed on — both unchanged. The vendor
+      // sees only the wrapped value.
+      const bouncer = getBouncerMode();
+      if (bouncer) {
+        try {
+          const wrapped = signEnvelope({
+            tid: bouncer.tid,
+            inner: state,
+            tenantKey: bouncer.tenantKey,
+          });
+          urlObj.searchParams.set("state", wrapped);
+          authorizationUrl = urlObj.toString();
+        } catch (err) {
+          // signEnvelope rejects inputs that violate the envelope's
+          // own contract (oversize inner, invalid tid). Both are
+          // pre-validated above (tid at config load, inner from the
+          // SDK), so reaching here implies a regression elsewhere.
+          // Match the error posture of the startAuth catch above:
+          // log the cause, surface a generic 500.
+          const msg = err instanceof Error ? err.message : String(err);
+          log.warn(`[mcp-auth] envelope wrap failed for ${serverName} in ${wsId}: ${msg}`);
+          return apiError(500, "internal_error", "Failed to wrap OAuth state.");
+        }
+      }
+
       const stateHash = sha256Hex(state);
 
       // Cookie scoped to /v1/mcp-auth/callback so it's only sent on the
@@ -212,7 +261,7 @@ export function mcpAuthRoutes(ctx: AppContext) {
     c.header("Pragma", "no-cache");
 
     const code = c.req.query("code");
-    const state = c.req.query("state");
+    const wireState = c.req.query("state");
     const error = c.req.query("error");
 
     if (error) {
@@ -221,8 +270,49 @@ export function mcpAuthRoutes(ctx: AppContext) {
         400,
       );
     }
-    if (!code || !state) {
+    if (!code || !wireState) {
       return c.text("missing code or state", 400);
+    }
+
+    // In bouncer mode the URL state arrives wrapped — unwrap it to
+    // recover the inner state, which is what the cookie binding and
+    // flow registry are keyed on. In direct mode (single-instance
+    // self-hosts) the wire state is the inner state. We refuse to
+    // unwrap an inner-shaped state in bouncer mode: a callback that
+    // bypassed the bouncer is either a stale flow from before bouncer
+    // mode was enabled (rare, user should re-initiate) or an attacker
+    // probing the platform's direct hostname.
+    const bouncer = getBouncerMode();
+    let state: string;
+    if (bouncer) {
+      if (!wireState.startsWith(`${ENVELOPE_VERSION}.`)) {
+        return c.html(
+          "<html><body><h3>Authorization state envelope missing.</h3>" +
+            "<p>Re-initiate the connection from NimbleBrain.</p></body></html>",
+          400,
+        );
+      }
+      try {
+        const payload = verifyEnvelopeAsTenant({
+          wire: wireState,
+          tenantKey: bouncer.tenantKey,
+          expectedTid: bouncer.tid,
+        });
+        state = payload.inner;
+      } catch (err) {
+        // Log the specific failure code for ops, but show the user a
+        // generic message — leaking which check failed gives an attacker
+        // an oracle for probing the envelope format.
+        const code = err instanceof EnvelopeError ? err.code : "unknown";
+        log.warn(`[mcp-auth] bouncer envelope verification failed: ${code}`);
+        return c.html(
+          "<html><body><h3>Authorization session invalid.</h3>" +
+            "<p>Re-initiate the connection from NimbleBrain.</p></body></html>",
+          400,
+        );
+      }
+    } else {
+      state = wireState;
     }
 
     // Session-binding check: the cookie set by /initiate must match the

--- a/src/oauth/bouncer-config.ts
+++ b/src/oauth/bouncer-config.ts
@@ -1,0 +1,177 @@
+/**
+ * Process-wide configuration for OAuth callback bouncer mode.
+ *
+ * The bouncer lets a multi-tenant deployment register a single
+ * `redirect_uri` per vendor (Google, Dropbox, ...) instead of one per
+ * tenant. When bouncer mode is enabled, the platform sends the bouncer's
+ * URL as `redirect_uri` and wraps the `state` parameter in a signed
+ * envelope so the bouncer can route the callback back to this tenant.
+ *
+ * Single-instance self-hosters leave these env vars unset; every
+ * branch in `mcp-auth.ts` falls back to direct mode (tenant host as
+ * `redirect_uri`, opaque `state`). See `envelope.ts` for the wire
+ * protocol.
+ *
+ * Configuration is via environment variables:
+ *
+ *   NB_OAUTH_BOUNCER_CALLBACK_URL: full URL the vendor will redirect to
+ *     (e.g. `https://connect.example.com/v1/mcp-auth/callback`).
+ *     Presence of this var enables bouncer mode; absence disables it.
+ *
+ *   NB_OAUTH_BOUNCER_TENANT_KEY: base64-encoded 32-byte HMAC key for
+ *     this tenant. Provisioned at deploy time from the bouncer's master
+ *     key via HKDF; the tenant pod never sees the master. Mount via
+ *     `secretKeyRef` so it lands in env from a k8s Secret.
+ *
+ *   NB_TENANT_ID: this pod's tenant identifier, matching the DNS label
+ *     grammar enforced by `ALLOWED_TID_PATTERN`. This is the general
+ *     "which tenant am I" primitive (useful beyond OAuth: structured
+ *     logs, telemetry, error reporting); bouncer mode reuses it as the
+ *     envelope tid and as the HKDF salt. Critically, the SAME value
+ *     must feed key derivation at deploy time and envelope signing at
+ *     runtime, so plumbing both endpoints from one source eliminates
+ *     a class of `bad_mac` mismatches from typos.
+ *
+ * Bouncer mode requires all three. Partial configuration of the two
+ * `NB_OAUTH_BOUNCER_*` vars, a missing `NB_TENANT_ID` while bouncer
+ * mode is requested, or any malformed value is a deploy-time error
+ * that fails closed at the first call to `getBouncerMode()`. The
+ * mcp-auth route module calls this at module load via `mcpAuthRoutes`,
+ * so a misconfigured deployment crashes immediately at server startup
+ * rather than serving traffic and failing on the first user OAuth
+ * attempt. Subsequent calls hit the cache and don't re-validate.
+ */
+
+import { ALLOWED_TID_PATTERN } from "./envelope.ts";
+
+export interface BouncerMode {
+  /** Full URL registered at every vendor's OAuth Client. */
+  callbackUrl: string;
+  /** This tenant's identifier, used in the state envelope. */
+  tid: string;
+  /** This tenant's derived HMAC key, 32 bytes. */
+  tenantKey: Buffer;
+}
+
+const CALLBACK_URL_ENV = "NB_OAUTH_BOUNCER_CALLBACK_URL";
+const TENANT_KEY_ENV = "NB_OAUTH_BOUNCER_TENANT_KEY";
+const TENANT_ID_ENV = "NB_TENANT_ID";
+
+const REQUIRED_KEY_BYTES = 32;
+
+/**
+ * Path the bouncer must serve. The platform-side `nb_oauth_state`
+ * cookie is scoped to this path; any divergence in the bouncer URL
+ * silently breaks every OAuth flow with a session-mismatch error
+ * that points nowhere obvious. Hardcoded here and in `mcp-auth.ts`
+ * by the same value; changing one without the other is incoherent.
+ */
+const EXPECTED_CALLBACK_PATH = "/v1/mcp-auth/callback";
+
+let _cached: BouncerMode | null | undefined;
+
+/**
+ * Returns the bouncer-mode config if configured, or `null` if direct
+ * mode is in use. Validates and caches on first access; throws if any
+ * of the three env vars are set without the others or with malformed
+ * values.
+ */
+export function getBouncerMode(): BouncerMode | null {
+  if (_cached !== undefined) return _cached;
+  _cached = readAndValidate(process.env);
+  return _cached;
+}
+
+/**
+ * Reset the cached config. Test-only — production code reads env once
+ * at process start and never re-reads.
+ */
+export function _resetBouncerModeForTest(): void {
+  _cached = undefined;
+}
+
+function readAndValidate(env: NodeJS.ProcessEnv): BouncerMode | null {
+  const callbackUrl = env[CALLBACK_URL_ENV];
+  const tenantKeyB64 = env[TENANT_KEY_ENV];
+  const tid = env[TENANT_ID_ENV];
+
+  const bouncerVarsPresent = [callbackUrl, tenantKeyB64].filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+
+  // Direct mode: neither bouncer-specific var is set. Don't care
+  // whether NB_TENANT_ID is set; other parts of the platform may use
+  // it for telemetry/logs without triggering bouncer mode.
+  if (bouncerVarsPresent.length === 0) return null;
+
+  // Partial config of the two bouncer vars is almost always a deploy
+  // mistake (operator wired one Helm value but not the other).
+  if (bouncerVarsPresent.length < 2) {
+    const missing = [
+      callbackUrl ? null : CALLBACK_URL_ENV,
+      tenantKeyB64 ? null : TENANT_KEY_ENV,
+    ].filter((v): v is string => v !== null);
+    throw new Error(
+      `[oauth bouncer] Partial configuration. Set both ${CALLBACK_URL_ENV} and ${TENANT_KEY_ENV} together or neither. Missing: ${missing.join(", ")}`,
+    );
+  }
+
+  // Bouncer mode requires the tenant identity primitive — both for the
+  // envelope tid and to keep deploy-time HKDF salting and runtime
+  // signing pinned to the same value.
+  if (typeof tid !== "string" || tid.length === 0) {
+    throw new Error(
+      `[oauth bouncer] Bouncer mode requires ${TENANT_ID_ENV} to be set. The chart should inject it from .Values.tenant.id.`,
+    );
+  }
+
+  // Narrow for TS. Both bouncer vars are non-empty strings at this point.
+  if (!callbackUrl || !tenantKeyB64) {
+    throw new Error("[oauth bouncer] internal: presence check failed unexpectedly");
+  }
+
+  // URL must be absolute https (or http for localhost-style dev only).
+  // Reject anything else — the vendor will reject non-https URIs anyway,
+  // and we'd rather fail at boot than at the first OAuth flow.
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(callbackUrl);
+  } catch {
+    throw new Error(`[oauth bouncer] ${CALLBACK_URL_ENV} is not a valid URL: ${callbackUrl}`);
+  }
+  if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+    throw new Error(
+      `[oauth bouncer] ${CALLBACK_URL_ENV} must use http(s); got ${parsedUrl.protocol}`,
+    );
+  }
+  // The platform-side cookie that binds the OAuth flow to a session is
+  // scoped to `Path=/v1/mcp-auth/callback`, hard-coded in `mcp-auth.ts`.
+  // A bouncer URL that lands callbacks on any other path means the cookie
+  // never travels back, and every flow fails the session-mismatch check
+  // with no clear root cause. Lock the implicit coupling explicit.
+  if (!parsedUrl.pathname.endsWith(EXPECTED_CALLBACK_PATH)) {
+    throw new Error(
+      `[oauth bouncer] ${CALLBACK_URL_ENV} must end with "${EXPECTED_CALLBACK_PATH}" (got "${parsedUrl.pathname}"). The platform's session-binding cookie is scoped to this path; a divergent URL silently breaks every OAuth flow.`,
+    );
+  }
+
+  if (!ALLOWED_TID_PATTERN.test(tid)) {
+    throw new Error(
+      `[oauth bouncer] ${TENANT_ID_ENV}="${tid}" does not match the DNS-label grammar required for tenant ids in bouncer mode`,
+    );
+  }
+
+  let tenantKey: Buffer;
+  try {
+    tenantKey = Buffer.from(tenantKeyB64, "base64");
+  } catch {
+    throw new Error(`[oauth bouncer] ${TENANT_KEY_ENV} is not valid base64`);
+  }
+  if (tenantKey.length !== REQUIRED_KEY_BYTES) {
+    throw new Error(
+      `[oauth bouncer] ${TENANT_KEY_ENV} must decode to ${REQUIRED_KEY_BYTES} bytes (got ${tenantKey.length})`,
+    );
+  }
+
+  return { callbackUrl, tid, tenantKey };
+}

--- a/test/unit/api/mcp-auth-routes.test.ts
+++ b/test/unit/api/mcp-auth-routes.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Hono } from "hono";
 import { securityHeaders } from "../../../src/api/middleware/security-headers.ts";
@@ -368,5 +368,143 @@ describe("GET /v1/mcp-auth/callback", () => {
     );
     expect(res.headers.get("Cache-Control")).toBe("no-store");
     expect(res.headers.get("Pragma")).toBe("no-cache");
+  });
+});
+
+describe("bouncer mode: state envelope wrap on initiate / unwrap on callback", () => {
+  const BOUNCER_CALLBACK = "https://connect.example.com/v1/mcp-auth/callback";
+  const TID = "tenant-a";
+  const TENANT_KEY_B64 = randomBytes(32).toString("base64");
+
+  const BOUNCER_ENV_VARS = [
+    "NB_OAUTH_BOUNCER_CALLBACK_URL",
+    "NB_OAUTH_BOUNCER_TENANT_KEY",
+    "NB_TENANT_ID",
+  ] as const;
+
+  let savedEnv: Record<string, string | undefined>;
+  let app: Hono<AppEnv>;
+  let lifecycle: StubLifecycle;
+
+  beforeEach(async () => {
+    savedEnv = Object.fromEntries(BOUNCER_ENV_VARS.map((k) => [k, process.env[k]]));
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = BOUNCER_CALLBACK;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = TENANT_KEY_B64;
+    process.env.NB_TENANT_ID = TID;
+    const { _resetBouncerModeForTest } = await import("../../../src/oauth/bouncer-config.ts");
+    _resetBouncerModeForTest();
+    lifecycle = makeStubLifecycle();
+    app = makeApp(lifecycle);
+  });
+
+  afterEach(async () => {
+    for (const k of BOUNCER_ENV_VARS) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    const { _resetBouncerModeForTest } = await import("../../../src/oauth/bouncer-config.ts");
+    _resetBouncerModeForTest();
+    _clearAll();
+  });
+
+  test("initiate wraps state in a v1 envelope and keeps the cookie keyed on inner", async () => {
+    const innerState = "sdk-generated-state-xyz";
+    const authUrl = `https://vendor.test/oauth/authorize?state=${innerState}&client_id=cid`;
+    lifecycle.instances.set(`granola|${WS_ID}`, { oauthScope: "workspace" });
+    lifecycle.authUrls.set(`granola|${WS_ID}|_workspace`, authUrl);
+
+    const res = await app.request("http://localhost/v1/mcp-auth/initiate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ serverName: "granola" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // The authorizationUrl returned to the client has the wrapped state
+    // in place of the SDK-generated inner state.
+    const parsed = new URL(body.authorizationUrl);
+    const wireState = parsed.searchParams.get("state");
+    expect(wireState).not.toBeNull();
+    expect(wireState).not.toBe(innerState);
+    expect(wireState!.startsWith("v1.")).toBe(true);
+
+    // The cookie is keyed on the INNER state — the existing CSRF check
+    // on /callback compares the cookie hash to the unwrapped inner.
+    const setCookie = res.headers.get("Set-Cookie");
+    expect(setCookie).not.toBeNull();
+    expect(setCookie!).toContain(`nb_oauth_state=${sha256Hex(innerState)}`);
+  });
+
+  test("callback unwraps the envelope, applies cookie binding, and resolves the flow", async () => {
+    const { signEnvelope } = await import("../../../src/oauth/envelope.ts");
+    const innerState = "inner-state-for-callback";
+    const wireState = signEnvelope({
+      tid: TID,
+      inner: innerState,
+      tenantKey: Buffer.from(TENANT_KEY_B64, "base64"),
+    });
+
+    const flowPromise = registerFlow(innerState, WS_ID, "granola");
+    flowPromise.catch(() => {});
+
+    const cookie = `nb_oauth_state=${sha256Hex(innerState)}`;
+    const res = await app.request(
+      `http://localhost/v1/mcp-auth/callback?code=auth-code-1&state=${encodeURIComponent(wireState)}`,
+      { headers: { cookie } },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(flowPromise).resolves.toBe("auth-code-1");
+  });
+
+  test("callback rejects state that lacks the v1 envelope prefix", async () => {
+    // An attacker bypassing the bouncer to hit our direct hostname sends
+    // a non-wrapped state. Refuse rather than silently fall through.
+    const res = await app.request(
+      "http://localhost/v1/mcp-auth/callback?code=c&state=raw-state-no-envelope",
+    );
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("state envelope missing");
+  });
+
+  test("callback rejects an envelope signed with a different tenant key", async () => {
+    const { signEnvelope } = await import("../../../src/oauth/envelope.ts");
+    const wireState = signEnvelope({
+      tid: TID,
+      inner: "doesnt-matter",
+      tenantKey: randomBytes(32),
+    });
+    const res = await app.request(
+      `http://localhost/v1/mcp-auth/callback?code=c&state=${encodeURIComponent(wireState)}`,
+    );
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("Authorization session invalid");
+  });
+
+  test("callback rejects an envelope minted for a different tid", async () => {
+    const { signEnvelope, deriveTenantKey } = await import("../../../src/oauth/envelope.ts");
+    const otherTid = "tenant-b";
+    const otherKey = deriveTenantKey(randomBytes(32), otherTid);
+    const wireState = signEnvelope({
+      tid: otherTid,
+      inner: "doesnt-matter",
+      tenantKey: otherKey,
+    });
+    const res = await app.request(
+      `http://localhost/v1/mcp-auth/callback?code=c&state=${encodeURIComponent(wireState)}`,
+    );
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("Authorization session invalid");
+  });
+
+  test("mcpAuthCallbackUrl returns the bouncer URL when bouncer mode is enabled", async () => {
+    const { mcpAuthCallbackUrl } = await import("../../../src/api/routes/mcp-auth.ts");
+    expect(mcpAuthCallbackUrl()).toBe(BOUNCER_CALLBACK);
   });
 });

--- a/test/unit/oauth-bouncer-config.test.ts
+++ b/test/unit/oauth-bouncer-config.test.ts
@@ -1,0 +1,170 @@
+import { randomBytes } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { _resetBouncerModeForTest, getBouncerMode } from "../../src/oauth/bouncer-config.ts";
+
+const ENV_VARS = [
+  "NB_OAUTH_BOUNCER_CALLBACK_URL",
+  "NB_OAUTH_BOUNCER_TENANT_KEY",
+  "NB_TENANT_ID",
+] as const;
+
+const VALID_KEY_B64 = randomBytes(32).toString("base64");
+const VALID_CALLBACK = "https://connect.example.com/v1/mcp-auth/callback";
+const VALID_TID = "tenant-a";
+
+/**
+ * Env-based config is tested via the real env. Each test snapshots and
+ * restores the relevant vars + resets the module's lazy cache so the
+ * next test reads cleanly.
+ */
+function snapshot(): Record<string, string | undefined> {
+  return Object.fromEntries(ENV_VARS.map((k) => [k, process.env[k]]));
+}
+function restore(saved: Record<string, string | undefined>): void {
+  for (const k of ENV_VARS) {
+    const v = saved[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+describe("bouncer-config: presence", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = snapshot();
+    for (const k of ENV_VARS) delete process.env[k];
+    _resetBouncerModeForTest();
+  });
+  afterEach(() => {
+    restore(saved);
+    _resetBouncerModeForTest();
+  });
+
+  test("returns null when no bouncer vars are set (direct mode)", () => {
+    expect(getBouncerMode()).toBeNull();
+  });
+
+  test("returns null even when NB_TENANT_ID is set alone (direct mode)", () => {
+    // NB_TENANT_ID is a general-purpose primitive; setting it without the
+    // OAuth-specific vars must NOT trip bouncer mode.
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(getBouncerMode()).toBeNull();
+  });
+
+  test("returns a populated config when both bouncer vars and NB_TENANT_ID are set", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    process.env.NB_TENANT_ID = VALID_TID;
+
+    const cfg = getBouncerMode();
+    expect(cfg).not.toBeNull();
+    expect(cfg?.callbackUrl).toBe(VALID_CALLBACK);
+    expect(cfg?.tid).toBe(VALID_TID);
+    expect(cfg?.tenantKey).toHaveLength(32);
+  });
+
+  test("caches the result — subsequent reads do not re-validate", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    process.env.NB_TENANT_ID = VALID_TID;
+
+    const first = getBouncerMode();
+    for (const k of ENV_VARS) delete process.env[k];
+    const second = getBouncerMode();
+    expect(second).toBe(first);
+  });
+});
+
+describe("bouncer-config: partial configuration is rejected", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = snapshot();
+    for (const k of ENV_VARS) delete process.env[k];
+    _resetBouncerModeForTest();
+  });
+  afterEach(() => {
+    restore(saved);
+    _resetBouncerModeForTest();
+  });
+
+  test("throws when only callback URL is set", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    expect(() => getBouncerMode()).toThrow(/Partial configuration/);
+  });
+
+  test("throws when only tenant key is set", () => {
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    expect(() => getBouncerMode()).toThrow(/Partial configuration/);
+  });
+
+  test("error message names the missing bouncer variable", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    expect(() => getBouncerMode()).toThrow(/NB_OAUTH_BOUNCER_TENANT_KEY/);
+  });
+
+  test("throws when bouncer vars are set but NB_TENANT_ID is missing", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    // NB_TENANT_ID deliberately unset
+    expect(() => getBouncerMode()).toThrow(/NB_TENANT_ID/);
+  });
+});
+
+describe("bouncer-config: value validation", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = snapshot();
+    for (const k of ENV_VARS) delete process.env[k];
+    _resetBouncerModeForTest();
+  });
+  afterEach(() => {
+    restore(saved);
+    _resetBouncerModeForTest();
+  });
+
+  test("rejects malformed callback URL", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = "not a url";
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(() => getBouncerMode()).toThrow(/not a valid URL/);
+  });
+
+  test("rejects non-http(s) callback URL", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = "javascript:alert(1)";
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(() => getBouncerMode()).toThrow(/must use http/);
+  });
+
+  test("rejects callback URL whose path doesn't end with /v1/mcp-auth/callback", () => {
+    // The session-binding cookie is path-scoped to /v1/mcp-auth/callback.
+    // A URL pointing elsewhere silently breaks every flow with a generic
+    // session-mismatch error and no clear root-cause signal — exactly the
+    // class of misconfiguration the boot check is meant to catch.
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = "https://connect.example.com/auth/callback";
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(() => getBouncerMode()).toThrow(/must end with "\/v1\/mcp-auth\/callback"/);
+  });
+
+  test("rejects callback URL with no path component", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = "https://connect.example.com";
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(() => getBouncerMode()).toThrow(/must end with/);
+  });
+
+  test("rejects tid that violates DNS-label grammar (in bouncer mode)", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    process.env.NB_TENANT_ID = "TENANT-UPPER";
+    expect(() => getBouncerMode()).toThrow(/DNS-label grammar/);
+  });
+
+  test("rejects tenant key shorter than 32 bytes", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = randomBytes(16).toString("base64");
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(() => getBouncerMode()).toThrow(/must decode to 32 bytes/);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the envelope module from #204 into `mcp-auth.ts` so the platform can opt into bouncer mode via env vars. When configured, the redirect URI sent to every vendor's OAuth Client points at a separate router service (deployed separately) instead of this tenant's own host; `state` is wrapped in a signed envelope so the router can route the callback back. Cookie binding and the single-use flow registry are unchanged.

Single-instance self-hosters who don't set the env vars keep today's behavior — no behavioral change for the default case.

## Why

Multi-tenant deployments need a single `redirect_uri` per vendor rather than one per tenant — registering N×M URIs at vendor consoles and cleaning them up on offboarding doesn't scale. The envelope landed in #204; this PR makes it actually used.

## What's in this PR

- `src/oauth/bouncer-config.ts` — process-wide config read from two bouncer-specific env vars plus the general-purpose `NB_TENANT_ID` primitive. Lazy, cached, all-or-nothing — partial configuration is a deploy-time mistake and fails closed.
- `src/api/routes/mcp-auth.ts` — three changes:
  - `mcpAuthCallbackUrl()` returns the bouncer URL when configured.
  - `/initiate` wraps the SDK-generated `state` in a signed envelope and replaces the URL's `state` query param before returning the auth URL. The cookie still keys on the inner state, so the existing CSRF binding works unchanged.
  - `/callback` unwraps the wire state into the inner before the existing cookie-hash check and flow-registry lookup. Non-wrapped state in bouncer mode is refused.
- `test/unit/oauth-bouncer-config.test.ts` — 12 tests covering presence, partial-config rejection, `NB_TENANT_ID` precondition, value validation, and caching.
- Six new tests in `test/unit/api/mcp-auth-routes.test.ts` for wrap-on-initiate, unwrap-on-callback, wrong-key forgery rejection, wrong-tid forgery rejection, non-wrapped-state rejection, and the callback URL switch.

## Configuration

Bouncer mode is opt-in via these env vars:

| Variable | Scope | Source |
|---|---|---|
| `NB_OAUTH_BOUNCER_CALLBACK_URL` | Cluster-wide | Helm `oauthBouncer.callbackUrl` — set once in `base-values.yaml` |
| `NB_OAUTH_BOUNCER_TENANT_KEY` | Per-tenant secret | ExternalSecret → k8s Secret. Provisioned by `make derive-tenant-key` at onboarding |
| `NB_TENANT_ID` | Per-tenant non-secret | Helm `tenant.id` — already required for every tenant |

`NB_TENANT_ID` is a general-purpose primitive (not OAuth-specific). Setting it alone does not enable bouncer mode. The two `NB_OAUTH_BOUNCER_*` vars are what trip the mode; `NB_TENANT_ID` is a precondition when they're set.

Why three rather than two earlier-revisions had: tying the envelope tid and the HKDF salt of the derived tenant key both to the same `tenant.id` Helm value eliminates a class of `bad_mac` errors from operator drift between deploy-time derivation and runtime signing.

## Local development

Direct mode is preserved. Run locally with no `NB_OAUTH_BOUNCER_*` vars set:

- `mcpAuthCallbackUrl()` returns `${NB_API_URL}/v1/mcp-auth/callback` as today
- `/initiate` sends opaque state to the vendor (no envelope)
- `/callback` accepts opaque state and runs existing cookie + flow-registry checks

For testing OAuth flows against localhost, register both URIs in the vendor console:

```
http://localhost:27247/v1/mcp-auth/callback          (local dev)
https://connect.<domain>/v1/mcp-auth/callback        (staging/prod bouncer)
```

Most vendors (Google, Dropbox, etc.) support multiple registered redirect URIs.

## Security properties

| Layer | Stops |
|---|---|
| All env vars validated at boot | Partial / malformed configuration silently weakening the system |
| `state` envelope (from #204) | Forged routing claims at the router |
| Tenant-side `expectedTid` match | Envelope minted for a different tenant routed to this one |
| `nb_oauth_state` cookie hash check | Leaked-state replay against another user session — unchanged |
| Single-use flow registry | Replay against the same user session — unchanged |
| `Authorization session invalid` on all envelope failures | Envelope-error oracle for attackers probing the wire format |

## What this PR does NOT do

- Does NOT modify any JSON config schema. Bouncer config is env-var only — appropriate because the tenant key is secret material that should arrive via `secretKeyRef`.
- Does NOT add deployments / Helm wiring. The companion infra PR (#9) updates the agent chart to inject these env vars from `tenant.id` and the `oauthBouncer` values block.

## Test plan

- [x] `bun run verify:static` clean (format + lint + check + codegen + cycle checks)
- [x] `bun test test/unit/oauth-envelope.test.ts test/unit/oauth-bouncer-config.test.ts test/unit/api/mcp-auth-routes.test.ts` → 63 pass, 0 fail
- [x] Existing mcp-auth route tests unchanged (14/14 still pass — direct mode unaffected)
- [ ] End-to-end test against a deployed bouncer (depends on deployments-repo PR)