### PR TITLE
fix(content): close the production token-leak seams (files__read, reasoning, conversations__get)

### DIFF
--- a/src/bundles/conversations/src/tools/get.ts
+++ b/src/bundles/conversations/src/tools/get.ts
@@ -1,8 +1,13 @@
 /**
  * Handler for conversations__get tool.
  *
- * Load a conversation's full message history.
- * Uses readConversation() from jsonl-reader.ts.
+ * Loads a conversation. Defaults to a bounded read: metadata + the most
+ * recent `limit` messages, with a hard char cap on the merged message
+ * payload. Callers opt into a metadata-only or full-transcript read via
+ * `expand`. The full transcript is intentionally opt-in: in prod we saw
+ * 897 KB tool results from agents calling `conversations__get` against
+ * long conversations, blowing through the model's context window via a
+ * single tool call.
  */
 
 import type { ConversationIndex } from "../index-cache.ts";
@@ -10,7 +15,49 @@ import { readConversation } from "../jsonl-reader.ts";
 
 export interface GetInput {
   id: string;
+  expand?: "metadata" | "messages" | "full";
   limit?: number;
+}
+
+/** Default number of trailing messages returned in "messages" mode. */
+export const DEFAULT_GET_LIMIT = 20;
+
+/**
+ * Hard cap on the serialized size of returned messages in "messages" mode.
+ * If the selected window exceeds this, older messages are dropped from
+ * the response (most-recent-wins) and a truncation note is emitted.
+ *
+ * Matches the engine's per-result cap (`MAX_TOOL_RESULT_CHARS`) so a
+ * single `conversations__get` call can never produce a tool result that
+ * would itself be truncated by the engine's downstream guard.
+ */
+export const DEFAULT_GET_CHAR_CAP = 50_000;
+
+interface GetMessagesResult {
+  messages: unknown[];
+  /** Count of messages omitted from the front of the selected window. */
+  droppedOlderMessages: number;
+  /** True when the char cap forced messages to be dropped. */
+  truncated: boolean;
+}
+
+function selectByCharCap(messages: unknown[], cap: number): GetMessagesResult {
+  if (cap <= 0 || messages.length === 0) {
+    return { messages, droppedOlderMessages: 0, truncated: false };
+  }
+  // Walk newest → oldest, keeping messages whose cumulative size fits.
+  // Always keep at least one (the most recent) so the response is useful
+  // even if a single message exceeds the cap.
+  const kept: unknown[] = [];
+  let used = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const size = JSON.stringify(messages[i]).length;
+    if (kept.length > 0 && used + size > cap) break;
+    kept.unshift(messages[i]);
+    used += size;
+  }
+  const dropped = messages.length - kept.length;
+  return { messages: kept, droppedOlderMessages: dropped, truncated: dropped > 0 };
 }
 
 export async function handleGet(input: GetInput, index: ConversationIndex): Promise<object> {
@@ -24,27 +71,57 @@ export async function handleGet(input: GetInput, index: ConversationIndex): Prom
     throw new Error(`Conversation not found: ${input.id}`);
   }
 
-  let { messages } = conversation;
+  const metadata = {
+    id: conversation.meta.id,
+    title: conversation.meta.title,
+    createdAt: conversation.meta.createdAt,
+    updatedAt: conversation.meta.updatedAt,
+    totalInputTokens: conversation.meta.totalInputTokens,
+    totalOutputTokens: conversation.meta.totalOutputTokens,
+    lastModel: conversation.meta.lastModel,
+    ...(conversation.meta.ownerId ? { ownerId: conversation.meta.ownerId } : {}),
+    ...(conversation.meta.visibility ? { visibility: conversation.meta.visibility } : {}),
+    ...(conversation.meta.participants ? { participants: conversation.meta.participants } : {}),
+  };
 
-  // When limit is provided, return only the last N messages
-  if (input.limit !== undefined && input.limit >= 0) {
-    messages = messages.slice(-input.limit);
+  const expand = input.expand ?? "messages";
+
+  if (expand === "metadata") {
+    return {
+      metadata,
+      messages: [],
+      totalMessages: conversation.messageCount,
+    };
   }
 
+  if (expand === "full") {
+    // Explicit opt-in to the full transcript. No limit, no char cap.
+    // Caller has acknowledged the cost.
+    return {
+      metadata,
+      messages: conversation.messages,
+      totalMessages: conversation.messageCount,
+    };
+  }
+
+  // Default: most-recent `limit` messages, with a char-cap safety net.
+  const limit = input.limit !== undefined && input.limit >= 0 ? input.limit : DEFAULT_GET_LIMIT;
+  const windowed = conversation.messages.slice(-limit);
+  const { messages, droppedOlderMessages, truncated } = selectByCharCap(
+    windowed,
+    DEFAULT_GET_CHAR_CAP,
+  );
+
   return {
-    metadata: {
-      id: conversation.meta.id,
-      title: conversation.meta.title,
-      createdAt: conversation.meta.createdAt,
-      updatedAt: conversation.meta.updatedAt,
-      totalInputTokens: conversation.meta.totalInputTokens,
-      totalOutputTokens: conversation.meta.totalOutputTokens,
-      lastModel: conversation.meta.lastModel,
-      ...(conversation.meta.ownerId ? { ownerId: conversation.meta.ownerId } : {}),
-      ...(conversation.meta.visibility ? { visibility: conversation.meta.visibility } : {}),
-      ...(conversation.meta.participants ? { participants: conversation.meta.participants } : {}),
-    },
+    metadata,
     messages,
     totalMessages: conversation.messageCount,
+    ...(truncated
+      ? {
+          truncated: true,
+          droppedOlderMessages,
+          truncationHint: `Returned ${messages.length} of the requested ${windowed.length} trailing messages; the older ${droppedOlderMessages} exceeded the ${DEFAULT_GET_CHAR_CAP}-char response budget. Use expand:"full" only if you genuinely need the entire transcript, or narrow the limit and request specific ranges.`,
+        }
+      : {}),
   };
 }

