### PR TITLE
fix(conversation): refuse to persist binary payloads (#54)

### DIFF
--- a/src/conversation/binary-guard.ts
+++ b/src/conversation/binary-guard.ts
@@ -1,0 +1,51 @@
+/**
+ * Refuse to persist binary payloads into the conversation log.
+ *
+ * Buffer / Uint8Array / any other ArrayBuffer view serialises through
+ * `JSON.stringify` as `{"0":N,"1":N,"2":N,...}` — one key per byte,
+ * ~10× the size of the raw bytes. A single 100 KB image bloats its
+ * conversation file by ~1 MB. The architectural fix is to persist a
+ * `resource_link` to the workspace `FileStore` and rehydrate at the
+ * model boundary; this guard is the defensive backstop that ensures
+ * the bug can't silently come back. See issue #54.
+ *
+ * Throws synchronously with a path-qualified message so the offending
+ * field is easy to locate. Cycles are guarded with a `WeakSet` so
+ * pathological self-referential events don't loop.
+ */
+export function assertNoBinaryPayloads(value: unknown, context: string): void {
+  visit(value, context, new WeakSet());
+}
+
+function visit(value: unknown, path: string, seen: WeakSet<object>): void {
+  if (value === null || typeof value !== "object") return;
+  const obj = value as object;
+  if (seen.has(obj)) return;
+  seen.add(obj);
+
+  // ArrayBuffer.isView covers Buffer, Uint8Array, Int8Array, Uint16Array,
+  // and every other typed-array view in one check.
+  if (ArrayBuffer.isView(value)) {
+    throw new Error(
+      `Refusing to persist binary payload at ${path} (${(value as { constructor: { name: string } }).constructor.name}). ` +
+        `Store bytes in the workspace FileStore and reference them via a resource_link — see issue #54.`,
+    );
+  }
+  if (value instanceof ArrayBuffer) {
+    throw new Error(
+      `Refusing to persist ArrayBuffer at ${path}. ` +
+        `Store bytes in the workspace FileStore and reference them via a resource_link — see issue #54.`,
+    );
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      visit(value[i], `${path}[${i}]`, seen);
+    }
+    return;
+  }
+
+  for (const key of Object.keys(obj)) {
+    visit((obj as Record<string, unknown>)[key], `${path}.${key}`, seen);
+  }
+}

--- a/src/conversation/event-sourced-store.ts
+++ b/src/conversation/event-sourced-store.ts
@@ -10,6 +10,7 @@ import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { EngineEvent, EventSink } from "../engine/types.ts";
+import { assertNoBinaryPayloads } from "./binary-guard.ts";
 import {
   deriveConversationMeta,
   deriveUsageMetrics,
@@ -231,7 +232,11 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
         } as ConversationEvent;
         this.appendEventSync(conversation.id, event);
       } else if (message.role === "assistant" && message.metadata) {
-        // Create synthetic run bookends + llm.response from assistant metadata
+        // Create synthetic run bookends + llm.response from assistant metadata.
+        // Route through `appendEventSync` (three calls instead of one batched
+        // `appendFileSync`) so the binary-payload guard covers this path too.
+        // The three events are written in order, terminated by a trailing
+        // newline each — same on-disk shape as the previous batched write.
         const runId = `append_${Date.now()}`;
         const runStart: ConversationEvent = {
           ts: message.timestamp,
@@ -259,16 +264,15 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
           totalMs: message.metadata.llmMs ?? 0,
         } as ConversationEvent;
 
-        const path = this.path(conversation.id);
-        appendFileSync(
-          path,
-          `${JSON.stringify(runStart)}\n${JSON.stringify(llmResponse)}\n${JSON.stringify(runDone)}\n`,
-        );
+        this.appendEventSync(conversation.id, runStart);
+        this.appendEventSync(conversation.id, llmResponse);
+        this.appendEventSync(conversation.id, runDone);
       }
       return;
     }
 
     // Legacy format — same pattern as JsonlConversationStore
