### PR TITLE
fix(bundles): slug path bundle data directories

### DIFF
--- a/src/bundles/paths.ts
+++ b/src/bundles/paths.ts
@@ -87,7 +87,14 @@ export function bundleNameFromRef(ref: BundleRef): string {
 /**
  * Derive a safe directory name for per-bundle data isolation.
  * Uses the full scoped name to avoid collisions (e.g., @foo/tasks vs @bar/tasks).
- * Matches the mpak cache convention: @scope/name → scope-name
+ * Matches the mpak cache convention: @scope/name → scope-name.
+ *
+ * Case is preserved — the unsafe-char strip uses `/gi` and there is no
+ * `toLowerCase()`. This diverges intentionally from `slugifyServerName`
+ * above: server names are URL-routable identifiers and must be lowercase;
+ * dataDir slugs only need to round-trip on the filesystem, so preserving
+ * the caller's casing keeps `path:` bundle dirs visually traceable back
+ * to their source. Don't "consolidate" the two functions.
  */
 export function deriveBundleDataDir(name: string): string {
   return name

--- a/src/bundles/paths.ts
+++ b/src/bundles/paths.ts
@@ -90,7 +90,12 @@ export function bundleNameFromRef(ref: BundleRef): string {
  * Matches the mpak cache convention: @scope/name → scope-name
  */
 export function deriveBundleDataDir(name: string): string {
-  return name.replace("@", "").replace("/", "-");
+  return name
+    .replace(/^@/, "")
+    .replace(/[/.]/g, "-")
+    .replace(/[^a-z0-9-]/gi, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 /**

--- a/test/unit/runtime/bundles-workspace.test.ts
+++ b/test/unit/runtime/bundles-workspace.test.ts
@@ -26,6 +26,16 @@ describe("resolveBundleDataDir", () => {
     expect(result).toBe("/home/user/.nimblebrain/workspaces/ws_abc/data/acme-tasks");
   });
 
+  it("keeps absolute path bundle refs inside one data directory", () => {
+    const result = resolveBundleDataDir(
+      "/home/user/.nimblebrain/workspaces/ws_abc",
+      "/Users/dev/Code/synapse-apps/synapse-crm",
+    );
+    expect(result).toBe(
+      "/home/user/.nimblebrain/workspaces/ws_abc/data/Users-dev-Code-synapse-apps-synapse-crm",
+    );
+  });
+
   it("default workspace resolves correctly for backward compat", () => {
     // Default workspace path is simply the workDir itself
     const workDir = "/home/user/.nimblebrain";
@@ -34,8 +44,8 @@ describe("resolveBundleDataDir", () => {
   });
 });
 
-describe("deriveBundleDataDir (unchanged)", () => {
-  it("strips @ and replaces / with -", () => {
+describe("deriveBundleDataDir", () => {
+  it("strips scoped-package @ and replaces slash with dash", () => {
     expect(deriveBundleDataDir("@nimblebraininc/crm")).toBe("nimblebraininc-crm");
   });
 
@@ -46,5 +56,21 @@ describe("deriveBundleDataDir (unchanged)", () => {
   it("handles @scope/name pattern", () => {
     expect(deriveBundleDataDir("@foo/tasks")).toBe("foo-tasks");
     expect(deriveBundleDataDir("@bar/tasks")).toBe("bar-tasks");
+  });
+
+  it("collapses absolute path bundle refs into one directory segment", () => {
+    expect(deriveBundleDataDir("/abs/path/with/slashes")).toBe("abs-path-with-slashes");
+  });
+
+  it("replaces reverse-DNS separators", () => {
+    expect(deriveBundleDataDir("com.example/app")).toBe("com-example-app");
+  });
+
+  it("preserves capitals while replacing dots", () => {
+    expect(deriveBundleDataDir("Name.With.Capitals/app")).toBe("Name-With-Capitals-app");
+  });
+
+  it("collapses unsafe characters and duplicate dashes", () => {
+    expect(deriveBundleDataDir("/a//b @ c")).toBe("a-b-c");
   });
 });


### PR DESCRIPTION
## Summary
- [Fixes #224](https://github.com/NimbleBrainInc/nimblebrain/issues/224)
- Fix `deriveBundleDataDir()` so path-installed bundles produce a single safe data directory segment instead of nested paths.
- Preserve scoped package behavior while also normalizing dots, unsafe characters, duplicate dashes, and leading/trailing separators.
- Add focused coverage for scoped packages, absolute path bundles, reverse-DNS names, capitals, and unsafe characters.
## Verification
- `bun run verify`