### PR TITLE
fix(mcp): reclaim leaked transports via idle TTL + LRU eviction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,11 +59,13 @@ POSTHOG_API_KEY=
 
 # ── MCP Session Limits (optional) ─────────────────────────────────────────────
 
-# Maximum concurrent MCP sessions. Default: 50
-# MCP_MAX_SESSIONS=50
+# Maximum concurrent MCP sessions. Above this, new initialize requests evict
+# the least-recently-used transport rather than returning 429. Default: 100
+# MCP_MAX_SESSIONS=100
 
-# MCP session TTL in milliseconds. Default: 3600000 (1 hour)
-# MCP_SESSION_TTL_MS=3600000
+# MCP session idle TTL in seconds. Drives both the host's transport-map sweep
+# and the registry TTL. Default: 28800 (8 hours)
+# MCP_SESSION_TTL_SECONDS=28800
 
 # ── Web Client (Vite, optional) ───────────────────────────────────────────────
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,25 +279,21 @@ If none of those apply, write a tool action. A simple JSON read like "what's the
 
 Two-layer state model for `/mcp`. Don't merge them.
 
-- **Transport map** (`McpServerHost.transports`): per-process `Map<sessionId, TransportEntry>`. Owns the live `WebStandardStreamableHTTPServerTransport`, the SDK `Server` instance, in-flight JSON-RPC state, and the `lastAccessedAt` timestamp used by reclamation. Process-bound — never serialize, never share across processes.
+- **Transport map** (`McpServerHost.transports`): per-process LRU `Map<sessionId, TransportEntry>`. Owns the live `WebStandardStreamableHTTPServerTransport`, the SDK `Server` instance, in-flight JSON-RPC state, and `lastAccessedAt`. Process-bound — never serialize, never share across processes.
 - **`SessionRegistry`** (`src/api/session-store/`): pluggable cluster-shared metadata. Stores `{sessionId, identityId, workspaceId, createdAt, lastAccessedAt}` only. **No pod / instance / owner fields** — adding any would leak deployment vocabulary into a metadata interface. Implementations: `InMemorySessionRegistry` (default) and `RedisSessionRegistry`.
 
 Routing requests to the process owning a session's transport is the **load balancer's** job (ALB `lb_cookie` stickiness or header-hash on `Mcp-Session-Id`). The registry doesn't route; it can't move transports.
 
-**Reclamation policy on the transport map** (`McpServerHost`):
+**Reclamation invariants** — see `mcp-server.ts` file header for the why:
 
-- **Idle TTL** — `setInterval` sweep closes transports past `idleTtlMs`. Uses the same TTL value as the registry (threaded in from `Runtime.getSessionStoreTtlMs()`), so both layers reclaim on the same schedule. The host's sweep is what actually frees the JS heap; the registry's TTL becomes redundant safety on the metadata layer.
-- **LRU on capacity** — the transport `Map` is re-inserted on every touch so iteration order is LRU. When `transports.size >= MAX_MCP_SESSIONS`, a new initialize evicts the oldest entry before being admitted. **Capacity overflow is not a client error.** No 429 is returned for "too many sessions"; well-formed initializes always succeed.
-- Both paths funnel through `evict(sid, reason)`, which removes the entry from the map *before* calling `close()` to prevent a concurrent request from dispatching into a half-dead transport.
-
-Eviction emits `[mcp] evicting transport reason=idle|pressure sessionId=… idleMs=…` log lines. A spike in `reason=pressure` indicates the tenant's natural concurrency exceeds `MAX_MCP_SESSIONS` and the cap should be raised — it's a memory-budget knob, not a feature gate.
+- Idle TTL and LRU-on-capacity both go through `evict(sid, reason)`. **Delete from the map before calling `close()`**, never the reverse — concurrent-request race.
+- Same TTL drives both layers (`Runtime.getSessionStoreTtlMs()` → host sweep + registry). One knob.
+- Capacity overflow is never a 4xx. A well-formed initialize at `MAX_MCP_SESSIONS` evicts the LRU and is admitted. Do not reintroduce `Too many active sessions`.
 
 **Session-miss `error.data.reason`** has exactly two values:
 
 - `not_found` — registry has no entry (idle-TTL eviction or never created).
 - `unavailable` — registry has an entry; this process doesn't have the transport. Don't try to distinguish process-restart from sticky-miss in the response — operators do that via deploy timing + `transport-count vs registry-size` divergence.
-
-During eviction there's a small window where the local map has removed the entry but the registry-side delete (via the `onclose` cascade) hasn't landed yet; a request that races into that window sees `reason=unavailable` instead of `not_found`. Not a bug.
 
 **Prerequisites for `platform.replicas > 1`** (all four required):
 
@@ -306,7 +302,7 @@ During eviction there's a small window where the local map has removed the entry
 3. `sessionStore.type: "redis"`. Each tenant gets its own Redis instance in its own namespace (see `infra/CLAUDE.md` per-tenant Redis pattern). Default `nb:mcp:session:` keyPrefix is correct under that model.
 4. `platform.strategy.type: RollingUpdate`. Only after (1).
 
