### PR TITLE
fix(briefing): invalidate cached briefing on workspace data change

### DIFF
--- a/src/services/briefing-cache.ts
+++ b/src/services/briefing-cache.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { type Dirent, existsSync, lstatSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { BundleInstance } from "../bundles/types.ts";
 import type { BriefingCacheEntry, BriefingOutput } from "./home-types.ts";
@@ -96,6 +96,14 @@ export function computeBriefingFingerprint(logDir: string, instances: BundleInst
  * Compact signature of a directory tree — file count, newest mtime, and
  * total size. Catches additions, deletions, and content edits (any write
  * advances mtime). `"absent"` for a missing directory.
+ *
+ * Resilient to a churning tree: `readdirSync` only descends into real
+ * directories (a symlink Dirent reports `isDirectory() === false`), so the
+ * recursion can't cycle. Entries are measured with `lstatSync` — it never
+ * follows a symlink (so a dangling link is sized, not a thrown `ENOENT`)
+ * and a symlink is counted as a leaf rather than its target. Any entry
+ * that vanishes between `readdir` and `lstat` (concurrent delete) is
+ * skipped; the next briefing call re-fingerprints the settled tree.
  */
 function dirSignature(dir: string): string {
   if (!existsSync(dir)) return "absent";
@@ -103,16 +111,26 @@ function dirSignature(dir: string): string {
   let newestMtimeMs = 0;
   let totalSize = 0;
   const walk = (current: string): void => {
-    for (const entry of readdirSync(current, { withFileTypes: true })) {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
       const full = join(current, entry.name);
       if (entry.isDirectory()) {
         walk(full);
         continue;
       }
-      const stat = statSync(full);
-      count++;
-      totalSize += stat.size;
-      if (stat.mtimeMs > newestMtimeMs) newestMtimeMs = stat.mtimeMs;
+      try {
+        const stat = lstatSync(full);
+        count++;
+        totalSize += stat.size;
+        if (stat.mtimeMs > newestMtimeMs) newestMtimeMs = stat.mtimeMs;
+      } catch {
+        // Entry removed between readdir and lstat — skip it.
+      }
     }
   };
   walk(dir);

--- a/src/services/briefing-cache.ts
+++ b/src/services/briefing-cache.ts
@@ -1,3 +1,6 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { BundleInstance } from "../bundles/types.ts";
 import type { BriefingCacheEntry, BriefingOutput } from "./home-types.ts";
 
 export class BriefingCache {
@@ -26,41 +29,92 @@ export class BriefingCache {
     this.refreshing = false;
   }
 
-  get(): BriefingOutput | null {
+  /**
+   * Return the cached briefing, or null when there is no entry, the TTL has
+   * expired, or `fingerprint` no longer matches the data the briefing was
+   * built from. The fingerprint check is what keeps a briefing from
+   * outliving the data it summarizes — see `computeBriefingFingerprint`.
+   */
+  get(fingerprint: string): BriefingOutput | null {
     if (!this.entry) return null;
-    if (this.entry.invalidated) return null;
+    if (this.entry.fingerprint !== fingerprint) return null;
     if (Date.now() - this.entry.generatedAt > this.ttlMs) return null;
     return { ...this.entry.briefing, cached: true };
   }
 
   /**
-   * Return the last briefing even if it's past its TTL — but not if it was
-   * explicitly invalidated, and not when there's none. For stale-while-
-   * revalidate: serve this instantly while a fresh one regenerates in the
-   * background, so a dashboard load never waits on the LLM after the first
-   * generation.
+   * Return the last briefing even when it's past its TTL or the data has moved
+   * on — only `null` when there is no entry at all. For stale-while-revalidate:
+   * serve this instantly while a fresh one regenerates in the background, so a
+   * dashboard load never waits on the LLM after the first generation. The
+   * fingerprint check lives in `get()`, not here — serving a briefly-stale
+   * briefing during the regen window is the whole point of this path.
    */
   getStale(): BriefingOutput | null {
     if (!this.entry) return null;
-    if (this.entry.invalidated) return null;
     return { ...this.entry.briefing, cached: true };
   }
 
-  set(briefing: BriefingOutput): void {
+  set(briefing: BriefingOutput, fingerprint: string): void {
     this.entry = {
       briefing,
       generatedAt: Date.now(),
-      invalidated: false,
+      fingerprint,
     };
   }
+}
 
-  invalidate(): void {
-    if (this.entry) {
-      this.entry.invalidated = true;
+/**
+ * Compute a fingerprint of the workspace data a briefing is built from:
+ * activity logs plus each running bundle's entity data. The cache compares
+ * it on every read — when the underlying data changes the fingerprint
+ * changes, so a stale briefing is never served.
+ *
+ * This deliberately replaces tool-call-event invalidation: events can't
+ * tell a read from a write, so app reads would invalidate the cache on
+ * every interaction. A content fingerprint invalidates if and only if the
+ * data actually changed.
+ *
+ * Facets sourced from MCP `resource`/`tool` calls rather than entity files
+ * are not captured here — those changes fall back to the cache TTL.
+ */
+export function computeBriefingFingerprint(logDir: string, instances: BundleInstance[]): string {
+  const parts: string[] = [`logs:${dirSignature(logDir)}`];
+  const running = instances
+    .filter((i) => i.state === "running")
+    .sort((a, b) => a.bundleName.localeCompare(b.bundleName));
+  for (const inst of running) {
+    parts.push(`bundle:${inst.bundleName}`);
+    if (inst.entityDataRoot) {
+      parts.push(`data:${dirSignature(inst.entityDataRoot)}`);
     }
   }
+  return parts.join("|");
+}
 
-  isStale(): boolean {
-    return this.get() === null;
-  }
+/**
+ * Compact signature of a directory tree — file count, newest mtime, and
+ * total size. Catches additions, deletions, and content edits (any write
+ * advances mtime). `"absent"` for a missing directory.
+ */
+function dirSignature(dir: string): string {
+  if (!existsSync(dir)) return "absent";
+  let count = 0;
+  let newestMtimeMs = 0;
+  let totalSize = 0;
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      const stat = statSync(full);
+      count++;
+      totalSize += stat.size;
+      if (stat.mtimeMs > newestMtimeMs) newestMtimeMs = stat.mtimeMs;
+    }
+  };
+  walk(dir);
+  return `${count}:${newestMtimeMs}:${totalSize}`;
 }

--- a/src/services/home-types.ts
+++ b/src/services/home-types.ts
@@ -19,7 +19,8 @@ export interface BriefingInput {
 export interface BriefingCacheEntry {
   briefing: BriefingOutput;
   generatedAt: number;
-  invalidated: boolean;
+  /** Fingerprint of the workspace data the briefing was built from. */
+  fingerprint: string;
 }
 
 /** Activity query input — passed to home__activity tool. */

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -20,7 +20,7 @@ const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
 const VERSION = process.env.NB_VERSION || pkg.version;
 
 import { ActivityCollector } from "../services/activity-collector.ts";
-import { BriefingCache } from "../services/briefing-cache.ts";
+import { BriefingCache, computeBriefingFingerprint } from "../services/briefing-cache.ts";
 import { collectBriefingFacets } from "../services/briefing-collector.ts";
 import { BriefingGenerator } from "../services/briefing-generator.ts";
 import type { BriefingOutput } from "../services/home-types.ts";
@@ -796,15 +796,25 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               return generator.generate(activity, facetContext);
             };
 
+            // Fingerprint the data this briefing is built from — activity logs
+            // plus each running bundle's entity data. The cache serves a stored
+            // briefing only while this matches, so a data edit (a new todo, CRM
+            // row, note) misses the cache on the very next load instead of
+            // waiting out the TTL. See `computeBriefingFingerprint`.
+            const logDir = join(runtime.getWorkspaceScopedDir(wsId), "logs");
+            const instances = runtime.getBundleInstancesForWorkspace(wsId);
+            const fingerprint = computeBriefingFingerprint(logDir, instances);
+
             if (!input.force_refresh) {
-              // Fresh cache → instant.
-              const fresh = briefingCache.get();
+              // Fresh cache + unchanged data → instant.
+              const fresh = briefingCache.get(fingerprint);
               if (fresh) return ok(fresh, "Briefing retrieved from cache.");
 
-              // Stale-while-revalidate: serve the last (expired) briefing
-              // immediately and regenerate in the BACKGROUND, so the dashboard
-              // never waits on the LLM after the first generation. The bg task
-              // re-establishes the workspace request context (captured here) —
+              // Stale-while-revalidate: a TTL miss OR a fingerprint miss (the
+              // data moved on) serves the last briefing immediately and
+              // regenerates in the BACKGROUND, so the dashboard never waits on
+              // the LLM after the first generation. The bg task re-establishes
+              // the workspace request context (captured here) —
               // `collectBriefingFacets` dispatches facet tools via
               // `registry.execute`, which read `requireWorkspaceId()` / identity
               // from that context.
@@ -824,7 +834,7 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
                     },
                   };
                   void runWithRequestContext(bgCtx, runGeneration)
-                    .then((b) => briefingCache.set(b))
+                    .then((b) => briefingCache.set(b, fingerprint))
                     .catch((err) =>
                       log.warn(
                         `[briefing] background refresh failed for ${wsId}: ${
@@ -843,7 +853,7 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
             // failure → the outer catch turns it into an isError result, which
             // the home UI renders as a retry state.
             const briefing = await runGeneration();
-            briefingCache.set(briefing);
+            briefingCache.set(briefing, fingerprint);
             return ok(briefing, "Briefing generated.");
           } catch (err) {
             return {

--- a/test/unit/services/briefing-cache.test.ts
+++ b/test/unit/services/briefing-cache.test.ts
@@ -1,5 +1,9 @@
-import { describe, test, expect, beforeEach } from "bun:test";
-import { BriefingCache } from "../../../src/services/briefing-cache.ts";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BundleInstance } from "../../../src/bundles/types.ts";
+import { BriefingCache, computeBriefingFingerprint } from "../../../src/services/briefing-cache.ts";
 import type { BriefingOutput } from "../../../src/services/home-types.ts";
 
 function makeBriefing(overrides?: Partial<BriefingOutput>): BriefingOutput {
@@ -22,45 +26,39 @@ describe("BriefingCache", () => {
 		cache = new BriefingCache(30); // 30 min TTL
 	});
 
-	test("initial state: get() returns null, isStale() returns true", () => {
-		expect(cache.get()).toBeNull();
-		expect(cache.isStale()).toBe(true);
+	test("initial state: get() returns null", () => {
+		expect(cache.get("fp-1")).toBeNull();
 	});
 
-	test("set() then get() returns briefing with cached: true", () => {
-		const briefing = makeBriefing();
-		cache.set(briefing);
-		const result = cache.get();
+	test("set() then get() with the same fingerprint returns the briefing", () => {
+		cache.set(makeBriefing(), "fp-1");
+		const result = cache.get("fp-1");
 		expect(result).not.toBeNull();
 		expect(result!.cached).toBe(true);
 		expect(result!.greeting).toBe("Good afternoon, Test");
 	});
 
-	test("invalidate() causes get() to return null", () => {
-		cache.set(makeBriefing());
-		cache.invalidate();
-		expect(cache.get()).toBeNull();
-		expect(cache.isStale()).toBe(true);
+	test("get() with a changed fingerprint returns null — the data moved on", () => {
+		cache.set(makeBriefing(), "fp-1");
+		expect(cache.get("fp-2")).toBeNull();
 	});
 
-	test("re-set after invalidation works", () => {
-		cache.set(makeBriefing());
-		cache.invalidate();
-		expect(cache.get()).toBeNull();
-		cache.set(makeBriefing({ lede: "Updated" }));
-		const result = cache.get();
+	test("re-set with a new fingerprint serves the fresh briefing", () => {
+		cache.set(makeBriefing(), "fp-1");
+		expect(cache.get("fp-2")).toBeNull();
+		cache.set(makeBriefing({ lede: "Updated" }), "fp-2");
+		const result = cache.get("fp-2");
 		expect(result).not.toBeNull();
 		expect(result!.lede).toBe("Updated");
 	});
 
-	test("expired cache returns null", () => {
+	test("expired cache returns null even when the fingerprint matches", () => {
 		const originalNow = Date.now;
 		try {
-			const cache31 = new BriefingCache(30);
 			Date.now = originalNow;
-			cache31.set(makeBriefing());
+			cache.set(makeBriefing(), "fp-1");
 			Date.now = () => originalNow() + 31 * 60 * 1000;
-			expect(cache31.get()).toBeNull();
+			expect(cache.get("fp-1")).toBeNull();
 		} finally {
 			Date.now = originalNow;
 		}
@@ -69,9 +67,9 @@ describe("BriefingCache", () => {
 	test("not expired within TTL", () => {
 		const originalNow = Date.now;
 		try {
-			cache.set(makeBriefing());
-			Date.now = () => originalNow() + 15 * 60 * 1000; // 15 minutes (within 30 min TTL)
-			expect(cache.get()).not.toBeNull();
+			cache.set(makeBriefing(), "fp-1");
+			Date.now = () => originalNow() + 15 * 60 * 1000; // within 30 min TTL
+			expect(cache.get("fp-1")).not.toBeNull();
 		} finally {
 			Date.now = originalNow;
 		}
@@ -80,9 +78,9 @@ describe("BriefingCache", () => {
 	test("getStale() returns an expired entry (stale-while-revalidate) while get() returns null", () => {
 		const originalNow = Date.now;
 		try {
-			cache.set(makeBriefing({ lede: "Stale but serviceable" }));
+			cache.set(makeBriefing({ lede: "Stale but serviceable" }), "fp-1");
 			Date.now = () => originalNow() + 31 * 60 * 1000; // past the 30 min TTL
-			expect(cache.get()).toBeNull(); // fresh check fails
+			expect(cache.get("fp-1")).toBeNull(); // fresh check fails
 			const stale = cache.getStale(); // but stale is still served
 			expect(stale).not.toBeNull();
 			expect(stale!.cached).toBe(true);
@@ -92,11 +90,19 @@ describe("BriefingCache", () => {
 		}
 	});
 
-	test("getStale() returns null when empty or invalidated", () => {
-		expect(cache.getStale()).toBeNull(); // empty
-		cache.set(makeBriefing());
-		cache.invalidate();
-		expect(cache.getStale()).toBeNull(); // invalidated is not served, even as stale
+	test("getStale() serves the last entry even after the fingerprint moves on", () => {
+		// getStale() is fingerprint-agnostic by design: get(fp) misses the
+		// moment data changes, then getStale() serves the prior briefing once
+		// while a fresh one regenerates in the background.
+		cache.set(makeBriefing({ lede: "Built from old data" }), "fp-1");
+		expect(cache.get("fp-2")).toBeNull(); // data moved on → fresh miss
+		const stale = cache.getStale();
+		expect(stale).not.toBeNull();
+		expect(stale!.lede).toBe("Built from old data");
+	});
+
+	test("getStale() returns null when there is no entry", () => {
+		expect(cache.getStale()).toBeNull();
 	});
 
 	test("beginRefresh() is a single-flight guard — blocks a second start until endRefresh()", () => {
@@ -107,3 +113,75 @@ describe("BriefingCache", () => {
 	});
 });
 
+/** Minimal BundleInstance — computeBriefingFingerprint reads only these fields. */
+function instance(bundleName: string, state: string, entityDataRoot?: string): BundleInstance {
+	return { bundleName, state, entityDataRoot } as unknown as BundleInstance;
+}
+
+describe("computeBriefingFingerprint", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "briefing-fp-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("is stable when nothing changes", () => {
+		const logDir = join(dir, "logs");
+		mkdirSync(logDir);
+		writeFileSync(join(logDir, "a.jsonl"), "line\n");
+		expect(computeBriefingFingerprint(logDir, [])).toBe(computeBriefingFingerprint(logDir, []));
+	});
+
+	test("changes when a log file is added", () => {
+		const logDir = join(dir, "logs");
+		mkdirSync(logDir);
+		writeFileSync(join(logDir, "a.jsonl"), "line\n");
+		const before = computeBriefingFingerprint(logDir, []);
+		writeFileSync(join(logDir, "b.jsonl"), "line\n");
+		expect(computeBriefingFingerprint(logDir, [])).not.toBe(before);
+	});
+
+	test("changes when a file's content changes", () => {
+		const logDir = join(dir, "logs");
+		mkdirSync(logDir);
+		const file = join(logDir, "a.jsonl");
+		writeFileSync(file, "line\n");
+		const before = computeBriefingFingerprint(logDir, []);
+		writeFileSync(file, "line one\nline two\n");
+		expect(computeBriefingFingerprint(logDir, [])).not.toBe(before);
+	});
+
+	test("reflects a running bundle's entity data — the issue's core case", () => {
+		const logDir = join(dir, "logs");
+		mkdirSync(logDir);
+		const entityRoot = join(dir, "todo-data");
+		mkdirSync(join(entityRoot, "tasks"), { recursive: true });
+		writeFileSync(join(entityRoot, "tasks", "t1.json"), "{}");
+
+		const before = computeBriefingFingerprint(logDir, [instance("todo", "running", entityRoot)]);
+		writeFileSync(join(entityRoot, "tasks", "t2.json"), "{}");
+		const after = computeBriefingFingerprint(logDir, [instance("todo", "running", entityRoot)]);
+		expect(after).not.toBe(before);
+	});
+
+	test("excludes bundles that are not running", () => {
+		const logDir = join(dir, "logs");
+		mkdirSync(logDir);
+		const withStopped = computeBriefingFingerprint(logDir, [
+			instance("todo", "stopped", join(dir, "todo-data")),
+		]);
+		expect(withStopped).toBe(computeBriefingFingerprint(logDir, []));
+	});
+
+	test("missing directories are tolerated, not crashes", () => {
+		expect(() =>
+			computeBriefingFingerprint(join(dir, "no-logs"), [
+				instance("todo", "running", join(dir, "absent")),
+			]),
+		).not.toThrow();
+	});
+});

--- a/test/unit/services/briefing-cache.test.ts
+++ b/test/unit/services/briefing-cache.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { BundleInstance } from "../../../src/bundles/types.ts";
@@ -183,5 +183,20 @@ describe("computeBriefingFingerprint", () => {
 				instance("todo", "running", join(dir, "absent")),
 			]),
 		).not.toThrow();
+	});
+
+	test("a dangling symlink in a data dir does not crash the walk", () => {
+		const logDir = join(dir, "logs");
+		mkdirSync(logDir);
+		symlinkSync(join(dir, "does-not-exist"), join(logDir, "broken-link"));
+		expect(() => computeBriefingFingerprint(logDir, [])).not.toThrow();
+	});
+
+	test("a symlink to a directory is a stable leaf, not infinite recursion", () => {
+		const logDir = join(dir, "logs");
+		mkdirSync(logDir);
+		symlinkSync(dir, join(logDir, "self-link"));
+		const fp = computeBriefingFingerprint(logDir, []);
+		expect(fp).toBe(computeBriefingFingerprint(logDir, []));
 	});
 });


### PR DESCRIPTION
## Summary

The home-dashboard briefing cache was purely TTL-based — adding entities to bundle apps (todos, CRM rows, notes) left the dashboard showing the pre-update briefing for up to the full TTL window. Closes #225.

Invalidation is now **content-based**. `computeBriefingFingerprint` signatures the data a briefing is built from — activity logs and each running bundle's entity data (file count, newest mtime, total size) — and `BriefingCache.get(fingerprint)` serves a stored briefing only while that fingerprint still matches.

## Composes with stale-while-revalidate

This branch was rebased onto the stale-while-revalidate (SWR) flow that landed after it was first opened. The two fit together cleanly:

- A data change now **misses `get()` even within the TTL** (fingerprint mismatch), instead of waiting out the TTL.
- The dashboard serves the prior briefing instantly via `getStale()` while a fresh one regenerates in the **background** — no synchronous wait on the model.
- `getStale()` is intentionally fingerprint-agnostic: serving a briefly-stale briefing during the regen window is the whole point of that path. The fingerprint check lives in `get()`.

Net effect: a todo added in-app shows up on the next dashboard load, and the load is still instant.

## Why a fingerprint, not events

#225 suggested subscribing to `data.changed`. Event-based invalidation doesn't work here:

- Emitting `data.changed` from `/mcp` **loops** — the iframe widget bridge calls tools over `/mcp`, so a broadcast triggers a `useDataSync` refresh, which is another `/mcp` call, which broadcasts again.
- An in-process notifier avoids the loop but fires on **every** tool call, including reads. Apps read constantly, so the briefing regenerated on every interaction.

A tool call can't distinguish a read from a write. A content fingerprint invalidates if and only if the underlying data actually changed — no heuristic, no event plumbing.

## Coverage

The fingerprint watches data, not the write path, so it is vector-agnostic — agent, iframe widget, external MCP client, and bundle install are all caught. Coverage is by data source:

- Bundle entity data (`entityDataRoot`) — the issue's core case. This is the same path entity facets read, so the fingerprint signatures exactly the data those facets summarize.
- Activity logs (`{wsDir}/logs`)
- Bundle install / uninstall (running-bundle set)
- Facets sourced from live MCP `resource`/`tool` calls instead of entity files are **not** fingerprinted; they fall back to the TTL. Documented on `computeBriefingFingerprint`.

`dirSignature` uses `lstatSync` (a dangling symlink is sized, not thrown) and skips entries that vanish mid-walk, so a concurrently-mutating tree cannot crash a briefing.

## Test plan

- [x] `bun run verify` — static, unit, web green
- [x] `briefing-cache` unit tests (18): fingerprint matching, SWR `getStale()` semantics, and `computeBriefingFingerprint` (file add/edit, entity data, non-running exclusion, missing dirs, dangling symlink, symlink-to-dir)
- [ ] Manual: add a todo in-app, reload home — briefing reflects it
- [ ] Manual: revisit home repeatedly with no change — served from cache, not regenerated
