### PR TITLE
fix(runtime/engine): compose message budget from model context + reactive overflow recovery (re-merge of #239)

### DIFF
--- a/src/conversation/window.ts
+++ b/src/conversation/window.ts
@@ -1,31 +1,19 @@
 import type { LanguageModelV3Message } from "@ai-sdk/provider";
+import { estimateMessageTokens } from "../engine/token-estimate.ts";
 
 /**
  * Estimate token count for a message.
- * Uses ~4 characters per token (rough but fast).
- * V3 messages: system has string content, user/assistant/tool have content as array of parts.
+ *
+ * Routed through the part-aware `estimateMessageTokens` (shared with the
+ * `context.assembled` telemetry path) so the windowing decision and the
+ * reported token count agree on the same numbers. The previous local
+ * `chars/4` heuristic over-counted by ~3 tokens per byte for any message
+ * carrying a rehydrated `file` part (a `Uint8Array` serialized as
+ * `{"0":n,"1":n,…}`), which caused excessive trimming when images were
+ * present even though the provider would charge the image ~1.5K tokens.
  */
 function estimateTokens(msg: LanguageModelV3Message): number {
-  if (typeof msg.content === "string") {
-    // system message
-    return Math.ceil(msg.content.length / 4);
-  }
-  // content is an array of parts — serialize each part's text/output
-  let length = 0;
-  for (const part of msg.content) {
-    if ("text" in part && typeof part.text === "string") {
-      length += part.text.length;
-    } else if ("input" in part) {
-      // tool-call part
-      length += JSON.stringify(part.input).length;
-    } else if ("output" in part) {
-      // tool-result part
-      length += JSON.stringify(part.output).length;
-    } else {
-      length += JSON.stringify(part).length;
-    }
-  }
-  return Math.ceil(length / 4);
+  return estimateMessageTokens(msg);
 }
 
 /**

--- a/src/engine/context-overflow.ts
+++ b/src/engine/context-overflow.ts
@@ -1,0 +1,81 @@
+/**
+ * Detect provider-reported "the prompt exceeds the model's context window"
+ * errors so the engine can react with a budget retrim + retry rather than
+ * surfacing the raw error to the caller.
+ *
+ * No provider has a stable, machine-readable error code for this condition
+ * — they all surface it as a 400 with a free-text message. We match
+ * conservatively on the union of phrasings the major providers use today
+ * (Anthropic, OpenAI, Google, Vercel AI SDK pass-throughs) and fall back
+ * to throwing the original error unchanged when we're unsure.
+ */
+
+interface ErrorLike {
+  status?: number;
+  statusCode?: number;
+  message?: unknown;
+  // Vercel AI SDK wraps provider errors and sometimes nests them.
+  cause?: unknown;
+  data?: unknown;
+  responseBody?: unknown;
+}
+
+function getStatus(err: ErrorLike): number | undefined {
+  if (typeof err.status === "number") return err.status;
+  if (typeof err.statusCode === "number") return err.statusCode;
+  return undefined;
+}
+
+function getMessages(err: ErrorLike): string[] {
+  const messages: string[] = [];
+  if (typeof err.message === "string") messages.push(err.message);
+  if (typeof err.responseBody === "string") messages.push(err.responseBody);
+  if (err.data && typeof err.data === "object") {
+    messages.push(JSON.stringify(err.data));
+  }
+  if (err.cause && typeof err.cause === "object") {
+    const inner = getMessages(err.cause as ErrorLike);
+    messages.push(...inner);
+  }
+  return messages;
+}
+
+/**
+ * Phrases observed in context-overflow errors across providers. Matched
+ * case-insensitively against the error message and any nested response
+ * body. Each phrase is on its own to keep the union explicit; adding a
+ * new provider phrasing is a one-line change here.
+ */
+const OVERFLOW_PHRASES: readonly string[] = [
+  // Anthropic: `prompt is too long: 1257504 tokens > 1000000 maximum`
+  "prompt is too long",
+  // OpenAI: `This model's maximum context length is N tokens. However, your messages resulted in M tokens.`
+  "maximum context length",
+  // OpenAI alt: `context length exceeded`
+  "context length exceeded",
+  // Google Gemini: `The input token count exceeds the maximum number of tokens allowed`
+  "input token count exceeds",
+  // Anthropic / generic: `tokens > <N> maximum`
+  "tokens >",
+  // Fallback that catches several providers' shared phrasing
+  "exceeds the maximum",
+];
+
+/**
+ * Returns true if the error looks like a provider-reported context-window
+ * overflow. Conservative — false negatives are OK (engine surfaces the
+ * original error) but false positives would cause us to retry-and-retrim
+ * on errors that retrimming can't fix.
+ */
+export function isContextOverflowError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const errLike = err as ErrorLike;
+  const status = getStatus(errLike);
+  // Every observed overflow error is a 400 (invalid_request_error). Status
+  // is not strictly required — when missing we still match on the message
+  // — but a non-4xx status almost certainly means something else (network,
+  // 5xx, etc.) and we don't want to retrim on those.
+  if (status !== undefined && status !== 400) return false;
+  const messages = getMessages(errLike).map((m) => m.toLowerCase());
+  return messages.some((m) => OVERFLOW_PHRASES.some((p) => m.includes(p)));
+}

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -21,6 +21,7 @@ import {
   extractTextForModel,
   textContent,
 } from "./content-helpers.ts";
