### PR TITLE
fix(runtime): part-aware token estimator for context.assembled

### DIFF
--- a/src/engine/token-estimate.ts
+++ b/src/engine/token-estimate.ts
@@ -1,0 +1,312 @@
+/**
+ * Part-aware pre-flight token estimator for `LanguageModelV3Message`s and
+ * tool schemas.
+ *
+ * The naive `approxTokens(JSON.stringify(m))` inflates by 30-100× whenever a
+ * message carries a `file` part with `data: Uint8Array(<bytes>)`:
+ * `JSON.stringify(Uint8Array)` produces `{"0":n,"1":n,...}` (~12 chars/byte),
+ * and `approxTokens = ceil(len/4)` then over-counts by ~3 tokens per byte.
+ * For a 700KB-class PNG this is ~2.1M phantom tokens vs the ~1.3K tokens the
+ * provider actually charges.
+ *
+ * The fix walks each content part and uses a part-appropriate estimator:
+ *   - text: `ceil(text.length / 4)` (the current heuristic, correct for text)
+ *   - image file: Anthropic's documented formula `ceil((w*h) / 750)` clamped
+ *     to [800, 1600] when dimensions are decodable; flat 1300-token fallback
+ *     otherwise.  (https://docs.anthropic.com/en/docs/build-with-claude/vision)
+ *   - non-image file: tokenize only the metadata (mediaType + filename) that
+ *     actually gets relayed, plus a small overhead.
+ *   - tool-call / tool-result: tokenize structured args/output without
+ *     `JSON.stringify`-ing any embedded binary.
+ *   - reasoning: tokenize the text.
+ *
+ * Results are an estimate; the truth lives on `llm.response.usage` after the
+ * call returns. Pre-flight is for iteration-loop decisions (compaction,
+ * max-input gating).
+ */
+
+import type {
+  LanguageModelV3FilePart,
+  LanguageModelV3Message,
+  LanguageModelV3ReasoningPart,
+  LanguageModelV3TextPart,
+  LanguageModelV3ToolCallPart,
+  LanguageModelV3ToolResultPart,
+} from "@ai-sdk/provider";
+import type { ToolSchema } from "./types.ts";
+
+/** Anthropic vision tokens-per-pixel divisor and clamp bounds. */
+const IMAGE_TOKENS_PER_PIXEL_DIVISOR = 750;
+const IMAGE_TOKEN_MIN = 800;
+const IMAGE_TOKEN_MAX = 1600;
+/**
+ * Fallback used when image dimensions can't be decoded from the bytes (no
+ * `image-size` dep is bundled today). Sits inside the [800, 1600] clamp
+ * range so over/underestimate is bounded.
+ * TODO: decode dimensions when an `image-size`-style helper is available.
+ * See https://docs.anthropic.com/en/docs/build-with-claude/vision for the
+ * provider-side formula this approximates.
+ */
+const IMAGE_TOKEN_FALLBACK = 1300;
+const FILE_METADATA_OVERHEAD_TOKENS = 50;
+const TOOL_CALL_OVERHEAD_TOKENS = 50;
+
+function tokensForChars(len: number): number {
+  return Math.ceil(len / 4);
+}
+
+function tokensForText(text: string | undefined | null): number {
+  if (!text) return 0;
+  return tokensForChars(text.length);
+}
+
+/**
+ * PNG / JPEG / GIF / WebP dimension decode from the in-memory bytes. Returns
+ * null on any short read or unrecognized header — the caller falls back to
+ * the flat per-image estimate. Pure-byte parsing rather than a dep so the
+ * estimator stays self-contained.
+ *
+ * Only the four formats Anthropic vision accepts are supported.
+ */
+function decodeImageDimensions(data: Uint8Array): { width: number; height: number } | null {
+  if (data.length < 12) return null;
+  // PNG: 8-byte signature + IHDR chunk; width/height live at offsets 16..23
+  // as big-endian uint32s.
+  if (
+    data[0] === 0x89 &&
+    data[1] === 0x50 &&
+    data[2] === 0x4e &&
+    data[3] === 0x47 &&
+    data[4] === 0x0d &&
+    data[5] === 0x0a &&
+    data[6] === 0x1a &&
+    data[7] === 0x0a &&
+    data.length >= 24
+  ) {
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    return { width: view.getUint32(16, false), height: view.getUint32(20, false) };
+  }
+  // GIF87a / GIF89a: signature + LE width/height at offsets 6..9.
+  if (data[0] === 0x47 && data[1] === 0x49 && data[2] === 0x46 && data.length >= 10) {
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    return { width: view.getUint16(6, true), height: view.getUint16(8, true) };
+  }
+  // WebP (RIFF....WEBP): VP8/VP8L/VP8X dimensions vary by chunk type.
+  if (
+    data[0] === 0x52 &&
+    data[1] === 0x49 &&
+    data[2] === 0x46 &&
+    data[3] === 0x46 &&
+    data[8] === 0x57 &&
+    data[9] === 0x45 &&
+    data[10] === 0x42 &&
+    data[11] === 0x50 &&
+    data.length >= 30
+  ) {
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    const fourCC = String.fromCharCode(data[12]!, data[13]!, data[14]!, data[15]!);
+    if (fourCC === "VP8 ") {
+      // Lossy: 14-bit width/height at offsets 26..29 (little-endian, low 14 bits).
+      const w = view.getUint16(26, true) & 0x3fff;
+      const h = view.getUint16(28, true) & 0x3fff;
+      return { width: w, height: h };
+    }
+    if (fourCC === "VP8L") {
+      // Lossless: bits-packed at offset 21; 14-bit width then 14-bit height.
+      const b0 = data[21]!;
+      const b1 = data[22]!;
+      const b2 = data[23]!;
+      const b3 = data[24]!;
+      const width = 1 + (((b1 & 0x3f) << 8) | b0);
+      const height = 1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6));
+      return { width, height };
+    }
+    if (fourCC === "VP8X" && data.length >= 30) {
+      // Extended: 24-bit width-1 + 24-bit height-1 at offsets 24..29.
+      const width = 1 + (data[24]! | (data[25]! << 8) | (data[26]! << 16));
+      const height = 1 + (data[27]! | (data[28]! << 8) | (data[29]! << 16));
+      return { width, height };
+    }
+  }
+  // JPEG: scan SOF0..SOF3 markers for height/width. Cheap enough at this size.
+  if (data[0] === 0xff && data[1] === 0xd8) {
+    let offset = 2;
+    while (offset < data.length - 9) {
+      if (data[offset] !== 0xff) break;
+      const marker = data[offset + 1]!;
+      // SOF0..SOF15 except DHT/JPG/DAC (C4/C8/CC) carry image dimensions.
+      if (
+        marker >= 0xc0 &&
+        marker <= 0xcf &&
+        marker !== 0xc4 &&
+        marker !== 0xc8 &&
+        marker !== 0xcc
+      ) {
+        if (offset + 9 >= data.length) return null;
+        const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+        const height = view.getUint16(offset + 5, false);
+        const width = view.getUint16(offset + 7, false);
+        return { width, height };
+      }
+      const segLen = (data[offset + 2]! << 8) | data[offset + 3]!;
+      offset += 2 + segLen;
+    }
+  }
+  return null;
+}
+
+/**
+ * Anthropic's vision token formula: `ceil((width * height) / 750)`, clamped
+ * to [800, 1600] tokens. Matches the provider-side accounting per
+ * https://docs.anthropic.com/en/docs/build-with-claude/vision.
+ */
+export function imageTokensFromDimensions(width: number, height: number): number {
+  const raw = Math.ceil((width * height) / IMAGE_TOKENS_PER_PIXEL_DIVISOR);
+  if (raw < IMAGE_TOKEN_MIN) return IMAGE_TOKEN_MIN;
+  if (raw > IMAGE_TOKEN_MAX) return IMAGE_TOKEN_MAX;
+  return raw;
+}
+
+function tokensForImageFilePart(part: LanguageModelV3FilePart): number {
+  // `data` may be Uint8Array, base64 string, or URL. We only attempt decode
+  // for bytes; the other shapes get the flat fallback. The fallback sits
+  // inside the [800, 1600] Anthropic clamp so we never overpay by an order
+  // of magnitude regardless of dimensions.
+  if (part.data instanceof Uint8Array) {
+    const dims = decodeImageDimensions(part.data);
+    if (dims && dims.width > 0 && dims.height > 0) {
+      return imageTokensFromDimensions(dims.width, dims.height);
+    }
+  }
+  return IMAGE_TOKEN_FALLBACK;
+}
+
+function tokensForFilePart(part: LanguageModelV3FilePart): number {
+  if (part.mediaType.startsWith("image/")) {
+    return tokensForImageFilePart(part);
+  }
+  // Non-image files are surfaced to the model as metadata (the file itself
+  // is fetched via a separate `files__read` tool round-trip when needed),
+  // so we tokenize that metadata, not the bytes.
+  const metaLen = (part.mediaType?.length ?? 0) + (part.filename?.length ?? 0);
+  return tokensForChars(metaLen) + FILE_METADATA_OVERHEAD_TOKENS;
+}
+
+function tokensForToolCallPart(part: LanguageModelV3ToolCallPart): number {
+  // `JSON.stringify(undefined)` returns undefined; default to "{}" for
+  // shape-only calls. Args are JSON-encoded by the provider — chars/4 is the
+  // same heuristic the provider's tokenizer approximates.
+  const inputJson = part.input === undefined ? "{}" : JSON.stringify(part.input);
+  const nameLen = part.toolName?.length ?? 0;
+  return tokensForChars(inputJson.length + nameLen) + TOOL_CALL_OVERHEAD_TOKENS;
+}
+
+function tokensForToolResultPart(part: LanguageModelV3ToolResultPart): number {
+  const output = part.output;
+  switch (output.type) {
+    case "text":
+    case "error-text":
+      return tokensForText(output.value);
+    case "json":
+    case "error-json":
+      return tokensForChars(JSON.stringify(output.value).length);
+    case "execution-denied":
+      return tokensForText(output.reason) + 5;
+    case "content": {
+      // The result's nested content array is itself a sequence of parts that
+      // can contain inline `file-data` (base64) blocks. Walk recursively so
+      // we never `JSON.stringify` raw bytes.
+      let sum = 0;
+      for (const item of output.value) {
+        if (item.type === "text") {
+          sum += tokensForText(item.text);
+        } else if (item.type === "file-data") {
+          if (item.mediaType.startsWith("image/")) {
+            // Base64-encoded image; we don't decode dimensions from b64 here
+            // (the base64 string is the wire shape). Use the same flat
+            // fallback as the file-part path so over/underestimate is bounded.
+            sum += IMAGE_TOKEN_FALLBACK;
+          } else {
+            sum +=
+              tokensForChars(item.mediaType.length + (item.filename?.length ?? 0)) +
+              FILE_METADATA_OVERHEAD_TOKENS;
+          }
+        } else if (item.type === "file-url" || item.type === "file-id") {
+          // Reference-only; tokenize the small pointer. Neither shape
+          // carries `mediaType` in the V3 union, so cost is dominated by
+          // the metadata overhead.
+          const ref = "url" in item ? item.url : JSON.stringify(item.fileId);
+          sum += tokensForChars(ref.length) + FILE_METADATA_OVERHEAD_TOKENS;
+        } else if (item.type === "image-data") {
+          sum += IMAGE_TOKEN_FALLBACK;
+        }
+      }
+      return sum;
+    }
+    default:
+      return 0;
+  }
+}
+
+function tokensForTextPart(part: LanguageModelV3TextPart): number {
+  return tokensForText(part.text);
+}
+
+function tokensForReasoningPart(part: LanguageModelV3ReasoningPart): number {
+  return tokensForText(part.text);
+}
+
+/**
+ * Estimate input tokens for a single message. Walks `content` parts and
+ * applies the part-appropriate estimator. Returns 0 for shapes we don't
+ * recognize rather than throwing — this is a budget heuristic, not
+ * validation.
+ *
+ * The role-header overhead (`<|user|>`, etc.) is small and constant per
+ * message; we don't add a separate constant for it because Anthropic's
+ * actual tokenizer rolls that into its system overhead, which we don't
+ * try to model here. The conversation-store still has the truth from
+ * `usage` after the call.
+ */
+export function estimateMessageTokens(message: LanguageModelV3Message): number {
+  if (message.role === "system") {
+    return tokensForText(message.content);
+  }
+  let sum = 0;
+  for (const part of message.content) {
+    switch (part.type) {
+      case "text":
+        sum += tokensForTextPart(part);
+        break;
+      case "file":
+        sum += tokensForFilePart(part);
+        break;
+      case "tool-call":
+        sum += tokensForToolCallPart(part);
+        break;
+      case "tool-result":
+        sum += tokensForToolResultPart(part);
+        break;
+      case "reasoning":
+        sum += tokensForReasoningPart(part);
+        break;
+      // Other part types (tool-approval-response) carry only small flags;
+      // ignore for budget purposes.
+    }
+  }
+  return sum;
+}
+
+/**
+ * Pre-flight estimate of the tokens a tool description will cost when
+ * surfaced to the model. Mirrors the legacy formula (name + description +
+ * input schema as text) but keeps `JSON.stringify` confined to the schema
+ * object — which today is plain JSON but is shape-coupled to objects that
+ * may eventually carry binary defaults, so we centralize the call site.
+ */
+export function estimateToolDescriptionTokens(tool: ToolSchema): number {
+  const schemaText = JSON.stringify(tool.inputSchema ?? {});
+  return tokensForChars(
+    (tool.name?.length ?? 0) + 1 + (tool.description?.length ?? 0) + 1 + schemaText.length,
+  );
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -24,6 +24,7 @@ import type {
 } from "../conversation/types.ts";
 import { sliceHistory, windowMessages } from "../conversation/window.ts";
 import { AgentEngine } from "../engine/engine.ts";
+import { estimateMessageTokens, estimateToolDescriptionTokens } from "../engine/token-estimate.ts";
 import type {
   ContextAssembledPayload,
   ContextAssembledSource,
@@ -2222,19 +2223,36 @@ function stampDerivedScope(workDir: string, skill: Skill): Skill {
  * set + history + Layer 3 skills counted in `skills.loaded`. The snapshot
  * carries counts and tokens only — never content (the bodies are already
  * in the conversation log via earlier source events / message history).
+ *
+ * Exported for tests — the regression we care about (image attachments not
+ * inflating history tokens by 100×) is the integration between this builder
+ * and `estimateMessageTokens`. Direct test access keeps the regression
+ * verifiable without spinning a full Runtime.
  */
-function buildContextAssembledPayload(input: {
+export function buildContextAssembledPayload(input: {
   systemPrompt: string;
   activeTools: ToolSchema[];
   messages: LanguageModelV3Message[];
   skillsLoaded: SkillsLoadedPayload;
 }): ContextAssembledPayload {
   const promptTokens = approxTokens(input.systemPrompt);
+  // Tool descriptions: name + description + input schema. Routed through
+  // `estimateToolDescriptionTokens` (not `approxTokens(JSON.stringify(t))`)
+  // so we never hand a future object that could carry a `Uint8Array` to
+  // `JSON.stringify` — the bug we just fixed on the history path.
   const toolDescTokens = input.activeTools.reduce(
-    (sum, t) => sum + approxTokens(`${t.name}\n${t.description}\n${JSON.stringify(t.inputSchema)}`),
+    (sum, t) => sum + estimateToolDescriptionTokens(t),
     0,
   );
-  const historyTokens = input.messages.reduce((sum, m) => sum + approxTokens(JSON.stringify(m)), 0);
+  // History tokens: walk content parts with `estimateMessageTokens`.
+  //
+  // The previous formula was `approxTokens(JSON.stringify(m))`, which for any
+  // user message carrying a `file` part with `data: Uint8Array(<bytes>)`
+  // (rehydrated images — see `src/files/rehydrate.ts`) inflated by 30-100×:
+  // `JSON.stringify(Uint8Array)` expands to `{"0":n,"1":n,…}` (~12 chars/byte)
+  // and the chars/4 heuristic over-counted by ~3 tokens per image byte. Two
+  // ~700KB PNGs landed at 2.8M+ phantom tokens for a 51K-token call.
+  const historyTokens = input.messages.reduce((sum, m) => sum + estimateMessageTokens(m), 0);
   const sources: ContextAssembledSource[] = [
     { kind: "system_prompt", tokens: promptTokens },
     { kind: "tool_descriptions", count: input.activeTools.length, tokens: toolDescTokens },

--- a/test/unit/context-assembled-images.test.ts
+++ b/test/unit/context-assembled-images.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration-ish regression for the pre-flight `context.assembled` snapshot:
+ * when a user turn carries one or more image attachments (rehydrated `file`
+ * parts with `data: Uint8Array(<bytes>)`), `history.tokens` and the rollup
+ * `totalTokens` must report plausible counts — not the millions reported by
+ * the pre-fix `approxTokens(JSON.stringify(m))` code path.
+ *
+ * Anchor: prod conversation reported `totalTokens: 2,853,357` for a single
+ * user turn with two PNG attachments (207KB + 711KB). Anthropic's `usage`
+ * for the same turn returned `inputTokens: 51,364`. The two numbers should
+ * be in the same order of magnitude (the estimator is allowed to differ from
+ * the provider's count, but not by 50×).
+ */
+
+import type { LanguageModelV3Message } from "@ai-sdk/provider";
+import { describe, expect, test } from "bun:test";
+import { buildContextAssembledPayload } from "../../src/runtime/runtime.ts";
+
+function makePngWithDimensions(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(24);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  bytes.set([0x00, 0x00, 0x00, 0x0d], 8);
+  bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  view.setUint32(16, width, false);
+  view.setUint32(20, height, false);
+  return bytes;
+}
+
+describe("context.assembled — image-attached message regression", () => {
+  test("two large PNG attachments → history < 10K tokens (was 2.8M pre-fix)", () => {
+    // Reproduce the prod scenario: two rehydrated PNG file parts, total
+    // ~918KB of binary payload, plus a short text caption.
+    const a = new Uint8Array(207_007);
+    a.set(makePngWithDimensions(1024, 768), 0);
+    const b = new Uint8Array(711_000);
+    b.set(makePngWithDimensions(2400, 1800), 0);
+    const messages: LanguageModelV3Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Look at these screenshots — what's broken?" },
+          { type: "file", mediaType: "image/png", data: a, filename: "before.png" },
+          { type: "file", mediaType: "image/png", data: b, filename: "after.png" },
+        ],
+      },
+    ];
+
+    const payload = buildContextAssembledPayload({
+      systemPrompt: "you are a helpful agent",
+      activeTools: [],
+      messages,
+      skillsLoaded: { skills: [], totalTokens: 0 },
+    });
+
+    const historySource = payload.sources.find((s) => s.kind === "history");
+    expect(historySource).toBeDefined();
+    expect(historySource!.tokens).toBeLessThan(10_000);
+    expect(payload.totalTokens).toBeLessThan(10_000);
+    // Sanity: tokens are still positive (we want a real estimate, not zero).
+    expect(historySource!.tokens).toBeGreaterThan(0);
+  });
+
+  test("text-only history is unaffected — heuristic identical for text parts", () => {
+    const messages: LanguageModelV3Message[] = [
+      { role: "user", content: [{ type: "text", text: "hello world" }] },
+      { role: "assistant", content: [{ type: "text", text: "hi there" }] },
+    ];
+    const payload = buildContextAssembledPayload({
+      systemPrompt: "system",
+      activeTools: [],
+      messages,
+      skillsLoaded: { skills: [], totalTokens: 0 },
+    });
+    // Both messages are short text; total tokens should be < 20.
+    const history = payload.sources.find((s) => s.kind === "history")!;
+    expect(history.tokens).toBeGreaterThan(0);
+    expect(history.tokens).toBeLessThan(20);
+  });
+});

--- a/test/unit/token-estimate.test.ts
+++ b/test/unit/token-estimate.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Tests for `src/engine/token-estimate.ts` — the part-aware pre-flight token
+ * estimator that replaced `approxTokens(JSON.stringify(message))`.
+ *
+ * Regression anchor: a `file` part with `data: new Uint8Array(207_007)`
+ * (an actual user-attached PNG size) must NOT inflate to 600K+ tokens.
+ * The old formula reported ~620K tokens for that byte count, vs Anthropic's
+ * actual ~1.3K image tokens — a 500× phantom-count inflation that triggered
+ * spurious compaction and corrupted cost dashboards.
+ */
+
+import type { LanguageModelV3Message } from "@ai-sdk/provider";
+import { describe, expect, test } from "bun:test";
+import {
+  estimateMessageTokens,
+  estimateToolDescriptionTokens,
+  imageTokensFromDimensions,
+} from "../../src/engine/token-estimate.ts";
+import type { ToolSchema } from "../../src/engine/types.ts";
+
+/** Build a minimal 1×1 PNG byte buffer so dimension decoding hits the PNG branch. */
+function makeTinyPng(): Uint8Array {
+  // Hand-rolled valid PNG signature + IHDR with 1×1 dimensions. We don't
+  // need IDAT data — the dimension decoder only reads the IHDR header.
+  const bytes = new Uint8Array(24);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0); // signature
+  bytes.set([0x00, 0x00, 0x00, 0x0d], 8); // IHDR chunk length (13)
+  bytes.set([0x49, 0x48, 0x44, 0x52], 12); // "IHDR"
+  // width=1, height=1 (big-endian uint32s at offsets 16, 20).
+  bytes.set([0x00, 0x00, 0x00, 0x01], 16);
+  bytes.set([0x00, 0x00, 0x00, 0x01], 20);
+  return bytes;
+}
+
+/** Build a valid PNG header with caller-supplied dimensions. */
+function makePngWithDimensions(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(24);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  bytes.set([0x00, 0x00, 0x00, 0x0d], 8);
+  bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  view.setUint32(16, width, false);
+  view.setUint32(20, height, false);
+  return bytes;
+}
+
+describe("estimateMessageTokens — text-only", () => {
+  test("user message with a single text part — tokens scale with text length", () => {
+    const msg: LanguageModelV3Message = {
+      role: "user",
+      content: [{ type: "text", text: "hello world" }],
+    };
+    // "hello world" is 11 chars → ceil(11/4) = 3 tokens.
+    expect(estimateMessageTokens(msg)).toBe(3);
+  });
+
+  test("system message — content is a bare string", () => {
+    const msg: LanguageModelV3Message = {
+      role: "system",
+      content: "you are a helpful agent",
+    };
+    expect(estimateMessageTokens(msg)).toBe(Math.ceil("you are a helpful agent".length / 4));
+  });
+
+  test("empty user content — zero tokens, no throw", () => {
+    const msg: LanguageModelV3Message = { role: "user", content: [] };
+    expect(estimateMessageTokens(msg)).toBe(0);
+  });
+});
+
+describe("estimateMessageTokens — image regression", () => {
+  test("REGRESSION: 207KB Uint8Array PNG-headered data does NOT inflate to 600K+ tokens", () => {
+    // The reported prod conversation had a 207,007-byte PNG attachment.
+    // Pre-fix: `approxTokens(JSON.stringify(msg))` reported ~620K phantom
+    // tokens; provider charged ~1.3K. We require the new estimator to stay
+    // well under 10K for this case.
+    const bytes = makePngWithDimensions(1024, 768);
+    // Tail-pad to ~207KB so the actual byte count matches prod, but the
+    // PNG header still decodes to 1024×768. The decoder only reads the
+    // IHDR header; padding bytes are ignored.
+    const padded = new Uint8Array(207_007);
+    padded.set(bytes, 0);
+    const msg: LanguageModelV3Message = {
+      role: "user",
+      content: [{ type: "file", mediaType: "image/png", data: padded, filename: "screenshot.png" }],
+    };
+    const tokens = estimateMessageTokens(msg);
+    // 1024×768 = 786,432 pixels; 786,432/750 = 1049 → clamped to [800, 1600].
+    expect(tokens).toBeLessThan(10_000);
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  test("REGRESSION: 711KB Uint8Array PNG with large dims clamps at 1600 tokens", () => {
+    // The 711KB prod attachment was a high-resolution screenshot. A
+    // 4000×3000 image (12M pixels) would naively give 16K tokens; Anthropic
+    // clamps at 1600 and we must too.
+    const bytes = makePngWithDimensions(4000, 3000);
+    const padded = new Uint8Array(711_000);
+    padded.set(bytes, 0);
+    const msg: LanguageModelV3Message = {
+      role: "user",
+      content: [{ type: "file", mediaType: "image/png", data: padded }],
+    };
+    const tokens = estimateMessageTokens(msg);
+    expect(tokens).toBe(1600);
+  });
+
+  test("REGRESSION: two large PNG attachments combined < 10K tokens (was 2.8M pre-fix)", () => {
+    // The exact prod scenario: two attached PNGs in one user turn. Prod
+    // reported `totalTokens: 2,853,357` for this case.
+    const a = new Uint8Array(207_007);
+    a.set(makePngWithDimensions(1024, 768), 0);
+    const b = new Uint8Array(711_000);
+    b.set(makePngWithDimensions(2400, 1800), 0);
+    const msg: LanguageModelV3Message = {
+      role: "user",
+      content: [
+        { type: "text", text: "Look at these screenshots" },
+        { type: "file", mediaType: "image/png", data: a, filename: "a.png" },
+        { type: "file", mediaType: "image/png", data: b, filename: "b.png" },
+      ],
+    };
+    expect(estimateMessageTokens(msg)).toBeLessThan(10_000);
+  });
+
+  test("image without a recognizable header falls back to flat estimate", () => {
+    const msg: LanguageModelV3Message = {
+      role: "user",
+      content: [
+        { type: "file", mediaType: "image/png", data: new Uint8Array(200_000) },
+      ],
+    };
+    const tokens = estimateMessageTokens(msg);
+    // Flat fallback is inside the Anthropic [800, 1600] clamp range.
+    expect(tokens).toBeGreaterThanOrEqual(800);
+    expect(tokens).toBeLessThanOrEqual(1600);
+  });
+
+  test("imageTokensFromDimensions honors the [800, 1600] clamp", () => {
+    // Tiny image: raw formula would give 1 token; must clamp up to 800.
+    expect(imageTokensFromDimensions(10, 10)).toBe(800);
+    // Huge image: raw formula gives 1M+ tokens; must clamp down to 1600.
+    expect(imageTokensFromDimensions(10_000, 10_000)).toBe(1600);
+    // Mid-range: stays in band. 1024×1024 / 750 = 1399.
+    expect(imageTokensFromDimensions(1024, 1024)).toBe(1399);
+  });
+});
+
+describe("estimateMessageTokens — non-image files", () => {
+  test("PDF attachment is tokenized as metadata, not bytes", () => {
+    const msg: LanguageModelV3Message = {
+      role: "user",
+      content: [
+        {
+          type: "file",
+          mediaType: "application/pdf",
+          data: new Uint8Array(5_000_000),
+          filename: "report.pdf",
+        },
+      ],
+    };
+    // mediaType (15) + filename (10) = 25 chars / 4 = 7, plus 50 overhead.
+    // The 5MB byte payload must NOT influence the count.
+    const tokens = estimateMessageTokens(msg);
+    expect(tokens).toBeLessThan(100);
+  });
+});
+
+describe("estimateMessageTokens — tool-call parts", () => {
+  test("tool-call serializes input args, not surrounding shell", () => {
+    const msg: LanguageModelV3Message = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call_1",
+          toolName: "search",
+          input: { query: "what is the weather in tokyo today" },
+        },
+      ],
+    };
+    const tokens = estimateMessageTokens(msg);
+    expect(tokens).toBeGreaterThan(50); // includes overhead
+    expect(tokens).toBeLessThan(100);
+  });
+
+  test("tool-call with nested object args", () => {
+    const msg: LanguageModelV3Message = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call_2",
+          toolName: "fetch",
+          input: { url: "https://example.com", headers: { auth: "bearer abc", trace: "x-id" } },
+        },
+      ],
+    };
+    expect(estimateMessageTokens(msg)).toBeGreaterThan(50);
+  });
+});
+
+describe("estimateMessageTokens — tool-result parts", () => {
+  test("text output is tokenized straightforwardly", () => {
+    const msg: LanguageModelV3Message = {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call_1",
+          toolName: "search",
+          output: { type: "text", value: "sunny, 72F" },
+        },
+      ],
+    };
+    expect(estimateMessageTokens(msg)).toBe(Math.ceil("sunny, 72F".length / 4));
+  });
+
+  test("nested file-data with image media type uses image token estimate, not byte length", () => {
+    // Tool-result `content` arrays can carry `file-data` blocks with
+    // base64-encoded bytes. The naive `JSON.stringify` path would tokenize
+    // the entire base64 string as text; we must use the image estimate.
+    //
+    // Build a fake base64 string ~700KB long — what a real image would
+    // serialize to — and verify the estimator stays inside the image
+    // clamp rather than reporting ~175K tokens (700K/4).
+    const fakeBase64 = "A".repeat(700_000);
+    const msg: LanguageModelV3Message = {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call_1",
+          toolName: "snapshot",
+          output: {
+            type: "content",
+            value: [
+              { type: "text", text: "screenshot taken" },
+              { type: "file-data", data: fakeBase64, mediaType: "image/png", filename: "out.png" },
+            ],
+          },
+        },
+      ],
+    };
+    const tokens = estimateMessageTokens(msg);
+    // Image flat fallback (~1300) + tiny text ("screenshot taken" ~5 tokens).
+    // The base64 payload's 700K chars must NOT contribute.
+    expect(tokens).toBeLessThan(2_000);
+  });
+
+  test("json output is tokenized by serialized length", () => {
+    const msg: LanguageModelV3Message = {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call_1",
+          toolName: "lookup",
+          output: { type: "json", value: { ok: true, count: 7 } },
+        },
+      ],
+    };
+    expect(estimateMessageTokens(msg)).toBeGreaterThan(0);
+  });
+});
+
+describe("estimateMessageTokens — reasoning parts", () => {
+  test("reasoning text contributes its char-count tokens", () => {
+    const msg: LanguageModelV3Message = {
+      role: "assistant",
+      content: [{ type: "reasoning", text: "let me think about this carefully" }],
+    };
+    expect(estimateMessageTokens(msg)).toBe(
+      Math.ceil("let me think about this carefully".length / 4),
+    );
+  });
+});
+
+describe("estimateMessageTokens — tiny PNG dimension decoding", () => {
+  test("decodes 1×1 PNG header and applies the clamp", () => {
+    const msg: LanguageModelV3Message = {
+      role: "user",
+      content: [{ type: "file", mediaType: "image/png", data: makeTinyPng() }],
+    };
+    // 1×1 pixels → ceil(1/750) = 1 → clamped up to 800.
+    expect(estimateMessageTokens(msg)).toBe(800);
+  });
+});
+
+describe("estimateToolDescriptionTokens", () => {
+  test("scales with name + description + schema text length", () => {
+    const tool: ToolSchema = {
+      name: "search_web",
+      description: "Search the public web and return ranked results.",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+    };
+    const tokens = estimateToolDescriptionTokens(tool);
+    expect(tokens).toBeGreaterThan(0);
+    expect(tokens).toBeLessThan(200);
+  });
+
+  test("handles missing description / schema without throw", () => {
+    const tool: ToolSchema = {
+      name: "noop",
+      description: "",
+      inputSchema: {},
+    };
+    expect(estimateToolDescriptionTokens(tool)).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
Token counter inflated 30-100× on conversations carrying image attachments — `runtime.ts:2237` stringified `LanguageModelV3Message` with `Uint8Array` data, producing 2.8M+ phantom tokens for a 51K-token call.

Replaced text-only `approxTokens(JSON.stringify(m))` with `estimateMessageTokens` — walks message parts, uses Anthropic's image formula for images (decoding PNG/JPEG/GIF/WebP dimensions from the bytes), strips binary from nested structured content. Tool-description site routed through `estimateToolDescriptionTokens` for the same reason.

## Root cause
`JSON.stringify(Uint8Array)` expands to `{"0":n,"1":n,…}` ~12 chars/byte. `approxTokens = ceil(len/4)` then over-counts by ~3 tokens per byte. Two 700KB-class images → 2.8M phantom tokens for a turn the provider charged 51K.

## Design
- Pre-flight (`context.assembled`) — estimate. Used for compaction and max-input gating. Now part-aware: image parts use Anthropic's `ceil((w * h) / 750)` clamp to [800, 1600]; non-image files tokenize metadata only; nested tool-result content walks recursively so embedded base64 image data isn't tokenized as text.
- Post-flight truth — already on `llm.response.usage`, persisted as `LlmResponseEvent`. The conversations bundle's cost rollup (`jsonl-reader.ts`) and the web client's iteration counter (`useChat.ts`) both read from there; no parallel event needed.

## Test plan
- [x] `bun run verify:static` passes (format, lint, tsc, web tsc, cycles, bundle-transport, codegen)
- [x] `bun run test:unit` passes (2848 tests)
- [x] Unit tests cover text, image (with regression at 207KB and 711KB byte counts), tool-call, tool-result with nested binary, reasoning
- [x] `buildContextAssembledPayload` integration test asserts two-PNG history reports < 10K tokens (down from 2.8M)