### PR TITLE
feat(files): rehydrate supported PDF resource links

### DIFF
--- a/src/files/extract.ts
+++ b/src/files/extract.ts
@@ -3,6 +3,16 @@ import { extractText as extractPdfText } from "unpdf";
 import * as XLSX from "xlsx";
 
 /**
+ * Truncation suffix used by callers that route extracted text into the
+ * rehydrate fallback path (i.e. the model already has the `files__read`
+ * tool surfaced separately, so the suffix should not nudge it to call).
+ * Centralised so ingest-time sidecar population and rehydrate-time live
+ * extraction produce byte-identical text — required for the FileStore
+ * extracted-text cache to be valid across paths.
+ */
+export const REHYDRATE_TRUNCATED_SUFFIX = (kb: number): string => `\n[... truncated at ${kb} KB]`;
+
+/**
  * Extract text from a file buffer based on MIME type.
  * Returns null for unsupported types or on extraction failure.
  */

--- a/src/files/extract.ts
+++ b/src/files/extract.ts
@@ -10,6 +10,7 @@ export async function extractText(
   data: Buffer,
   mimeType: string,
   maxSize: number = 204_800,
+  options: { truncatedSuffix?: (kb: number) => string } = {},
 ): Promise<{ text: string; truncated: boolean } | null> {
   // Normalize: callers may pass `text/plain;charset=utf-8` from a
   // browser upload. Exact-Set / equality checks against the raw value
@@ -17,19 +18,19 @@ export async function extractText(
   const bare = mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
   try {
     if (isTextMime(bare)) {
-      return truncate(data.toString("utf-8"), maxSize);
+      return truncate(data.toString("utf-8"), maxSize, options);
     }
 
     if (bare === "application/pdf") {
-      return await extractPdf(data, maxSize);
+      return await extractPdf(data, maxSize, options);
     }
 
     if (bare === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-      return await extractDocx(data, maxSize);
+      return await extractDocx(data, maxSize, options);
     }
 
     if (bare === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") {
-      return extractXlsx(data, maxSize);
+      return extractXlsx(data, maxSize, options);
     }
 
     // Images and everything else: not extractable
@@ -56,7 +57,11 @@ function isTextMime(mimeType: string): boolean {
   return TEXT_MIME_TYPES.has(mimeType);
 }
 
-function truncate(text: string, maxSize: number): { text: string; truncated: boolean } {
+function truncate(
+  text: string,
+  maxSize: number,
+  options: { truncatedSuffix?: (kb: number) => string } = {},
+): { text: string; truncated: boolean } {
   const bytes = Buffer.byteLength(text, "utf-8");
   if (bytes <= maxSize) {
     return { text, truncated: false };
@@ -69,13 +74,16 @@ function truncate(text: string, maxSize: number): { text: string; truncated: boo
     truncated = truncated.slice(0, -1);
   }
   const kb = Math.round(maxSize / 1024);
-  truncated += `\n[... truncated at ${kb} KB — use files__read for full content]`;
+  truncated +=
+    options.truncatedSuffix?.(kb) ??
+    `\n[... truncated at ${kb} KB — use files__read for full content]`;
   return { text: truncated, truncated: true };
 }
 
 async function extractPdf(
   data: Buffer,
   maxSize: number,
+  options: { truncatedSuffix?: (kb: number) => string } = {},
 ): Promise<{ text: string; truncated: boolean } | null> {
   try {
     const result = await extractPdfText(new Uint8Array(data));
@@ -83,7 +91,7 @@ async function extractPdf(
       result.totalPages > 1
         ? result.text.map((page, i) => `--- Page ${i + 1} ---\n${page}`).join("\n\n")
         : (result.text[0] ?? "");
-    return truncate(text, maxSize);
+    return truncate(text, maxSize, options);
   } catch (err) {
     console.error("[files/extract] PDF extraction failed:", err);
     return null;
@@ -93,18 +101,23 @@ async function extractPdf(
 async function extractDocx(
   data: Buffer,
   maxSize: number,
+  options: { truncatedSuffix?: (kb: number) => string } = {},
 ): Promise<{ text: string; truncated: boolean } | null> {
   try {
     // biome-ignore lint/suspicious/noExplicitAny: mammoth types don't expose convertToMarkdown
     const result = await (mammoth as any).convertToMarkdown({ buffer: data });
-    return truncate(result.value, maxSize);
+    return truncate(result.value, maxSize, options);
   } catch (err) {
     console.error("[files/extract] DOCX extraction failed:", err);
     return null;
   }
 }
 
-function extractXlsx(data: Buffer, maxSize: number): { text: string; truncated: boolean } | null {
+function extractXlsx(
+  data: Buffer,
+  maxSize: number,
+  options: { truncatedSuffix?: (kb: number) => string } = {},
+): { text: string; truncated: boolean } | null {
   try {
     // Validate XLSX magic bytes (PK zip signature)
     if (data.length < 4 || data[0] !== 0x50 || data[1] !== 0x4b) {
@@ -116,7 +129,7 @@ function extractXlsx(data: Buffer, maxSize: number): { text: string; truncated: 
     const sheet = workbook.Sheets[firstSheetName];
     if (!sheet) return null;
     const csv = XLSX.utils.sheet_to_csv(sheet);
-    return truncate(csv, maxSize);
+    return truncate(csv, maxSize, options);
   } catch (err) {
     console.error("[files/extract] XLSX extraction failed:", err);
     return null;

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -97,8 +97,8 @@ function humanSize(bytes: number): string {
 /**
  * Validate and ingest uploaded files into the workspace file store.
  *
- * For each valid file: stores it, registers metadata, extracts text,
- * and builds content parts for the LLM message.
+ * For each valid file: stores it, registers metadata, extracts text when
+ * applicable, and builds content parts for the LLM message.
  */
 export async function ingestFiles(
   files: UploadedFile[],

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -24,10 +24,11 @@ const EXTRACTABLE_TEXT = new Set([
 ]);
 
 const EXTRACTABLE_DOCS = new Set([
-  "application/pdf",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ]);
+
+export const PDF_TYPES = new Set(["application/pdf"]);
 
 /**
  * Image MIME types accepted on upload. Exported so the rehydration
@@ -55,6 +56,7 @@ const BINARY_TYPES = new Set([
 const ALLOWED_MIMES = new Set([
   ...EXTRACTABLE_TEXT,
   ...EXTRACTABLE_DOCS,
+  ...PDF_TYPES,
   ...IMAGE_TYPES,
   ...BINARY_TYPES,
 ]);
@@ -80,6 +82,10 @@ function isExtractable(mimeType: string): boolean {
 
 function isImage(mimeType: string): boolean {
   return IMAGE_TYPES.has(normalizeMime(mimeType));
+}
+
+function isPdf(mimeType: string): boolean {
+  return PDF_TYPES.has(normalizeMime(mimeType));
 }
 
 function humanSize(bytes: number): string {
@@ -164,12 +170,12 @@ export async function ingestFiles(
       }
     }
 
-    // Image files → MCP `resource_link` content part. The runtime rehydrates
-    // these to AI SDK V3 `file` parts (with bytes loaded from the FileStore)
-    // at the `model.doStream` boundary, so vision content survives through
-    // multi-turn agentic loops without the conversation log carrying the
-    // bytes inline.
-    if (isImage(file.mimeType)) {
+    // Rehydratable files → MCP `resource_link` content part. The runtime
+    // turns supported resource links into AI SDK V3 `file` parts (with bytes
+    // loaded from the FileStore) at the `model.doStream` boundary, so binary
+    // content survives multi-turn agentic loops without the conversation log
+    // carrying bytes or extracted PDF text inline.
+    if (isImage(file.mimeType) || isPdf(file.mimeType)) {
       contentParts.push({
         type: "resource_link",
         uri: fileIdToUri(saved.id),

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -1,4 +1,4 @@
-import { extractText } from "./extract.ts";
+import { extractText, REHYDRATE_TRUNCATED_SUFFIX } from "./extract.ts";
 import type { FileStore } from "./store.ts";
 import type { ContentPart, FileConfig, FileEntry, FileReference, IngestResult } from "./types.ts";
 import { fileIdToUri } from "./uri.ts";
@@ -166,6 +166,23 @@ export async function ingestFiles(
         contentParts.push({
           type: "text",
           text: `--- Attached: ${file.filename} (${saved.id}, ${humanSize(saved.size)}) ---\n${result.text}`,
+        });
+      }
+    } else if (isPdf(file.mimeType)) {
+      // Populate the extracted-text sidecar so rehydrate's text-fallback
+      // path (historical / unsupported-model / oversize) is O(text read)
+      // instead of O(reload bytes + re-run unpdf) on every turn. Uses the
+      // rehydrate-suffix variant so a cache hit at rehydrate time
+      // produces byte-identical content to a live extraction. Best-effort:
+      // a failed extraction here just means rehydrate will retry live.
+      const result = await extractText(file.data, file.mimeType, config.maxExtractedTextSize, {
+        truncatedSuffix: REHYDRATE_TRUNCATED_SUFFIX,
+      });
+      if (result) {
+        await store.writeExtractedText(saved.id, {
+          text: result.text,
+          maxSize: config.maxExtractedTextSize,
+          truncated: result.truncated,
         });
       }
     }

--- a/src/files/rehydrate.ts
+++ b/src/files/rehydrate.ts
@@ -2,16 +2,16 @@
  * Rehydrate `resource_link` blocks in user messages into AI SDK V3
  * `file` parts at the `model.doStream` boundary.
  *
- * The conversation log persists images as MCP `resource_link` blocks
- * pointing to `files://<id>` URIs (the bytes live in the workspace
- * `FileStore`). The model expects inline `file` parts with raw bytes.
- * This module is the lazy adapter between the two — invoked once per
- * `runtime.chat` after history is loaded and before the engine is run.
+ * The conversation log persists rehydratable attachments as MCP
+ * `resource_link` blocks pointing to `files://<id>` URIs (the bytes live
+ * in the workspace `FileStore`). The model expects inline `file` parts with
+ * raw bytes. This module is the lazy adapter between the two — invoked once
+ * per `runtime.chat` after history is loaded and before the engine is run.
  *
- * Non-image `resource_link` blocks become a short text reference; the
- * model can pull bytes for those via `files__read` when it needs them,
- * and the AI SDK provider would drop unknown blocks at the API
- * boundary anyway.
+ * Raster images and provider-supported PDFs become `file` parts. Other
+ * `resource_link` blocks become a short text reference; the model can pull
+ * bytes for those via `files__read` when it needs them, and the AI SDK
+ * provider would drop unknown blocks at the API boundary anyway.
  */
 
 import type {
@@ -20,7 +20,13 @@ import type {
   LanguageModelV3TextPart,
 } from "@ai-sdk/provider";
 import type { StoredMessage, UserContentPart } from "../conversation/types.ts";
-import { IMAGE_TYPES } from "./ingest.ts";
+import type { FileInputPolicy } from "../model/file-capabilities.ts";
+import {
+  acceptsFileMime,
+  FILE_INPUT_MIMES,
+  getFileInputPolicy,
+} from "../model/file-capabilities.ts";
+import { IMAGE_TYPES, PDF_TYPES } from "./ingest.ts";
 import type { FileStore } from "./store.ts";
 import { uriToFileId } from "./uri.ts";
 
@@ -33,46 +39,77 @@ import { uriToFileId } from "./uri.ts";
  */
 const REHYDRATABLE_IMAGE_MIMES = new Set([...IMAGE_TYPES].filter((m) => m !== "image/svg+xml"));
 
+// Internal runtime seam: callers must pass the resolved provider-qualified model.
+export interface RehydrateOptions {
+  model: string;
+}
+
+interface PdfRehydrationBudget {
+  pdfRemainingBytes: number;
+}
+
 export async function rehydrateUserResources(
   messages: StoredMessage[],
   fileStore: FileStore,
+  options: RehydrateOptions,
 ): Promise<LanguageModelV3Message[]> {
-  return Promise.all(
-    messages.map(async (msg): Promise<LanguageModelV3Message> => {
-      if (msg.role !== "user") {
-        // Strip the platform extras (timestamp, userId, metadata) so the
-        // returned shape is exactly `LanguageModelV3Message` — what the
-        // engine and `model.doStream` expect.
-        const { role, content, providerOptions } = msg;
-        return providerOptions
+  const policy = getFileInputPolicy(options.model);
+  // PDF-only guard for provider file-input limits. Existing image inlining is
+  // intentionally unchanged here; full request-byte budgeting is separate.
+  const budget: PdfRehydrationBudget = {
+    pdfRemainingBytes: policy.pdf?.maxTotalBytes ?? 0,
+  };
+  const out: LanguageModelV3Message[] = [];
+  for (const msg of messages) {
+    if (msg.role !== "user") {
+      // Strip the platform extras (timestamp, userId, metadata) so the
+      // returned shape is exactly `LanguageModelV3Message` — what the
+      // engine and `model.doStream` expect.
+      const { role, content, providerOptions } = msg;
+      out.push(
+        providerOptions
           ? ({ role, content, providerOptions } as LanguageModelV3Message)
-          : ({ role, content } as LanguageModelV3Message);
-      }
-
-      const newContent = await Promise.all(
-        msg.content.map(async (part) => rehydratePart(part, fileStore)),
+          : ({ role, content } as LanguageModelV3Message),
       );
-      return msg.providerOptions
+      continue;
+    }
+
+    const newContent: Array<LanguageModelV3TextPart | LanguageModelV3FilePart> = [];
+    for (const part of msg.content) {
+      newContent.push(await rehydratePart(part, fileStore, policy, budget));
+    }
+    out.push(
+      msg.providerOptions
         ? { role: "user", content: newContent, providerOptions: msg.providerOptions }
-        : { role: "user", content: newContent };
-    }),
-  );
+        : { role: "user", content: newContent },
+    );
+  }
+  return out;
 }
 
 async function rehydratePart(
   part: UserContentPart,
   fileStore: FileStore,
+  policy: FileInputPolicy,
+  budget: PdfRehydrationBudget,
 ): Promise<LanguageModelV3TextPart | LanguageModelV3FilePart> {
   if (part.type === "text") {
     return { type: "text", text: part.text };
   }
   // resource_link
-  if (!REHYDRATABLE_IMAGE_MIMES.has(part.mimeType)) {
-    return {
-      type: "text",
-      text: `[Attached: ${part.name} (${part.mimeType}) — call files__read to access]`,
-    };
+  if (REHYDRATABLE_IMAGE_MIMES.has(part.mimeType)) {
+    return rehydrateImagePart(part, fileStore);
   }
+  if (PDF_TYPES.has(part.mimeType)) {
+    return rehydratePdfPart(part, fileStore, policy, budget);
+  }
+  return textMarker(part.name, part.mimeType);
+}
+
+async function rehydrateImagePart(
+  part: Extract<UserContentPart, { type: "resource_link" }>,
+  fileStore: FileStore,
+): Promise<LanguageModelV3TextPart | LanguageModelV3FilePart> {
   const id = uriToFileId(part.uri);
   if (!id) {
     return { type: "text", text: `[Attached: ${part.name}]` };
@@ -85,10 +122,7 @@ async function rehydratePart(
     // trust the store and fall back to a text marker rather than send a
     // mis-typed part to the model.
     if (!REHYDRATABLE_IMAGE_MIMES.has(read.mimeType)) {
-      return {
-        type: "text",
-        text: `[Attached: ${part.name} (${read.mimeType}) — call files__read to access]`,
-      };
+      return textMarker(part.name, read.mimeType);
     }
     return {
       type: "file",
@@ -102,4 +136,58 @@ async function rehydratePart(
     // than silently dropping it.
     return { type: "text", text: `[Attachment unavailable: ${part.name}]` };
   }
+}
+
+async function rehydratePdfPart(
+  part: Extract<UserContentPart, { type: "resource_link" }>,
+  fileStore: FileStore,
+  policy: FileInputPolicy,
+  budget: PdfRehydrationBudget,
+): Promise<LanguageModelV3TextPart | LanguageModelV3FilePart> {
+  if (!acceptsFileMime(policy, FILE_INPUT_MIMES.pdf) || !policy.pdf) {
+    return textMarker(part.name, part.mimeType);
+  }
+
+  const id = uriToFileId(part.uri);
+  if (!id) {
+    return { type: "text", text: `[Attached: ${part.name}]` };
+  }
+
+  try {
+    const entry = await fileStore.findEntry(id);
+    if (!entry) {
+      return { type: "text", text: `[Attachment unavailable: ${part.name}]` };
+    }
+    if (!PDF_TYPES.has(entry.mimeType)) {
+      return textMarker(part.name, entry.mimeType);
+    }
+    if (entry.size > policy.pdf.maxFileBytes || entry.size > budget.pdfRemainingBytes) {
+      return textMarker(part.name, entry.mimeType);
+    }
+
+    const read = await fileStore.readFile(id);
+    if (!PDF_TYPES.has(read.mimeType)) {
+      return textMarker(part.name, read.mimeType);
+    }
+    if (read.size > policy.pdf.maxFileBytes || read.size > budget.pdfRemainingBytes) {
+      return textMarker(part.name, read.mimeType);
+    }
+
+    budget.pdfRemainingBytes -= read.size;
+    return {
+      type: "file",
+      mediaType: read.mimeType,
+      data: new Uint8Array(read.data),
+      filename: part.name,
+    };
+  } catch {
+    return { type: "text", text: `[Attachment unavailable: ${part.name}]` };
+  }
+}
+
+function textMarker(name: string, mimeType: string): LanguageModelV3TextPart {
+  return {
+    type: "text",
+    text: `[Attached: ${name} (${mimeType}) — call files__read to access]`,
+  };
 }

--- a/src/files/rehydrate.ts
+++ b/src/files/rehydrate.ts
@@ -26,6 +26,7 @@ import {
   FILE_INPUT_MIMES,
   getFileInputPolicy,
 } from "../model/file-capabilities.ts";
+import { extractText } from "./extract.ts";
 import { IMAGE_TYPES, PDF_TYPES } from "./ingest.ts";
 import type { FileStore } from "./store.ts";
 import { uriToFileId } from "./uri.ts";
@@ -42,6 +43,7 @@ const REHYDRATABLE_IMAGE_MIMES = new Set([...IMAGE_TYPES].filter((m) => m !== "i
 // Internal runtime seam: callers must pass the resolved provider-qualified model.
 export interface RehydrateOptions {
   model: string;
+  maxExtractedTextSize: number;
 }
 
 interface PdfRehydrationBudget {
@@ -59,8 +61,10 @@ export async function rehydrateUserResources(
   const budget: PdfRehydrationBudget = {
     pdfRemainingBytes: policy.pdf?.maxTotalBytes ?? 0,
   };
+  const currentUserMessageIndex = findLastUserMessageIndex(messages);
   const out: LanguageModelV3Message[] = [];
-  for (const msg of messages) {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]!;
     if (msg.role !== "user") {
       // Strip the platform extras (timestamp, userId, metadata) so the
       // returned shape is exactly `LanguageModelV3Message` — what the
@@ -76,7 +80,12 @@ export async function rehydrateUserResources(
 
     const newContent: Array<LanguageModelV3TextPart | LanguageModelV3FilePart> = [];
     for (const part of msg.content) {
-      newContent.push(await rehydratePart(part, fileStore, policy, budget));
+      newContent.push(
+        await rehydratePart(part, fileStore, policy, budget, {
+          isCurrentUserMessage: i === currentUserMessageIndex,
+          maxExtractedTextSize: options.maxExtractedTextSize,
+        }),
+      );
     }
     out.push(
       msg.providerOptions
@@ -87,11 +96,19 @@ export async function rehydrateUserResources(
   return out;
 }
 
+function findLastUserMessageIndex(messages: StoredMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") return i;
+  }
+  return -1;
+}
+
 async function rehydratePart(
   part: UserContentPart,
   fileStore: FileStore,
   policy: FileInputPolicy,
   budget: PdfRehydrationBudget,
+  options: { isCurrentUserMessage: boolean; maxExtractedTextSize: number },
 ): Promise<LanguageModelV3TextPart | LanguageModelV3FilePart> {
   if (part.type === "text") {
     return { type: "text", text: part.text };
@@ -101,7 +118,7 @@ async function rehydratePart(
     return rehydrateImagePart(part, fileStore);
   }
   if (PDF_TYPES.has(part.mimeType)) {
-    return rehydratePdfPart(part, fileStore, policy, budget);
+    return rehydratePdfPart(part, fileStore, policy, budget, options);
   }
   return textMarker(part.name, part.mimeType);
 }
@@ -143,11 +160,8 @@ async function rehydratePdfPart(
   fileStore: FileStore,
   policy: FileInputPolicy,
   budget: PdfRehydrationBudget,
+  options: { isCurrentUserMessage: boolean; maxExtractedTextSize: number },
 ): Promise<LanguageModelV3TextPart | LanguageModelV3FilePart> {
-  if (!acceptsFileMime(policy, FILE_INPUT_MIMES.pdf) || !policy.pdf) {
-    return textMarker(part.name, part.mimeType);
-  }
-
   const id = uriToFileId(part.uri);
   if (!id) {
     return { type: "text", text: `[Attached: ${part.name}]` };
@@ -161,28 +175,65 @@ async function rehydratePdfPart(
     if (!PDF_TYPES.has(entry.mimeType)) {
       return textMarker(part.name, entry.mimeType);
     }
-    if (entry.size > policy.pdf.maxFileBytes || entry.size > budget.pdfRemainingBytes) {
-      return textMarker(part.name, entry.mimeType);
-    }
+
+    const canInlineNativePdf =
+      options.isCurrentUserMessage &&
+      acceptsFileMime(policy, FILE_INPUT_MIMES.pdf) &&
+      policy.pdf &&
+      entry.size <= policy.pdf.maxFileBytes &&
+      entry.size <= budget.pdfRemainingBytes;
 
     const read = await fileStore.readFile(id);
     if (!PDF_TYPES.has(read.mimeType)) {
       return textMarker(part.name, read.mimeType);
     }
-    if (read.size > policy.pdf.maxFileBytes || read.size > budget.pdfRemainingBytes) {
-      return textMarker(part.name, read.mimeType);
+
+    if (
+      canInlineNativePdf &&
+      policy.pdf &&
+      read.size <= policy.pdf.maxFileBytes &&
+      read.size <= budget.pdfRemainingBytes
+    ) {
+      budget.pdfRemainingBytes -= read.size;
+      return {
+        type: "file",
+        mediaType: read.mimeType,
+        data: new Uint8Array(read.data),
+        filename: part.name,
+      };
     }
 
-    budget.pdfRemainingBytes -= read.size;
-    return {
-      type: "file",
-      mediaType: read.mimeType,
-      data: new Uint8Array(read.data),
-      filename: part.name,
-    };
+    return await pdfTextFallback(part.name, id, read, options.maxExtractedTextSize);
   } catch {
     return { type: "text", text: `[Attachment unavailable: ${part.name}]` };
   }
+}
+
+async function pdfTextFallback(
+  name: string,
+  id: string,
+  read: { data: Buffer; mimeType: string; size: number },
+  maxExtractedTextSize: number,
+): Promise<LanguageModelV3TextPart> {
+  const result = await extractText(read.data, read.mimeType, maxExtractedTextSize, {
+    truncatedSuffix: (kb) => `\n[... truncated at ${kb} KB]`,
+  });
+  if (!result) {
+    return {
+      type: "text",
+      text: `[Attached PDF: ${name} (${read.mimeType}). This model cannot receive the PDF bytes directly, and text extraction failed.]`,
+    };
+  }
+  return {
+    type: "text",
+    text: `--- Attached PDF: ${name} (${id}, ${humanSize(read.size)}) ---\n${result.text}`,
+  };
+}
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1_048_576) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / 1_048_576).toFixed(1)} MB`;
 }
 
 function textMarker(name: string, mimeType: string): LanguageModelV3TextPart {

--- a/src/files/rehydrate.ts
+++ b/src/files/rehydrate.ts
@@ -26,9 +26,10 @@ import {
   FILE_INPUT_MIMES,
   getFileInputPolicy,
 } from "../model/file-capabilities.ts";
-import { extractText } from "./extract.ts";
+import { extractText, REHYDRATE_TRUNCATED_SUFFIX } from "./extract.ts";
 import { IMAGE_TYPES, PDF_TYPES } from "./ingest.ts";
 import type { FileStore } from "./store.ts";
+import type { ExtractedTextSidecar } from "./types.ts";
 import { uriToFileId } from "./uri.ts";
 
 /**
@@ -176,25 +177,30 @@ async function rehydratePdfPart(
       return textMarker(part.name, entry.mimeType);
     }
 
+    // Narrow the policy once. `acceptsFileMime` already gates on
+    // `policy.pdf` being defined, but we need the narrowed reference
+    // for the size + budget checks below.
+    const pdfPolicy =
+      options.isCurrentUserMessage && acceptsFileMime(policy, FILE_INPUT_MIMES.pdf)
+        ? policy.pdf
+        : undefined;
+
     const canInlineNativePdf =
-      options.isCurrentUserMessage &&
-      acceptsFileMime(policy, FILE_INPUT_MIMES.pdf) &&
-      policy.pdf &&
-      entry.size <= policy.pdf.maxFileBytes &&
+      pdfPolicy !== undefined &&
+      entry.size <= pdfPolicy.maxFileBytes &&
       entry.size <= budget.pdfRemainingBytes;
 
-    const read = await fileStore.readFile(id);
-    if (!PDF_TYPES.has(read.mimeType)) {
-      return textMarker(part.name, read.mimeType);
-    }
-
-    if (
-      canInlineNativePdf &&
-      policy.pdf &&
-      read.size <= policy.pdf.maxFileBytes &&
-      read.size <= budget.pdfRemainingBytes
-    ) {
+    if (canInlineNativePdf) {
+      // Native inline path: bytes go straight to the model. We also
+      // opportunistically populate the extracted-text sidecar so the
+      // next turn (when this PDF is historical) hits the cache instead
+      // of re-loading bytes and re-running unpdf.
+      const read = await fileStore.readFile(id);
+      if (!PDF_TYPES.has(read.mimeType)) {
+        return textMarker(part.name, read.mimeType);
+      }
       budget.pdfRemainingBytes -= read.size;
+      void ensureSidecar(fileStore, id, read.data, read.mimeType, options.maxExtractedTextSize);
       return {
         type: "file",
         mediaType: read.mimeType,
@@ -203,30 +209,114 @@ async function rehydratePdfPart(
       };
     }
 
-    return await pdfTextFallback(part.name, id, read, options.maxExtractedTextSize);
+    // Text fallback: try the cached sidecar first. On hit, no bytes
+    // are loaded off disk and unpdf is not invoked.
+    const sidecar = await readUsableSidecar(fileStore, id, options.maxExtractedTextSize);
+    if (sidecar) {
+      return formatPdfFallback(part.name, id, entry.size, sidecar.text);
+    }
+
+    // Cache miss — fall back to live extraction and persist the result
+    // so subsequent turns are cheap. This is the only path that loads
+    // bytes for a non-current PDF.
+    const read = await fileStore.readFile(id);
+    if (!PDF_TYPES.has(read.mimeType)) {
+      return textMarker(part.name, read.mimeType);
+    }
+    const extracted = await extractAndPersist(
+      fileStore,
+      id,
+      read.data,
+      read.mimeType,
+      options.maxExtractedTextSize,
+    );
+    if (!extracted) {
+      return {
+        type: "text",
+        text: `[Attached PDF: ${part.name} (${read.mimeType}). This model cannot receive the PDF bytes directly, and text extraction failed.]`,
+      };
+    }
+    return formatPdfFallback(part.name, id, read.size, extracted.text);
   } catch {
     return { type: "text", text: `[Attachment unavailable: ${part.name}]` };
   }
 }
 
-async function pdfTextFallback(
+/**
+ * Return a sidecar suitable for the current `maxExtractedTextSize`. A
+ * sidecar written with a smaller budget is treated as stale because the
+ * caller may now want more text; a sidecar written with a larger budget
+ * is still usable (its text is bounded by the larger limit and the
+ * extracted-truncation suffix is stable).
+ */
+async function readUsableSidecar(
+  fileStore: FileStore,
+  id: string,
+  maxExtractedTextSize: number,
+): Promise<ExtractedTextSidecar | null> {
+  const sidecar = await fileStore.readExtractedText(id);
+  if (!sidecar) return null;
+  if (sidecar.maxSize < maxExtractedTextSize) return null;
+  return sidecar;
+}
+
+async function extractAndPersist(
+  fileStore: FileStore,
+  id: string,
+  data: Buffer,
+  mimeType: string,
+  maxExtractedTextSize: number,
+): Promise<ExtractedTextSidecar | null> {
+  const result = await extractText(data, mimeType, maxExtractedTextSize, {
+    truncatedSuffix: REHYDRATE_TRUNCATED_SUFFIX,
+  });
+  if (!result) return null;
+  const sidecar: ExtractedTextSidecar = {
+    text: result.text,
+    maxSize: maxExtractedTextSize,
+    truncated: result.truncated,
+  };
+  try {
+    await fileStore.writeExtractedText(id, sidecar);
+  } catch {
+    // Sidecar persistence is an optimisation; failing to write should
+    // not fail the rehydration.
+  }
+  return sidecar;
+}
+
+/**
+ * Background sidecar population for the native-inline path. We've already
+ * loaded the bytes for the file part, so extraction is cheap relative to
+ * the model call. Running it without awaiting means the user-visible
+ * latency on this turn is unchanged; on the next turn (this PDF now
+ * historical) the cache will be warm.
+ */
+function ensureSidecar(
+  fileStore: FileStore,
+  id: string,
+  data: Buffer,
+  mimeType: string,
+  maxExtractedTextSize: number,
+): void {
+  void (async () => {
+    const existing = await fileStore.readExtractedText(id);
+    if (existing && existing.maxSize >= maxExtractedTextSize) return;
+    await extractAndPersist(fileStore, id, data, mimeType, maxExtractedTextSize);
+  })().catch(() => {
+    // Best effort; rehydrate's text-fallback path will retry on miss.
+  });
+}
+
+function formatPdfFallback(
   name: string,
   id: string,
-  read: { data: Buffer; mimeType: string; size: number },
-  maxExtractedTextSize: number,
-): Promise<LanguageModelV3TextPart> {
-  const result = await extractText(read.data, read.mimeType, maxExtractedTextSize, {
-    truncatedSuffix: (kb) => `\n[... truncated at ${kb} KB]`,
-  });
-  if (!result) {
-    return {
-      type: "text",
-      text: `[Attached PDF: ${name} (${read.mimeType}). This model cannot receive the PDF bytes directly, and text extraction failed.]`,
-    };
-  }
+  size: number,
+  text: string,
+): LanguageModelV3TextPart {
   return {
     type: "text",
-    text: `--- Attached PDF: ${name} (${id}, ${humanSize(read.size)}) ---\n${result.text}`,
+    text: `--- Attached PDF: ${name} (${id}, ${humanSize(size)}) ---\n${text}`,
   };
 }
 

--- a/src/files/store.ts
+++ b/src/files/store.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { appendFile, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
-import type { FileEntry } from "./types.ts";
+import type { ExtractedTextSidecar, FileEntry } from "./types.ts";
 
 /** Sanitize a filename: strip path separators, null bytes, and control chars (0x00-0x1F). */
 export function sanitizeFilename(name: string): string {
@@ -43,6 +43,14 @@ export interface FileStore {
   appendTombstone(id: string): Promise<void>;
   deleteFile(id: string): Promise<void>;
   ensureFilesDir(): Promise<void>;
+  /**
+   * Read the extracted-text sidecar for `id`. Returns null if the sidecar
+   * is missing or unreadable. Callers decide invalidation by comparing
+   * `maxSize` against their current config.
+   */
+  readExtractedText(id: string): Promise<ExtractedTextSidecar | null>;
+  /** Write (or overwrite) the extracted-text sidecar for `id`. */
+  writeExtractedText(id: string, sidecar: ExtractedTextSidecar): Promise<void>;
 }
 
 /**
@@ -180,6 +188,39 @@ export function createFileStore(filesDir: string): FileStore {
     } catch {
       // File already gone from disk — tombstone still recorded.
     }
+    // Best-effort sidecar cleanup. The sidecar is derived, so a stale
+    // copy isn't a correctness issue, but leaving it on disk leaks space.
+    try {
+      await unlink(extractedSidecarPath(id));
+    } catch {
+      // Sidecar never existed or already removed.
+    }
+  }
+
+  function extractedSidecarPath(id: string): string {
+    return join(filesDir, `${id}.extracted.json`);
+  }
+
+  async function readExtractedText(id: string): Promise<ExtractedTextSidecar | null> {
+    try {
+      const raw = await readFile(extractedSidecarPath(id), "utf-8");
+      const parsed = JSON.parse(raw) as ExtractedTextSidecar;
+      if (
+        typeof parsed.text !== "string" ||
+        typeof parsed.maxSize !== "number" ||
+        typeof parsed.truncated !== "boolean"
+      ) {
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  async function writeExtractedText(id: string, sidecar: ExtractedTextSidecar): Promise<void> {
+    await ensureFilesDir();
+    await writeFile(extractedSidecarPath(id), JSON.stringify(sidecar));
   }
 
   return {
@@ -192,5 +233,7 @@ export function createFileStore(filesDir: string): FileStore {
     appendTombstone,
     deleteFile,
     ensureFilesDir,
+    readExtractedText,
+    writeExtractedText,
   };
 }

--- a/src/files/types.ts
+++ b/src/files/types.ts
@@ -34,9 +34,9 @@ export interface IngestResult {
  *
  * Text and MCP `resource_link` only — bytes for binary attachments are
  * persisted in the workspace `FileStore` and referenced by URI. The
- * runtime rehydrates image resource_links into AI SDK V3 `file` parts at
- * the `model.doStream` boundary; non-image resource_links are surfaced
- * to the model as text references.
+ * runtime rehydrates supported resource_links into AI SDK V3 `file` parts
+ * at the `model.doStream` boundary; unsupported resource_links are
+ * surfaced to the model as text references.
  */
 export type ContentPart =
   | { type: "text"; text: string }

--- a/src/files/types.ts
+++ b/src/files/types.ts
@@ -1,3 +1,17 @@
+/**
+ * Cached extracted-text sidecar for a stored file.
+ *
+ * Persisted next to the bytes (`${id}.extracted.json`) so derived text is
+ * computed once per file and reused on every rehydration. Invalidated by
+ * `maxSize` mismatch — if the runtime's `maxExtractedTextSize` changes,
+ * the cache is regenerated on next read.
+ */
+export interface ExtractedTextSidecar {
+  text: string;
+  maxSize: number;
+  truncated: boolean;
+}
+
 /** Workspace file entry stored in registry.jsonl */
 export interface FileEntry {
   id: string;

--- a/src/model/file-capabilities.ts
+++ b/src/model/file-capabilities.ts
@@ -1,7 +1,20 @@
+import { getModelByString } from "./catalog.ts";
+
 const PDF_MIME = "application/pdf";
 
-const ANTHROPIC_PDF_REQUEST_LIMIT_BYTES = 32 * 1024 * 1024;
-const OPENAI_PDF_REQUEST_LIMIT_BYTES = 50 * 1024 * 1024;
+// Per-provider PDF byte budgets. Per-file and per-request use the same
+// value: we keep one knob until the catalog grows a budget field.
+// Sources:
+//   - Anthropic: 32 MB request total (including all inputs).
+//   - OpenAI: 50 MB request total; per-file documented at 32 MB but the
+//     platform's `maxFileSize` upload cap (26 MB default) is what bounds
+//     per-file in practice.
+//   - Other providers fall through to a conservative default.
+const PROVIDER_PDF_LIMIT_BYTES: Record<string, number> = {
+  anthropic: 32 * 1024 * 1024,
+  openai: 50 * 1024 * 1024,
+};
+const DEFAULT_PDF_LIMIT_BYTES = 32 * 1024 * 1024;
 
 export interface FileInputPolicy {
   pdf?: {
@@ -10,42 +23,23 @@ export interface FileInputPolicy {
   };
 }
 
+/**
+ * Derive a provider-aware file-input policy for the resolved model from
+ * the model catalog (`src/model/catalog-data.json`). PDF support is read
+ * from `modalities.input` — one source of truth. Adding a new model or
+ * provider via `bun run sync-models` automatically picks up here; no
+ * second prefix list to keep in sync.
+ */
 export function getFileInputPolicy(modelString: string): FileInputPolicy {
-  const { provider, modelId } = parseResolvedModelString(modelString);
-
-  if (provider === "anthropic" && modelId.startsWith("claude-")) {
-    return {
-      pdf: {
-        maxFileBytes: ANTHROPIC_PDF_REQUEST_LIMIT_BYTES,
-        maxTotalBytes: ANTHROPIC_PDF_REQUEST_LIMIT_BYTES,
-      },
-    };
-  }
-
-  if (provider === "openai" && supportsOpenAiPdfInput(modelId)) {
-    return {
-      pdf: {
-        maxFileBytes: OPENAI_PDF_REQUEST_LIMIT_BYTES,
-        maxTotalBytes: OPENAI_PDF_REQUEST_LIMIT_BYTES,
-      },
-    };
-  }
-
-  return {};
+  const model = getModelByString(modelString);
+  if (!model) return {};
+  if (!model.modalities.input.includes("pdf")) return {};
+  const limit = PROVIDER_PDF_LIMIT_BYTES[model.provider] ?? DEFAULT_PDF_LIMIT_BYTES;
+  return { pdf: { maxFileBytes: limit, maxTotalBytes: limit } };
 }
 
 export function acceptsFileMime(policy: FileInputPolicy, mimeType: string): boolean {
   return mimeType === PDF_MIME && Boolean(policy.pdf);
-}
-
-function parseResolvedModelString(modelString: string): { provider: string; modelId: string } {
-  const idx = modelString.indexOf(":");
-  if (idx === -1) return { provider: "anthropic", modelId: modelString };
-  return { provider: modelString.slice(0, idx), modelId: modelString.slice(idx + 1) };
-}
-
-function supportsOpenAiPdfInput(modelId: string): boolean {
-  return modelId.startsWith("gpt-4o") || modelId.startsWith("gpt-5");
 }
 
 export const FILE_INPUT_MIMES = {

--- a/src/model/file-capabilities.ts
+++ b/src/model/file-capabilities.ts
@@ -1,0 +1,53 @@
+const PDF_MIME = "application/pdf";
+
+const ANTHROPIC_PDF_REQUEST_LIMIT_BYTES = 32 * 1024 * 1024;
+const OPENAI_PDF_REQUEST_LIMIT_BYTES = 50 * 1024 * 1024;
+
+export interface FileInputPolicy {
+  pdf?: {
+    maxFileBytes: number;
+    maxTotalBytes: number;
+  };
+}
+
+export function getFileInputPolicy(modelString: string): FileInputPolicy {
+  const { provider, modelId } = parseResolvedModelString(modelString);
+
+  if (provider === "anthropic" && modelId.startsWith("claude-")) {
+    return {
+      pdf: {
+        maxFileBytes: ANTHROPIC_PDF_REQUEST_LIMIT_BYTES,
+        maxTotalBytes: ANTHROPIC_PDF_REQUEST_LIMIT_BYTES,
+      },
+    };
+  }
+
+  if (provider === "openai" && supportsOpenAiPdfInput(modelId)) {
+    return {
+      pdf: {
+        maxFileBytes: OPENAI_PDF_REQUEST_LIMIT_BYTES,
+        maxTotalBytes: OPENAI_PDF_REQUEST_LIMIT_BYTES,
+      },
+    };
+  }
+
+  return {};
+}
+
+export function acceptsFileMime(policy: FileInputPolicy, mimeType: string): boolean {
+  return mimeType === PDF_MIME && Boolean(policy.pdf);
+}
+
+function parseResolvedModelString(modelString: string): { provider: string; modelId: string } {
+  const idx = modelString.indexOf(":");
+  if (idx === -1) return { provider: "anthropic", modelId: modelString };
+  return { provider: modelString.slice(0, idx), modelId: modelString.slice(idx + 1) };
+}
+
+function supportsOpenAiPdfInput(modelId: string): boolean {
+  return modelId.startsWith("gpt-4o") || modelId.startsWith("gpt-5");
+}
+
+export const FILE_INPUT_MIMES = {
+  pdf: PDF_MIME,
+} as const;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -849,15 +849,6 @@ export class Runtime {
       layer3Entries,
     );
 
-    // Load history and rehydrate any `resource_link` blocks (attached
-    // images persisted as URI references) into AI SDK V3 `file` parts
-    // with bytes loaded from the workspace FileStore. This is the seam
-    // where the storage shape (URI references) meets the model-call
-    // shape (inline bytes) — see `src/files/rehydrate.ts`.
-    const history = await store.history(conversation);
-    const fileStore = createFileStore(join(this.getWorkspaceScopedDir(wsId), "files"));
-    const messages = await rehydrateUserResources(history, fileStore);
-
     // Workspace model overrides are in the RequestContext — read via getModelSlot()
 
     // Resolve model: support alias references (e.g., "alias:fast", "alias:reasoning")
@@ -875,6 +866,17 @@ export class Runtime {
     // options shape, log lines) reads `engineConfig.model` directly
     // and depends on it being qualified.
     resolvedModelString = resolveModelString(resolvedModelString);
+
+    // Load history and rehydrate any supported `resource_link` blocks
+    // (attached files persisted as URI references) into AI SDK V3 `file`
+    // parts with bytes loaded from the workspace FileStore. This is the seam
+    // where the storage shape (URI references) meets the model-call
+    // shape (inline bytes) — see `src/files/rehydrate.ts`.
+    const history = await store.history(conversation);
+    const fileStore = createFileStore(join(this.getWorkspaceScopedDir(wsId), "files"));
+    const messages = await rehydrateUserResources(history, fileStore, {
+      model: resolvedModelString,
+    });
 
     // Resolve maxOutputTokens FIRST — resolveThinking needs it to clamp the
     // thinking budget so visible-content headroom is always preserved.

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -876,6 +876,7 @@ export class Runtime {
     const fileStore = createFileStore(join(this.getWorkspaceScopedDir(wsId), "files"));
     const messages = await rehydrateUserResources(history, fileStore, {
       model: resolvedModelString,
+      maxExtractedTextSize: this.getFilesConfig().maxExtractedTextSize,
     });
 
     // Resolve maxOutputTokens FIRST — resolveThinking needs it to clamp the

--- a/test/unit/files/extract.test.ts
+++ b/test/unit/files/extract.test.ts
@@ -57,6 +57,17 @@ describe("extractText", () => {
     expect(Buffer.byteLength(beforeNotice, "utf-8")).toBeLessThanOrEqual(maxSize);
   });
 
+  test("custom truncation notice replaces files__read hint", async () => {
+    const result = await extractText(Buffer.from("x".repeat(300)), "text/plain", 200, {
+      truncatedSuffix: (kb) => `\n[... truncated at ${kb} KB]`,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.truncated).toBe(true);
+    expect(result!.text).toContain("[... truncated at 0 KB]");
+    expect(result!.text).not.toContain("files__read");
+  });
+
   test("default maxSize truncates at 200KB", async () => {
     const size = 204_800 + 1000;
     const largeText = "a".repeat(size);

--- a/test/unit/files/integration.test.ts
+++ b/test/unit/files/integration.test.ts
@@ -97,6 +97,29 @@ describe("Integration: upload PNG image → ingest → verify resource_link cont
   });
 });
 
+describe("Integration: upload PDF → ingest → verify resource_link without extracted text", () => {
+  test("PDF file produces a resource_link content part and skips prompt text extraction", async () => {
+    const store = createFileStore(join(workDir, "files"));
+    const files = [makeFile(Buffer.from("%PDF-1.4\n%%EOF"), "report.pdf", "application/pdf")];
+
+    const result = await ingestFiles(files, "conv_int_pdf", store, DEFAULT_CONFIG);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.fileRefs).toHaveLength(1);
+    expect(result.fileRefs[0].extracted).toBe(false);
+    expect(result.fileRefs[0].mimeType).toBe("application/pdf");
+    expect(result.contentParts.filter((p) => p.type === "text")).toHaveLength(0);
+
+    const linkPart = result.contentParts.find((p) => p.type === "resource_link");
+    expect(linkPart).toBeDefined();
+    if (linkPart && linkPart.type === "resource_link") {
+      expect(linkPart.uri).toBe(`files://${result.fileRefs[0].id}`);
+      expect(linkPart.mimeType).toBe("application/pdf");
+      expect(linkPart.name).toBe("report.pdf");
+    }
+  });
+});
+
 describe("Integration: backward compat — no files → empty result", () => {
   test("empty files array returns empty contentParts, fileRefs, and no errors", async () => {
     const store = createFileStore(join(workDir, "files"));

--- a/test/unit/files/rehydrate.test.ts
+++ b/test/unit/files/rehydrate.test.ts
@@ -50,7 +50,7 @@ function fakeStore(
 
 const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const PDF_BYTES = Buffer.from("%PDF-1.4");
-const DEFAULT_OPTIONS = { model: "anthropic:claude-sonnet-4-6" };
+const DEFAULT_OPTIONS = { model: "anthropic:claude-sonnet-4-6", maxExtractedTextSize: 1024 };
 
 function userMessage(content: StoredMessage["content"]): StoredMessage {
   return {
@@ -120,7 +120,7 @@ describe("rehydrateUserResources", () => {
       const out = await rehydrateUserResources(
         [userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "doc.pdf" }])],
         store,
-        { model },
+        { model, maxExtractedTextSize: 1024 },
       );
 
       const msg = out[0]!;
@@ -130,7 +130,7 @@ describe("rehydrateUserResources", () => {
     }
   });
 
-  test("PDF resource_link on unsupported model -> text reference", async () => {
+  test("PDF resource_link on unsupported model -> safe text fallback", async () => {
     const store = fakeStore({
       fl_pdf1: { data: PDF_BYTES, mimeType: "application/pdf", filename: "doc.pdf" },
     });
@@ -138,7 +138,7 @@ describe("rehydrateUserResources", () => {
     const out = await rehydrateUserResources(
       [userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "doc.pdf" }])],
       store,
-      { model: "openai:o3-mini" },
+      { model: "openai:o3-mini", maxExtractedTextSize: 1024 },
     );
 
     const msg = out[0]!;
@@ -147,8 +147,34 @@ describe("rehydrateUserResources", () => {
     expect(msg.content[0]?.type).toBe("text");
     if (msg.content[0]?.type !== "text") return;
     expect(msg.content[0].text).toContain("doc.pdf");
-    expect(msg.content[0].text).toContain("files__read");
-    expect(store.readFileCalls).toHaveLength(0);
+    expect(msg.content[0].text).not.toContain("files__read");
+    expect(store.readFileCalls).toEqual(["fl_pdf1"]);
+  });
+
+  test("historical PDF resource_link on supported model does not replay as native file", async () => {
+    const store = fakeStore({
+      fl_pdf1: { data: PDF_BYTES, mimeType: "application/pdf", filename: "old.pdf" },
+    });
+
+    const out = await rehydrateUserResources(
+      [
+        userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "old.pdf" }]),
+        userMessage([{ type: "text", text: "next turn" }]),
+      ],
+      store,
+      DEFAULT_OPTIONS,
+    );
+
+    const historical = out[0]!;
+    const current = out[1]!;
+    expect(historical.role).toBe("user");
+    expect(current.role).toBe("user");
+    if (historical.role !== "user" || current.role !== "user") return;
+    expect(historical.content[0]?.type).toBe("text");
+    if (historical.content[0]?.type !== "text") return;
+    expect(historical.content[0].text).toContain("old.pdf");
+    expect(historical.content[0].text).not.toContain("files__read");
+    expect(current.content).toEqual([{ type: "text", text: "next turn" }]);
   });
 
   test("missing file -> text marker, no throw", async () => {
@@ -219,7 +245,7 @@ describe("rehydrateUserResources", () => {
     expect(msg.content[0]?.type).toBe("text");
   });
 
-  test("oversized PDF falls back without reading bytes", async () => {
+  test("oversized PDF falls back without files__read hint", async () => {
     const store = fakeStore({
       fl_big: {
         data: Buffer.from("tiny stub"),
@@ -239,7 +265,9 @@ describe("rehydrateUserResources", () => {
     expect(msg.role).toBe("user");
     if (msg.role !== "user") return;
     expect(msg.content[0]?.type).toBe("text");
-    expect(store.readFileCalls).toHaveLength(0);
+    if (msg.content[0]?.type !== "text") return;
+    expect(msg.content[0].text).not.toContain("files__read");
+    expect(store.readFileCalls).toEqual(["fl_big"]);
   });
 
   test("PDF total request budget falls back after budget is consumed", async () => {
@@ -267,7 +295,7 @@ describe("rehydrateUserResources", () => {
         ]),
       ],
       store,
-      { model: "openai:gpt-5" },
+      { model: "openai:gpt-5", maxExtractedTextSize: 1024 },
     );
 
     const msg = out[0]!;
@@ -275,6 +303,8 @@ describe("rehydrateUserResources", () => {
     if (msg.role !== "user") return;
     expect(msg.content[0]?.type).toBe("file");
     expect(msg.content[1]?.type).toBe("text");
-    expect(store.readFileCalls).toEqual(["fl_a"]);
+    if (msg.content[1]?.type !== "text") return;
+    expect(msg.content[1].text).not.toContain("files__read");
+    expect(store.readFileCalls).toEqual(["fl_a", "fl_b"]);
   });
 });

--- a/test/unit/files/rehydrate.test.ts
+++ b/test/unit/files/rehydrate.test.ts
@@ -1,31 +1,47 @@
 import { describe, expect, test } from "bun:test";
+import type { StoredMessage } from "../../../src/conversation/types.ts";
 import { rehydrateUserResources } from "../../../src/files/rehydrate.ts";
 import type { FileStore } from "../../../src/files/store.ts";
-import type { StoredMessage } from "../../../src/conversation/types.ts";
+import type { FileEntry } from "../../../src/files/types.ts";
 
-/**
- * Minimal FileStore stub. Only `readFile` is exercised by the rehydration
- * path; the other methods throw to make any unintended use loud.
- */
-function fakeStore(byId: Record<string, { data: Buffer; mimeType: string; filename: string }>): FileStore {
+function fakeStore(
+  byId: Record<string, { data: Buffer; mimeType: string; filename: string; size?: number }>,
+): FileStore & { readFileCalls: string[] } {
+  const readFileCalls: string[] = [];
   return {
+    readFileCalls,
     saveFile: () => {
       throw new Error("not used");
     },
     readFile: async (id) => {
+      readFileCalls.push(id);
       const entry = byId[id];
       if (!entry) throw new Error(`File not found: ${id}`);
       return {
         data: entry.data,
         filename: entry.filename,
         mimeType: entry.mimeType,
-        size: entry.data.length,
+        size: entry.size ?? entry.data.length,
       };
     },
     resolveFilePath: () => Promise.reject(new Error("not used")),
     appendRegistry: () => Promise.reject(new Error("not used")),
     readRegistry: () => Promise.reject(new Error("not used")),
-    findEntry: () => Promise.reject(new Error("not used")),
+    findEntry: async (id) => {
+      const entry = byId[id];
+      if (!entry) return null;
+      return {
+        id,
+        filename: entry.filename,
+        mimeType: entry.mimeType,
+        size: entry.size ?? entry.data.length,
+        tags: [],
+        source: "chat",
+        conversationId: "conv_test",
+        createdAt: "2026-05-07T00:00:00.000Z",
+        description: null,
+      } satisfies FileEntry;
+    },
     appendTombstone: () => Promise.reject(new Error("not used")),
     deleteFile: () => Promise.reject(new Error("not used")),
     ensureFilesDir: () => Promise.reject(new Error("not used")),
@@ -33,99 +49,116 @@ function fakeStore(byId: Record<string, { data: Buffer; mimeType: string; filena
 }
 
 const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PDF_BYTES = Buffer.from("%PDF-1.4");
+const DEFAULT_OPTIONS = { model: "anthropic:claude-sonnet-4-6" };
+
+function userMessage(content: StoredMessage["content"]): StoredMessage {
+  return {
+    role: "user",
+    content,
+    timestamp: "2026-05-07T00:00:00.000Z",
+  };
+}
 
 describe("rehydrateUserResources", () => {
-  test("image resource_link → AI SDK file part with raw bytes", async () => {
+  test("image resource_link -> AI SDK file part with raw bytes", async () => {
     const store = fakeStore({
       fl_test1: { data: PNG_BYTES, mimeType: "image/png", filename: "photo.png" },
     });
 
-    const messages: StoredMessage[] = [
-      {
-        role: "user",
-        content: [
+    const out = await rehydrateUserResources(
+      [
+        userMessage([
           { type: "text", text: "what's in this picture?" },
-          {
-            type: "resource_link",
-            uri: "files://fl_test1",
-            mimeType: "image/png",
-            name: "photo.png",
-          },
-        ],
-        timestamp: "2026-05-07T00:00:00.000Z",
-      },
-    ];
+          { type: "resource_link", uri: "files://fl_test1", mimeType: "image/png", name: "photo.png" },
+        ]),
+      ],
+      store,
+      DEFAULT_OPTIONS,
+    );
 
-    const out = await rehydrateUserResources(messages, store);
-    expect(out).toHaveLength(1);
     const msg = out[0]!;
     expect(msg.role).toBe("user");
     if (msg.role !== "user") return;
-    expect(msg.content).toHaveLength(2);
-
     expect(msg.content[0]).toEqual({ type: "text", text: "what's in this picture?" });
-
     const filePart = msg.content[1]!;
     expect(filePart.type).toBe("file");
     if (filePart.type !== "file") return;
     expect(filePart.mediaType).toBe("image/png");
     expect(filePart.filename).toBe("photo.png");
-    expect(filePart.data).toBeInstanceOf(Uint8Array);
     expect(Buffer.from(filePart.data as Uint8Array).equals(PNG_BYTES)).toBe(true);
   });
 
-  test("non-image resource_link → text reference (no model-side file part)", async () => {
-    // PDFs and other non-image attachments survive as a text marker — the
-    // model can call `files__read` if it needs the bytes, and the AI SDK
-    // would drop unknown blocks at the API boundary anyway.
+  test("PDF resource_link -> AI SDK file part for Anthropic Claude", async () => {
     const store = fakeStore({
-      fl_pdf1: { data: Buffer.from("%PDF-1.4"), mimeType: "application/pdf", filename: "doc.pdf" },
+      fl_pdf1: { data: PDF_BYTES, mimeType: "application/pdf", filename: "doc.pdf" },
     });
 
-    const messages: StoredMessage[] = [
-      {
-        role: "user",
-        content: [
-          {
-            type: "resource_link",
-            uri: "files://fl_pdf1",
-            mimeType: "application/pdf",
-            name: "doc.pdf",
-          },
-        ],
-        timestamp: "2026-05-07T00:00:00.000Z",
-      },
-    ];
+    const out = await rehydrateUserResources(
+      [userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "doc.pdf" }])],
+      store,
+      DEFAULT_OPTIONS,
+    );
 
-    const out = await rehydrateUserResources(messages, store);
     const msg = out[0]!;
     expect(msg.role).toBe("user");
     if (msg.role !== "user") return;
-    expect(msg.content).toHaveLength(1);
+    const filePart = msg.content[0]!;
+    expect(filePart.type).toBe("file");
+    if (filePart.type !== "file") return;
+    expect(filePart.mediaType).toBe("application/pdf");
+    expect(filePart.filename).toBe("doc.pdf");
+    expect(Buffer.from(filePart.data as Uint8Array).equals(PDF_BYTES)).toBe(true);
+  });
+
+  test("PDF resource_link -> AI SDK file part for supported OpenAI models", async () => {
+    for (const model of ["openai:gpt-4o", "openai:gpt-5", "openai:gpt-5.5"]) {
+      const store = fakeStore({
+        fl_pdf1: { data: PDF_BYTES, mimeType: "application/pdf", filename: "doc.pdf" },
+      });
+
+      const out = await rehydrateUserResources(
+        [userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "doc.pdf" }])],
+        store,
+        { model },
+      );
+
+      const msg = out[0]!;
+      expect(msg.role).toBe("user");
+      if (msg.role !== "user") return;
+      expect(msg.content[0]?.type).toBe("file");
+    }
+  });
+
+  test("PDF resource_link on unsupported model -> text reference", async () => {
+    const store = fakeStore({
+      fl_pdf1: { data: PDF_BYTES, mimeType: "application/pdf", filename: "doc.pdf" },
+    });
+
+    const out = await rehydrateUserResources(
+      [userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "doc.pdf" }])],
+      store,
+      { model: "openai:o3-mini" },
+    );
+
+    const msg = out[0]!;
+    expect(msg.role).toBe("user");
+    if (msg.role !== "user") return;
     expect(msg.content[0]?.type).toBe("text");
     if (msg.content[0]?.type !== "text") return;
     expect(msg.content[0].text).toContain("doc.pdf");
     expect(msg.content[0].text).toContain("files__read");
+    expect(store.readFileCalls).toHaveLength(0);
   });
 
-  test("missing file → text marker, no throw", async () => {
+  test("missing file -> text marker, no throw", async () => {
     const store = fakeStore({});
-    const messages: StoredMessage[] = [
-      {
-        role: "user",
-        content: [
-          {
-            type: "resource_link",
-            uri: "files://fl_missing",
-            mimeType: "image/png",
-            name: "ghost.png",
-          },
-        ],
-        timestamp: "2026-05-07T00:00:00.000Z",
-      },
-    ];
+    const out = await rehydrateUserResources(
+      [userMessage([{ type: "resource_link", uri: "files://fl_missing", mimeType: "image/png", name: "ghost.png" }])],
+      store,
+      DEFAULT_OPTIONS,
+    );
 
-    const out = await rehydrateUserResources(messages, store);
     const msg = out[0]!;
     expect(msg.role).toBe("user");
     if (msg.role !== "user") return;
@@ -146,47 +179,26 @@ describe("rehydrateUserResources", () => {
       },
     ];
 
-    const out = await rehydrateUserResources(messages, store);
-    expect(out).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "hi" }],
-      },
-    ]);
+    const out = await rehydrateUserResources(messages, store, DEFAULT_OPTIONS);
+    expect(out).toEqual([{ role: "assistant", content: [{ type: "text", text: "hi" }] }]);
   });
 
   test("link-vs-store MIME drift: trust the store, fall back to text", async () => {
-    // The link claims image/png (passes the early-exit check) but the
-    // FileStore reports something non-rehydratable (e.g., a manual JSONL
-    // edit or a forward-compat MIME taxonomy migration). The store is
-    // the source of truth — fall back to a text marker rather than send
-    // a part with a media type that lies about the bytes.
     const store = fakeStore({
       fl_drift: { data: Buffer.from("<svg/>"), mimeType: "image/svg+xml", filename: "ghost.png" },
     });
 
-    const messages: StoredMessage[] = [
-      {
-        role: "user",
-        content: [
-          {
-            type: "resource_link",
-            uri: "files://fl_drift",
-            mimeType: "image/png",
-            name: "ghost.png",
-          },
-        ],
-        timestamp: "2026-05-07T00:00:00.000Z",
-      },
-    ];
+    const out = await rehydrateUserResources(
+      [userMessage([{ type: "resource_link", uri: "files://fl_drift", mimeType: "image/png", name: "ghost.png" }])],
+      store,
+      DEFAULT_OPTIONS,
+    );
 
-    const out = await rehydrateUserResources(messages, store);
     const msg = out[0]!;
     expect(msg.role).toBe("user");
     if (msg.role !== "user") return;
     expect(msg.content[0]?.type).toBe("text");
     if (msg.content[0]?.type !== "text") return;
-    // Text marker uses the store's MIME — that's what the bytes really are.
     expect(msg.content[0].text).toContain("image/svg+xml");
   });
 
@@ -195,25 +207,74 @@ describe("rehydrateUserResources", () => {
       fl_svg: { data: Buffer.from("<svg/>"), mimeType: "image/svg+xml", filename: "logo.svg" },
     });
 
-    const messages: StoredMessage[] = [
-      {
-        role: "user",
-        content: [
-          {
-            type: "resource_link",
-            uri: "files://fl_svg",
-            mimeType: "image/svg+xml",
-            name: "logo.svg",
-          },
-        ],
-        timestamp: "2026-05-07T00:00:00.000Z",
-      },
-    ];
+    const out = await rehydrateUserResources(
+      [userMessage([{ type: "resource_link", uri: "files://fl_svg", mimeType: "image/svg+xml", name: "logo.svg" }])],
+      store,
+      DEFAULT_OPTIONS,
+    );
 
-    const out = await rehydrateUserResources(messages, store);
     const msg = out[0]!;
     expect(msg.role).toBe("user");
     if (msg.role !== "user") return;
     expect(msg.content[0]?.type).toBe("text");
+  });
+
+  test("oversized PDF falls back without reading bytes", async () => {
+    const store = fakeStore({
+      fl_big: {
+        data: Buffer.from("tiny stub"),
+        mimeType: "application/pdf",
+        filename: "big.pdf",
+        size: 32 * 1024 * 1024 + 1,
+      },
+    });
+
+    const out = await rehydrateUserResources(
+      [userMessage([{ type: "resource_link", uri: "files://fl_big", mimeType: "application/pdf", name: "big.pdf" }])],
+      store,
+      DEFAULT_OPTIONS,
+    );
+
+    const msg = out[0]!;
+    expect(msg.role).toBe("user");
+    if (msg.role !== "user") return;
+    expect(msg.content[0]?.type).toBe("text");
+    expect(store.readFileCalls).toHaveLength(0);
+  });
+
+  test("PDF total request budget falls back after budget is consumed", async () => {
+    const halfOpenAiLimit = 25 * 1024 * 1024;
+    const store = fakeStore({
+      fl_a: {
+        data: Buffer.from("first"),
+        mimeType: "application/pdf",
+        filename: "a.pdf",
+        size: halfOpenAiLimit,
+      },
+      fl_b: {
+        data: Buffer.from("second"),
+        mimeType: "application/pdf",
+        filename: "b.pdf",
+        size: halfOpenAiLimit + 1,
+      },
+    });
+
+    const out = await rehydrateUserResources(
+      [
+        userMessage([
+          { type: "resource_link", uri: "files://fl_a", mimeType: "application/pdf", name: "a.pdf" },
+          { type: "resource_link", uri: "files://fl_b", mimeType: "application/pdf", name: "b.pdf" },
+        ]),
+      ],
+      store,
+      { model: "openai:gpt-5" },
+    );
+
+    const msg = out[0]!;
+    expect(msg.role).toBe("user");
+    if (msg.role !== "user") return;
+    expect(msg.content[0]?.type).toBe("file");
+    expect(msg.content[1]?.type).toBe("text");
+    expect(store.readFileCalls).toEqual(["fl_a"]);
   });
 });

--- a/test/unit/files/rehydrate.test.ts
+++ b/test/unit/files/rehydrate.test.ts
@@ -2,14 +2,36 @@ import { describe, expect, test } from "bun:test";
 import type { StoredMessage } from "../../../src/conversation/types.ts";
 import { rehydrateUserResources } from "../../../src/files/rehydrate.ts";
 import type { FileStore } from "../../../src/files/store.ts";
-import type { FileEntry } from "../../../src/files/types.ts";
+import type { ExtractedTextSidecar, FileEntry } from "../../../src/files/types.ts";
 
-function fakeStore(
-  byId: Record<string, { data: Buffer; mimeType: string; filename: string; size?: number }>,
-): FileStore & { readFileCalls: string[] } {
+interface FakeStoreEntry {
+  data: Buffer;
+  mimeType: string;
+  filename: string;
+  size?: number;
+  sidecar?: ExtractedTextSidecar;
+}
+
+interface FakeStore extends FileStore {
+  readFileCalls: string[];
+  readSidecarCalls: string[];
+  writeSidecarCalls: string[];
+  sidecars: Map<string, ExtractedTextSidecar>;
+}
+
+function fakeStore(byId: Record<string, FakeStoreEntry>): FakeStore {
   const readFileCalls: string[] = [];
+  const readSidecarCalls: string[] = [];
+  const writeSidecarCalls: string[] = [];
+  const sidecars = new Map<string, ExtractedTextSidecar>();
+  for (const [id, entry] of Object.entries(byId)) {
+    if (entry.sidecar) sidecars.set(id, entry.sidecar);
+  }
   return {
     readFileCalls,
+    readSidecarCalls,
+    writeSidecarCalls,
+    sidecars,
     saveFile: () => {
       throw new Error("not used");
     },
@@ -45,6 +67,14 @@ function fakeStore(
     appendTombstone: () => Promise.reject(new Error("not used")),
     deleteFile: () => Promise.reject(new Error("not used")),
     ensureFilesDir: () => Promise.reject(new Error("not used")),
+    readExtractedText: async (id) => {
+      readSidecarCalls.push(id);
+      return sidecars.get(id) ?? null;
+    },
+    writeExtractedText: async (id, sidecar) => {
+      writeSidecarCalls.push(id);
+      sidecars.set(id, sidecar);
+    },
   };
 }
 
@@ -306,5 +336,134 @@ describe("rehydrateUserResources", () => {
     if (msg.content[1]?.type !== "text") return;
     expect(msg.content[1].text).not.toContain("files__read");
     expect(store.readFileCalls).toEqual(["fl_a", "fl_b"]);
+  });
+
+  test("historical PDF cache hit reads sidecar without loading bytes or extracting", async () => {
+    const store = fakeStore({
+      fl_pdf1: {
+        data: Buffer.from("doesn't matter, should not be read"),
+        mimeType: "application/pdf",
+        filename: "doc.pdf",
+        sidecar: { text: "cached page text", maxSize: 1024, truncated: false },
+      },
+    });
+
+    const out = await rehydrateUserResources(
+      [
+        userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "doc.pdf" }]),
+        userMessage([{ type: "text", text: "follow up" }]),
+      ],
+      store,
+      DEFAULT_OPTIONS,
+    );
+
+    const historical = out[0]!;
+    expect(historical.role).toBe("user");
+    if (historical.role !== "user") return;
+    expect(historical.content[0]?.type).toBe("text");
+    if (historical.content[0]?.type !== "text") return;
+    expect(historical.content[0].text).toContain("cached page text");
+    expect(historical.content[0].text).not.toContain("files__read");
+    expect(store.readFileCalls).toEqual([]); // bytes never loaded
+    expect(store.writeSidecarCalls).toEqual([]); // cache hit, no rewrite
+    expect(store.readSidecarCalls).toEqual(["fl_pdf1"]);
+  });
+
+  test("historical PDF cache miss live-extracts and persists the sidecar", async () => {
+    // Real PDF bytes here would be ideal, but unpdf rejects the stub and
+    // returns null — which exercises the extraction-failed branch. The
+    // important behaviour is: bytes loaded once, sidecar write attempted
+    // (or skipped on failure), and the next turn would hit the cache.
+    const store = fakeStore({
+      fl_pdf1: { data: Buffer.from("%PDF-1.4\n%%EOF"), mimeType: "application/pdf", filename: "doc.pdf" },
+    });
+
+    const out = await rehydrateUserResources(
+      [
+        userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "doc.pdf" }]),
+        userMessage([{ type: "text", text: "follow up" }]),
+      ],
+      store,
+      DEFAULT_OPTIONS,
+    );
+
+    expect(store.readSidecarCalls).toEqual(["fl_pdf1"]); // sidecar checked first
+    expect(store.readFileCalls).toEqual(["fl_pdf1"]); // bytes loaded once on miss
+    const msg = out[0]!;
+    if (msg.role !== "user") return;
+    expect(msg.content[0]?.type).toBe("text");
+  });
+
+  test("sidecar with smaller maxSize than current config is invalidated", async () => {
+    const store = fakeStore({
+      fl_pdf1: {
+        data: Buffer.from("%PDF-1.4\n%%EOF"),
+        mimeType: "application/pdf",
+        filename: "doc.pdf",
+        sidecar: { text: "old cached text from smaller budget", maxSize: 512, truncated: true },
+      },
+    });
+
+    const out = await rehydrateUserResources(
+      [
+        userMessage([{ type: "resource_link", uri: "files://fl_pdf1", mimeType: "application/pdf", name: "doc.pdf" }]),
+        userMessage([{ type: "text", text: "follow up" }]),
+      ],
+      store,
+      { model: "anthropic:claude-sonnet-4-6", maxExtractedTextSize: 1024 },
+    );
+
+    // Stale sidecar is ignored; bytes loaded to live-extract.
+    expect(store.readSidecarCalls).toEqual(["fl_pdf1"]);
+    expect(store.readFileCalls).toEqual(["fl_pdf1"]);
+    const msg = out[0]!;
+    if (msg.role !== "user") return;
+    expect(msg.content[0]?.type).toBe("text");
+    if (msg.content[0]?.type !== "text") return;
+    expect(msg.content[0].text).not.toContain("old cached text");
+  });
+
+  test("registry entry missing on PDF path returns unavailable marker", async () => {
+    const store = fakeStore({});
+
+    const out = await rehydrateUserResources(
+      [userMessage([{ type: "resource_link", uri: "files://fl_gone", mimeType: "application/pdf", name: "ghost.pdf" }])],
+      store,
+      DEFAULT_OPTIONS,
+    );
+
+    const msg = out[0]!;
+    if (msg.role !== "user") return;
+    expect(msg.content[0]?.type).toBe("text");
+    if (msg.content[0]?.type !== "text") return;
+    expect(msg.content[0].text).toContain("unavailable");
+    expect(store.readFileCalls).toEqual([]); // never tried to load bytes
+  });
+
+  test("PDF link-vs-store MIME drift falls back to text marker without loading bytes", async () => {
+    // Link claims PDF but registry says the bytes are a docx. Trust the
+    // registry — emit a text marker, don't try to inline a mis-typed file.
+    const store = fakeStore({
+      fl_drift: {
+        data: Buffer.from("PK\x03\x04"),
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        filename: "report.pdf",
+      },
+    });
+
+    const out = await rehydrateUserResources(
+      [userMessage([{ type: "resource_link", uri: "files://fl_drift", mimeType: "application/pdf", name: "report.pdf" }])],
+      store,
+      DEFAULT_OPTIONS,
+    );
+
+    const msg = out[0]!;
+    if (msg.role !== "user") return;
+    expect(msg.content[0]?.type).toBe("text");
+    if (msg.content[0]?.type !== "text") return;
+    expect(msg.content[0].text).toContain(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+    expect(store.readFileCalls).toEqual([]); // routing decided from metadata only
   });
 });

--- a/test/unit/files/rehydrate.test.ts
+++ b/test/unit/files/rehydrate.test.ts
@@ -142,7 +142,9 @@ describe("rehydrateUserResources", () => {
   });
 
   test("PDF resource_link -> AI SDK file part for supported OpenAI models", async () => {
-    for (const model of ["openai:gpt-4o", "openai:gpt-5", "openai:gpt-5.5"]) {
+    // gpt-5 base is intentionally excluded — the catalog reports
+    // `modalities.input: ["text","image"]` for it (no pdf).
+    for (const model of ["openai:gpt-4o", "openai:gpt-4.1", "openai:gpt-5.5"]) {
       const store = fakeStore({
         fl_pdf1: { data: PDF_BYTES, mimeType: "application/pdf", filename: "doc.pdf" },
       });
@@ -325,7 +327,7 @@ describe("rehydrateUserResources", () => {
         ]),
       ],
       store,
-      { model: "openai:gpt-5", maxExtractedTextSize: 1024 },
+      { model: "openai:gpt-4o", maxExtractedTextSize: 1024 },
     );
 
     const msg = out[0]!;


### PR DESCRIPTION
## Summary
Addresses Issue [#189.](https://github.com/NimbleBrainInc/nimblebrain/issues/189)
This adds model-aware PDF rehydration for uploaded `resource_link` attachments. PDFs now persist as `files://` resource links, then rehydrate into AI SDK V3 `file` parts only when the resolved model supports native PDF file input and the file fits provider limits.
Audio remains out of scope per the issue.
## What Changed
- Added a model file-input capability policy for PDFs:
  - Anthropic `claude-*`: `application/pdf`, 32 MB request budget
  - OpenAI `gpt-4o*` and `gpt-5*`: `application/pdf`, 50 MB request budget
- Threaded the resolved provider-qualified model into `rehydrateUserResources(...)` from `runtime.chat`.
- Changed PDF ingest behavior:
  - Uploaded PDFs now persist as MCP `resource_link` parts.
  - PDFs no longer inject extracted text directly into the stored user message.
- Added PDF routing behavior:
  - Current user turn + supported model + within PDF byte budget: native AI SDK `file` part
  - Historical PDF, unsupported model, oversized PDF, or over request budget: bounded text fallback
  - Fallback text does not tell the model to call `files__read`, avoiding large base64 replay loops
- Preserved existing raster image rehydration behavior.
## Why
Before this change, PDFs were surfaced to the model as text markers like:
```text
[Attached: doc.pdf (application/pdf) — call files__read to access]
```
That forced capable models to spend an extra tool round-trip retrieving base64 content instead of receiving the PDF through native provider file input.
This PR lets PDF-capable models receive the latest uploaded PDF directly while avoiding repeated replay of historical PDFs as native file parts.

## Important Behavior Notes
- Native PDF inlining only applies to the latest/current user message.
- Historical PDFs are converted to bounded extracted text fallback instead of full native file parts.
- This prevents old uploaded PDFs from being resent as large binary inputs on every future turn.
- PDF request budgeting is scoped to PDFs only; broader mixed image/PDF byte budgeting can be handled separately.
- Audio is intentionally not implemented because Anthropic does not currently accept audio file parts.

## Tests
Focused tests pass locally:
```
bun test test/unit/files/rehydrate.test.ts test/unit/files/integration.test.ts test/unit/files/extract.test.ts
```
Result:
39 pass
0 fail

Static verification also passed earlier after refreshing dependencies with bun install:
bun run verify:static
Full bun run verify was started but interrupted during check:web, so CI should be treated as the final full-suite confirmation.

## Coverage Added
- PDF rehydrates to a native file part for Anthropic Claude.
- PDF rehydrates to a native file part for supported OpenAI models.
- PDF falls back to safe text on unsupported models.
- Historical PDFs do not replay as native file parts.
- Oversized PDFs fall back without a files__read hint.
- PDF request budget overflow falls back after budget is consumed.
- PDF ingest emits resource_link without extracted prompt text.
- Custom truncation fallback avoids the files__read hint.