### PR TITLE
chore(deploy): bump Node 22 → 24 in platform and web Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 # fails with no clear cause.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl unzip git ca-certificates gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr bash \
     && rm -rf /var/lib/apt/lists/*

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,6 @@
 # check=skip=SecretsUsedInArgOrEnv
 # VITE_TURNSTILE_SITE_KEY is a public client-side key, not a secret.
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY package.json bun.lock ./
 RUN npm install


### PR DESCRIPTION
## Summary

- `Dockerfile`: `setup_22.x` → `setup_24.x` (agent platform image)
- `web/Dockerfile`: `node:22-alpine` → `node:24-alpine` (web build stage)

Node 24 has been Active LTS since October 2025. Node 22 LTS ends April 2027; Node 24 LTS ends April 2028 — bumping now buys ~12 extra months of support runway with effectively zero work.

## Risk

Low. Bun is the runtime; Node only serves:

1. Bundle UI build steps (Vite, Astro, etc.) inside `RUN for ui in src/bundles/*/ui ...`
2. The globally-installed `@nimblebrain/mpak` CLI
3. Bundles that shell out to Node tooling at runtime (e.g. synapse-astro-editor)
4. Web image's `vite build` stage

Neither tree has native deps, neither has an `engines` pin restricting Node version, and Vite 6 / TypeScript 5.7 both support Node 24.

CI uses `bun-version: latest` only (no `setup-node`), so no workflow changes needed.

## Test plan

- [ ] `docker build` agent platform image succeeds
- [ ] `docker run --rm --entrypoint node <image> --version` reports `v24.x`
- [ ] All bundle UIs build during image build (`src/bundles/*/ui`)
- [ ] `docker build` web image succeeds (`vite build` under Node 24)
- [ ] Staging acme tenant runs cleanly post-deploy
- [ ] All prod tenants redeployed

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)