-**TTL units: seconds at the surface, ms internally.** Operator-facing: `MCP_SESSION_TTL_SECONDS` env (highest priority) > `sessionStore.ttlSeconds` config > 8h default. Conversion to ms happens in `Runtime.getSessionStoreTtlMs()` only — registry constructors, the host's idle sweep, and any other sweep math take ms. Don't add mixed-unit code elsewhere.
+**TTL units: seconds at the surface, ms internally.** Operator-facing: `MCP_SESSION_TTL_SECONDS` env (highest priority) > `sessionStore.ttlSeconds` config > 8h default. Conversion to ms happens in `Runtime.getSessionStoreTtlMs()` only — registry constructors and the host's idle sweep both take ms from there. Don't add mixed-unit code elsewhere.
 
 ## MCP App Bridge Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,15 +279,25 @@ If none of those apply, write a tool action. A simple JSON read like "what's the
 
 Two-layer state model for `/mcp`. Don't merge them.
 
-- **Transport map** (`McpServerHost.transports`): per-process `Map<sessionId, transport>`. Owns the live `WebStandardStreamableHTTPServerTransport`, the SDK `Server` instance, and in-flight JSON-RPC state. Process-bound — never serialize, never share across processes.
+- **Transport map** (`McpServerHost.transports`): per-process `Map<sessionId, TransportEntry>`. Owns the live `WebStandardStreamableHTTPServerTransport`, the SDK `Server` instance, in-flight JSON-RPC state, and the `lastAccessedAt` timestamp used by reclamation. Process-bound — never serialize, never share across processes.
 - **`SessionRegistry`** (`src/api/session-store/`): pluggable cluster-shared metadata. Stores `{sessionId, identityId, workspaceId, createdAt, lastAccessedAt}` only. **No pod / instance / owner fields** — adding any would leak deployment vocabulary into a metadata interface. Implementations: `InMemorySessionRegistry` (default) and `RedisSessionRegistry`.
 
 Routing requests to the process owning a session's transport is the **load balancer's** job (ALB `lb_cookie` stickiness or header-hash on `Mcp-Session-Id`). The registry doesn't route; it can't move transports.
+
+**Reclamation policy on the transport map** (`McpServerHost`):
+
+- **Idle TTL** — `setInterval` sweep closes transports past `idleTtlMs`. Uses the same TTL value as the registry (threaded in from `Runtime.getSessionStoreTtlMs()`), so both layers reclaim on the same schedule. The host's sweep is what actually frees the JS heap; the registry's TTL becomes redundant safety on the metadata layer.
+- **LRU on capacity** — the transport `Map` is re-inserted on every touch so iteration order is LRU. When `transports.size >= MAX_MCP_SESSIONS`, a new initialize evicts the oldest entry before being admitted. **Capacity overflow is not a client error.** No 429 is returned for "too many sessions"; well-formed initializes always succeed.
+- Both paths funnel through `evict(sid, reason)`, which removes the entry from the map *before* calling `close()` to prevent a concurrent request from dispatching into a half-dead transport.
+
+Eviction emits `[mcp] evicting transport reason=idle|pressure sessionId=… idleMs=…` log lines. A spike in `reason=pressure` indicates the tenant's natural concurrency exceeds `MAX_MCP_SESSIONS` and the cap should be raised — it's a memory-budget knob, not a feature gate.
 
 **Session-miss `error.data.reason`** has exactly two values:
 
 - `not_found` — registry has no entry (idle-TTL eviction or never created).
 - `unavailable` — registry has an entry; this process doesn't have the transport. Don't try to distinguish process-restart from sticky-miss in the response — operators do that via deploy timing + `transport-count vs registry-size` divergence.
+
+During eviction there's a small window where the local map has removed the entry but the registry-side delete (via the `onclose` cascade) hasn't landed yet; a request that races into that window sees `reason=unavailable` instead of `not_found`. Not a bug.
 
 **Prerequisites for `platform.replicas > 1`** (all four required):
 
@@ -296,7 +306,7 @@ Routing requests to the process owning a session's transport is the **load balan
 3. `sessionStore.type: "redis"`. Each tenant gets its own Redis instance in its own namespace (see `infra/CLAUDE.md` per-tenant Redis pattern). Default `nb:mcp:session:` keyPrefix is correct under that model.
 4. `platform.strategy.type: RollingUpdate`. Only after (1).
 