+import { isContextOverflowError } from "./context-overflow.ts";
 import { withRetry } from "./retry.ts";
 import { createRunSupervisor } from "./supervisor.ts";
 import { toolSchemaForLlm } from "./tool-schema-for-llm.ts";
@@ -486,12 +487,17 @@ export class AgentEngine {
           toolSchemaMap.set(t.name, t);
         }
 
-        // 1. Apply context/prompt hooks and call LLM
-        const windowed = config.hooks?.transformContext
-          ? config.hooks.transformContext([...history])
-          : history;
+        // 1. Apply context/prompt hooks and call LLM. The transformContext
+        //    hook is also re-invoked on a context-overflow recovery (see
+        //    the call loop below) with `overflowAttempt: 1` so the hook
+        //    can return more aggressively trimmed messages.
+        const runTransform = (attempt: number): LanguageModelV3Message[] =>
+          config.hooks?.transformContext
+            ? config.hooks.transformContext([...history], { overflowAttempt: attempt })
+            : history;
+        const windowed = runTransform(0);
         // Sanitize: filter out empty text content blocks that the API rejects
-        const callMessages = sanitizeMessages(windowed);
+        let callMessages = sanitizeMessages(windowed);
         let callPrompt = config.hooks?.transformPrompt
           ? config.hooks.transformPrompt(systemPrompt)
           : systemPrompt;
