### PR TITLE
fix(oauth): drive bouncer mode off URL presence; warn on stray key

### DIFF
--- a/src/oauth/bouncer-config.ts
+++ b/src/oauth/bouncer-config.ts
@@ -32,16 +32,28 @@
  *     runtime, so plumbing both endpoints from one source eliminates
  *     a class of `bad_mac` mismatches from typos.
  *
- * Bouncer mode requires all three. Partial configuration of the two
- * `NB_OAUTH_BOUNCER_*` vars, a missing `NB_TENANT_ID` while bouncer
- * mode is requested, or any malformed value is a deploy-time error
- * that fails closed at the first call to `getBouncerMode()`. The
- * mcp-auth route module calls this at module load via `mcpAuthRoutes`,
- * so a misconfigured deployment crashes immediately at server startup
- * rather than serving traffic and failing on the first user OAuth
- * attempt. Subsequent calls hit the cache and don't re-validate.
+ * `NB_OAUTH_BOUNCER_CALLBACK_URL` is the mode signal — its presence,
+ * specifically, enables bouncer mode. When it is set, the key and the
+ * tenant id must also be set (and valid); a missing or malformed value
+ * in that state is a deploy-time error that fails closed at the first
+ * call to `getBouncerMode()`. The mcp-auth route module calls this at
+ * module load via `mcpAuthRoutes`, so a misconfigured deployment
+ * crashes immediately at server startup rather than serving traffic
+ * and failing on the first user OAuth attempt.
+ *
+ * The asymmetric case: `NB_OAUTH_BOUNCER_TENANT_KEY` set without the
+ * URL. This is the shape of a rolled-back tenant where the chart's
+ * `envFrom: secretRef` keeps injecting the key from `agent-secrets`
+ * even though `oauthBouncer.enabled: false`. Treat it as direct mode
+ * and log a single boot-time warning suggesting the cleanup step
+ * (drop the entry from the ExternalSecret). Crashing here would brick
+ * the pod for an issue that has no runtime consequence — the key
+ * just sits unused.
+ *
+ * Subsequent calls hit the cache and don't re-validate.
  */
 