-**TTL units: seconds at the surface, ms internally.** Operator-facing: `MCP_SESSION_TTL_SECONDS` env (highest priority) > `sessionStore.ttlSeconds` config > 8h default. Conversion to ms happens in `Runtime.getSessionStoreTtlMs()` only — registry constructors and sweep math take ms. Don't add mixed-unit code elsewhere.
+**TTL units: seconds at the surface, ms internally.** Operator-facing: `MCP_SESSION_TTL_SECONDS` env (highest priority) > `sessionStore.ttlSeconds` config > 8h default. Conversion to ms happens in `Runtime.getSessionStoreTtlMs()` only — registry constructors, the host's idle sweep, and any other sweep math take ms. Don't add mixed-unit code elsewhere.
 
 ## MCP App Bridge Rules
 

--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ Run `nb --help` or `nb <command> --help` for full usage. If you haven't run `bun
 |----------|---------|
 | `NB_WORK_DIR` | Override working directory (takes precedence over config and `--workdir`) |
 | `ALLOWED_ORIGINS` | Comma-separated allowed CORS origins (for cookie-based auth) |
-| `MCP_MAX_SESSIONS` | Max concurrent MCP sessions (default: 100) |
-| `MCP_SESSION_TTL_MS` | MCP session inactivity TTL in ms (default: 1800000) |
+| `MCP_MAX_SESSIONS` | Max concurrent MCP sessions before LRU eviction kicks in (default: 100) |
+| `MCP_SESSION_TTL_SECONDS` | MCP session idle TTL in seconds; drives both transport-map sweep and registry TTL (default: 28800, i.e. 8h) |
 | `NB_CHAT_RATE_LIMIT` | Chat requests per minute per user (default: 20) |
 | `NB_TOOL_RATE_LIMIT` | Tool calls per minute per user (default: 60) |
 | `NB_BUNDLE_START_CONCURRENCY` | Max bundle subprocesses spawned in parallel at boot (default: 4, set to 1 for sequential) |
@@ -598,7 +598,7 @@ Bundles can be installed per-workspace (tracked via `BundleInstance.wsId`). Each
 
 **CORS:** Dynamic. Dev mode: `Access-Control-Allow-Origin: *`. With auth: only `ALLOWED_ORIGINS` env var origins, with credentials support.
 