@@ -507,33 +513,72 @@ export class AgentEngine {
 
         const callProviderOptions = buildThinkingProviderOptions(config.model, config.thinking);
 
-        const llmStart = performance.now();
-        const response: StreamResult = await withRetry(() =>
-          callModel(
-            this.model,
-            {
-              prompt: [
-                {
-                  role: "system",
-                  content: callPrompt,
-                  providerOptions: {
-                    anthropic: { cacheControl: { type: "ephemeral" } },
+        const callOnce = (msgs: LanguageModelV3Message[]) =>
+          withRetry(() =>
+            callModel(
+              this.model,
+              {
+                prompt: [
+                  {
+                    role: "system",
+                    content: callPrompt,
+                    providerOptions: {
+                      anthropic: { cacheControl: { type: "ephemeral" } },
+                    },
                   },
+                  ...addCacheBreakpoint(msgs),
+                ],
+                tools: modelTools,
+                maxOutputTokens: config.maxOutputTokens,
+                ...(Object.keys(callProviderOptions).length > 0
+                  ? { providerOptions: callProviderOptions }
+                  : {}),
+              },
+              (text) => this.events.emit({ type: "text.delta", data: { runId, text } }),
+              (text) => this.events.emit({ type: "reasoning.delta", data: { runId, text } }),
+              (id, name) => this.events.emit({ type: "tool.preparing", data: { runId, id, name } }),
+              (id) => this.events.emit({ type: "tool.preparing.done", data: { runId, id } }),
+            ),
+          );
+
+        const llmStart = performance.now();
+        let response: StreamResult;
+        let overflowAttempt = 0;
+        while (true) {
+          try {
+            response = await callOnce(callMessages);
+            break;
+          } catch (err) {
+            // Reactive recovery for provider-reported context-window
+            // overflows. The pre-flight `resolveMessageBudget` should make
+            // this rare; when it fires, we re-window with the hook's
+            // own `overflowAttempt`-driven scaling (typically halves the
+            // budget) and retry once. A second overflow propagates the
+            // original error so the UI can surface a clear "conversation
+            // too long" message rather than silently looping.
+            if (
+              overflowAttempt === 0 &&
+              isContextOverflowError(err) &&
+              config.hooks?.transformContext
+            ) {
+              overflowAttempt = 1;
+              const previousMessageCount = callMessages.length;
+              const errorMessage = err instanceof Error ? err.message : String(err);
+              this.events.emit({
+                type: "context.overflow_recovery",
+                data: {
+                  runId,
+                  attempt: overflowAttempt,
+                  previousMessageCount,
+                  errorMessage,
                 },
-                ...addCacheBreakpoint(callMessages),
-              ],
-              tools: modelTools,
-              maxOutputTokens: config.maxOutputTokens,
-              ...(Object.keys(callProviderOptions).length > 0
-                ? { providerOptions: callProviderOptions }
-                : {}),
-            },
-            (text) => this.events.emit({ type: "text.delta", data: { runId, text } }),
-            (text) => this.events.emit({ type: "reasoning.delta", data: { runId, text } }),
-            (id, name) => this.events.emit({ type: "tool.preparing", data: { runId, id, name } }),
-            (id) => this.events.emit({ type: "tool.preparing.done", data: { runId, id } }),
-          ),
-        );
+              });
+              callMessages = sanitizeMessages(runTransform(overflowAttempt));
+              continue;
+            }
+            throw err;
+          }
+        }
         const llmMs = Math.round(performance.now() - llmStart);
 
         // Accumulate text output (add newline between turns if needed)

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -76,6 +76,12 @@ export type EngineEventType =
   | "run.error"
   | "skills.loaded"
   | "context.assembled"
+  /**
+   * Emitted when a model call is rejected for exceeding the context window
+   * and the engine re-windows history with a tighter budget before retrying.
+   * Payload: { runId, attempt, previousMessageCount, errorMessage }.
+   */
+  | "context.overflow_recovery"
   | "bundle.installed"
   | "bundle.uninstalled"
   | "bundle.crashed"
@@ -117,8 +123,19 @@ export interface EngineEvent {
 
 /** Hooks for intercepting the engine loop at 4 strategic points. */
 export interface EngineHooks {
-  /** Modify messages before LLM call (e.g., windowing, context injection). */
-  transformContext?: (messages: LanguageModelV3Message[]) => LanguageModelV3Message[];
+  /**
+   * Modify messages before LLM call (e.g., windowing, context injection).
+   *
+   * `opts.overflowAttempt` is set by the engine when re-invoking after a
+   * provider-reported context-overflow error. `0` (or undefined) is the
+   * first attempt; positive values are recovery retries — the hook is
+   * expected to return more aggressively trimmed messages each step.
+   * Hooks that don't care about recovery can ignore the second argument.
+   */
+  transformContext?: (
+    messages: LanguageModelV3Message[],
+    opts?: { overflowAttempt?: number },
+  ) => LanguageModelV3Message[];
 
   /** Gate or modify tool calls before execution. Return null to skip the tool. */
   beforeToolCall?: (call: ToolCall) => ToolCall | null | Promise<ToolCall | null>;

--- a/src/runtime/resolve-message-budget.ts
+++ b/src/runtime/resolve-message-budget.ts
@@ -1,0 +1,121 @@
+import { estimateToolDescriptionTokens } from "../engine/token-estimate.ts";
+import type { ToolSchema } from "../engine/types.ts";
+import { getModelByString } from "../model/catalog.ts";
+
+/**
+ * Per-call safety margin reserved against the model's context window after
+ * subtracting the system prompt, tool schemas, and `maxOutputTokens`. This
+ * covers (a) drift between our pre-flight token estimates and the provider's
+ * real tokenizer, (b) per-call overhead the provider charges that we don't
+ * see (Anthropic cache framing, etc.), and (c) leaves room for reactive
+ * recovery to retry without immediately re-overflowing.
+ *
+ * Sized to be meaningful relative to typical conversation budgets without
+ * eating substantial headroom on small-context models.
+ */
+export const DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS = 8_192;
+
+export interface ResolveMessageBudgetInput {
+  /** Resolved provider-qualified model id (e.g. "anthropic:claude-opus-4-7"). */
+  model: string;
+  /** Operator/tenant cap from runtime config. Acts as an upper bound only. */
+  configMaxInputTokens: number;
+  /** The system prompt that will go on this call. */
+  systemPrompt: string;
+  /** Active tool schemas that will be advertised on this call. */
+  tools: ToolSchema[];
+  /** Already-resolved `maxOutputTokens` for this call (catalog-clamped). */
+  maxOutputTokens: number;
+  /** Override for the safety margin. Defaults to DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS. */
+  safetyMarginTokens?: number;
+}
+
+export interface ResolveMessageBudgetResult {
+  /** Tokens available for message history on this call. May be 0 in pathological cases. */
+  budget: number;
+  /** Breakdown of the composition — useful for telemetry / debugging. */
+  breakdown: {
+    modelContextWindow: number | null;
+    systemPromptTokens: number;
+    toolTokens: number;
+    maxOutputTokens: number;
+    safetyMarginTokens: number;
+    configMaxInputTokens: number;
+    /** True when the composed headroom was the binding constraint. False when the config cap was. */
+    boundedByModel: boolean;
+  };
+}
+
+/**
+ * Compose the per-call message token budget from first principles:
+ *
+ *   budget = min(
+ *     configMaxInputTokens,
+ *     modelContextWindow − systemTokens − toolTokens − maxOutputTokens − safetyMargin
+ *   )
+ *
+ * The model's catalog `limits.context` is the absolute ceiling. Subtracting
+ * the static per-call overhead (system + tools + reserved output + safety)
+ * yields the maximum tokens we can spend on message history without the
+ * provider rejecting the request for exceeding the context window. The
+ * operator's `configMaxInputTokens` caps that headroom from below — never
+ * raises it.
+ *
+ * If the resolved model isn't in the catalog (typo, brand-new model
+ * pre-sync), fall back to `configMaxInputTokens` directly. This preserves
+ * the prior behavior for unknown models rather than silently zeroing the
+ * budget; missing catalog data should not break sends.
+ *
+ * Estimators are intentionally cheap and conservative:
+ *   - System prompt: chars/4 (text-only, matches `approxTokens` elsewhere).
+ *   - Tool schemas: `estimateToolDescriptionTokens` from
+ *     `src/engine/token-estimate.ts` — same estimator the `context.assembled`
+ *     telemetry uses, so the reported and enforced budgets agree.
+ *
+ * The reactive-recovery path (engine-side, on a provider-reported overflow)
+ * can call this with the same inputs and a tighter `safetyMarginTokens` to
+ * re-trim before a retry. The composition is pure; callers own the policy.
+ */
+export function resolveMessageBudget(input: ResolveMessageBudgetInput): ResolveMessageBudgetResult {
+  const safety = input.safetyMarginTokens ?? DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS;
+  const catalogModel = getModelByString(input.model);
+  const modelCtx = catalogModel?.limits.context ?? null;
+
+  const systemTokens = Math.ceil(input.systemPrompt.length / 4);
+  const toolTokens = input.tools.reduce((sum, t) => sum + estimateToolDescriptionTokens(t), 0);
+
+  const baseBreakdown = {
+    modelContextWindow: modelCtx,
+    systemPromptTokens: systemTokens,
+    toolTokens,
+    maxOutputTokens: input.maxOutputTokens,
+    safetyMarginTokens: safety,
+    configMaxInputTokens: input.configMaxInputTokens,
+  };
+
+  if (modelCtx === null) {
+    // Catalog miss. Fall back to config cap so the call still ships;
+    // operators see model-not-in-catalog warnings elsewhere.
+    return {
+      budget: input.configMaxInputTokens,
+      breakdown: { ...baseBreakdown, boundedByModel: false },
+    };
+  }
+
+  const headroom = modelCtx - systemTokens - toolTokens - input.maxOutputTokens - safety;
+  if (headroom <= 0) {
+    // The static per-call cost already exceeds the context window. The
+    // call will almost certainly fail at the provider; returning 0 lets
+    // `windowMessages` keep only the anchor message and surfaces the
+    // condition via the breakdown.
+    return { budget: 0, breakdown: { ...baseBreakdown, boundedByModel: true } };
+  }
+
+  if (headroom <= input.configMaxInputTokens) {
+    return { budget: headroom, breakdown: { ...baseBreakdown, boundedByModel: true } };
+  }
+  return {
+    budget: input.configMaxInputTokens,
+    breakdown: { ...baseBreakdown, boundedByModel: false },
+  };
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -92,6 +92,7 @@ const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 import { DEFAULT_MAX_INPUT_TOKENS, DEFAULT_MAX_ITERATIONS } from "../limits.ts";
 import { resolveMaxOutputTokens } from "./resolve-max-output-tokens.ts";
+import { resolveMessageBudget } from "./resolve-message-budget.ts";
 import { resolveThinking } from "./resolve-thinking.ts";
 import { isToolEligibleForPromotion } from "./tool-eligibility.ts";
 
@@ -345,8 +346,15 @@ export class Runtime {
 
     const gate = config.confirmationGate ?? new NoopConfirmationGate();
 
-    const maxInputTokens = config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS;
-    const maxHistoryMessages = config.maxHistoryMessages ?? DEFAULT_MAX_HISTORY_MESSAGES;
+    // Neither `maxInputTokens` nor `maxHistoryMessages` are composed at
+    // runtime startup anymore — they're read per-call from `this.config`
+    // in `chat()`. The per-call message budget comes from the resolved
+    // model's context window minus the static per-call overhead (system
+    // prompt + tools + reserved output + safety margin), capped by the
+    // operator's `config.maxInputTokens`. See `resolve-message-budget.ts`.
+    // The runtime-level hooks below carry only `beforeToolCall`;
+    // `transformContext` is built per-request so the budget reflects
+    // what the model actually sees on each call.
 
     // Build delegate context for nb__delegate tool
     // Use a late-bound getter for defaultModel so it reflects live config changes
@@ -387,7 +395,7 @@ export class Runtime {
       getRemainingIterations: () => delegateTracker.getRemainingIterations(),
       getParentRunId: () => delegateTracker.getParentRunId(),
       defaultModel: getDefaultModel(),
-      defaultMaxInputTokens: maxInputTokens,
+      defaultMaxInputTokens: config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS,
       // Raw operator config (may be undefined). Delegate resolves against
       // the child's model at execution time so the resolved values fit
       // the child's model rather than the parent's.
@@ -422,15 +430,11 @@ export class Runtime {
     const features = resolveFeatures(config.features);
     const hooks: EngineHooks = {
       beforeToolCall: createPrivilegeHook(gate, events, features),
-      transformContext: (messages) => {
-        // Order matters: slice by count first (cheap, deterministic), then
-        // strip older-turn reasoning (drops bytes we'd otherwise budget for),
-        // then window by token budget. Reasoning stripping runs before
-        // windowing so the budget reflects what the model actually sees.
-        const sliced = sliceHistory(messages, maxHistoryMessages);
-        const reasoningStripped = stripOlderReasoning(sliced);
-        return windowMessages(reasoningStripped, maxInputTokens);
-      },
+      // `transformContext` is intentionally NOT set here. It is composed
+      // per-request in `chat()` because the message budget depends on
+      // values only known at call time (the resolved model's context
+      // window, the per-call system prompt and tool set, and the
+      // resolved `maxOutputTokens`). See `resolveMessageBudget`.
     };
 
     const store = buildStore(config);
@@ -944,6 +948,33 @@ export class Runtime {
       maxOutputTokens: resolvedMaxOutputTokens,
     });
 
+    // Compose the per-call message budget from the model's actual context
+    // window minus the static per-call overhead. `configMaxInputTokens`
+    // is treated as a CAP — never a target. See
+    // `src/runtime/resolve-message-budget.ts`.
+    const configMaxInputTokens = this.config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS;
+    const messageBudget = resolveMessageBudget({
+      model: resolvedModelString,
+      configMaxInputTokens,
+      systemPrompt,
+      tools,
+      maxOutputTokens: resolvedMaxOutputTokens,
+    });
+
+    // Per-request hooks: inherit `beforeToolCall` from the runtime-level
+    // hooks; compose `transformContext` here so the windowing budget is
+    // the one we just resolved for THIS call. The order (slice → strip
+    // older reasoning → window by token budget) is preserved.
+    const maxHistoryMessages = this.config.maxHistoryMessages ?? DEFAULT_MAX_HISTORY_MESSAGES;
+    const perRequestHooks: EngineHooks = {
+      ...this.hooks,
+      transformContext: (historyMessages) => {
+        const sliced = sliceHistory(historyMessages, maxHistoryMessages);
+        const reasoningStripped = stripOlderReasoning(sliced);
+        return windowMessages(reasoningStripped, messageBudget.budget);
+      },
+    };
+
     // Build pre-emit run telemetry tied to the engine's runId. The engine fires
     // these immediately after `run.start` and before any LLM call so the conv
     // log records what the prompt looked like for this turn — even if the LLM
@@ -959,11 +990,15 @@ export class Runtime {
     const engineConfig: EngineConfig = {
       model: resolvedModelString,
       maxIterations: request.maxIterations ?? this.config.maxIterations ?? DEFAULT_MAX_ITERATIONS,
-      maxInputTokens: this.config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS,
+      // Surfaced on run.start telemetry. The actual budget enforcement
+      // happens inside `perRequestHooks.transformContext` above; this
+      // value is reported for observability so operators can see what
+      // the call was allotted vs. what it actually used.
+      maxInputTokens: messageBudget.budget,
       maxOutputTokens: resolvedMaxOutputTokens,
       ...(resolvedThinking ? { thinking: resolvedThinking } : {}),
       maxToolResultSize: this.config.maxToolResultSize,
-      hooks: this.hooks,
+      hooks: perRequestHooks,
       runMetadata: {
         skillsLoaded,
         contextAssembled,

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -968,10 +968,17 @@ export class Runtime {
     const maxHistoryMessages = this.config.maxHistoryMessages ?? DEFAULT_MAX_HISTORY_MESSAGES;
     const perRequestHooks: EngineHooks = {
       ...this.hooks,
-      transformContext: (historyMessages) => {
+      transformContext: (historyMessages, opts) => {
+        // `overflowAttempt > 0` means the provider rejected the prior
+        // call for exceeding the model's context window. Halve the
+        // composed budget per attempt and re-window. The engine caps
+        // recovery at one attempt today so this scales at most by 1/2.
+        const attempt = opts?.overflowAttempt ?? 0;
+        const budget =
+          attempt > 0 ? Math.floor(messageBudget.budget / (1 << attempt)) : messageBudget.budget;
         const sliced = sliceHistory(historyMessages, maxHistoryMessages);
         const reasoningStripped = stripOlderReasoning(sliced);
-        return windowMessages(reasoningStripped, messageBudget.budget);
+        return windowMessages(reasoningStripped, budget);
       },
     };
 

--- a/test/unit/context-overflow.test.ts
+++ b/test/unit/context-overflow.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { isContextOverflowError } from "../../src/engine/context-overflow.ts";
+
+describe("isContextOverflowError", () => {
+  it("matches Anthropic's prompt-too-long error", () => {
+    const err = Object.assign(new Error("prompt is too long: 1257504 tokens > 1000000 maximum"), {
+      status: 400,
+    });
+    expect(isContextOverflowError(err)).toBe(true);
+  });
+
+  it("matches OpenAI's maximum-context-length error", () => {
+    const err = Object.assign(
+      new Error(
+        "This model's maximum context length is 128000 tokens. However, your messages resulted in 145000 tokens.",
+      ),
+      { status: 400 },
+    );
+    expect(isContextOverflowError(err)).toBe(true);
+  });
+
+  it("matches Google Gemini's input-token-count error", () => {
+    const err = Object.assign(
+      new Error("The input token count exceeds the maximum number of tokens allowed (1000000)."),
+      { status: 400 },
+    );
+    expect(isContextOverflowError(err)).toBe(true);
+  });
+
+  it("matches a context-length-exceeded shape via responseBody", () => {
+    const err = {
+      status: 400,
+      message: "Bad Request",
+      responseBody: JSON.stringify({
+        error: { message: "context length exceeded", type: "invalid_request_error" },
+      }),
+    };
+    expect(isContextOverflowError(err)).toBe(true);
+  });
+
+  it("unwraps nested causes (Vercel AI SDK pattern)", () => {
+    const inner = Object.assign(new Error("prompt is too long: 1.2M tokens > 1M maximum"), {
+      status: 400,
+    });
+    const outer = Object.assign(new Error("AI_APICallError"), { status: 400, cause: inner });
+    expect(isContextOverflowError(outer)).toBe(true);
+  });
+
+  it("returns false for unrelated 400s", () => {
+    const err = Object.assign(new Error("Invalid model id 'foo'"), { status: 400 });
+    expect(isContextOverflowError(err)).toBe(false);
+  });
+
+  it("returns false for non-4xx errors even if the message hints at length", () => {
+    const err = Object.assign(new Error("prompt is too long for cache"), { status: 500 });
+    expect(isContextOverflowError(err)).toBe(false);
+  });
+
+  it("returns false for non-Error inputs", () => {
+    expect(isContextOverflowError(null)).toBe(false);
+    expect(isContextOverflowError(undefined)).toBe(false);
+    expect(isContextOverflowError("string error")).toBe(false);
+    expect(isContextOverflowError(404)).toBe(false);
+  });
+
+  it("matches when status is absent but message is unambiguous", () => {
+    // Some upstream wrappers strip status; the message alone is enough.
+    const err = new Error("prompt is too long: 1.5M tokens > 1M maximum");
+    expect(isContextOverflowError(err)).toBe(true);
+  });
+
+  it("is case-insensitive on the message", () => {
+    const err = Object.assign(new Error("PROMPT IS TOO LONG: huge"), { status: 400 });
+    expect(isContextOverflowError(err)).toBe(true);
+  });
+});

--- a/test/unit/conversation.test.ts
+++ b/test/unit/conversation.test.ts
@@ -122,7 +122,11 @@ describe("JsonlConversationStore (persistence)", () => {
 
 describe("windowMessages", () => {
   function wmsg(role: "user" | "assistant", text: string): Message {
-    return { role, content: text };
+    // V3 shape: user/assistant content is an array of typed parts. Some
+    // older tests passed strings here, which fell through the legacy
+    // `chars/4` reducer; the part-aware `estimateMessageTokens` is strict
+    // about the V3 shape so all helpers below use the correct one.
+    return { role, content: [{ type: "text", text }] } as Message;
   }
 
   it("returns all messages when under budget", () => {

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -3272,4 +3272,130 @@ describe("malformed tool call input", () => {
       expect(result.toolCalls[0]!.output).toContain("string");
     });
   });
+
+  describe("context-overflow recovery", () => {
+    it("re-invokes transformContext with overflowAttempt=1 and retries once on a context-overflow error", async () => {
+      let callCount = 0;
+      const recordedAttempts: Array<number | undefined> = [];
+      const events: EngineEvent[] = [];
+      const recordingSink: EventSink = {
+        emit(e: EngineEvent) {
+          events.push(e);
+        },
+      };
+
+      // First call throws an Anthropic-shaped overflow error; second succeeds.
+      const model = createMockModel(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          throw Object.assign(
+            new Error("prompt is too long: 1257504 tokens > 1000000 maximum"),
+            { status: 400 },
+          );
+        }
+        return {
+          content: [{ type: "text", text: "recovered" }],
+        };
+      });
+
+      const engine = new AgentEngine(
+        model,
+        new StaticToolRouter([], () => ({ content: textContent(""), isError: false })),
+        recordingSink,
+      );
+
+      const result = await engine.run(
+        {
+          ...defaultConfig,
+          hooks: {
+            transformContext: (msgs, opts) => {
+              recordedAttempts.push(opts?.overflowAttempt);
+              return msgs;
+            },
+          },
+        },
+        "",
+        [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        [],
+      );
+
+      // The model was called twice: once that overflowed, once that succeeded.
+      expect(callCount).toBe(2);
+
+      // transformContext got called twice — once at overflowAttempt=0
+      // (or undefined), once at overflowAttempt=1.
+      expect(recordedAttempts).toEqual([0, 1]);
+
+      // The recovery event was emitted exactly once with attempt=1.
+      const recoveryEvents = events.filter((e) => e.type === "context.overflow_recovery");
+      expect(recoveryEvents).toHaveLength(1);
+      expect(recoveryEvents[0]!.data).toMatchObject({ attempt: 1 });
+
+      // The run succeeded with the second call's output.
+      expect(result.output).toBe("recovered");
+      expect(result.stopReason).toBe("complete");
+    });
+
+    it("propagates the original overflow error after a single recovery attempt fails", async () => {
+      let callCount = 0;
+      const model = createMockModel(() => {
+        callCount += 1;
+        // Both calls overflow.
+        throw Object.assign(
+          new Error("prompt is too long: still too big"),
+          { status: 400 },
+        );
+      });
+
+      const engine = new AgentEngine(
+        model,
+        new StaticToolRouter([], () => ({ content: textContent(""), isError: false })),
+        new NoopEventSink(),
+      );
+
+      await expect(
+        engine.run(
+          {
+            ...defaultConfig,
+            hooks: { transformContext: (msgs) => msgs },
+          },
+          "",
+          [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+          [],
+        ),
+      ).rejects.toThrow(/prompt is too long/);
+
+      // Two model calls: the original + one recovery attempt.
+      expect(callCount).toBe(2);
+    });
+
+    it("does NOT retry on a non-overflow error (auth, unrelated 400, etc.)", async () => {
+      let callCount = 0;
+      const model = createMockModel(() => {
+        callCount += 1;
+        throw Object.assign(new Error("invalid api key"), { status: 401 });
+      });
+
+      const engine = new AgentEngine(
+        model,
+        new StaticToolRouter([], () => ({ content: textContent(""), isError: false })),
+        new NoopEventSink(),
+      );
+
+      await expect(
+        engine.run(
+          {
+            ...defaultConfig,
+            hooks: { transformContext: (msgs) => msgs },
+          },
+          "",
+          [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+          [],
+        ),
+      ).rejects.toThrow(/Authentication failed/);
+
+      // No recovery — the auth error is non-retryable and surfaces immediately.
+      expect(callCount).toBe(1);
+    });
+  });
 });

--- a/test/unit/resolve-message-budget.test.ts
+++ b/test/unit/resolve-message-budget.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import type { ToolSchema } from "../../src/engine/types.ts";
+import {
+  DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS,
+  resolveMessageBudget,
+} from "../../src/runtime/resolve-message-budget.ts";
+
+function tool(name: string, description: string): ToolSchema {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: "object",
+      properties: { q: { type: "string" } },
+    },
+  };
+}
+
+describe("resolveMessageBudget", () => {
+  it("uses model context window minus overhead when headroom is the binding constraint", () => {
+    const result = resolveMessageBudget({
+      model: "anthropic:claude-opus-4-7", // 1M context
+      configMaxInputTokens: 5_000_000, // far above headroom
+      systemPrompt: "you are a helpful assistant",
+      tools: [],
+      maxOutputTokens: 16_384,
+    });
+
+    expect(result.breakdown.modelContextWindow).toBe(1_000_000);
+    expect(result.breakdown.boundedByModel).toBe(true);
+    // budget = 1M − sysTokens − 0 − 16384 − 8192 ≈ 975K
+    expect(result.budget).toBeGreaterThan(900_000);
+    expect(result.budget).toBeLessThan(1_000_000);
+  });
+
+  it("uses configMaxInputTokens when it's lower than the model headroom", () => {
+    const result = resolveMessageBudget({
+      model: "anthropic:claude-opus-4-7",
+      configMaxInputTokens: 500_000,
+      systemPrompt: "you are a helpful assistant",
+      tools: [],
+      maxOutputTokens: 16_384,
+    });
+
+    expect(result.budget).toBe(500_000);
+    expect(result.breakdown.boundedByModel).toBe(false);
+  });
+
+  it("falls back to configMaxInputTokens when the model is not in the catalog", () => {
+    const result = resolveMessageBudget({
+      model: "anthropic:claude-not-a-real-model",
+      configMaxInputTokens: 200_000,
+      systemPrompt: "system",
+      tools: [],
+      maxOutputTokens: 16_384,
+    });
+
+    expect(result.budget).toBe(200_000);
+    expect(result.breakdown.modelContextWindow).toBeNull();
+    expect(result.breakdown.boundedByModel).toBe(false);
+  });
+
+  it("subtracts tool description tokens from headroom", () => {
+    const tools = Array.from({ length: 20 }, (_, i) =>
+      tool(`tool_${i}`, "a description that uses a few tokens".repeat(4)),
+    );
+    const result = resolveMessageBudget({
+      model: "anthropic:claude-opus-4-7",
+      configMaxInputTokens: 5_000_000,
+      systemPrompt: "",
+      tools,
+      maxOutputTokens: 16_384,
+    });
+
+    expect(result.breakdown.toolTokens).toBeGreaterThan(0);
+    // headroom = 1M − 0 − toolTokens − 16384 − 8192
+    const expectedHeadroom =
+      1_000_000 -
+      result.breakdown.toolTokens -
+      16_384 -
+      DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS;
+    expect(result.budget).toBe(expectedHeadroom);
+  });
+
+  it("subtracts maxOutputTokens from headroom", () => {
+    const a = resolveMessageBudget({
+      model: "anthropic:claude-opus-4-7",
+      configMaxInputTokens: 5_000_000,
+      systemPrompt: "",
+      tools: [],
+      maxOutputTokens: 1_000,
+    });
+    const b = resolveMessageBudget({
+      model: "anthropic:claude-opus-4-7",
+      configMaxInputTokens: 5_000_000,
+      systemPrompt: "",
+      tools: [],
+      maxOutputTokens: 100_000,
+    });
+
+    expect(a.budget - b.budget).toBe(100_000 - 1_000);
+  });
+
+  it("returns budget=0 when static overhead alone exceeds the model context window", () => {
+    const result = resolveMessageBudget({
+      model: "anthropic:claude-opus-4-7",
+      configMaxInputTokens: 5_000_000,
+      systemPrompt: "x".repeat(4_000_000), // ~1M tokens — already over the window
+      tools: [],
+      maxOutputTokens: 16_384,
+    });
+
+    expect(result.budget).toBe(0);
+    expect(result.breakdown.boundedByModel).toBe(true);
+  });
+
+  it("honors a custom safety margin", () => {
+    const tight = resolveMessageBudget({
+      model: "anthropic:claude-opus-4-7",
+      configMaxInputTokens: 5_000_000,
+      systemPrompt: "",
+      tools: [],
+      maxOutputTokens: 16_384,
+      safetyMarginTokens: 100_000,
+    });
+    const default_ = resolveMessageBudget({
+      model: "anthropic:claude-opus-4-7",
+      configMaxInputTokens: 5_000_000,
+      systemPrompt: "",
+      tools: [],
+      maxOutputTokens: 16_384,
+    });
+
+    expect(default_.budget - tight.budget).toBe(
+      100_000 - DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS,
+    );
+  });
+});


### PR DESCRIPTION
## Why this PR exists

**#239 was marked merged on GitHub but its content never made it to \`main\`.** The PR was stacked on #238 with base \`fix/lean-content-protocol\`. When #238 was merged to \`main\` (and its branch auto-deleted), GitHub did **not** auto-rebase #239's base to \`main\`. 43 seconds later #239 was merged — into the now-empty \`fix/lean-content-protocol\` branch. The merge commit (\`eed85c5a\`) exists in git's object database but is unreachable from any branch; \`origin/main\` does not contain \`src/engine/context-overflow.ts\` or \`src/runtime/resolve-message-budget.ts\`.

This PR re-ships #239's two original commits cherry-picked directly onto current \`main\`. No changes to the content — same commits, same messages, just targeted at the right base this time.

## What changes (verbatim from #239)

### \`fix(runtime): compose message budget from model context window, not configCap\`

Compose per-call from first principles:

\`\`\`
budget = min(
  configMaxInputTokens,
  modelContext − systemTokens − toolTokens − maxOutputTokens − safetyMargin
)
\`\`\`

- The model's catalog \`limits.context\` is the absolute ceiling.
- \`configMaxInputTokens\` becomes a **cap, never a target**.
- Static overhead is estimated by \`estimateToolDescriptionTokens\` (same primitive \`context.assembled\` uses) so budget and reported usage agree.
- New \`src/runtime/resolve-message-budget.ts\` owns the composition.
- \`transformContext\` moves from a runtime-level closure to a per-request hook built in \`chat()\`.
- \`windowMessages\` routes its internal estimator through the part-aware \`estimateMessageTokens\` so rehydrated \`file\` parts no longer report as ~875K phantom tokens.

### \`fix(engine): retry once on provider context-overflow with halved budget\`

Reactive recovery when pre-flight estimation is wrong:

1. Engine catches the model call exception.
2. \`isContextOverflowError\` matches Anthropic / OpenAI / Gemini phrasings, gated to status 400.
3. Engine re-invokes \`transformContext\` with \`overflowAttempt: 1\`; the runtime hook halves the budget.
4. Engine retries once. A second overflow propagates the original error.

Adds \`context.overflow_recovery\` as an emitted event type. \`EngineHooks.transformContext\` extends to \`(messages, { overflowAttempt? })\` — backward compatible.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run test:unit\`: 2919 pass, 0 fail
- [x] Cherry-picks applied cleanly with no conflicts against current \`main\`

## Follow-up

A small follow-up PR with five defensive-polish edits (recovery \`log.warn\`, catalog-miss \`log.warn\`, \`responseBody\`-as-object branch + test, tightened budget test) will follow once this lands.