+import { log } from "../cli/log.ts";
 import { ALLOWED_TID_PATTERN, isUniformByte } from "./envelope.ts";
 
 export interface BouncerMode {
@@ -77,6 +89,12 @@ let _cached: BouncerMode | null | undefined;
  * values.
  */
 export function getBouncerMode(): BouncerMode | null {
+  // The "warn once at boot" property for the stray-key path is a
+  // side-effect of this cache, not a separate hasWarned flag: the
+  // warning is emitted inside readAndValidate, and the cache prevents
+  // re-entry. If a future refactor introduces a non-test code path
+  // that clears the cache mid-process, the warning would re-fire on
+  // the next call — noisy but not incorrect.
   if (_cached !== undefined) return _cached;
   _cached = readAndValidate(process.env);
   return _cached;
@@ -95,24 +113,35 @@ function readAndValidate(env: NodeJS.ProcessEnv): BouncerMode | null {
   const tenantKeyB64 = env[TENANT_KEY_ENV];
   const tid = env[TENANT_ID_ENV];
 
-  const bouncerVarsPresent = [callbackUrl, tenantKeyB64].filter(
-    (v): v is string => typeof v === "string" && v.length > 0,
-  );
+  const hasUrl = typeof callbackUrl === "string" && callbackUrl.length > 0;
+  const hasKey = typeof tenantKeyB64 === "string" && tenantKeyB64.length > 0;
 
-  // Direct mode: neither bouncer-specific var is set. Don't care
-  // whether NB_TENANT_ID is set; other parts of the platform may use
-  // it for telemetry/logs without triggering bouncer mode.
-  if (bouncerVarsPresent.length === 0) return null;
+  // Direct mode. The URL is the authoritative mode signal; when it's
+  // unset, we run in direct mode regardless of the other vars.
+  //
+  // Asymmetric case: the key is present but the URL isn't. This is the
+  // shape left behind by a tenant that was rolled back from bouncer
+  // mode while the chart's `envFrom: secretRef` keeps injecting the
+  // key from `agent-secrets`. The key is harmless here — no code reads
+  // it — but the leak suggests an incomplete cleanup, so emit a
+  // one-time warning pointing the operator at the fix.
+  if (!hasUrl) {
+    if (hasKey) {
+      log.warn(
+        `[oauth bouncer] ${TENANT_KEY_ENV} is set but ${CALLBACK_URL_ENV} is not — running in direct mode. ` +
+          `This typically means the ExternalSecret still lists the key after a bouncer-mode rollback. ` +
+          `Drop the NB_OAUTH_BOUNCER_TENANT_KEY entry from the tenant's external-secret.yaml and kubectl apply to clean up.`,
+      );
+    }
+    return null;
+  }
 
-  // Partial config of the two bouncer vars is almost always a deploy
-  // mistake (operator wired one Helm value but not the other).
-  if (bouncerVarsPresent.length < 2) {
-    const missing = [
-      callbackUrl ? null : CALLBACK_URL_ENV,
-      tenantKeyB64 ? null : TENANT_KEY_ENV,
-    ].filter((v): v is string => v !== null);
+  // From here on, bouncer mode is requested. Everything must be valid.
+
+  if (!hasKey) {
     throw new Error(
-      `[oauth bouncer] Partial configuration. Set both ${CALLBACK_URL_ENV} and ${TENANT_KEY_ENV} together or neither. Missing: ${missing.join(", ")}`,
+      `[oauth bouncer] ${CALLBACK_URL_ENV} is set but ${TENANT_KEY_ENV} is missing. Bouncer mode needs both. ` +
+        `Run \`make derive-tenant-key CLIENT=<x> ENV=<env>\` to provision the per-tenant signing key.`,
     );
   }
 
@@ -125,7 +154,8 @@ function readAndValidate(env: NodeJS.ProcessEnv): BouncerMode | null {
     );
   }
 
-  // Narrow for TS. Both bouncer vars are non-empty strings at this point.
+  // Narrow for TS — the two hasUrl/hasKey checks above guarantee
+  // these are non-empty strings at this point.
   if (!callbackUrl || !tenantKeyB64) {
     throw new Error("[oauth bouncer] internal: presence check failed unexpectedly");
   }

--- a/test/unit/oauth-bouncer-config.test.ts
+++ b/test/unit/oauth-bouncer-config.test.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { log } from "../../src/cli/log.ts";
 import { _resetBouncerModeForTest, getBouncerMode } from "../../src/oauth/bouncer-config.ts";
 
 const ENV_VARS = [
@@ -30,25 +31,31 @@ function restore(saved: Record<string, string | undefined>): void {
 
 describe("bouncer-config: presence", () => {
   let saved: Record<string, string | undefined>;
+  let warnSpy: ReturnType<typeof spyOn>;
   beforeEach(() => {
     saved = snapshot();
     for (const k of ENV_VARS) delete process.env[k];
     _resetBouncerModeForTest();
+    warnSpy = spyOn(log, "warn").mockImplementation(() => {});
   });
   afterEach(() => {
     restore(saved);
     _resetBouncerModeForTest();
+    warnSpy.mockRestore();
   });
 
-  test("returns null when no bouncer vars are set (direct mode)", () => {
+  test("returns null when no bouncer vars are set (direct mode), no warning", () => {
     expect(getBouncerMode()).toBeNull();
+    // Locks in "warning only on stray key, never on clean direct mode."
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  test("returns null even when NB_TENANT_ID is set alone (direct mode)", () => {
+  test("returns null even when NB_TENANT_ID is set alone (direct mode), no warning", () => {
     // NB_TENANT_ID is a general-purpose primitive; setting it without the
-    // OAuth-specific vars must NOT trip bouncer mode.
+    // OAuth-specific vars must NOT trip bouncer mode and must NOT warn.
     process.env.NB_TENANT_ID = VALID_TID;
     expect(getBouncerMode()).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("returns a populated config when both bouncer vars and NB_TENANT_ID are set", () => {
@@ -61,6 +68,7 @@ describe("bouncer-config: presence", () => {
     expect(cfg?.callbackUrl).toBe(VALID_CALLBACK);
     expect(cfg?.tid).toBe(VALID_TID);
     expect(cfg?.tenantKey).toHaveLength(32);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("caches the result — subsequent reads do not re-validate", () => {
@@ -75,38 +83,77 @@ describe("bouncer-config: presence", () => {
   });
 });
 
-describe("bouncer-config: partial configuration is rejected", () => {
+describe("bouncer-config: URL is the mode signal", () => {
   let saved: Record<string, string | undefined>;
+  let warnSpy: ReturnType<typeof spyOn>;
   beforeEach(() => {
     saved = snapshot();
     for (const k of ENV_VARS) delete process.env[k];
     _resetBouncerModeForTest();
+    warnSpy = spyOn(log, "warn").mockImplementation(() => {});
   });
   afterEach(() => {
     restore(saved);
     _resetBouncerModeForTest();
+    warnSpy.mockRestore();
   });
 
-  test("throws when only callback URL is set", () => {
+  test("URL set + KEY missing → fatal (operator clearly meant to enable bouncer)", () => {
     process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
-    expect(() => getBouncerMode()).toThrow(/Partial configuration/);
+    // Key deliberately unset
+    expect(() => getBouncerMode()).toThrow(/NB_OAUTH_BOUNCER_TENANT_KEY is missing/);
+    // Fatal path, not the warn path — confirm we didn't also fire the warn.
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  test("throws when only tenant key is set", () => {
+  test("URL unset + KEY set → direct mode + warn (residue from rollback, not fatal)", () => {
+    // This is the shape after rolling back oauthBouncer.enabled: false:
+    // the chart's envFrom: secretRef keeps injecting the key from
+    // agent-secrets even though the URL is gone. The platform should
+    // treat this as direct mode, not crash. And it must WARN —
+    // otherwise the operator never knows there's leftover state.
     process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
-    expect(() => getBouncerMode()).toThrow(/Partial configuration/);
+    expect(getBouncerMode()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toMatch(
+      /NB_OAUTH_BOUNCER_TENANT_KEY is set but NB_OAUTH_BOUNCER_CALLBACK_URL is not/,
+    );
+    // Names the cleanup step explicitly — otherwise the warning is
+    // sympathetic noise that doesn't tell the operator what to do.
+    expect(msg).toMatch(/external-secret\.yaml/);
   });
 
-  test("error message names the missing bouncer variable", () => {
-    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
-    expect(() => getBouncerMode()).toThrow(/NB_OAUTH_BOUNCER_TENANT_KEY/);
+  test("URL unset + KEY set + TID set → direct mode + warn (still benign)", () => {
+    // NB_TENANT_ID is always injected by the chart (general primitive).
+    // Stray key + tid without URL is still just rollback residue.
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    process.env.NB_TENANT_ID = VALID_TID;
+    expect(getBouncerMode()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("throws when bouncer vars are set but NB_TENANT_ID is missing", () => {
+  test("warn fires only once across repeated getBouncerMode() calls (cache property)", () => {
+    // The "warn once at boot" property is a side-effect of the lazy
+    // cache: readAndValidate runs on the first call, the result is
+    // memoized, subsequent calls return the cached value without
+    // re-running validation. If a future refactor adds a code path
+    // that clears the cache mid-process, the warn would re-fire on
+    // the next call — which would be noisy but not incorrect. This
+    // test pins the once-at-boot behavior under the cache.
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
+    expect(getBouncerMode()).toBeNull();
+    expect(getBouncerMode()).toBeNull();
+    expect(getBouncerMode()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Bouncer mode requires NB_TENANT_ID when URL+KEY are both set", () => {
     process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = VALID_CALLBACK;
     process.env.NB_OAUTH_BOUNCER_TENANT_KEY = VALID_KEY_B64;
     // NB_TENANT_ID deliberately unset
     expect(() => getBouncerMode()).toThrow(/NB_TENANT_ID/);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

The platform's bouncer config was strict in both directions — URL set without key OR key set without URL — and that two-way strictness turned out to be wrong in one direction. This change keeps the strict check where strictness matters and relaxes it where it doesn't.

## Why

Surfaced during the OAuth bouncer rollout (deployments PR #12). The agent chart uses `envFrom: secretRef` on `agent-secrets`, which pulls **every** key in the Secret into env regardless of whether the chart's `oauthBouncer.enabled` block renders the bouncer-specific env vars. So rolling a tenant back from bouncer mode (set `oauthBouncer.enabled: false`, redeploy) **doesn't** remove `NB_OAUTH_BOUNCER_TENANT_KEY` from env — it stays as long as the ExternalSecret still lists the field. The platform's old strict check then crashed the pod with `Partial configuration. Missing: NB_OAUTH_BOUNCER_CALLBACK_URL`, turning routine rollback into an incident. The deployments PR documented a two-step rollback workaround (edit the ExternalSecret first, then flip the Helm value), but that's friction operators forget.

## What changes

`NB_OAUTH_BOUNCER_CALLBACK_URL` becomes the authoritative mode signal:

| `URL` | `KEY` | Before | After |
|---|---|---|---|
| set | set | bouncer mode | bouncer mode (unchanged) |
| set | unset | fatal (partial config) | fatal: operator clearly meant to enable bouncer (unchanged) |
| unset | set | **fatal (partial config) ← rollback footgun** | **direct mode + one-time boot warn** |
| unset | unset | direct mode | direct mode (unchanged) |

The stray-key warn fires once at boot (via the eager `getBouncerMode()` call in `mcpAuthRoutes`) and names the cleanup step: drop the entry from the ExternalSecret and kubectl apply. The key is harmless when unused — no code reads it once URL is gone — so direct-mode operation continues.

## Test plan

- [x] 16/16 unit tests in `oauth-bouncer-config.test.ts` (incl. 3 new "URL is the mode signal" cases)
- [x] 20/20 unchanged tests in `mcp-auth-routes.test.ts`
- [x] `bun run verify:static` clean
- [ ] After deploy: confirm the stray-key warn fires on a tenant rolled back from bouncer mode

## Follow-ups

- Deployments-side docs (`hq.yaml` comment + `ONBOARD_TENANT.md`) currently describe the two-step rollback. Once this lands and ships to production, update the docs to describe the one-step toggle as the primary path. Separate PR; depends on this image rolling out to relevant tenants.