+    assertNoBinaryPayloads(message, `message(${message.role})`);
     const path = this.path(conversation.id);
     if (message.role === "assistant" && message.metadata) {
       conversation.lastModel = message.metadata.model ?? conversation.lastModel;
@@ -373,6 +377,14 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
       // the turn (see event-reconstructor.ts: assistant messages are
       // only emitted inside an active run scope). Pre-fix, history() on
       // a forked event-format conversation returned only user messages.
+      //
+      // Reconstructed messages should already be free of binary payloads
+      // (we read them out of the event log, which is guarded on write).
+      // Re-assert anyway so an in-memory source that somehow held bytes
+      // can't poison the forked file.
+      for (const msg of messagesToCopy) {
+        assertNoBinaryPayloads(msg, `fork.message(${msg.role})`);
+      }
       const eventLines: string[] = [];
       let runCounter = 0;
       for (const msg of messagesToCopy) {
@@ -666,6 +678,7 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
 
   /** Synchronously append an event line to a conversation file. */
   private appendEventSync(id: string, event: ConversationEvent): void {
+    assertNoBinaryPayloads(event, `event(${event.type})`);
     const path = this.path(id);
     appendFileSync(path, `${JSON.stringify(event)}\n`);
   }

--- a/src/conversation/jsonl-store.ts
+++ b/src/conversation/jsonl-store.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { assertNoBinaryPayloads } from "./binary-guard.ts";
 import { ConversationIndex, canAccess } from "./index-cache.ts";
 import {
   type Conversation,
@@ -130,6 +131,7 @@ export class JsonlConversationStore implements ConversationStore {
   }
 
   async append(conversation: Conversation, message: StoredMessage): Promise<void> {
+    assertNoBinaryPayloads(message, `message(${message.role})`);
     const path = this.path(conversation.id);
 
     // Track lastModel for display. Token totals are derived from the
@@ -238,6 +240,12 @@ export class JsonlConversationStore implements ConversationStore {
       newConv.updatedAt =
         messagesToCopy[messagesToCopy.length - 1]?.timestamp ?? new Date().toISOString();
 
+      // Defence-in-depth: rebuilt-from-history shouldn't carry bytes,
+      // but assert before stringify so an in-memory source that does
+      // can't poison the forked file.
+      for (const msg of messagesToCopy) {
+        assertNoBinaryPayloads(msg, `fork.message(${msg.role})`);
+      }
       const lines = [JSON.stringify(newConv)];
       for (const msg of messagesToCopy) {
         lines.push(JSON.stringify(msg));

--- a/test/unit/conversation/binary-guard.test.ts
+++ b/test/unit/conversation/binary-guard.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Defensive guard against issue #54: binary payloads (Buffer / Uint8Array)
+ * must not be persisted into conversation JSONL files, where they
+ * serialise as `{"0":N,"1":N,...}` and bloat the file ~10×.
+ *
+ * Two layers tested here:
+ *   1. The `assertNoBinaryPayloads` helper itself — sanity tests for the
+ *      detection logic across the typed-array family and nested shapes.
+ *   2. The store wiring — `append()` on both event-sourced and JSONL
+ *      stores must reject binary-bearing messages, and a clean message
+ *      with a `resource_link` must round-trip without producing the
+ *      per-byte dict pattern on disk.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assertNoBinaryPayloads } from "../../../src/conversation/binary-guard.ts";
+import { EventSourcedConversationStore } from "../../../src/conversation/event-sourced-store.ts";
+import { JsonlConversationStore } from "../../../src/conversation/jsonl-store.ts";
+import type { StoredMessage } from "../../../src/conversation/types.ts";
+
+function makeDir(): string {
+  const base = mkdtempSync(join(tmpdir(), "binary-guard-"));
+  const dir = join(base, "conversations");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Per-byte dict shape that bloats JSONL — see issue #54. */
+const PER_BYTE_DICT_RE = /"\d+":\d+,"\d+":\d+/;
+
+describe("assertNoBinaryPayloads", () => {
+  it("accepts plain JSON-shaped objects", () => {
+    expect(() =>
+      assertNoBinaryPayloads(
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hi" },
+            { type: "resource_link", uri: "files://fl_x", mimeType: "image/png", name: "p.png" },
+          ],
+          timestamp: "2026-05-18T00:00:00.000Z",
+        },
+        "msg",
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws on Buffer at the top level", () => {
+    expect(() => assertNoBinaryPayloads(Buffer.from([1, 2, 3]), "top")).toThrow(
+      /Refusing to persist binary payload at top/,
+    );
+  });
+
+  it("throws on Uint8Array nested inside contentParts", () => {
+    expect(() =>
+      assertNoBinaryPayloads(
+        {
+          role: "user",
+          content: [{ type: "image", image: new Uint8Array([137, 80, 78, 71]) }],
+        },
+        "message",
+      ),
+    ).toThrow(/message\.content\[0\]\.image/);
+  });
+
+  it("throws on a raw ArrayBuffer", () => {
+    expect(() => assertNoBinaryPayloads({ data: new ArrayBuffer(4) }, "msg")).toThrow(
+      /ArrayBuffer at msg\.data/,
+    );
+  });
+
+  it("detects typed-array subclasses other than Uint8Array", () => {
+    expect(() =>
+      assertNoBinaryPayloads({ samples: new Int16Array([1, 2, 3]) }, "audio"),
+    ).toThrow(/audio\.samples \(Int16Array\)/);
+  });
+
+  it("does not loop forever on a cyclic object", () => {
+    const obj: Record<string, unknown> = { role: "user" };
+    obj.self = obj;
+    expect(() => assertNoBinaryPayloads(obj, "cyclic")).not.toThrow();
+  });
+});
+
+describe("conversation stores reject binary-bearing messages (issue #54)", () => {
+  it("EventSourcedConversationStore.append throws on Buffer in contentParts", async () => {
+    const store = new EventSourcedConversationStore({ dir: makeDir() });
+    const conv = await store.create();
+
+    const poisoned = {
+      role: "user",
+      timestamp: "2026-05-18T00:00:00.000Z",
+      content: [
+        { type: "text", text: "what's this?" },
+        // The historical bug shape: bytes inline in the content part.
+        { type: "image", image: Buffer.from([0x89, 0x50, 0x4e, 0x47]) },
+      ],
+    } as unknown as StoredMessage;
+
+    await expect(store.append(conv, poisoned)).rejects.toThrow(/Refusing to persist binary/);
+  });
+
+  it("JsonlConversationStore.append throws on Uint8Array in contentParts", async () => {
+    const store = new JsonlConversationStore(makeDir());
+    const conv = await store.create();
+
+    const poisoned = {
+      role: "user",
+      timestamp: "2026-05-18T00:00:00.000Z",
+      content: [{ type: "image", image: new Uint8Array([1, 2, 3, 4]) }],
+    } as unknown as StoredMessage;
+
+    await expect(store.append(conv, poisoned)).rejects.toThrow(/Refusing to persist binary/);
+  });
+
+  it("clean message with resource_link round-trips without per-byte dict pattern", async () => {
+    const dir = makeDir();
+    const store = new EventSourcedConversationStore({ dir });
+    const conv = await store.create();
+
+    const clean: StoredMessage = {
+      role: "user",
+      timestamp: "2026-05-18T00:00:00.000Z",
+      content: [
+        { type: "text", text: "see this image" },
+        { type: "resource_link", uri: "files://fl_test", mimeType: "image/png", name: "p.png" },
+      ],
+    };
+    await store.append(conv, clean);
+
+    const raw = readFileSync(join(dir, `${conv.id}.jsonl`), "utf-8");
+    expect(raw).toContain("files://fl_test");
+    expect(raw).not.toMatch(PER_BYTE_DICT_RE);
+  });
+});


### PR DESCRIPTION
## Summary

Defensive guard against issue #54. Binary payloads (`Buffer`, `Uint8Array`, any `ArrayBuffer.isView`) refuse to be persisted into the conversation log — they serialise as `{\"0\":N,\"1\":N,...}` and bloat JSONL ~10×.

PR #188 (images) and #210 (PDFs) already moved real binary content out of the message log and into `resource_link` references pointing at the workspace `FileStore`. This PR adds the backstop the issue specifically asked for, so the regression can't silently come back via a new code path.

## What changed

- **New** `src/conversation/binary-guard.ts` — recursive walk that throws a path-qualified error on any `ArrayBuffer.isView` value or raw `ArrayBuffer`. Handles cycles via `WeakSet`. The thrown message names the offending field and points at #54.
- **Wired in** at every append seam that ends in `JSON.stringify`:
  - `event-sourced-store.appendEventSync` — covers `appendEvent`, the `EventSink` engine-event path, and every `metadata.*` event.
  - `event-sourced-store.append` legacy-format branch (writes the entire `StoredMessage`).
  - `event-sourced-store.append` event-format-assistant branch — refactored from one batched `appendFileSync` to three `appendEventSync` calls so the guard covers it for free with identical on-disk shape.
  - `event-sourced-store.fork` and `jsonl-store.fork` — defence-in-depth before stringifying replayed messages.
  - `jsonl-store.append`.
- Memory store is intentionally not wired in — it doesn't serialise.

## Tests

`test/unit/conversation/binary-guard.test.ts` covers:
- Guard helper: typed-array family (Buffer / Uint8Array / Int16Array / ArrayBuffer), nested shapes, cyclic objects.
- `EventSourcedConversationStore.append` and `JsonlConversationStore.append` rejecting messages with `Buffer` / `Uint8Array` in `contentParts`.
- A clean round-trip with a `resource_link` asserting the on-disk JSONL contains no `\"\\d+\":\\d+,\"\\d+\":\\d+` pattern.

## Verification

```
bun run verify:static       # clean
bun run test:unit           # 2837 pass / 0 fail
```

## Test plan

- [ ] CI green
- [ ] Spot-check that uploading an image and then a PDF still works end-to-end (the existing resource_link paths are unaffected; the guard only fires if bytes leak into the persistence path)

Fixes #54