-**MCP endpoint (`/mcp`):** Streamable HTTP. The bundled web UI uses this endpoint to drive the platform, and external MCP clients (Claude Code, Claude Desktop, Cursor) can connect to the same endpoint. 100 concurrent sessions (env: `MCP_MAX_SESSIONS`), 30-minute TTL (env: `MCP_SESSION_TTL_MS`). When `authkitDomain` is configured, returns `WWW-Authenticate` header on 401 for automatic OAuth discovery by MCP clients. Full setup guide: [MCP Endpoint](https://docs.nimblebrain.ai/api/mcp-endpoint/) and [Connecting External Clients](https://docs.nimblebrain.ai/guide/mcp-connect/) on docs.nimblebrain.ai.
+**MCP endpoint (`/mcp`):** Streamable HTTP. The bundled web UI uses this endpoint to drive the platform, and external MCP clients (Claude Code, Claude Desktop, Cursor) can connect to the same endpoint. 100 concurrent sessions (env: `MCP_MAX_SESSIONS`, LRU-evicted at the cap rather than 429'd), 8-hour idle TTL (env: `MCP_SESSION_TTL_SECONDS`). When `authkitDomain` is configured, returns `WWW-Authenticate` header on 401 for automatic OAuth discovery by MCP clients. Full setup guide: [MCP Endpoint](https://docs.nimblebrain.ai/api/mcp-endpoint/) and [Connecting External Clients](https://docs.nimblebrain.ai/guide/mcp-connect/) on docs.nimblebrain.ai.
 
 **Deploying behind a TLS-terminating proxy:** OAuth discovery advertises its `resource` URL from `X-Forwarded-Proto`, falling back to the request scheme. Upstream proxies (AWS ALB, nginx, Cloudflare, etc.) must set that header to the client-facing scheme (`https`) for MCP OAuth to work. The bundled `nimblebrain-web` Caddy container already honors it via `trusted_proxies static private_ranges`; if you front it with an additional proxy, ensure that proxy also propagates `X-Forwarded-Proto`. Without this, `/.well-known/oauth-protected-resource` returns `resource: http://...` and modern MCP clients reject the response. See [MCP OAuth behind a reverse proxy](https://docs.nimblebrain.ai/deploy/security/#mcp-oauth-behind-a-reverse-proxy) for ALB / nginx / Caddy snippets.
 

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -20,6 +20,26 @@
  *      the load balancer's job (cookie stickiness, header-hash), not the
  *      registry's.
  *
+ * Reclamation policy on the transport map (the layer that holds the heap):
+ *
+ *   - **Idle TTL** — a periodic sweep closes any transport whose
+ *     `lastAccessedAt` is older than the configured idle TTL. Same TTL the
+ *     registry uses; one knob (`MCP_SESSION_TTL_SECONDS`). This releases
+ *     orphaned transports from clients that vanish without sending DELETE
+ *     (mobile backgrounding, closed tabs, abandoned OAuth flows). The
+ *     registry's own TTL becomes redundant safety on the metadata layer.
+ *
+ *   - **LRU on capacity** — the map is ordered most-recently-used last.
+ *     When a new initialize arrives at capacity, the least-recently-used
+ *     transport is closed and replaced. Capacity overflow is **not** a
+ *     client error; well-formed initializes always succeed. The cap
+ *     (`MCP_MAX_SESSIONS`) is a memory-budget device, not a feature gate.
+ *
+ * Both reclamation paths funnel through `evict(sid, reason)`, which removes
+ * the entry from the map *before* calling `close()` — preventing a
+ * concurrent request from finding a half-dead transport between the close
+ * call and the SDK's `onclose` cascade.
+ *
  * On a request whose sessionId we don't have a local transport for:
  *
  *   - Registry says nothing exists → `not_found`. Session evicted or never
@@ -31,7 +51,10 @@
  *
  * Both return 404 with a JSON-RPC envelope; `error.data.reason` lets
  * operators correlate logs without the registry having to know what an
- * "instance" is.
+ * "instance" is. During eviction there is a small window where the local
+ * map has already removed the entry but the registry-side delete has not
+ * yet landed — in that window the response carries `reason: "unavailable"`
+ * instead of `"not_found"`. Not a bug; operators should be aware.
  */
 
 import { readFileSync } from "node:fs";
@@ -82,17 +105,22 @@ const MCP_SERVER_VERSION = process.env.NB_VERSION || mcpPkg.version;
 
 /* ── Capacity limit (configurable via env) ──
  *
- * Sessions are evicted on idle TTL (managed by the injected SessionRegistry,
- * not by this module). The cap below is a memory ceiling on the local
- * transport map: a misbehaving client that re-inits on every request can't
- * blow the heap by allocating transports faster than the registry's TTL
- * reclaims them. Override via `MCP_MAX_SESSIONS`.
+ * The cap is a memory ceiling on the local transport map. When a new
+ * initialize lands at capacity, the least-recently-used transport is
+ * evicted to make room — we never refuse a well-formed initialize.
+ * Override via `MCP_MAX_SESSIONS`.
  *
- * The TTL knob (`MCP_SESSION_TTL_SECONDS` / `sessionStore.ttlSeconds`) is
- * applied in `Runtime.getSessionStoreTtlMs()` — it shapes the registry,
- * not this map.
+ * Idle reclamation is independent: a periodic sweep closes transports
+ * whose `lastAccessedAt` is past the idle TTL. Same TTL knob the
+ * registry uses (`MCP_SESSION_TTL_SECONDS` / `sessionStore.ttlSeconds`),
+ * applied in `Runtime.getSessionStoreTtlMs()` and threaded into the
+ * host. Under normal load the cap should never bind; LRU is the safety
+ * valve, idle TTL is the primary release path.
  */
 const MAX_MCP_SESSIONS = parsePositiveIntEnv("MCP_MAX_SESSIONS", 100);
+
+/** Sweep cadence for the idle reclamation loop. Matches the in-memory registry. */
+const DEFAULT_SWEEP_INTERVAL_MS = 60_000;
 
 /**
  * Validate a positive-integer env var. Rejects NaN / non-positive values
@@ -115,6 +143,31 @@ export function parsePositiveIntEnv(name: string, fallback: number): number {
 interface TransportEntry {
   transport: WebStandardStreamableHTTPServerTransport;
   workspaceId: string;
+  /**
+   * Wall-clock ms of the last request that touched this transport. Drives
+   * both idle eviction (sweep closes entries older than `idleTtlMs`) and
+   * LRU ordering (the Map is mutated on each touch so iteration order is
+   * least-recently-used first).
+   */
+  lastAccessedAt: number;
+}
+
+export interface McpServerHostOptions {
+  registry: SessionRegistry;
+  /**
+   * Idle TTL in ms. Transports with no activity past this window are
+   * evicted by the periodic sweep. Required: there is no sensible default
+   * that wouldn't silently disable eviction on misconfiguration.
+   */
+  idleTtlMs: number;
+  /** Soft cap on concurrent transports. Overflow evicts least-recently-used. */
+  maxSessions?: number;
+  /**
+   * Sweep cadence in ms. Internal knob; production uses
+   * `DEFAULT_SWEEP_INTERVAL_MS`. Tests override to advance faster than
+   * wall-clock so short-TTL assertions don't take seconds.
+   */
+  sweepIntervalMs?: number;
 }
 
 /** Workspace context captured at session creation time. */
@@ -149,9 +202,35 @@ const TASKS_CAPABILITY: NonNullable<ServerCapabilities["tasks"]> = {
 export class McpServerHost {
   private readonly transports = new Map<string, TransportEntry>();
   private readonly registry: SessionRegistry;
+  private readonly idleTtlMs: number;
+  private readonly maxSessions: number;
+  private readonly sweepInterval: ReturnType<typeof setInterval>;
 
-  constructor(opts: { registry: SessionRegistry }) {
+  constructor(opts: McpServerHostOptions) {
     this.registry = opts.registry;
+    this.idleTtlMs = opts.idleTtlMs;
+    this.maxSessions = opts.maxSessions ?? MAX_MCP_SESSIONS;
+
+    // Validate up-front: silent eviction-disabled state must not ship to
+    // prod. Mirrors the philosophy of `parsePositiveIntEnv` for the env path.
+    if (!Number.isFinite(this.idleTtlMs) || this.idleTtlMs <= 0) {
+      throw new Error(`McpServerHost: idleTtlMs must be a positive number, got ${this.idleTtlMs}`);
+    }
+    if (
+      !Number.isFinite(this.maxSessions) ||
+      this.maxSessions <= 0 ||
+      !Number.isInteger(this.maxSessions)
+    ) {
+      throw new Error(
+        `McpServerHost: maxSessions must be a positive integer, got ${this.maxSessions}`,
+      );
+    }
+
+    const intervalMs = opts.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
+    this.sweepInterval = setInterval(() => this.sweepIdle(Date.now()), intervalMs);
+    if (typeof this.sweepInterval === "object" && "unref" in this.sweepInterval) {
+      this.sweepInterval.unref();
+    }
   }
 
   /**
@@ -201,6 +280,7 @@ export class McpServerHost {
    * during graceful server stop.
    */
   async shutdown(): Promise<void> {
+    clearInterval(this.sweepInterval);
     for (const [sid, entry] of this.transports) {
       try {
         await entry.transport.close();
@@ -230,9 +310,15 @@ export class McpServerHost {
     if (sessionId) {
       const local = this.transports.get(sessionId);
       if (local) {
-        // Fast path: we own this transport. Best-effort registry touch
-        // keeps the cluster-shared TTL aligned without blocking the request.
-        this.registry.touch(sessionId, Date.now()).catch((err) => {
+        // Fast path: we own this transport. Touch + re-insert moves the
+        // entry to the MRU end of the Map so LRU eviction picks the oldest
+        // first. Best-effort registry touch keeps the cluster-shared TTL
+        // aligned without blocking the request.
+        const now = Date.now();
+        local.lastAccessedAt = now;
+        this.transports.delete(sessionId);
+        this.transports.set(sessionId, local);
+        this.registry.touch(sessionId, now).catch((err) => {
           log.warn(`[mcp] registry touch failed: ${(err as Error).message}`);
         });
         return local.transport.handleRequest(request);
@@ -255,8 +341,13 @@ export class McpServerHost {
       return jsonRpcError(400, -32000, "Bad Request: No valid session ID provided");
     }
 
-    if (this.transports.size >= MAX_MCP_SESSIONS) {
-      return jsonRpcError(429, -32000, "Too many active sessions");
+    // At capacity, evict the least-recently-used transport (front of the
+    // Map iteration order) before admitting the new initialize. Well-formed
+    // initializes always succeed; the cap is a memory budget, not a 4xx.
+    while (this.transports.size >= this.maxSessions) {
+      const oldest = this.transports.keys().next();
+      if (oldest.done) break;
+      this.evict(oldest.value, "pressure");
     }
 
     return this.initializeSession(request, body, toolRegistry, features, workspaceCtx);
@@ -354,7 +445,7 @@ export class McpServerHost {
           return;
         }
 
-        this.transports.set(sid, { transport, workspaceId: wsId });
+        this.transports.set(sid, { transport, workspaceId: wsId, lastAccessedAt: now });
         // Fire-and-forget the registry write. The session is already live
         // on this process; if the registry is down we still serve the client.
         this.registry
@@ -385,6 +476,47 @@ export class McpServerHost {
     const server = createServer(toolRegistry, features, workspaceCtx);
     await server.connect(transport);
     return transport.handleRequest(request, { parsedBody });
+  }
+
+  /**
+   * Close a transport and remove it from the lookup map. Used by both
+   * reclamation paths (`sweepIdle` and capacity-pressure eviction in
+   * `handlePost`).
+   *
+   * Order matters: remove from `this.transports` BEFORE calling `close()`.
+   * The SDK's `close()` fires `transport.onclose` synchronously inside its
+   * body, which would run the existing cleanup cascade (map delete +
+   * registry delete) — but during the window between the close call and
+   * onclose firing, a concurrent request to the fast path could still see
+   * the entry and dispatch into a half-dead transport. Deleting first
+   * closes that window. The cascade's second `transports.delete(sid)` then
+   * becomes an idempotent no-op.
+   *
+   * Registry cleanup is delegated to the existing `transport.onclose`
+   * handler so we don't double-call `bestEffortDelete` from both paths.
+   */
+  private evict(sessionId: string, reason: "idle" | "pressure"): void {
+    const entry = this.transports.get(sessionId);
+    if (!entry) return;
+    const idleMs = Date.now() - entry.lastAccessedAt;
+    log.info(`[mcp] evicting transport reason=${reason} sessionId=${sessionId} idleMs=${idleMs}`);
+    this.transports.delete(sessionId);
+    entry.transport.close().catch((err) => {
+      log.warn(`[mcp] evict close failed sessionId=${sessionId}: ${(err as Error).message}`);
+    });
+  }
+
+  /**
+   * Walk the transport map oldest-first and evict any entry whose idle
+   * window has elapsed. Map iteration order is LRU order (we re-insert on
+   * touch), so we can stop at the first entry that's still within TTL —
+   * everything after it is newer.
+   */
+  private sweepIdle(now: number): void {
+    for (const [sid, entry] of this.transports) {
+      if (now - entry.lastAccessedAt <= this.idleTtlMs) break;
+      this.evict(sid, "idle");
+    }
   }
 
   /**

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -169,10 +169,14 @@ export function startServer(options: ServerOptions): ServerHandle {
   // session-metadata registry is either supplied by the caller (production
   // bootstrap building a Redis registry from config) or defaulted to an
   // in-memory store using the runtime's configured TTL.
+  const sessionTtlMs = runtime.getSessionStoreTtlMs();
   const sessionRegistry: SessionRegistry =
-    options.sessionRegistry ??
-    new InMemorySessionRegistry({ ttlMs: runtime.getSessionStoreTtlMs() });
-  const mcpHost = new McpServerHost({ registry: sessionRegistry });
+    options.sessionRegistry ?? new InMemorySessionRegistry({ ttlMs: sessionTtlMs });
+  // The host's idle-eviction TTL mirrors the registry's TTL: both layers
+  // reclaim the same logical session on the same schedule, with the host's
+  // sweep being what actually frees the JS heap. The registry TTL is a
+  // backstop on the metadata layer for the cluster-shared view.
+  const mcpHost = new McpServerHost({ registry: sessionRegistry, idleTtlMs: sessionTtlMs });
 
   // Build shared context for all route groups
   const ctx: AppContext = {

--- a/test/unit/api/mcp-server-host.test.ts
+++ b/test/unit/api/mcp-server-host.test.ts
@@ -44,7 +44,7 @@ describe("McpServerHost — session-miss classification", () => {
 
 	beforeEach(() => {
 		registry = new InMemorySessionRegistry({ ttlMs: 60_000 });
-		host = new McpServerHost({ registry });
+		host = new McpServerHost({ registry, idleTtlMs: 60_000 });
 		toolRegistry = new ToolRegistry();
 	});
 
@@ -105,7 +105,7 @@ describe("McpServerHost — session-miss classification", () => {
 			sweepExpired: async () => {},
 			shutdown: async () => {},
 		};
-		const flakyHost = new McpServerHost({ registry: flakyRegistry });
+		const flakyHost = new McpServerHost({ registry: flakyRegistry, idleTtlMs: 60_000 });
 
 		const res = await flakyHost.handle(postRequest(SAMPLE_SID), toolRegistry, FAKE_FEATURES, {
 			registry: toolRegistry,

--- a/test/unit/api/mcp-server-reclamation.test.ts
+++ b/test/unit/api/mcp-server-reclamation.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for `McpServerHost`'s reclamation policy:
+ *
+ *   - **Idle TTL** — periodic sweep closes transports past the idle window.
+ *   - **LRU on capacity** — new initialize at cap evicts the oldest, not 429.
+ *   - **Touch reorders LRU** — an active session is never the eviction target.
+ *
+ * Each test drives the real `initializeSession` path via `host.handle()` with
+ * a JSON-RPC initialize body. That gives us real `WebStandardStreamableHTTP`
+ * transports in the map, with the SDK's full onclose cascade wired up — so
+ * a successful eviction is observable both via `transportCount()` and via
+ * the subsequent client request returning `Session not found`.
+ *
+ * TTLs are short wall-clock values (25–40 ms) matching the pattern used by
+ * `test/unit/api/session-store/conformance.ts` — no fake clock required.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { McpServerHost } from "../../../src/api/mcp-server.ts";
+import {
+	InMemorySessionRegistry,
+	type SessionRegistry,
+} from "../../../src/api/session-store/index.ts";
+import type { ResolvedFeatures } from "../../../src/config/features.ts";
+import { ToolRegistry } from "../../../src/tools/registry.ts";
+
+const FAKE_FEATURES = {} as ResolvedFeatures;
+const WORKSPACE_ID = "ws_test";
+
+function initRequest(): Request {
+	return new Request("http://test/mcp", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+		},
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			method: "initialize",
+			params: {
+				protocolVersion: "2025-11-25",
+				clientInfo: { name: "test", version: "0" },
+				capabilities: {},
+			},
+			id: 1,
+		}),
+	});
+}
+
+function listRequest(sessionId: string): Request {
+	return new Request("http://test/mcp", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+			"mcp-session-id": sessionId,
+		},
+		body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+	});
+}
+
+async function initSession(
+	host: McpServerHost,
+	toolRegistry: ToolRegistry,
+): Promise<string> {
+	const res = await host.handle(initRequest(), toolRegistry, FAKE_FEATURES, {
+		registry: toolRegistry,
+		identity: null,
+		workspaceId: WORKSPACE_ID,
+	});
+	const sid = res.headers.get("mcp-session-id");
+	if (!sid) {
+		throw new Error(`expected mcp-session-id header on init response; status=${res.status}`);
+	}
+	return sid;
+}
+
+async function touch(
+	host: McpServerHost,
+	toolRegistry: ToolRegistry,
+	sessionId: string,
+): Promise<void> {
+	await host.handle(listRequest(sessionId), toolRegistry, FAKE_FEATURES, {
+		registry: toolRegistry,
+		identity: null,
+		workspaceId: WORKSPACE_ID,
+	});
+}
+
+describe("McpServerHost — reclamation", () => {
+	let registry: SessionRegistry;
+	let host: McpServerHost;
+	let toolRegistry: ToolRegistry;
+
+	afterEach(async () => {
+		await host?.shutdown();
+	});
+
+	describe("idle TTL", () => {
+		beforeEach(() => {
+			registry = new InMemorySessionRegistry({ ttlMs: 25, sweepIntervalMs: 5 });
+			host = new McpServerHost({
+				registry,
+				idleTtlMs: 25,
+				sweepIntervalMs: 5,
+			});
+			toolRegistry = new ToolRegistry();
+		});
+
+		it("closes transports whose idle window has elapsed", async () => {
+			const sid = await initSession(host, toolRegistry);
+			expect(host.transportCount()).toBe(1);
+
+			// Wait past TTL + a sweep tick.
+			await new Promise((r) => setTimeout(r, 50));
+
+			expect(host.transportCount()).toBe(0);
+
+			// Subsequent request reports `not_found` — the registry was
+			// also cleaned by the onclose cascade.
+			const res = await host.handle(listRequest(sid), toolRegistry, FAKE_FEATURES, {
+				registry: toolRegistry,
+				identity: null,
+				workspaceId: WORKSPACE_ID,
+			});
+			expect(res.status).toBe(404);
+			const body = (await res.json()) as { error: { data: { reason: string } } };
+			expect(body.error.data.reason).toBe("not_found");
+		});
+
+		it("keeps an actively-touched session alive past TTL", async () => {
+			const sid = await initSession(host, toolRegistry);
+			// Touch every 10ms across a window > TTL (25ms).
+			for (let i = 0; i < 6; i++) {
+				await new Promise((r) => setTimeout(r, 10));
+				await touch(host, toolRegistry, sid);
+			}
+			expect(host.transportCount()).toBe(1);
+		});
+	});
+
+	describe("LRU on capacity", () => {
+		beforeEach(() => {
+			// Long idle TTL so only the LRU path is exercised here.
+			registry = new InMemorySessionRegistry({ ttlMs: 60_000 });
+			host = new McpServerHost({
+				registry,
+				idleTtlMs: 60_000,
+				maxSessions: 3,
+				sweepIntervalMs: 60_000,
+			});
+			toolRegistry = new ToolRegistry();
+		});
+
+		it("evicts the least-recently-used transport when a new init arrives at cap", async () => {
+			const s1 = await initSession(host, toolRegistry);
+			await initSession(host, toolRegistry);
+			await initSession(host, toolRegistry);
+			expect(host.transportCount()).toBe(3);
+
+			// Fourth init at cap=3 → s1 evicted (it's the oldest).
+			const s4 = await initSession(host, toolRegistry);
+			expect(host.transportCount()).toBe(3);
+
+			// s1 is gone — should now miss with not_found.
+			const res = await host.handle(listRequest(s1), toolRegistry, FAKE_FEATURES, {
+				registry: toolRegistry,
+				identity: null,
+				workspaceId: WORKSPACE_ID,
+			});
+			expect(res.status).toBe(404);
+			const body = (await res.json()) as { error: { data: { reason: string } } };
+			expect(body.error.data.reason).toBe("not_found");
+
+			// s4 is live.
+			expect(typeof s4).toBe("string");
+		});
+
+		it("touching a session moves it out of LRU eviction range", async () => {
+			const s1 = await initSession(host, toolRegistry);
+			const s2 = await initSession(host, toolRegistry);
+			const s3 = await initSession(host, toolRegistry);
+
+			// Touch s1 — now LRU order is s2, s3, s1.
+			await touch(host, toolRegistry, s1);
+
+			// Fourth init evicts the new oldest, which is s2.
+			await initSession(host, toolRegistry);
+
+			// s1 still live (we touched it).
+			const r1 = await host.handle(listRequest(s1), toolRegistry, FAKE_FEATURES, {
+				registry: toolRegistry,
+				identity: null,
+				workspaceId: WORKSPACE_ID,
+			});
+			expect(r1.status).not.toBe(404);
+
+			// s2 evicted.
+			const r2 = await host.handle(listRequest(s2), toolRegistry, FAKE_FEATURES, {
+				registry: toolRegistry,
+				identity: null,
+				workspaceId: WORKSPACE_ID,
+			});
+			expect(r2.status).toBe(404);
+
+			// s3 still live (untouched but newer than s2).
+			const r3 = await host.handle(listRequest(s3), toolRegistry, FAKE_FEATURES, {
+				registry: toolRegistry,
+				identity: null,
+				workspaceId: WORKSPACE_ID,
+			});
+			expect(r3.status).not.toBe(404);
+		});
+	});
+
+	describe("construction guards", () => {
+		afterEach(async () => {
+			// no host to shut down in these failure-mode tests
+		});
+
+		it("rejects non-positive idleTtlMs", () => {
+			const reg = new InMemorySessionRegistry({ ttlMs: 60_000 });
+			expect(
+				() => new McpServerHost({ registry: reg, idleTtlMs: 0 }),
+			).toThrow(/idleTtlMs/);
+			expect(
+				() => new McpServerHost({ registry: reg, idleTtlMs: Number.NaN }),
+			).toThrow(/idleTtlMs/);
+			reg.shutdown();
+		});
+
+		it("rejects non-positive maxSessions", () => {
+			const reg = new InMemorySessionRegistry({ ttlMs: 60_000 });
+			expect(
+				() => new McpServerHost({ registry: reg, idleTtlMs: 60_000, maxSessions: 0 }),
+			).toThrow(/maxSessions/);
+			reg.shutdown();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The local transport map in `McpServerHost` had a finite cap (`MAX_MCP_SESSIONS`, default 100) but **no reclamation policy**. Sessions whose clients vanished without sending DELETE — mobile suspension, closed tabs, abandoned OAuth flows, network drops without clean TCP teardown — stayed pinned for the lifetime of the pod. After enough leakage, every new initialize returned:

```
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Too many active sessions"},"id":null}
```

The architecture doc said the registry's TTL reclaimed memory, but the registry only manages its own metadata entries — it never closed the local transport objects. The doc's invariant was aspirational.

This PR makes it real.

## What changes

Two reclamation triggers on `McpServerHost`, both funneling through a single `evict(sid, reason)` primitive:

- **Idle TTL** — periodic sweep closes transports whose `lastAccessedAt` is older than `idleTtlMs`. Threaded in from `Runtime.getSessionStoreTtlMs()`, so both layers (transport map + registry) reclaim on the same schedule with one operator knob (`MCP_SESSION_TTL_SECONDS`). The host's sweep is what actually frees the JS heap; the registry TTL becomes redundant safety on the metadata layer.

- **LRU on capacity** — the transport `Map` is re-inserted on every touch so iteration order is LRU. A new initialize at capacity evicts the oldest before being admitted. **The 429 `Too many active sessions` path is removed.** Capacity overflow is a memory-budget concern, not a client error.

`evict()` deletes from the lookup map **before** calling `transport.close()` — closing the race where a concurrent request could otherwise dispatch into a half-dead transport between the close call and the SDK's `onclose` cascade. The existing `onclose` handler still owns registry-side cleanup, so there is a single source of truth for that delete.

Architecture doc in `AGENTS.md` is updated to describe the policy and the no-429 contract.

## Operator-facing

- `MCP_MAX_SESSIONS` (default 100) is now a memory-budget cap, not a feature gate. A spike in `[mcp] evicting transport reason=pressure ...` logs means the tenant's natural concurrency exceeds the cap and it should be raised.
- `MCP_SESSION_TTL_SECONDS` (default 8h) now drives the host's idle sweep in addition to the registry's TTL. Same knob, both layers.
- Eviction emits structured log lines: `[mcp] evicting transport reason=idle|pressure sessionId=... idleMs=...`.

## Test plan

- [x] `bun run verify:static` — format, lint, typecheck, cycles, codegen
- [x] `bun run verify:test-unit` — 246 unit tests pass (includes 6 new in `mcp-server-reclamation.test.ts`)
- [x] `bun run test:integration` — 475 integration tests pass
- [x] Manual: new tests confirm both eviction reasons fire and the `onclose` cascade reaches `session miss reason=not_found` on the client's next request — i.e. the architecture-doc invariant now holds end-to-end.

## Out of scope (worth listing)

- **Client-side DELETE on `pagehide`/`sendBeacon`** in the web bridge. Complementary nicety; reduces TTL pressure for the polite-tab-close case. Independent PR.
- **Resumable tasks across transport eviction.** MCP `tasks` spec supports re-attach by task ID; verifying our client path handles it cleanly is separate.
- **Per-tenant session quotas.** Different concern (user-facing capacity), belongs in tenant policy, not the transport map.

## Backward compatibility

Zero protocol change. Existing clients see the same wire behavior — except they no longer get 429 on a well-formed initialize when the pod is full.