### PR TITLE
fix(engine): drop tripped tool from modelTools; soften synth message

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -466,7 +466,17 @@ export class AgentEngine {
     const unregisterToolControls = config.toolPromotion?.registerControls(toolControls);
     try {
       while (iteration < maxIter) {
-        const modelTools: LanguageModelV3FunctionTool[] = directTools.map((t) => ({
+        // Filter out any tool the supervisor has tripped this run. Removing
+        // the tool from the model's toolset is more reliable than telling
+        // the model "do not call this tool" via prose — the model literally
+        // can't call a tool that isn't in its list. Other tools remain
+        // available so the run can recover.
+        const trippedSet = new Set(supervisor.snapshot().trippedTools);
+        const usableDirectTools =
+          trippedSet.size === 0
+            ? directTools
+            : directTools.filter((t) => !trippedSet.has(t.name));
+        const modelTools: LanguageModelV3FunctionTool[] = usableDirectTools.map((t) => ({
           type: "function" as const,
           name: t.name,
           description: t.description,
@@ -474,7 +484,7 @@ export class AgentEngine {
         }));
 
         const toolSchemaMap = new Map<string, ToolSchema>();
-        for (const t of directTools) {
+        for (const t of usableDirectTools) {
           toolSchemaMap.set(t.name, t);
         }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -473,9 +473,7 @@ export class AgentEngine {
         // available so the run can recover.
         const trippedSet = new Set(supervisor.snapshot().trippedTools);
         const usableDirectTools =
-          trippedSet.size === 0
-            ? directTools
-            : directTools.filter((t) => !trippedSet.has(t.name));
+          trippedSet.size === 0 ? directTools : directTools.filter((t) => !trippedSet.has(t.name));
         const modelTools: LanguageModelV3FunctionTool[] = usableDirectTools.map((t) => ({
           type: "function" as const,
           name: t.name,

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -507,18 +507,6 @@ export class AgentEngine {
             "remains unfinished so the user can continue in a follow-up message.]";
         }
 
-        // One-shot nudge after the supervisor tripped on the previous iteration.
-        // Pairs with the synth-stop replacement so the directive is unambiguous:
-        // the tool result tells the model what to say, the system-prompt nudge
-        // forecloses further tool calls.
-        if (supervisor.needsPromptNudge()) {
-          callPrompt +=
-            "\n\n[IMPORTANT: A tool was detected to be in a loop and has been disabled " +
-            "for the remainder of this run. Do NOT call any more tools. Produce a final " +
-            "response now per the instructions in the last tool result.]";
-          supervisor.consumeNudge();
-        }
-
         const callProviderOptions = buildThinkingProviderOptions(config.model, config.thinking);
 
         const llmStart = performance.now();
@@ -734,9 +722,10 @@ export class AgentEngine {
 
             // Supervisor sees the post-hook, post-A.3-normalization result.
             // On a trip, the replacement directive flows downstream in place
-            // of the original — the model sees the directive in its tool
-            // message and the engine appends a system-prompt nudge on the
-            // next iteration via `needsPromptNudge()`.
+            // of the original tool result. The tripped tool is filtered out
+            // of `modelTools` on subsequent iterations (see the top of the
+            // run loop), so the model can't call it again regardless of
+            // what the directive says.
             const verdict = supervisor.observe(gatedCall, hookedResult);
             const finalResult = verdict.type === "synth" ? verdict.replacement : hookedResult;
 

--- a/src/engine/supervisor.ts
+++ b/src/engine/supervisor.ts
@@ -101,6 +101,12 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
   }
 
   function fingerprint(call: ToolCall, result: ToolResult): string {
+    // Known limitation: hashing only the first `textCap` chars can
+    // false-positive on tools that return a long stable preamble (e.g. a
+    // verbose header) followed by a short varying field. Two semantically
+    // distinct results may collapse to the same fingerprint and trip the
+    // supervisor early. Addressable later by hashing head+tail or
+    // structuredContent when present; out of scope here.
     const text = extractTextForModel(result.content).trim().slice(0, textCap);
     return createHash("sha1")
       .update(`${call.name}\0${result.isError ? "E" : "S"}\0${text}`)
@@ -108,15 +114,17 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
   }
 
   function synthReplacement(toolName: string, originalText: string, repeats: number): ToolResult {
+    // Wording note: this content persists in the conversation log across
+    // future runs, so the message is scoped to *this* tool and phrased as a
+    // record of what happened. No universal directives ("stop using tools",
+    // "end the run") — those rot when reread in a later turn where other
+    // tools are still callable.
     const directive =
-      `[NB supervisor] Tool \`${toolName}\` has returned the same result ${repeats} times in a row. ` +
-      `This is a loop. Stop calling this tool.\n\n` +
-      `Underlying tool output (last call):\n${originalText}\n\n` +
-      `Required action: produce a final response to the user that includes:\n` +
-      `1. What you were trying to accomplish.\n` +
-      `2. The literal error or output above so the user can act on it.\n` +
-      `3. One concrete suggestion (check the connection, narrow the question, try a different tool, etc.).\n\n` +
-      `Do not call any tools. End the run.`;
+      `[NB supervisor] Tool \`${toolName}\` returned the same result ${repeats} times in a row; ` +
+      `this tool has been disabled for the rest of this run.\n\n` +
+      `Underlying output (last call):\n${originalText}\n\n` +
+      `Other tools remain available. Consider an alternative approach or summarize current findings ` +
+      `if no path forward exists.`;
     return {
       content: textContent(directive),
       isError: true,

--- a/src/engine/supervisor.ts
+++ b/src/engine/supervisor.ts
@@ -21,10 +21,11 @@ import type { ToolCall, ToolResult } from "./types.ts";
  * behaviour (a tool that fails once with error A, then once with error B,
  * then succeeds, never trips).
  *
- * Pairs with a one-shot system-prompt nudge consumed by the engine on the
- * iteration after a trip — see `needsPromptNudge` / `consumeNudge`. The
- * supervisor itself never aborts the run; the engine reads the verdict and
- * decides what to surface.
+ * The supervisor itself never aborts the run; the engine reads the verdict
+ * and decides what to surface. On a trip the engine also filters the
+ * tripped tool out of the model's toolset for the rest of the run, so the
+ * model can't call the broken tool again regardless of how it reads the
+ * synth directive.
  */
 
 export interface SupervisorConfig {
@@ -62,14 +63,6 @@ export interface RunSupervisor {
    * normalization). Returns the verdict the engine should act on.
    */
   observe(call: ToolCall, result: ToolResult): SupervisorVerdict;
-  /**
-   * True when a synth verdict was issued since the last `consumeNudge` —
-   * the engine should append a single-shot system-prompt nudge to the
-   * next iteration.
-   */
-  needsPromptNudge(): boolean;
-  /** Clear the nudge flag after the engine emits the nudge. */
-  consumeNudge(): void;
   /** Telemetry snapshot. */
   snapshot(): SupervisorSnapshot;
 }
@@ -89,7 +82,6 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
   const textCap = config.fingerprintTextCap ?? DEFAULT_FINGERPRINT_CAP;
 
   const states = new Map<string, ToolState>();
-  let pendingNudge = false;
 
   function getState(toolName: string): ToolState {
     let s = states.get(toolName);
@@ -137,12 +129,10 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
 
     if (state.tripped) {
       // Once tripped, every subsequent call to the same tool keeps getting
-      // the synthetic directive. The model receives an unambiguous "this
-      // tool is unusable" signal regardless of whether the upstream call
-      // would now succeed — recovering from a stuck loop happens in a new
-      // run, not mid-run.
+      // the synthetic directive. In practice the engine drops tripped tools
+      // from modelTools so the model can't call again — this branch is a
+      // belt-and-suspenders fallback if a caller invokes the tool anyway.
       const originalText = extractTextForModel(result.content).trim();
-      pendingNudge = true;
       return {
         type: "synth",
         replacement: synthReplacement(call.name, originalText, state.consecutiveRepeats),
@@ -161,7 +151,6 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
 
     if (state.consecutiveRepeats >= maxRepeats) {
       state.tripped = true;
-      pendingNudge = true;
       const originalText = extractTextForModel(result.content).trim();
       return {
         type: "synth",
@@ -176,10 +165,6 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
 
   return {
     observe,
-    needsPromptNudge: () => pendingNudge,
-    consumeNudge: () => {
-      pendingNudge = false;
-    },
     snapshot: () => ({
       trippedTools: [...states.entries()].filter(([, s]) => s.tripped).map(([name]) => name),
       callCounts: Object.fromEntries(

--- a/test/unit/engine-supervisor.test.ts
+++ b/test/unit/engine-supervisor.test.ts
@@ -180,4 +180,105 @@ describe("engine ↔ supervisor wiring", () => {
     );
     expect(tripped.length).toBe(0);
   });
+
+  it("drops the tripped tool from modelTools while keeping other tools available", async () => {
+    // Two tools: `stuck` always errors identically (trips on 3rd call);
+    // `other` is a fallback the model can still pick after the trip.
+    const otherSchema: ToolSchema = {
+      name: "other",
+      description: "Works fine.",
+      inputSchema: { type: "object", properties: {} },
+    };
+
+    type ToolSnapshot = { names: string[]; iteration: number };
+    const offered: ToolSnapshot[] = [];
+    let iter = 0;
+    const model = createMockModel((opts) => {
+      iter += 1;
+      const names = (opts.tools ?? []).map((t) => (t as { name?: string }).name ?? "");
+      offered.push({ names, iteration: iter });
+
+      // While `stuck` is offered, keep calling it (drives the trip).
+      if (names.includes("stuck")) {
+        return {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: `call-${iter}`,
+              toolName: "stuck",
+              input: JSON.stringify({}),
+            },
+          ],
+          inputTokens: 1,
+          outputTokens: 1,
+        };
+      }
+
+      // `stuck` is gone but `other` is still available — call it once.
+      if (names.includes("other") && offered.filter((o) => !o.names.includes("stuck")).length === 1) {
+        return {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: `call-${iter}`,
+              toolName: "other",
+              input: JSON.stringify({}),
+            },
+          ],
+          inputTokens: 1,
+          outputTokens: 1,
+        };
+      }
+
+      // Done.
+      return {
+        content: [{ type: "text", text: "Fell back to other tool successfully." }],
+        inputTokens: 1,
+        outputTokens: 1,
+      };
+    });
+
+    const stuckCalls: number[] = [];
+    const otherCalls: number[] = [];
+    const handler = (call: ToolCall): ToolResult => {
+      if (call.name === "stuck") {
+        stuckCalls.push(stuckCalls.length + 1);
+        return { content: textContent("Request failed with status code 400"), isError: true };
+      }
+      otherCalls.push(otherCalls.length + 1);
+      return { content: textContent("ok"), isError: false };
+    };
+
+    const events: EngineEvent[] = [];
+    const engine = new AgentEngine(
+      model,
+      new StaticToolRouter([stuckToolSchema, otherSchema], handler),
+      collect(events),
+    );
+
+    const result = await engine.run(
+      config,
+      "system",
+      [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      [stuckToolSchema, otherSchema],
+    );
+
+    expect(result.stopReason).toBe("complete");
+
+    // `stuck` was called exactly 3 times (trip threshold) and never again.
+    expect(stuckCalls.length).toBe(3);
+    // `other` was invoked after the trip, proving the rest of the toolset
+    // remains available.
+    expect(otherCalls.length).toBe(1);
+
+    // First 3 model invocations had `stuck` in the toolset; later ones
+    // did not — but `other` always remained.
+    const withStuck = offered.filter((o) => o.names.includes("stuck"));
+    const withoutStuck = offered.filter((o) => !o.names.includes("stuck"));
+    expect(withStuck.length).toBe(3);
+    expect(withoutStuck.length).toBeGreaterThan(0);
+    for (const snap of withoutStuck) {
+      expect(snap.names).toContain("other");
+    }
+  });
 });

--- a/test/unit/engine-supervisor.test.ts
+++ b/test/unit/engine-supervisor.test.ts
@@ -33,32 +33,32 @@ function collect(events: EngineEvent[]): EventSink {
 
 describe("engine ↔ supervisor wiring", () => {
   it("emits supervisorTripped on the 3rd identical failure and stops the loop", async () => {
-    // Model behaviour: emit a `stuck` tool call every iteration UNLESS the
-    // supervisor's prompt nudge appears in the system prompt — then produce
-    // a final text response. This mirrors how a well-behaved real model
-    // responds to the synth-stop + nudge pair.
-    let prepostNudge: { before: number; after: number } = { before: 0, after: 0 };
+    // Model behaviour: emit a `stuck` tool call every iteration as long as
+    // it's in the toolset. Once the supervisor filters it out, the model has
+    // no tools to call and produces a final text response. This mirrors how
+    // a real model behaves under the affordance-level recovery: the tool
+    // literally isn't on the menu so it can't be picked.
+    const trace: { toolsOffered: number; sawStuck: boolean }[] = [];
     const model = createMockModel((opts) => {
-      const systemMsg = opts.prompt.find((m) => m.role === "system");
-      const systemText =
-        systemMsg && typeof systemMsg.content === "string" ? systemMsg.content : "";
-      const sawNudge = systemText.includes(
-        "A tool was detected to be in a loop",
+      const tools = opts.tools ?? [];
+      const sawStuck = tools.some(
+        (t) => (t as { name?: string }).name === "stuck",
       );
-      if (sawNudge) {
-        prepostNudge.after += 1;
+      trace.push({ toolsOffered: tools.length, sawStuck });
+      if (!sawStuck) {
         return {
-          content: [{ type: "text", text: "Stopping per the supervisor directive." }],
+          content: [
+            { type: "text", text: "Stopping — stuck tool is no longer available." },
+          ],
           inputTokens: 1,
           outputTokens: 1,
         };
       }
-      prepostNudge.before += 1;
       return {
         content: [
           {
             type: "tool-call",
-            toolCallId: `call-${prepostNudge.before}`,
+            toolCallId: `call-${trace.length}`,
             toolName: "stuck",
             input: JSON.stringify({}),
           },
@@ -92,15 +92,15 @@ describe("engine ↔ supervisor wiring", () => {
 
     // The tool was actually invoked exactly 3 times (the supervisor caught
     // the loop on the 3rd call). Subsequent iterations don't invoke the
-    // tool because the nudge stops the model from calling it again.
+    // tool because it's filtered out of modelTools.
     expect(toolCallCount).toBe(3);
 
     // Loop terminated cleanly, not via max_iterations.
     expect(result.stopReason).toBe("complete");
     expect(result.iterations).toBeLessThan(config.maxIterations);
 
-    // Final user-visible text came from the post-nudge model response.
-    expect(result.output).toContain("Stopping per the supervisor directive");
+    // Final user-visible text came from the model's no-tools response.
+    expect(result.output).toContain("stuck tool is no longer available");
 
     // Exactly one tool.done event carries supervisorTripped.
     const tripped = events.filter(
@@ -114,9 +114,12 @@ describe("engine ↔ supervisor wiring", () => {
     expect(trippedData.consecutiveRepeats).toBe(3);
     expect(trippedData.ok).toBe(false);
 
-    // The model saw the nudge exactly once (one post-trip iteration).
-    expect(prepostNudge.before).toBe(3);
-    expect(prepostNudge.after).toBe(1);
+    // Model saw `stuck` on the first 3 iterations, then no `stuck` after
+    // the supervisor tripped.
+    const withStuck = trace.filter((t) => t.sawStuck).length;
+    const withoutStuck = trace.filter((t) => !t.sawStuck).length;
+    expect(withStuck).toBe(3);
+    expect(withoutStuck).toBe(1);
   });
 
   it("does not trip when tool results vary across calls", async () => {

--- a/test/unit/engine/supervisor.test.ts
+++ b/test/unit/engine/supervisor.test.ts
@@ -20,7 +20,7 @@ describe("supervisor — pass-through behavior", () => {
       const verdict = sup.observe(call("foo"), textResult(`distinct-${i}`));
       expect(verdict.type).toBe("pass");
     }
-    expect(sup.needsPromptNudge()).toBe(false);
+    expect(sup.snapshot().trippedTools).toEqual([]);
   });
 
   it("passes through varied errors (each different fingerprint resets counter)", () => {
@@ -61,7 +61,12 @@ describe("supervisor — trips on repeated identical results", () => {
       const synthText = (v3.replacement.content[0] as { text: string }).text;
       expect(synthText).toContain(sameError);
       expect(synthText).toContain("foo");
-      expect(synthText).toContain("Do not call any tools");
+      // Scoped to this tool, past-tense, no universal directives that would
+      // rot in conversation history across future runs.
+      expect(synthText).toContain("disabled for the rest of this run");
+      expect(synthText).not.toContain("Do not call any tools");
+      expect(synthText).not.toContain("End the run");
+      expect(synthText).toContain("Other tools remain available");
     }
   });
 
@@ -74,23 +79,13 @@ describe("supervisor — trips on repeated identical results", () => {
     expect(v3.type).toBe("synth");
   });
 
-  it("sets needsPromptNudge after a trip", () => {
+  it("reports tripped tool in snapshot after a trip", () => {
     const sup = createRunSupervisor();
     const e = textResult("err", true);
     sup.observe(call("foo"), e);
     sup.observe(call("foo"), e);
     sup.observe(call("foo"), e);
-    expect(sup.needsPromptNudge()).toBe(true);
-  });
-
-  it("consumeNudge clears the flag", () => {
-    const sup = createRunSupervisor();
-    const e = textResult("err", true);
-    sup.observe(call("foo"), e);
-    sup.observe(call("foo"), e);
-    sup.observe(call("foo"), e);
-    sup.consumeNudge();
-    expect(sup.needsPromptNudge()).toBe(false);
+    expect(sup.snapshot().trippedTools).toEqual(["foo"]);
   });
 });
 
@@ -106,16 +101,15 @@ describe("supervisor — stickiness once tripped", () => {
     expect(recovery.type).toBe("synth");
   });
 
-  it("renudges on every post-trip call", () => {
+  it("keeps the tool in trippedTools across subsequent calls", () => {
     const sup = createRunSupervisor();
     const e = textResult("err", true);
     sup.observe(call("foo"), e);
     sup.observe(call("foo"), e);
     sup.observe(call("foo"), e);
-    sup.consumeNudge();
 
     sup.observe(call("foo"), e);
-    expect(sup.needsPromptNudge()).toBe(true);
+    expect(sup.snapshot().trippedTools).toEqual(["foo"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Loop-detector halt told the model "do not call any tools" via prompt + tool result; over-broad (only the tripped tool is disabled) and the directive rots in conversation history.
- Now: tripped tool is filtered out of `modelTools` on subsequent iterations of the run. Affordance, not prose.
- Synth `ToolResult` text rewritten to be durable in history: past-tense, scoped to the disabled tool, no universal directives.
- Removed redundant system-prompt nudge (and the dead `needsPromptNudge` / `consumeNudge` API on the supervisor).

## Why this approach
- The model can't call a tool that isn't in its list. Filtering at the toolset level is more reliable than instructing the model to abstain.
- Synth message in `tool_result` content persists in conversation log forever. Reworded to be past-tense + scoped means it reads sensibly across future runs.

## Test plan
- [ ] `bun run verify` passes
- [ ] After supervisor trip, tripped tool absent from modelTools on next iteration
- [ ] Other tools still callable post-trip
- [ ] Synth message text does not contain universal directives