### PR TITLE
fix(oauth): tighten envelope inner-length, key, and tid checks

### DIFF
--- a/src/oauth/bouncer-config.ts
+++ b/src/oauth/bouncer-config.ts
@@ -42,7 +42,7 @@
  * attempt. Subsequent calls hit the cache and don't re-validate.
  */
 
-import { ALLOWED_TID_PATTERN } from "./envelope.ts";
+import { ALLOWED_TID_PATTERN, isUniformByte } from "./envelope.ts";
 
 export interface BouncerMode {
   /** Full URL registered at every vendor's OAuth Client. */
@@ -170,6 +170,15 @@ function readAndValidate(env: NodeJS.ProcessEnv): BouncerMode | null {
   if (tenantKey.length !== REQUIRED_KEY_BYTES) {
     throw new Error(
       `[oauth bouncer] ${TENANT_KEY_ENV} must decode to ${REQUIRED_KEY_BYTES} bytes (got ${tenantKey.length})`,
+    );
+  }
+  // Symmetric defense with the master-key check in `deriveTenantKey`.
+  // The blast radius is smaller here (one tenant, not all), but the
+  // operator failure mode is identical: a base64-encoded placeholder
+  // buffer lands in 1Password and passes the length check.
+  if (isUniformByte(tenantKey, 0) || isUniformByte(tenantKey, 0xff)) {
+    throw new Error(
+      `[oauth bouncer] ${TENANT_KEY_ENV} is a placeholder pattern (all 0x00 or all 0xff); ensure HKDF derivation ran during onboarding`,
     );
   }
 

--- a/src/oauth/envelope.ts
+++ b/src/oauth/envelope.ts
@@ -64,7 +64,7 @@ const MAX_PAYLOAD_BYTES = 1024;
  * inputs upfront rather than producing wire bytes that every peer
  * refuses to verify.
  */
-const MAX_INNER_LENGTH = 512;
+export const MAX_INNER_LENGTH = 512;
 
 /**
  * Tenant identifiers are interpolated into hostnames downstream by the
@@ -131,10 +131,33 @@ export function deriveTenantKey(masterKey: Buffer, tid: string): Buffer {
       `oauth envelope: master key must be at least ${MIN_MASTER_KEY_BYTES} bytes (got ${masterKey.length})`,
     );
   }
+  // Reject obvious placeholder values. All-zeros and all-0xff are never
+  // legitimate keys; allowing them means a misconfigured deployment can
+  // pass the length check, run, and have every "signed" state be a
+  // deterministic function of payload. Cheap sanity check; no false
+  // positives since no CSPRNG output matches these patterns.
+  if (isUniformByte(masterKey, 0) || isUniformByte(masterKey, 0xff)) {
+    throw new Error(
+      "oauth envelope: master key is a placeholder pattern (all 0x00 or all 0xff); generate with a CSPRNG",
+    );
+  }
   if (!ALLOWED_TID_PATTERN.test(tid)) {
     throw new EnvelopeError("invalid_tid");
   }
   return Buffer.from(hkdfSync("sha256", masterKey, Buffer.from(tid, "utf8"), HKDF_INFO, 32));
+}
+
+/**
+ * Detect placeholder/footgun key material. Exported so the same check
+ * can guard derived keys at config-load time (see `bouncer-config.ts`),
+ * keeping master-key and tenant-key defenses symmetric — one source of
+ * truth if the predicate ever grows to catch additional patterns.
+ */
+export function isUniformByte(buf: Buffer, byte: number): boolean {
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] !== byte) return false;
+  }
+  return true;
 }
 
 export function signEnvelope(opts: SignOptions): string {
@@ -144,7 +167,10 @@ export function signEnvelope(opts: SignOptions): string {
   if (
     typeof opts.inner !== "string" ||
     opts.inner.length === 0 ||
-    opts.inner.length > MAX_INNER_LENGTH
+    // Compare UTF-8 bytes (not UTF-16 code units) to match the
+    // verify-side check in validatePayloadShape and to keep the
+    // intent — "limit bytes on wire" — accurate for non-ASCII inputs.
+    Buffer.byteLength(opts.inner, "utf8") > MAX_INNER_LENGTH
   ) {
     throw new EnvelopeError("invalid_payload");
   }
@@ -208,8 +234,14 @@ export function verifyEnvelopeAsRouter(opts: { wire: string; masterKey: Buffer; 
   // `peeked`. The check survives a future change to the parsing path
   // (streaming parser, different runtime, key-deduplication semantics)
   // that would otherwise silently let `peeked` and `payload.tid`
-  // diverge — turning a routing decision into an attacker-controlled
+  // diverge, turning a routing decision into an attacker-controlled
   // primitive. The cost is one comparison.
+  //
+  // No direct unit test: constructing a divergence requires the same
+  // parsing-path change this guard protects against. Removing the
+  // check should be paired with a different forward-compatibility
+  // story (e.g. a single-pass parser that returns both `tid` and the
+  // full payload).
   if (peeked !== payload.tid) {
     throw new EnvelopeError("invalid_tid");
   }
@@ -324,7 +356,11 @@ function validatePayloadShape(raw: unknown): EnvelopePayload {
   if (typeof r.tid !== "string" || !ALLOWED_TID_PATTERN.test(r.tid)) {
     throw new EnvelopeError("invalid_tid");
   }
-  if (typeof r.inner !== "string" || r.inner.length === 0 || r.inner.length > MAX_INNER_LENGTH) {
+  if (
+    typeof r.inner !== "string" ||
+    r.inner.length === 0 ||
+    Buffer.byteLength(r.inner, "utf8") > MAX_INNER_LENGTH
+  ) {
     throw new EnvelopeError("invalid_payload");
   }
   if (typeof r.iat !== "number" || !Number.isFinite(r.iat) || r.iat < 0) {

--- a/test/unit/oauth-bouncer-config.test.ts
+++ b/test/unit/oauth-bouncer-config.test.ts
@@ -167,4 +167,18 @@ describe("bouncer-config: value validation", () => {
     process.env.NB_TENANT_ID = VALID_TID;
     expect(() => getBouncerMode()).toThrow(/must decode to 32 bytes/);
   });
+
+  test("rejects all-zeros tenant key (placeholder pattern)", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = Buffer.alloc(32, 0).toString("base64");
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(() => getBouncerMode()).toThrow(/placeholder pattern/);
+  });
+
+  test("rejects all-0xff tenant key (placeholder pattern)", () => {
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = Buffer.alloc(32, 0xff).toString("base64");
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(() => getBouncerMode()).toThrow(/placeholder pattern/);
+  });
 });

--- a/test/unit/oauth-envelope.test.ts
+++ b/test/unit/oauth-envelope.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_TTL_SECONDS,
   EnvelopeError,
   ENVELOPE_VERSION,
+  MAX_INNER_LENGTH,
   deriveTenantKey,
   signEnvelope,
   verifyEnvelopeAsRouter,
@@ -201,18 +202,18 @@ describe("envelope expiration", () => {
 });
 
 describe("envelope payload boundary checks", () => {
-  test("accepts inner at the 512-char upper bound", () => {
-    const inner512 = "x".repeat(512);
-    const wire = signEnvelope({ tid: TID, inner: inner512, tenantKey: tenantKey() });
+  test("accepts inner at the MAX_INNER_LENGTH upper bound (ASCII)", () => {
+    const innerAtCap = "x".repeat(MAX_INNER_LENGTH);
+    const wire = signEnvelope({ tid: TID, inner: innerAtCap, tenantKey: tenantKey() });
     const payload = verifyEnvelopeAsTenant({ wire, tenantKey: tenantKey(), expectedTid: TID });
-    expect(payload.inner).toHaveLength(512);
+    expect(payload.inner).toHaveLength(MAX_INNER_LENGTH);
   });
 
-  test("signEnvelope rejects inner one character past the upper bound", () => {
+  test("signEnvelope rejects inner one character past MAX_INNER_LENGTH", () => {
     // Sign-side check keeps the contract symmetric with verify — a signer
     // should never produce wire bytes that every peer rejects.
     expectError(
-      () => signEnvelope({ tid: TID, inner: "x".repeat(513), tenantKey: tenantKey() }),
+      () => signEnvelope({ tid: TID, inner: "x".repeat(MAX_INNER_LENGTH + 1), tenantKey: tenantKey() }),
       "invalid_payload",
     );
   });
@@ -221,7 +222,12 @@ describe("envelope payload boundary checks", () => {
     // Belt-and-suspenders: even if a future signer regression slips an
     // oversize inner past the sign-side check, the verifier still catches it.
     const now = Math.floor(Date.now() / 1000);
-    const payload = { tid: TID, inner: "x".repeat(513), iat: now, exp: now + 900 };
+    const payload = {
+      tid: TID,
+      inner: "x".repeat(MAX_INNER_LENGTH + 1),
+      iat: now,
+      exp: now + 900,
+    };
     const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
     const signed = `v1.${payloadB64}`;
     const mac = createHmac("sha256", tenantKey()).update(signed).digest().toString("base64url");
@@ -240,7 +246,7 @@ describe("master key validation", () => {
   });
 
   test("deriveTenantKey accepts a 32-byte master key", () => {
-    const ok = Buffer.alloc(32);
+    const ok = randomBytes(32);
     expect(() => deriveTenantKey(ok, TID)).not.toThrow();
   });
 });
@@ -259,13 +265,62 @@ describe("HKDF key derivation", () => {
   });
 
   test("derived key is 32 bytes", () => {
-    expect(deriveTenantKey(MASTER, "tenant-a")).toHaveLength(32);
+    const key = deriveTenantKey(MASTER, "tenant-a");
+    expect(key).toHaveLength(32);
   });
 
   test("changing master changes all derived keys", () => {
     const m1 = randomBytes(32);
     const m2 = randomBytes(32);
-    expect(deriveTenantKey(m1, "tenant-a").equals(deriveTenantKey(m2, "tenant-a"))).toBe(false);
+    const k1 = deriveTenantKey(m1, "tenant-a");
+    const k2 = deriveTenantKey(m2, "tenant-a");
+    expect(k1.equals(k2)).toBe(false);
+  });
+});
+
+describe("master key entropy sanity checks", () => {
+  test("rejects all-zeros master key (placeholder pattern)", () => {
+    const zeros = Buffer.alloc(32, 0);
+    expect(() => deriveTenantKey(zeros, "tenant-a")).toThrow(/placeholder pattern/);
+  });
+
+  test("rejects all-0xff master key (placeholder pattern)", () => {
+    const ffs = Buffer.alloc(32, 0xff);
+    expect(() => deriveTenantKey(ffs, "tenant-a")).toThrow(/placeholder pattern/);
+  });
+
+  test("accepts a CSPRNG-generated master key with one byte differing", () => {
+    // Even a master key where 31/32 bytes are zero is acceptable — the
+    // check is for the obvious "Buffer.alloc(32)" foot-gun, not for
+    // measuring entropy in general.
+    const nearZero = Buffer.alloc(32, 0);
+    nearZero[7] = 0x42;
+    expect(() => deriveTenantKey(nearZero, "tenant-a")).not.toThrow();
+  });
+});
+
+describe("inner length is measured in UTF-8 bytes", () => {
+  test("signEnvelope accepts inner exactly at the byte boundary with multibyte chars", () => {
+    // "🙂" is 4 UTF-8 bytes and 2 UTF-16 code units. Pack the cap full.
+    const emojiCount = MAX_INNER_LENGTH / 4;
+    const inner = "🙂".repeat(emojiCount);
+    expect(Buffer.byteLength(inner, "utf8")).toBe(MAX_INNER_LENGTH);
+    expect(() => signEnvelope({ tid: TID, inner, tenantKey: tenantKey() })).not.toThrow();
+  });
+
+  test("signEnvelope rejects inner whose UTF-8 byte length exceeds the cap, even when UTF-16 length fits", () => {
+    // One emoji past the cap = MAX_INNER_LENGTH + 4 UTF-8 bytes, but the
+    // UTF-16 length stays at (MAX_INNER_LENGTH / 4 + 1) * 2, still under
+    // the cap if it were measured in code units. The pre-fix
+    // `inner.length` check would have allowed this; the byte-length
+    // check correctly rejects.
+    const inner = "🙂".repeat(MAX_INNER_LENGTH / 4 + 1);
+    expect(inner.length).toBeLessThan(MAX_INNER_LENGTH);
+    expect(Buffer.byteLength(inner, "utf8")).toBeGreaterThan(MAX_INNER_LENGTH);
+    expectError(
+      () => signEnvelope({ tid: TID, inner, tenantKey: tenantKey() }),
+      "invalid_payload",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Four small follow-ups to the envelope module from #204, all driven by review feedback. Originally three; expanded after a round-2 suggestion flagged a symmetric defense gap on the derived tenant key.

## Changes

### 1. `inner` length is measured in UTF-8 bytes

`String.prototype.length` counts UTF-16 code units. A 257-emoji inner string is 514 UTF-16 units but ~1028 UTF-8 bytes, and the post-serialization payload-cap check catches the oversize wire either way. The asymmetry is harmless in practice (CSRF tokens are ASCII), but the intent of `MAX_INNER_LENGTH` is "limit bytes on wire" — switching to `Buffer.byteLength(opts.inner, "utf8")` makes both checks consistent in units. Both `signEnvelope` and `validatePayloadShape` now agree.

### 2. `deriveTenantKey` rejects placeholder master keys

`Buffer.alloc(32)` is a real deployment foot-gun: an operator who wires up the env var with an unset secret or a copy-pasted placeholder gets a 32-byte buffer of zeros. The length check passes, the system runs, and every "signed" state is a deterministic function of payload. The new check rejects all-zeros and all-0xff master keys with a clear error. Zero false positives — CSPRNG output never matches these patterns.

### 3. `bouncer-config` rejects placeholder tenant keys

Symmetric defense at the derived layer. The pre-derived `NB_OAUTH_BOUNCER_TENANT_KEY` is loaded at config time and previously only got a length check. Same operator failure mode as the master (base64 of `Buffer.alloc(32)` passing length validation), smaller blast radius (one tenant vs. all). `isUniformByte` is exported from `envelope.ts` so the predicate has one source of truth; if we ever extend it to catch other patterns, both layers update together.

### 4. Comment on the unreachable defensive tid check

The `peeked !== payload.tid` check in `verifyEnvelopeAsRouter` is unreachable today because V8's `JSON.parse` is deterministic over identical bytes. The check was retained as defense-in-depth for a future parsing-path change. Added a comment explaining that no direct unit test exists for this branch, since constructing a divergence requires the same future change the guard exists to survive — and that removing the check should be paired with a single-pass parser instead.

No code change to the check itself; just the comment.

## Test plan

- [x] `bun run verify:static` clean
- [x] `bun test test/unit/oauth-envelope.test.ts` → 36 pass (was 31)
- [x] `bun test test/unit/oauth-bouncer-config.test.ts` → 16 pass (was 14)

New tests:
- Inner exactly at the 512-byte boundary with multibyte chars (accept)
- Inner over the 512-byte boundary but under the 512 UTF-16-unit boundary (reject — the pre-fix behavior would have accepted)
- All-zeros master rejected
- All-0xff master rejected
- 31 zero bytes + one real byte accepted (the entropy floor is "not the obvious placeholder," not "looks random")
- All-zeros tenant key rejected at config-load
- All-0xff tenant key rejected at config-load