### PR TITLE
fix(runtime/engine): observability + detector hardening for overflow recovery

### DIFF
--- a/src/engine/context-overflow.ts
+++ b/src/engine/context-overflow.ts
@@ -29,7 +29,13 @@ function getStatus(err: ErrorLike): number | undefined {
 function getMessages(err: ErrorLike): string[] {
   const messages: string[] = [];
   if (typeof err.message === "string") messages.push(err.message);
-  if (typeof err.responseBody === "string") messages.push(err.responseBody);
+  if (typeof err.responseBody === "string") {
+    messages.push(err.responseBody);
+  } else if (err.responseBody && typeof err.responseBody === "object") {
+    // Some SDK versions pre-parse the body before throwing; stringify so
+    // the phrase match below still has something to scan. Mirrors `data`.
+    messages.push(JSON.stringify(err.responseBody));
+  }
   if (err.data && typeof err.data === "object") {
     messages.push(JSON.stringify(err.data));
   }

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -7,6 +7,7 @@ import type {
   LanguageModelV3ToolResultPart,
   SharedV3ProviderOptions,
 } from "@ai-sdk/provider";
+import { log } from "../cli/log.ts";
 import { DEFAULT_MAX_DIRECT_TOOLS, MAX_ITERATIONS, MAX_TOOL_RESULT_CHARS } from "../limits.ts";
 import { getProviderFromModel, supportsEnabledThinking } from "../model/catalog.ts";
 import { normalizeForReplay } from "../model/inbound-fit.ts";
@@ -564,6 +565,16 @@ export class AgentEngine {
               overflowAttempt = 1;
               const previousMessageCount = callMessages.length;
               const errorMessage = err instanceof Error ? err.message : String(err);
+              // Always-on stderr line so a frequency uptick is visible in
+              // operator logs without flipping a debug flag. Recovery
+              // firing means the pre-flight budget composition disagreed
+              // with the provider's tokenizer — actionable signal for
+              // tuning DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS or the
+              // estimator. Per-conversation correlation via runId; the
+              // aggregate is what drives action.
+              log.warn(
+                `[engine] context overflow recovery runId=${runId} attempt=${overflowAttempt} previousMessages=${previousMessageCount} model=${config.model} error="${errorMessage}"`,
+              );
               this.events.emit({
                 type: "context.overflow_recovery",
                 data: {

--- a/src/runtime/resolve-message-budget.ts
+++ b/src/runtime/resolve-message-budget.ts
@@ -1,3 +1,4 @@
+import { log } from "../cli/log.ts";
 import { estimateToolDescriptionTokens } from "../engine/token-estimate.ts";
 import type { ToolSchema } from "../engine/types.ts";
 import { getModelByString } from "../model/catalog.ts";
@@ -94,8 +95,18 @@ export function resolveMessageBudget(input: ResolveMessageBudgetInput): ResolveM
   };
 
   if (modelCtx === null) {
-    // Catalog miss. Fall back to config cap so the call still ships;
-    // operators see model-not-in-catalog warnings elsewhere.
+    // Catalog miss. Fall back to the config cap so the call still ships,
+    // but warn loudly: this is the only path where `configMaxInputTokens`
+    // re-acquires its old "target" semantics (no overhead subtracted), so
+    // a typo'd model id or a brand-new model that's ahead of the vendored
+    // catalog can still overflow on the first call. The engine's reactive
+    // recovery (one retry, halved budget) is the safety net; operators
+    // tuning catalog sync should see this in stderr aggregates.
+    log.warn(
+      `[runtime] resolveMessageBudget: model "${input.model}" not in catalog; ` +
+        `falling back to configMaxInputTokens=${input.configMaxInputTokens} as budget. ` +
+        `Per-call overhead is NOT subtracted on this path — the call may overflow and rely on engine recovery.`,
+    );
     return {
       budget: input.configMaxInputTokens,
       breakdown: { ...baseBreakdown, boundedByModel: false },

--- a/test/unit/context-overflow.test.ts
+++ b/test/unit/context-overflow.test.ts
@@ -38,6 +38,17 @@ describe("isContextOverflowError", () => {
     expect(isContextOverflowError(err)).toBe(true);
   });
 
+  it("matches when responseBody is a pre-parsed object (some SDK versions)", () => {
+    const err = {
+      status: 400,
+      message: "Bad Request",
+      responseBody: {
+        error: { message: "prompt is too long: 1.5M tokens > 1M maximum", type: "invalid_request_error" },
+      },
+    };
+    expect(isContextOverflowError(err)).toBe(true);
+  });
+
   it("unwraps nested causes (Vercel AI SDK pattern)", () => {
     const inner = Object.assign(new Error("prompt is too long: 1.2M tokens > 1M maximum"), {
       status: 400,

--- a/test/unit/resolve-message-budget.test.ts
+++ b/test/unit/resolve-message-budget.test.ts
@@ -18,19 +18,27 @@ function tool(name: string, description: string): ToolSchema {
 
 describe("resolveMessageBudget", () => {
   it("uses model context window minus overhead when headroom is the binding constraint", () => {
+    const systemPrompt = "you are a helpful assistant";
     const result = resolveMessageBudget({
       model: "anthropic:claude-opus-4-7", // 1M context
       configMaxInputTokens: 5_000_000, // far above headroom
-      systemPrompt: "you are a helpful assistant",
+      systemPrompt,
       tools: [],
       maxOutputTokens: 16_384,
     });
 
     expect(result.breakdown.modelContextWindow).toBe(1_000_000);
     expect(result.breakdown.boundedByModel).toBe(true);
-    // budget = 1M − sysTokens − 0 − 16384 − 8192 ≈ 975K
-    expect(result.budget).toBeGreaterThan(900_000);
-    expect(result.budget).toBeLessThan(1_000_000);
+    // Deterministic: budget = 1M − ceil(sysLen/4) − 0 − maxOutput − safety.
+    // Asserting the exact number so any silent change to the formula or the
+    // safety-margin constant fails this test rather than slipping through.
+    const expected =
+      1_000_000 -
+      Math.ceil(systemPrompt.length / 4) -
+      0 -
+      16_384 -
+      DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS;
+    expect(result.budget).toBe(expected);
   });
 
   it("uses configMaxInputTokens when it's lower than the model headroom", () => {


### PR DESCRIPTION
Five small followups on #241's budget composition + recovery work. Surfaced during the QA review of #239 but deferred so #239 could land first. None are bug fixes for shipped behavior; they make the recovery path debuggable and harden the detector against SDK shape drift.

## What changes

### Observability
- **`engine.ts`** — emit a single `log.warn` line when context-overflow recovery fires (`runId`, `attempt`, `previousMessages`, `model`, `error`). The runtime already emits a live `context.overflow_recovery` event for the UI; this is the operator-facing signal that aggregates in log infra. Considered persisting the event to the JSONL but the signal that matters for action is aggregate (estimator drift), not per-conversation.
- **`resolve-message-budget.ts`** — emit a `log.warn` on catalog miss. The fallback path returns `configMaxInputTokens` without subtracting per-call overhead — the only path where the value re-acquires its old "target" semantics. Operators need to know when this fires so they can fix the catalog or the typo'd model id. The old \"operators see warnings elsewhere\" comment was aspirational — there was no such warning anywhere in the codebase (grep'd).

### Detector hardening
- **`context-overflow.ts`** — handle `responseBody` when it's a pre-parsed object, mirroring the existing `data` branch. Some SDK versions hand back parsed bodies; without this the detector misses the overflow phrase and recovery doesn't fire. New test locks in the branch.

### Test rigor
- **`resolve-message-budget.test.ts`** — tighten the first test's bound from \`> 900K && < 1M\` to the exact computed value. The math is deterministic; a silent change to \`DEFAULT_BUDGET_SAFETY_MARGIN_TOKENS\` or the formula should fail this test, not slip through.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run test:unit\`: 2920 pass, 0 fail (+1 vs. main from the new responseBody case)

## Not in this PR

A few diminishing-returns items from the same review were intentionally skipped:

- Replacing \`1 << attempt\` with \`/ 2\` in \`runtime.ts\` (cosmetic; engine hard-caps recovery at one retry).
- Surfacing \`breakdown.boundedByModel\` on \`run.start\` telemetry (no current consumer; would expand wire format without a reader).
- Persisting \`context.overflow_recovery\` to the conversation JSONL (wire-format additions are one-way doors; the stderr line above covers the actual ops use case).