### PR TITLE
chore: drop internal deployment path from heartbeat comment

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -35,9 +35,8 @@ const VERSION = process.env.NB_VERSION || pkg.version;
 
 /**
  * Interval between SSE comment heartbeats on /v1/chat/stream. Chosen to sit
- * safely below AWS ALB idle-timeout (60s default, raised to 900s in
- * `deployments/agent-platform/*`) while staying quiet enough to be
- * invisible to the user.
+ * safely below a typical proxy/load-balancer idle-timeout (60s on AWS ALB
+ * by default) while staying quiet enough to be invisible to the user.
  */
 const HEARTBEAT_INTERVAL_MS = 20_000;
 


### PR DESCRIPTION
## Summary

`src/api/handlers.ts:36-40` referenced `deployments/agent-platform/*` and a specific `900s` raised timeout in the SSE heartbeat comment. Both are internal infra details that don't belong in OSS code. Rewrite to cite the generic proxy idle-timeout rationale (60s AWS ALB default).

## Test plan

- [x] No behavior change (comment only)
- [x] HEARTBEAT_INTERVAL_MS still 20s; the 60s ceiling justification still holds