--- a/src/bundles/conversations/src/tools/get.ts
+++ b/src/bundles/conversations/src/tools/get.ts
@@ -23,15 +23,21 @@ export interface GetInput {
 export const DEFAULT_GET_LIMIT = 20;
 
 /**
- * Hard cap on the serialized size of returned messages in "messages" mode.
- * If the selected window exceeds this, older messages are dropped from
- * the response (most-recent-wins) and a truncation note is emitted.
+ * Soft cap on the serialized size of returned messages in "messages" mode,
+ * measured against compact `JSON.stringify(msg).length` summed across
+ * messages. If the selected window exceeds this, older messages are
+ * dropped from the response (most-recent-wins) and a truncation note is
+ * emitted.
  *
- * Matches the engine's per-result cap (`MAX_TOOL_RESULT_CHARS`) so a
- * single `conversations__get` call can never produce a tool result that
- * would itself be truncated by the engine's downstream guard.
+ * Sized to stay under the engine's `MAX_TOOL_RESULT_CHARS` (50,000) after
+ * (a) the wrapper object is added, and (b) the final result is serialized
+ * with `JSON.stringify(result, null, 2)` — pretty-print typically inflates
+ * a nested message array by 30–50%. 30k of compact messages → ~40–45 KB
+ * pretty-printed total, comfortably under the engine cap. The result shape
+ * below puts `truncated` / `droppedOlderMessages` / `truncationHint` ahead
+ * of `messages` so the flags survive even if the engine ever does slice.
  */
-export const DEFAULT_GET_CHAR_CAP = 50_000;
+export const DEFAULT_GET_CHAR_CAP = 30_000;
 
 interface GetMessagesResult {
   messages: unknown[];
@@ -112,9 +118,13 @@ export async function handleGet(input: GetInput, index: ConversationIndex): Prom
     DEFAULT_GET_CHAR_CAP,
   );
 
+  // Field order matters: small flags first, large `messages` last. The
+  // engine's per-result cap (`MAX_TOOL_RESULT_CHARS`) slices the
+  // pretty-printed JSON from the END if anything ever overshoots, so
+  // putting `truncated` / `droppedOlderMessages` / `truncationHint` ahead
+  // of `messages` keeps the diagnostic flags intact in the worst case.
   return {
     metadata,
-    messages,
     totalMessages: conversation.messageCount,
     ...(truncated
       ? {
@@ -123,5 +133,6 @@ export async function handleGet(input: GetInput, index: ConversationIndex): Prom
           truncationHint: `Returned ${messages.length} of the requested ${windowed.length} trailing messages; the older ${droppedOlderMessages} exceeded the ${DEFAULT_GET_CHAR_CAP}-char response budget. Use expand:"full" only if you genuinely need the entire transcript, or narrow the limit and request specific ranges.`,
         }
       : {}),
+    messages,
   };
 }

--- a/src/conversation/window.ts
+++ b/src/conversation/window.ts
@@ -86,6 +86,52 @@ function groupMessages(messages: LanguageModelV3Message[]): LanguageModelV3Messa
 }
 
 /**
+ * Strip reasoning blocks from assistant messages older than the most recent
+ * assistant turn.
+ *
+ * Anthropic's guidance for extended thinking: pass thinking blocks from the
+ * most recent turn back to the API unchanged; strip thinking blocks from
+ * older turns to reduce token usage. The reasoning blocks attached to the
+ * last assistant message are still load-bearing — they pair with any
+ * tool-use chain currently in flight — but every earlier assistant message's
+ * reasoning is historical and replays as opaque signature bytes that bloat
+ * the prompt linearly with turn count.
+ *
+ * In production conv_e00606c7aab7423d we saw 100+ KB `llm.response` events
+ * dominated by Anthropic signatures with empty `text`. This is the seam
+ * where that growth is cut.
+ *
+ * Edge case: an assistant message that contains ONLY reasoning blocks is a
+ * legitimate placeholder for a turn that produced reasoning-only output
+ * (see `event-reconstructor.ts` step 4a). Stripping its only content would
+ * leave an empty assistant message that Anthropic rejects on replay, so
+ * those placeholders are kept intact.
+ */
+export function stripOlderReasoning(messages: LanguageModelV3Message[]): LanguageModelV3Message[] {
+  let lastAssistantIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") {
+      lastAssistantIdx = i;
+      break;
+    }
+  }
+  if (lastAssistantIdx <= 0) return messages;
+
+  let changed = false;
+  const out = messages.map((msg, idx) => {
+    if (idx === lastAssistantIdx) return msg;
+    if (msg.role !== "assistant") return msg;
+    if (typeof msg.content === "string") return msg;
+    const nonReasoning = msg.content.filter((part) => part.type !== "reasoning");
+    if (nonReasoning.length === msg.content.length) return msg;
+    if (nonReasoning.length === 0) return msg; // pure-reasoning placeholder
+    changed = true;
+    return { ...msg, content: nonReasoning };
+  });
+  return changed ? out : messages;
+}
+
+/**
  * Limit conversation history by message group count.
  * Keeps the first message (initial user request) plus the most recent
  * `maxGroups` message groups. Tool call/result pairs count as one group.

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -10,8 +10,10 @@ export interface UploadedFile {
   mimeType: string;
 }
 
-// MIME types we accept, grouped by category
-const EXTRACTABLE_TEXT = new Set([
+// MIME types we accept, grouped by category. Exported so other modules
+// (notably `src/tools/platform/files.ts::handleRead`) classify files
+// against the same source of truth instead of duplicating the lists.
+export const EXTRACTABLE_TEXT = new Set([
   "text/plain",
   "text/csv",
   "text/markdown",
@@ -23,7 +25,7 @@ const EXTRACTABLE_TEXT = new Set([
   "application/yaml",
 ]);
 
-const EXTRACTABLE_DOCS = new Set([
+export const EXTRACTABLE_DOCS = new Set([
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ]);
@@ -75,7 +77,14 @@ export function isAllowedMime(mimeType: string): boolean {
   return ALLOWED_MIMES.has(normalizeMime(mimeType));
 }
 
-function isExtractable(mimeType: string): boolean {
+/**
+ * True if `extractText` knows how to surface a textual representation
+ * of bytes of this MIME type. PDF is excluded: `rehydrate.ts` and
+ * `handleRead` route PDFs through their own (capability-aware) policy,
+ * not the generic ingest extraction path, so the set stays focused on
+ * formats where the only useful surface to the model is extracted text.
+ */
+export function isExtractable(mimeType: string): boolean {
   const bare = normalizeMime(mimeType);
   return EXTRACTABLE_TEXT.has(bare) || EXTRACTABLE_DOCS.has(bare);
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -22,7 +22,7 @@ import type {
   ConversationStore,
   ParticipantInfo,
 } from "../conversation/types.ts";
-import { sliceHistory, windowMessages } from "../conversation/window.ts";
+import { sliceHistory, stripOlderReasoning, windowMessages } from "../conversation/window.ts";
 import { AgentEngine } from "../engine/engine.ts";
 import { estimateMessageTokens, estimateToolDescriptionTokens } from "../engine/token-estimate.ts";
 import type {
@@ -423,8 +423,13 @@ export class Runtime {
     const hooks: EngineHooks = {
       beforeToolCall: createPrivilegeHook(gate, events, features),
       transformContext: (messages) => {
+        // Order matters: slice by count first (cheap, deterministic), then
+        // strip older-turn reasoning (drops bytes we'd otherwise budget for),
+        // then window by token budget. Reasoning stripping runs before
+        // windowing so the budget reflects what the model actually sees.
         const sliced = sliceHistory(messages, maxHistoryMessages);
-        return windowMessages(sliced, maxInputTokens);
+        const reasoningStripped = stripOlderReasoning(sliced);
+        return windowMessages(reasoningStripped, maxInputTokens);
       },
     };
 

--- a/src/tools/platform/conversations.ts
+++ b/src/tools/platform/conversations.ts
@@ -92,7 +92,7 @@ export async function createConversationsSource(
     {
       name: "get",
       description:
-        "Load a conversation's full message history including metadata, message content, tool calls, and token usage per message.",
+        'Load a conversation by ID. Returns metadata plus, by default, the most recent ~20 messages (capped to a 50 KB response budget). Use expand:"metadata" for just the metadata or expand:"full" when you actually need the entire transcript — long conversations can run hundreds of thousands of tokens and full reads are recorded in tool history.',
       inputSchema: ConversationsGetInput,
       handler: withErrorHandling(async (input) => {
         const { index } = await getIndex();

--- a/src/tools/platform/conversations.ts
+++ b/src/tools/platform/conversations.ts
@@ -92,7 +92,7 @@ export async function createConversationsSource(
     {
       name: "get",
       description:
-        'Load a conversation by ID. Returns metadata plus, by default, the most recent ~20 messages (capped to a 50 KB response budget). Use expand:"metadata" for just the metadata or expand:"full" when you actually need the entire transcript — long conversations can run hundreds of thousands of tokens and full reads are recorded in tool history.',
+        'Load a conversation by ID. Returns metadata plus, by default, the most recent ~20 messages (with the message payload capped to ~30 KB; the full pretty-printed response stays under ~50 KB). Use expand:"metadata" for just the metadata or expand:"full" when you actually need the entire transcript — long conversations can run hundreds of thousands of tokens and full reads are recorded in tool history.',
       inputSchema: ConversationsGetInput,
       handler: withErrorHandling(async (input) => {
         const { index } = await getIndex();

--- a/src/tools/platform/files.ts
+++ b/src/tools/platform/files.ts
@@ -16,7 +16,9 @@
 
 import { join } from "node:path";
 import { textContent } from "../../engine/content-helpers.ts";
-import type { EventSink, ToolResult } from "../../engine/types.ts";
+import type { ContentBlock, EventSink, ToolResult } from "../../engine/types.ts";
+import { extractText } from "../../files/extract.ts";
+import { IMAGE_TYPES, isExtractable, PDF_TYPES } from "../../files/ingest.ts";
 import { createFileStore, type FileStore } from "../../files/store.ts";
 import type { FileEntry } from "../../files/types.ts";
 import { fileIdToUri, uriToFileId } from "../../files/uri.ts";
@@ -109,15 +111,115 @@ async function handleSearch(store: FileStore, args: SearchInput): Promise<object
   return { files: files.slice(0, limit), total: files.length };
 }
 
-async function handleRead(store: FileStore, args: { id: string }): Promise<object> {
-  // `readFile` throws `File not found` if the registry entry is missing, so
-  // a separate `findEntry` pre-check would just re-scan the registry.
-  const read = await store.readFile(args.id);
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1_048_576) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / 1_048_576).toFixed(1)} MB`;
+}
+
+/**
+ * Read a file. Returns a `resource_link` reference plus a human-readable
+ * text block; never returns the bytes inline. For text-extractable types
+ * (text/code, PDF, DOCX, XLSX) the text block includes the extracted text
+ * up to `maxExtractedTextSize`.
+ *
+ * Bytes were previously surfaced as a base64 string in the tool result.
+ * The model could not consume base64 as image/PDF input — providers handle
+ * those via native file parts on user uploads (see `src/files/rehydrate.ts`)
+ * — so the base64 path produced unusable payloads while inflating the
+ * conversation log and replay tokens by 5–10× per byte. This handler is the
+ * single seam where that leak is closed for the agent-pull direction; the
+ * user-attachment direction is already lean via `ingest.ts`.
+ */
+async function handleRead(
+  store: FileStore,
+  maxExtractedTextSize: number,
+  args: { id: string },
+): Promise<ToolResult> {
+  // `findEntry` so a missing id is a clean "not found" without touching
+  // bytes. Mirrors the prior behavior of the pre-change `readFile` throw.
+  const entry = await store.findEntry(args.id);
+  if (!entry) {
+    return {
+      content: textContent(JSON.stringify({ error: `File not found: ${args.id}` })),
+      isError: true,
+    };
+  }
+
+  const sizeText = humanSize(entry.size);
+  const intro = `Read ${entry.filename} (${sizeText}, ${entry.mimeType}).`;
+
+  // The resource_link is the durable, byte-free reference. Every result
+  // includes one so any resource_link-aware consumer can locate the
+  // workspace `files://` resource without re-reading through this tool.
+  // Today `extractTextForModel` filters these out of the LLM-bound text,
+  // which is what we want: the model receives the human text block; the
+  // link rides alongside for tool-result metadata, UI rendering, and a
+  // future tool-side rehydration pass.
+  const link: ContentBlock = {
+    type: "resource_link",
+    uri: fileIdToUri(args.id),
+    name: entry.filename,
+    mimeType: entry.mimeType,
+    size: entry.size,
+    description: sizeText,
+  } as ContentBlock;
+
+  const structured: Record<string, unknown> = {
+    id: entry.id,
+    filename: entry.filename,
+    mimeType: entry.mimeType,
+    size: entry.size,
+    extractedText: null,
+    truncated: false,
+  };
+
+  // PDFs route through the same `extractText` path as docs/text because the
+  // agent-pull surface only ever delivers text from this tool. (Native PDF
+  // input for capable models is a different seam — `rehydrate.ts` at the
+  // user-attachment boundary.)
+  const canExtract = isExtractable(entry.mimeType) || PDF_TYPES.has(entry.mimeType);
+  if (canExtract) {
+    const read = await store.readFile(args.id);
+    const extracted = await extractText(read.data, read.mimeType, maxExtractedTextSize);
+    if (extracted) {
+      structured.extractedText = extracted.text;
+      structured.truncated = extracted.truncated;
+      return {
+        content: [
+          link,
+          { type: "text", text: `${intro}\n\n--- Extracted text ---\n${extracted.text}` },
+        ],
+        structuredContent: structured,
+        isError: false,
+      };
+    }
+    // Extraction supported in principle but failed at runtime (corrupt /
+    // empty / decoder error). Fall through to a metadata-only response;
+    // the resource_link is still useful, the bytes aren't.
+    return {
+      content: [
+        link,
+        {
+          type: "text",
+          text: `${intro} Text extraction was not successful for this file; only metadata is available.`,
+        },
+      ],
+      structuredContent: structured,
+      isError: false,
+    };
+  }
+
+  // Non-extractable: images, fonts, archives, raw binary. The model has no
+  // useful surface for these via the tool — vision-capable models receive
+  // images through the user-attachment rehydration path, not here.
+  const note = IMAGE_TYPES.has(entry.mimeType)
+    ? " Images attached to a user message are rehydrated as native vision input on the next turn; reading them here returns metadata only."
+    : " This MIME type is not text-extractable; only metadata is available.";
   return {
-    base64Data: read.data.toString("base64"),
-    filename: read.filename,
-    mimeType: read.mimeType,
-    size: read.size,
+    content: [link, { type: "text", text: `${intro}${note}` }],
+    structuredContent: structured,
+    isError: false,
   };
 }
 
@@ -250,11 +352,21 @@ export function createFilesSource(runtime: Runtime, eventSink: EventSink): McpSo
     },
     {
       name: "read",
-      description: "Read a file's content by ID. Returns base64-encoded data along with metadata.",
+      description:
+        "Read a file by ID. Returns a resource_link reference and a human-readable summary. " +
+        "For text-extractable formats (text, code, JSON, Markdown, CSV, HTML, XML, YAML, PDF, " +
+        "DOCX, XLSX) the summary includes the extracted text up to the workspace's " +
+        "max-extracted-text size. For images and other non-extractable binary, only metadata " +
+        "is returned — images attached to a user message are delivered to the model via native " +
+        "file input on the next turn, not through this tool.",
       inputSchema: FilesReadInput,
       handler: async (input: Record<string, unknown>): Promise<ToolResult> => {
         try {
-          return ok(await handleRead(getStore(), input as unknown as { id: string }));
+          return await handleRead(
+            getStore(),
+            runtime.getFilesConfig().maxExtractedTextSize,
+            input as unknown as { id: string },
+          );
         } catch (err) {
           return fail(err instanceof Error ? err.message : String(err));
         }

--- a/src/tools/platform/schemas/conversations.ts
+++ b/src/tools/platform/schemas/conversations.ts
@@ -28,8 +28,17 @@ export type ConversationsListInput = Static<typeof ConversationsListInput>;
 export const ConversationsGetInput = Type.Object(
   {
     id: Type.String({ description: "Conversation ID." }),
+    expand: Type.Optional(
+      StringEnum(["metadata", "messages", "full"] as const, {
+        description:
+          'How much of the conversation to return. "metadata" returns just metadata (no messages). "messages" (default) returns metadata + the most recent `limit` messages, capped by a content-size guard. "full" returns every message — use only when you genuinely need the entire transcript; long conversations can run hundreds of thousands of tokens.',
+      }),
+    ),
     limit: Type.Optional(
-      Type.Number({ description: "Max messages to return (from end of conversation)." }),
+      Type.Number({
+        description:
+          'Max messages to return when expand is "messages" (the default mode). Counted from the end of the conversation. Default: 20. Ignored when expand is "metadata" or "full".',
+      }),
     ),
   },
   { required: ["id"] },

--- a/test/integration/chat-file-visibility.test.ts
+++ b/test/integration/chat-file-visibility.test.ts
@@ -118,20 +118,36 @@ describe("chat multipart upload ↔ files__* visibility (bug 4)", () => {
   });
 
   it("file uploaded via /v1/chat/stream is readable by files__read", async () => {
-    await uploadChatFile("round trip", "roundtrip.bin", "application/octet-stream");
+    const payload = "round trip";
+    await uploadChatFile(payload, "roundtrip.bin", "application/octet-stream");
     const files = await listFiles();
     const id = files.find((f) => f.filename === "roundtrip.bin")?.id;
     expect(id).toBeDefined();
 
     const read = await callFilesTool("read", { id });
     expect(read.status).toBe(200);
-    const structured = extractStructured(read.body) as {
-      base64Data: string;
-      filename: string;
-      mimeType: string;
+
+    // Lean contract: tool result is a resource_link + a human-readable text
+    // block. The bytes are NOT returned inline (see commit "files__read
+    // returns resource_link + extracted text, never base64"). The file
+    // remains addressable via the resource_link URI and via GET /v1/files/:id
+    // (covered by the next test) — that's what "readable" means now.
+    const body = read.body as {
+      content?: Array<{ type: string; uri?: string; mimeType?: string; text?: string }>;
+      structuredContent?: { id: string; filename: string; mimeType: string; size: number };
     };
-    expect(Buffer.from(structured.base64Data, "base64").toString("utf-8")).toBe("round trip");
-    expect(structured.filename).toBe("roundtrip.bin");
+
+    const link = body.content?.find((c) => c.type === "resource_link");
+    expect(link?.uri).toBe(`files://${id}`);
+    expect(link?.mimeType).toBe("application/octet-stream");
+
+    expect(body.structuredContent?.filename).toBe("roundtrip.bin");
+    expect(body.structuredContent?.size).toBe(payload.length);
+
+    // Regression guard for the base64 leak.
+    const serialized = JSON.stringify(read.body);
+    expect(serialized).not.toContain("base64Data");
+    expect(serialized).not.toContain(Buffer.from(payload).toString("base64"));
   });
 
   it("file uploaded via /v1/chat/stream is served by GET /v1/files/:id", async () => {

--- a/test/unit/bundles/conversations/tools/get.test.ts
+++ b/test/unit/bundles/conversations/tools/get.test.ts
@@ -338,4 +338,45 @@ describe("conversations__get", () => {
 		expect(result.messages[0]!.content).toBe(overCap);
 		expect(result.truncated).toBe(true);
 	});
+
+	it("the bounded result fits under MAX_TOOL_RESULT_CHARS once pretty-printed and wrapped", async () => {
+		// The platform serializes tool results via JSON.stringify(result, null, 2)
+		// (see src/tools/platform/conversations.ts), then the engine's per-result
+		// cap (`MAX_TOOL_RESULT_CHARS = 50_000`) slices the resulting text from
+		// the end if it overshoots. This test guards against drift between
+		// DEFAULT_GET_CHAR_CAP and the actual budget the engine measures —
+		// the cap must be sized so the pretty-printed wrapper stays under
+		// 50,000 chars in the worst case (truncation firing on the windowed
+		// slice). Bug history: DEFAULT_GET_CHAR_CAP = 50_000 originally, but
+		// pretty-print inflation pushed the serialized result over the engine
+		// cap, which then sliced away the `truncationHint` field.
+		const MAX_TOOL_RESULT_CHARS = 50_000;
+
+		const ts = "2025-01-15T10:00:00.000Z";
+		// Worst case: many messages, each fat enough that the char-cap fires
+		// inside the windowed slice. Force the cap path to do work.
+		const fatChunk = "Z".repeat(2_000);
+		const messages = Array.from({ length: DEFAULT_GET_LIMIT * 2 }, (_, i) => ({
+			role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+			content: `${fatChunk}-${i}`,
+			timestamp: ts,
+			// Realistic message shape: nested usage / blocks add pretty-print overhead.
+			blocks: [{ type: "text", text: `${fatChunk}-${i}` }],
+			usage: { inputTokens: 100, outputTokens: 50, model: "claude-sonnet-4-6", llmMs: 1200 },
+		}));
+		writeConversation(dir, "conv-fits-under-engine-cap", { messages });
+		await index.build(dir);
+
+		const result = await handleGet({ id: "conv-fits-under-engine-cap" }, index);
+		const serialized = JSON.stringify(result, null, 2);
+		expect(serialized.length).toBeLessThan(MAX_TOOL_RESULT_CHARS);
+
+		// And the truncation flags must precede `messages` in the serialized
+		// output, so an end-slice would lose messages first (not the flags).
+		const truncatedAt = serialized.indexOf('"truncated"');
+		const messagesAt = serialized.indexOf('"messages"');
+		expect(truncatedAt).toBeGreaterThan(-1);
+		expect(messagesAt).toBeGreaterThan(-1);
+		expect(truncatedAt).toBeLessThan(messagesAt);
+	});
 });

--- a/test/unit/bundles/conversations/tools/get.test.ts
+++ b/test/unit/bundles/conversations/tools/get.test.ts
@@ -3,7 +3,11 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { ConversationIndex } from "../../../../../src/bundles/conversations/src/index-cache.ts";
-import { handleGet } from "../../../../../src/bundles/conversations/src/tools/get.ts";
+import {
+	DEFAULT_GET_CHAR_CAP,
+	DEFAULT_GET_LIMIT,
+	handleGet,
+} from "../../../../../src/bundles/conversations/src/tools/get.ts";
 
 function tempDir(): string {
 	const dir = join(tmpdir(), `nb-get-test-${crypto.randomUUID()}`);
@@ -205,5 +209,133 @@ describe("conversations__get", () => {
 		expect(assistantMsg.usage!.outputTokens).toBe(80);
 		expect(assistantMsg.usage!.model).toBe("claude-sonnet-4-5-20250929");
 		expect(assistantMsg.usage!.llmMs).toBe(1200);
+	});
+
+	it('expand:"metadata" returns metadata only — no messages', async () => {
+		const ts = "2025-01-15T10:00:00.000Z";
+		writeConversation(dir, "conv-meta-only", {
+			title: "Metadata only",
+			messages: [
+				{ role: "user", content: "u1", timestamp: ts },
+				{ role: "assistant", content: "a1", timestamp: ts },
+				{ role: "user", content: "u2", timestamp: ts },
+				{ role: "assistant", content: "a2", timestamp: ts },
+			],
+		});
+		await index.build(dir);
+
+		const result = (await handleGet(
+			{ id: "conv-meta-only", expand: "metadata" },
+			index,
+		)) as {
+			metadata: Record<string, unknown>;
+			messages: unknown[];
+			totalMessages: number;
+		};
+
+		expect(result.metadata.id).toBe("conv-meta-only");
+		expect(result.metadata.title).toBe("Metadata only");
+		expect(result.messages).toEqual([]);
+		expect(result.totalMessages).toBe(4);
+	});
+
+	it("defaults to returning the last DEFAULT_GET_LIMIT messages when there are more", async () => {
+		const ts = "2025-01-15T10:00:00.000Z";
+		const totalMsgs = DEFAULT_GET_LIMIT + 5;
+		const messages = Array.from({ length: totalMsgs }, (_, i) => ({
+			role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+			content: `msg-${i}`,
+			timestamp: ts,
+		}));
+		writeConversation(dir, "conv-many", { messages });
+		await index.build(dir);
+
+		const result = (await handleGet({ id: "conv-many" }, index)) as {
+			messages: Array<{ content: string }>;
+			totalMessages: number;
+			truncated?: boolean;
+		};
+
+		expect(result.totalMessages).toBe(totalMsgs);
+		expect(result.messages).toHaveLength(DEFAULT_GET_LIMIT);
+		// Most recent message preserved at the end.
+		expect(result.messages.at(-1)!.content).toBe(`msg-${totalMsgs - 1}`);
+		// First returned is the (totalMsgs - DEFAULT_GET_LIMIT)-th message.
+		expect(result.messages[0]!.content).toBe(`msg-${totalMsgs - DEFAULT_GET_LIMIT}`);
+		// No char-cap truncation when messages are small.
+		expect(result.truncated).toBeUndefined();
+	});
+
+	it('expand:"full" returns every message regardless of the char cap', async () => {
+		const ts = "2025-01-15T10:00:00.000Z";
+		const bigContent = "X".repeat(Math.floor(DEFAULT_GET_CHAR_CAP / 4));
+		const messages = Array.from({ length: 10 }, (_, i) => ({
+			role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+			content: `${bigContent}-${i}`,
+			timestamp: ts,
+		}));
+		writeConversation(dir, "conv-full", { messages });
+		await index.build(dir);
+
+		const result = (await handleGet({ id: "conv-full", expand: "full" }, index)) as {
+			messages: unknown[];
+			totalMessages: number;
+			truncated?: boolean;
+		};
+
+		expect(result.messages).toHaveLength(10);
+		expect(result.totalMessages).toBe(10);
+		expect(result.truncated).toBeUndefined();
+	});
+
+	it("default mode truncates the older end of the window when the char cap is hit and surfaces a hint", async () => {
+		const ts = "2025-01-15T10:00:00.000Z";
+		const bigContent = "X".repeat(Math.floor(DEFAULT_GET_CHAR_CAP / 4));
+		const messages = Array.from({ length: 10 }, (_, i) => ({
+			role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+			content: `${bigContent}-${i}`,
+			timestamp: ts,
+		}));
+		writeConversation(dir, "conv-bigwindow", { messages });
+		await index.build(dir);
+
+		const result = (await handleGet({ id: "conv-bigwindow" }, index)) as {
+			messages: Array<{ content: string }>;
+			totalMessages: number;
+			truncated?: boolean;
+			droppedOlderMessages?: number;
+			truncationHint?: string;
+		};
+
+		expect(result.totalMessages).toBe(10);
+		expect(result.truncated).toBe(true);
+		expect(result.droppedOlderMessages).toBeGreaterThan(0);
+		expect(result.messages.length).toBeLessThan(10);
+		// Newest survives.
+		expect(result.messages.at(-1)!.content).toBe(`${bigContent}-9`);
+		expect(result.truncationHint).toContain("budget");
+	});
+
+	it("always returns at least the single most recent message even if it exceeds the cap", async () => {
+		const ts = "2025-01-15T10:00:00.000Z";
+		const overCap = "Y".repeat(DEFAULT_GET_CHAR_CAP * 2);
+		writeConversation(dir, "conv-onehuge", {
+			messages: [
+				{ role: "user", content: "small", timestamp: ts },
+				{ role: "assistant", content: overCap, timestamp: ts },
+			],
+		});
+		await index.build(dir);
+
+		const result = (await handleGet({ id: "conv-onehuge" }, index)) as {
+			messages: Array<{ content: string }>;
+			totalMessages: number;
+			truncated?: boolean;
+		};
+
+		// Single most recent message kept even though it alone exceeds cap.
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0]!.content).toBe(overCap);
+		expect(result.truncated).toBe(true);
 	});
 });

--- a/test/unit/bundles/files/source.test.ts
+++ b/test/unit/bundles/files/source.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NoopEventSink } from "../../../../src/adapters/noop-events.ts";
 import { createFilesSource } from "../../../../src/tools/platform/files.ts";
-import type { ToolResult } from "../../../../src/engine/types.ts";
+import type { ContentBlock, ToolResult } from "../../../../src/engine/types.ts";
 import type { Runtime } from "../../../../src/runtime/runtime.ts";
 import type { McpSource } from "../../../../src/tools/mcp-source.ts";
 
@@ -23,9 +23,38 @@ function parseFirst(result: ToolResult): unknown {
   return JSON.parse(first.text);
 }
 
+function findText(result: ToolResult): string {
+  for (const block of result.content as ContentBlock[]) {
+    if (block.type === "text" && typeof (block as { text?: unknown }).text === "string") {
+      return (block as { text: string }).text;
+    }
+  }
+  throw new Error("expected a text block in tool result");
+}
+
+function findResourceLink(result: ToolResult): {
+  uri: string;
+  name: string;
+  mimeType?: string;
+  size?: number;
+} {
+  for (const block of result.content as ContentBlock[]) {
+    if ((block as { type?: string }).type === "resource_link") {
+      return block as unknown as {
+        uri: string;
+        name: string;
+        mimeType?: string;
+        size?: number;
+      };
+    }
+  }
+  throw new Error("expected a resource_link block in tool result");
+}
+
 function makeRuntime(workDir: string): Runtime {
   return {
     getWorkspaceScopedDir: () => workDir,
+    getFilesConfig: () => ({ maxExtractedTextSize: 204_800 }),
   } as unknown as Runtime;
 }
 
@@ -51,7 +80,7 @@ describe("files bundle", () => {
     expect(names).not.toContain("files__write");
   });
 
-  test("create → read round-trips content on disk", async () => {
+  test("read of an extractable text file inlines the extracted text — never base64", async () => {
     const payload = "the quick brown fox";
     const encoded = Buffer.from(payload).toString("base64");
 
@@ -65,10 +94,72 @@ describe("files bundle", () => {
 
     const read = await source.execute("read", { id });
     expect(read.isError).toBe(false);
-    const body = parseFirst(read) as { base64Data: string; filename: string; mimeType: string };
-    expect(Buffer.from(body.base64Data, "base64").toString("utf-8")).toBe(payload);
-    expect(body.filename).toBe("fox.txt");
-    expect(body.mimeType).toBe("text/plain");
+
+    // resource_link is present and points at the workspace file.
+    const link = findResourceLink(read);
+    expect(link.uri).toBe(`files://${id}`);
+    expect(link.name).toBe("fox.txt");
+    expect(link.mimeType).toBe("text/plain");
+    expect(link.size).toBe(payload.length);
+
+    // The text block contains the extracted text — that's how the model
+    // actually receives the file's content.
+    const text = findText(read);
+    expect(text).toContain("Read fox.txt");
+    expect(text).toContain(payload);
+
+    // structuredContent carries the same shape, machine-readable.
+    expect(read.structuredContent).toMatchObject({
+      id,
+      filename: "fox.txt",
+      mimeType: "text/plain",
+      extractedText: payload,
+      truncated: false,
+    });
+
+    // Regression guard for the base64 bug: no part of the result can
+    // serialize to a payload containing `base64Data` or the raw payload-as-base64.
+    const serialized = JSON.stringify(read);
+    expect(serialized).not.toContain("base64Data");
+    expect(serialized).not.toContain(Buffer.from(payload).toString("base64"));
+  });
+
+  test("read of an image returns metadata only — no bytes", async () => {
+    // Minimal valid 1x1 PNG.
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+    const pngBytes = Buffer.from(pngBase64, "base64");
+
+    const created = await source.execute("create", {
+      manifest: { filename: "pixel.png", mimeType: "image/png" },
+      body: pngBase64,
+    });
+    expect(created.isError).toBe(false);
+    const { id } = parseFirst(created) as { id: string };
+
+    const read = await source.execute("read", { id });
+    expect(read.isError).toBe(false);
+
+    const link = findResourceLink(read);
+    expect(link.uri).toBe(`files://${id}`);
+    expect(link.mimeType).toBe("image/png");
+    expect(link.size).toBe(pngBytes.length);
+
+    const text = findText(read);
+    expect(text).toContain("Read pixel.png");
+    // The text must NOT contain the PNG signature characters or the base64.
+    expect(text).not.toContain(pngBase64);
+    expect(text).not.toContain("iVBORw0KGgo");
+
+    expect(read.structuredContent).toMatchObject({
+      filename: "pixel.png",
+      mimeType: "image/png",
+      extractedText: null,
+    });
+
+    const serialized = JSON.stringify(read);
+    expect(serialized).not.toContain("base64Data");
+    expect(serialized).not.toContain(pngBase64);
   });
 
   test("read of nonexistent id surfaces a clean message (not a raw fs error)", async () => {

--- a/test/unit/window.test.ts
+++ b/test/unit/window.test.ts
@@ -1,6 +1,32 @@
 import { describe, expect, it } from "bun:test";
 import type { LanguageModelV3Message } from "@ai-sdk/provider";
-import { sliceHistory, windowMessages } from "../../src/conversation/window.ts";
+import {
+	sliceHistory,
+	stripOlderReasoning,
+	windowMessages,
+} from "../../src/conversation/window.ts";
+
+/** Helper: create an assistant message with reasoning + text blocks. */
+function assistantWithReasoning(
+	reasoningText: string,
+	visibleText: string,
+): LanguageModelV3Message {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "reasoning" as const, text: reasoningText },
+			{ type: "text" as const, text: visibleText },
+		],
+	};
+}
+
+/** Helper: create an assistant message with only reasoning (placeholder turn). */
+function assistantReasoningOnly(reasoningText: string): LanguageModelV3Message {
+	return {
+		role: "assistant",
+		content: [{ type: "reasoning" as const, text: reasoningText }],
+	};
+}
 
 /** Helper: create a simple text message. */
 function textMsg(role: "user" | "assistant", text: string): LanguageModelV3Message {
@@ -329,5 +355,108 @@ describe("sliceHistory", () => {
 		];
 		const result = sliceHistory(msgs, 1);
 		expect(result).toEqual(msgs);
+	});
+});
+
+describe("stripOlderReasoning", () => {
+	it("keeps reasoning on the most recent assistant message", () => {
+		const msgs: LanguageModelV3Message[] = [
+			textMsg("user", "first"),
+			assistantWithReasoning("thinking 1", "answer 1"),
+			textMsg("user", "second"),
+			assistantWithReasoning("thinking 2", "answer 2"),
+		];
+		const result = stripOlderReasoning(msgs);
+
+		// First assistant message: reasoning stripped, text kept.
+		expect(result[1]).toEqual({
+			role: "assistant",
+			content: [{ type: "text", text: "answer 1" }],
+		});
+		// Last assistant message: untouched.
+		expect(result[3]).toEqual(msgs[3]!);
+	});
+
+	it("returns the input unchanged when there is nothing to strip", () => {
+		const msgs: LanguageModelV3Message[] = [
+			textMsg("user", "hi"),
+			assistantWithReasoning("thinking", "hello"),
+		];
+		const result = stripOlderReasoning(msgs);
+		// Only assistant message is the latest — no older turns to strip.
+		// Returns the same reference (identity) for the common no-op path.
+		expect(result).toBe(msgs);
+	});
+
+	it("preserves reasoning-only placeholder messages instead of leaving an empty assistant turn", () => {
+		const msgs: LanguageModelV3Message[] = [
+			textMsg("user", "first"),
+			assistantReasoningOnly("opaque signature"),
+			textMsg("user", "second"),
+			assistantWithReasoning("thinking", "answer"),
+		];
+		const result = stripOlderReasoning(msgs);
+
+		// The earlier reasoning-only assistant message is kept as-is —
+		// stripping would leave an empty content array, which Anthropic
+		// rejects on replay.
+		expect(result[1]).toEqual(msgs[1]!);
+		expect(result[3]).toEqual(msgs[3]!);
+	});
+
+	it("strips reasoning from earlier assistant messages even when they also contain tool-calls", () => {
+		const msgs: LanguageModelV3Message[] = [
+			textMsg("user", "do something"),
+			{
+				role: "assistant",
+				content: [
+					{ type: "reasoning" as const, text: "considering options" },
+					{
+						type: "tool-call" as const,
+						toolCallId: "call_1",
+						toolName: "search",
+						input: { q: "x" },
+					},
+				],
+			},
+			toolResultMsg("call_1"),
+			assistantWithReasoning("now reasoning again", "done"),
+		];
+		const result = stripOlderReasoning(msgs);
+
+		// Older assistant message: reasoning stripped, tool-call retained
+		// so the tool_result it pairs with still has its tool_use anchor.
+		expect(result[1]).toEqual({
+			role: "assistant",
+			content: [
+				{
+					type: "tool-call",
+					toolCallId: "call_1",
+					toolName: "search",
+					input: { q: "x" },
+				},
+			],
+		});
+		// Tool-result unchanged.
+		expect(result[2]).toEqual(msgs[2]!);
+		// Latest assistant unchanged.
+		expect(result[3]).toEqual(msgs[3]!);
+	});
+
+	it("is a no-op when there are no assistant messages", () => {
+		const msgs: LanguageModelV3Message[] = [textMsg("user", "hi")];
+		const result = stripOlderReasoning(msgs);
+		expect(result).toBe(msgs);
+	});
+
+	it("is a no-op when no reasoning blocks exist", () => {
+		const msgs: LanguageModelV3Message[] = [
+			textMsg("user", "hi"),
+			textMsg("assistant", "hello"),
+			textMsg("user", "again"),
+			textMsg("assistant", "hello again"),
+		];
+		const result = stripOlderReasoning(msgs);
+		expect(result).toBe(msgs);
 	});
 });

--- a/web/src/_generated/platform-schemas/catalog.d.ts
+++ b/web/src/_generated/platform-schemas/catalog.d.ts
@@ -242,6 +242,7 @@ export declare const PlatformToolCatalog: {
         readonly get: {
             readonly input: import("@sinclair/typebox").TObject<{
                 id: import("@sinclair/typebox").TString;
+                expand: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"metadata" | "messages" | "full">>;
                 limit: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TNumber>;
             }>;
         };

--- a/web/src/_generated/platform-schemas/conversations.d.ts
+++ b/web/src/_generated/platform-schemas/conversations.d.ts
@@ -14,6 +14,7 @@ export declare const ConversationsListInput: import("@sinclair/typebox").TObject
 export type ConversationsListInput = Static<typeof ConversationsListInput>;
 export declare const ConversationsGetInput: import("@sinclair/typebox").TObject<{
     id: import("@sinclair/typebox").TString;
+    expand: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"metadata" | "messages" | "full">>;
     limit: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TNumber>;
 }>;
 export type ConversationsGetInput = Static<typeof ConversationsGetInput>;

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -543,7 +543,11 @@ export function useChat(initialConversationId?: string, currentUserId?: string):
   const loadConversation = useCallback(async (id: string) => {
     setError(null);
     try {
-      const res = await callTool("conversations", "get", { id });
+      // expand:"full" — the shell is rendering the entire chat, not
+      // sampling for an LLM. The bounded default (`expand:"messages"`,
+      // last 20) exists to keep agent tool-results small; the trusted
+      // web shell needs every turn or the UI silently shows only the tail.
+      const res = await callTool("conversations", "get", { id, expand: "full" });
       if (res.isError) {
         const errText = res.content
           ?.map((b) => b.text ?? "")


### PR DESCRIPTION
## Summary

Closes the three biggest content-leak seams identified in prod conversation `conv_e00606c7aab7423d` (and similar). Each commit is independently mergeable; together they reduce real production token usage on day one.

- **`files__read` returns `resource_link` + extracted text, never base64.** The agent-pull file path used to return raw bytes as a `base64Data` string. The model couldn't actually consume base64 as image/PDF input — providers handle those via native file parts on user uploads — so the path produced unusable payloads while tokenizing as text and replaying through every subsequent turn. Observed cost in prod: 948 KB and 276 KB `files__read` outputs of base64 image bytes in a single conversation. The new contract returns a `resource_link` (the durable reference, no bytes) plus a human-readable text block. For text-extractable types (text, code, JSON, MD, CSV, HTML, XML, YAML, PDF, DOCX, XLSX) the text block includes the extracted text up to `maxExtractedTextSize`. For images and other binary, only metadata.
- **Strip reasoning blocks from older assistant turns.** Anthropic-aligned: pass the most recent turn's thinking blocks back unchanged; strip thinking blocks from older turns to reduce token usage. The reasoning blocks attached to the last assistant message are still load-bearing (they pair with any tool-use chain in flight) but every earlier assistant message's reasoning replays as opaque signature bytes that bloat the prompt linearly with turn count. Prod conv showed 100+ KB `llm.response` events dominated by Anthropic signatures with empty `text`. Pure-reasoning placeholder messages are preserved intact (stripping to empty would be rejected on replay).
- **`conversations__get` defaults to bounded read; explicit `expand` mode.** The tool used to return the full transcript by default. One agent call against a long conversation produced an 897 KB tool result in the trace, blowing through context on the very turn that referenced it. New schema:
  - `expand: "metadata"` — metadata only, no messages
  - `expand: "messages"` (default) — metadata + the most recent `limit` messages (default 20), capped to a 50,000-char response budget; older messages dropped from the window if the cap is hit, with `truncated: true` + `droppedOlderMessages` + a hint suggesting `expand:"full"` or a narrower fetch
  - `expand: "full"` — explicit opt-in to the full transcript; legitimate uses (export, fork) still work

## Symmetry with prior work

This continues the lean-protocol arc:

- **User-attachment seam**: images via #188, PDFs via #210 — already store as `resource_link`, materialize bytes only at the rehydration boundary
- **Storage layer**: #54 (binary-guard) — refuses to persist any `Buffer` / `Uint8Array` in the conversation log
- **Telemetry**: #231 — part-aware estimator counts image bytes correctly for `context.assembled`

The agent-pull seam (`files__read`) was the remaining hole on the file path. `conversations__get` and reasoning stripping address the two other dominant in-history bloat patterns.

## What's NOT in this PR

- Engine-side promotion of tool-result `resource_link` to native V3 `file-data` content (so a model could *view* an image returned from a tool natively). The `resource_link` blocks emitted by `files__read` are infrastructure for that, but the engine doesn't yet hydrate them — separate future PR.
- Migration of legacy 7 MB conversations with raw-bytes user messages (#54 noted out of scope; same here — one-shot rewriter is its own change).
- Budget composition + reactive recovery on context overflow — separate stacked PR (`fix/budget-composition-and-recovery`).

## Test plan

- [x] `bun run verify` green: 2896 unit + 484 integration + 17 smoke, zero failures
- [x] New `files__read` tests: extractable text round-trip with regression guard, image case (metadata only), not-found, no base64 anywhere in the result
- [x] New `stripOlderReasoning` tests: latest-turn preserved, mixed reasoning+tool-call retains tool-call so paired tool_result has its anchor, pure-reasoning placeholder preserved, no-op cases
- [x] New `conversations__get` tests: metadata-only mode, default windowing on long conversation, full-mode bypass, char-cap truncation with hint, single-message-over-cap safety
- [x] Updated `chat-file-visibility` integration test for the new `files__read` contract