### PR TITLE
fix(bundles): unify data dir on manifest-name slug; absolutize workDir

### DIFF
--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -24,7 +24,7 @@ import {
 } from "./connection.ts";
 import { getMpak } from "./mpak.ts";
 import { hasPersistedWorkspaceOAuthTokens } from "./oauth-tokens.ts";
-import { deriveServerName, resolveBundleDataDirForRef } from "./paths.ts";
+import { defaultWorkDir, deriveServerName, resolveBundleDataDirForRef } from "./paths.ts";
 import { consumePendingAuth } from "./pending-auth-buffer.ts";
 import { startBundleSource } from "./startup.ts";
 import type {
@@ -138,7 +138,7 @@ export class BundleLifecycleManager {
     // bundle from stomping on each other's entity data. Slug source is
     // `manifest.name` via `resolveBundleDataDirForRef` — same call used by
     // the boot-time inventory and the JIT install path, so all three agree.
-    const nbWorkDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+    const nbWorkDir = defaultWorkDir();
     const wsContext = new WorkspaceContext({ wsId, workDir: nbWorkDir });
     const configDir = this.configPath ? dirname(this.configPath) : undefined;
     const bundleDataDir = resolveBundleDataDirForRef(nbWorkDir, wsId, { name }, configDir);
@@ -157,7 +157,7 @@ export class BundleLifecycleManager {
     }
 
     const isUpjack = manifest._meta?.["ai.nimblebrain/upjack"] != null;
-    const instance = createInstance(sourceName, name, manifest, isUpjack, wsId);
+    const instance = createInstance(sourceName, name, manifest, isUpjack, wsId, bundleDataDir);
     instance.configKey = name;
     this.transition(instance, "running");
 
@@ -209,7 +209,7 @@ export class BundleLifecycleManager {
     // Without this override `buildLocalSource`'s fallback would compose a
     // `<nbWorkDir>/data/<slug>` path that bypasses the workspace prefix
     // and uses a path-derived slug.
-    const nbWorkDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+    const nbWorkDir = defaultWorkDir();
     const configDir = this.configPath ? dirname(this.configPath) : undefined;
     const bundleDataDir = resolveBundleDataDirForRef(
       nbWorkDir,
@@ -233,7 +233,14 @@ export class BundleLifecycleManager {
 
     const isUpjack = manifest._meta?.["ai.nimblebrain/upjack"] != null;
     // Use manifest.name (scoped name) as bundleName, not the filesystem path.
-    const instance = createInstance(sourceName, manifest.name, manifest, isUpjack, wsId);
+    const instance = createInstance(
+      sourceName,
+      manifest.name,
+      manifest,
+      isUpjack,
+      wsId,
+      bundleDataDir,
+    );
     instance.configKey = bundlePath; // config entry uses the filesystem path
     this.transition(instance, "running");
 
@@ -294,7 +301,7 @@ export class BundleLifecycleManager {
     ui?: BundleUiMeta | null,
     trustScore?: number | null,
   ): Promise<BundleInstance> {
-    const nbWorkDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+    const nbWorkDir = defaultWorkDir();
 
     // Pre-register the instance + Connection BEFORE startBundleSource so
     // the interactive-auth callback (fired during source.start()) can find
@@ -454,7 +461,7 @@ export class BundleLifecycleManager {
     // Credentials are config, not data — they should not persist across
     // uninstalls. Data directories are preserved (step 6).
     if (instance) {
-      const workDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+      const workDir = defaultWorkDir();
       try {
         await new WorkspaceContext({ wsId: instance.wsId, workDir })
           .getCredentialStore()
@@ -1590,7 +1597,7 @@ export class BundleLifecycleManager {
           authorizationUrl: pendingAuthUrl,
         });
       } else {
-        const workDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+        const workDir = defaultWorkDir();
         // Composio-backed connectors live in a parallel credential
         // namespace — the user-presence signal is
         // `credentials/composio/<connectorId>/connection.json`, not
@@ -1643,7 +1650,17 @@ function createInstance(
   manifest: BundleManifest,
   isUpjack: boolean,
   wsId: string,
+  dataDir: string,
 ): BundleInstance {
+  // Mirror the entityDataRoot composition `seedInstance` does at boot so
+  // JIT installs (installLocal / installNamed) leave the BundleInstance in
+  // the same shape as a boot-seeded one. Without this, briefing facets
+  // pointed at a freshly-installed upjack bundle would find
+  // `instance.entityDataRoot === undefined` and silently report nothing.
+  const upjackMeta = manifest._meta?.["ai.nimblebrain/upjack"] as
+    | { namespace?: string }
+    | undefined;
+  const namespace = upjackMeta?.namespace;
   return {
     serverName,
     bundleName,
@@ -1657,6 +1674,7 @@ function createInstance(
     protected: false,
     type: isUpjack ? "upjack" : "plain",
     wsId,
+    ...(namespace ? { entityDataRoot: join(dataDir, namespace, "data") } : {}),
   };
 }
 

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -24,7 +24,7 @@ import {
 } from "./connection.ts";
 import { getMpak } from "./mpak.ts";
 import { hasPersistedWorkspaceOAuthTokens } from "./oauth-tokens.ts";
-import { deriveBundleDataDir, deriveServerName } from "./paths.ts";
+import { deriveServerName, resolveBundleDataDirForRef } from "./paths.ts";
 import { consumePendingAuth } from "./pending-auth-buffer.ts";
 import { startBundleSource } from "./startup.ts";
 import type {
@@ -135,13 +135,13 @@ export class BundleLifecycleManager {
     await mpak.bundleCache.loadBundle(name);
 
     // Workspace-scoped data dir keeps two workspaces installing the same
-    // bundle from stomping on each other's entity data. Matches the
-    // seedInstance layout used at platform boot. Routed through
-    // WorkspaceContext so the `workspaces/{wsId}/data/{slug}` layout has
-    // one definition site (see src/workspace/context.ts).
+    // bundle from stomping on each other's entity data. Slug source is
+    // `manifest.name` via `resolveBundleDataDirForRef` — same call used by
+    // the boot-time inventory and the JIT install path, so all three agree.
     const nbWorkDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
     const wsContext = new WorkspaceContext({ wsId, workDir: nbWorkDir });
-    const bundleDataDir = wsContext.getDataPath("data", deriveBundleDataDir(name));
+    const configDir = this.configPath ? dirname(this.configPath) : undefined;
+    const bundleDataDir = resolveBundleDataDirForRef(nbWorkDir, wsId, { name }, configDir);
 
     const { sourceName, manifest } = await startBundleSource(
       { name, env },
@@ -203,11 +203,26 @@ export class BundleLifecycleManager {
     wsId: string,
     env?: Record<string, string>,
   ): Promise<BundleInstance> {
+    // Workspace-scoped data dir computed up-front via the canonical helper
+    // (slug = manifest.name) so the subprocess's MPAK_WORKSPACE and the
+    // seedInstance / briefing reader path agree on a single location.
+    // Without this override `buildLocalSource`'s fallback would compose a
+    // `<nbWorkDir>/data/<slug>` path that bypasses the workspace prefix
+    // and uses a path-derived slug.
+    const nbWorkDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+    const configDir = this.configPath ? dirname(this.configPath) : undefined;
+    const bundleDataDir = resolveBundleDataDirForRef(
+      nbWorkDir,
+      wsId,
+      { path: bundlePath },
+      configDir,
+    );
     const { sourceName, manifest } = await startBundleSource(
       { path: bundlePath, env },
       registry,
       this.eventSink,
-      this.configPath ? dirname(this.configPath) : undefined,
+      configDir,
+      { dataDir: bundleDataDir },
     );
     if (!manifest) {
       // Local bundles always have a manifest.json on disk; startBundleSource
@@ -1480,37 +1495,14 @@ export class BundleLifecycleManager {
      *  test callers; production callers should always pass it. */
     registry?: ToolRegistry,
   ): void {
-    // Resolve entity data root from dataDir + upjack namespace at seed time.
-    // This is the single source of truth — downstream consumers read it directly.
-    //
-    // Subtlety: for `path:` bundles, `dataDir` ends in a multi-segment broken
-    // slug because `deriveBundleDataDir` only replaces the first `/` (string
-    // replace, not regex). So `/Users/foo/bar` becomes `-Users/foo/bar`, and
-    // `join(wsData, that)` nests the install path into the workspace's data
-    // tree instead of producing a flat one-segment dir. `dirname()` can't
-    // walk back out of that — we have to anchor on the known
-    // `workspaces/<wsId>/data/` prefix to find the workspace's data root.
-    // Safe to anchor on substring because `dataDir` is canonically constructed
-    // upstream as `join(workDir, "workspaces", wsId, "data", ...)`; the marker
-    // would only collide if a workDir itself contained an identical wsId-keyed
-    // workspace sub-tree, which the install path doesn't allow.
-    //
-    // The bundle itself writes data using its manifest name (e.g.
-    // `@nimblebraininc/synapse-crm` → `nimblebraininc-synapse-crm`), so we
-    // re-derive the bundle-data parent from `manifestName` here. Registry
-    // installs are unaffected — their install name and manifest name
-    // produce identical slugs.
-    const bundleDataParent = ((): string | undefined => {
-      if (!manifestMeta?.manifestName || !dataDir) return dataDir;
-      const wsDataAnchor = `/workspaces/${wsId}/data/`;
-      const anchorIdx = dataDir.indexOf(wsDataAnchor);
-      if (anchorIdx < 0) return dataDir;
-      const wsDataRoot = dataDir.slice(0, anchorIdx + wsDataAnchor.length);
-      return join(wsDataRoot, deriveBundleDataDir(manifestMeta.manifestName));
-    })();
+    // Resolve entity data root from dataDir + upjack namespace. `dataDir` is
+    // already the canonical bundle-data parent (slug = manifest.name) thanks
+    // to `resolveBundleDataDirForRef` at every caller — buildProcessInventory,
+    // installLocal, installNamed, installBundleInWorkspace. No re-derivation
+    // here: launcher and reader agree by construction.
     const entityDataRoot =
-      bundleDataParent && manifestMeta?.upjackNamespace
-        ? join(bundleDataParent, manifestMeta.upjackNamespace, "data")
+      dataDir && manifestMeta?.upjackNamespace
+        ? join(dataDir, manifestMeta.upjackNamespace, "data")
         : undefined;
 
     // Resolve oauthScope for URL bundles. Member-scoped bundles seed with

--- a/src/bundles/paths.ts
+++ b/src/bundles/paths.ts
@@ -1,4 +1,8 @@
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { log } from "../cli/log.ts";
+import { WorkspaceContext } from "../workspace/context.ts";
+import { resolveLocalBundle } from "./resolve.ts";
 import type { BundleRef } from "./types.ts";
 
 /** Prefixes reserved for system tools — bundles must not use these as source names. */
@@ -74,17 +78,6 @@ export function serverNameFromRef(ref: BundleRef): string {
 }
 
 /**
- * Derive the bundle-name string from a `BundleRef` (for data-dir
- * resolution). Returns the npm-style scoped name for `name` refs, the
- * filesystem path for `path` refs, the URL for `url` refs.
- */
-export function bundleNameFromRef(ref: BundleRef): string {
-  if ("name" in ref) return ref.name;
-  if ("path" in ref) return ref.path;
-  return ref.url;
-}
-
-/**
  * Derive a safe directory name for per-bundle data isolation.
  * Uses the full scoped name to avoid collisions (e.g., @foo/tasks vs @bar/tasks).
  * Matches the mpak cache convention: @scope/name → scope-name.
@@ -106,11 +99,69 @@ export function deriveBundleDataDir(name: string): string {
 }
 
 /**
- * Resolve the absolute data directory for a bundle within a workspace.
- * Combines the workspace path with the derived bundle directory name.
- * E.g., resolveBundleDataDir("workspaces/ws_eng", "@nimblebraininc/crm")
- *   → "workspaces/ws_eng/data/nimblebraininc-crm"
+ * Canonical entry point for the bundle-data-dir contract:
+ *
+ *   <workDir>/workspaces/<wsId>/data/<slug-of-manifest.name>/
+ *
+ * The slug source is ALWAYS the bundle's manifest name — its stable
+ * identity, not the way you happen to be locating its source code
+ * (filesystem path, npm-scoped registry name, or URL). Every call site
+ * that needs to know where a bundle's data lives must route through
+ * here, so the launch path (which sets `MPAK_WORKSPACE` for the
+ * subprocess) and the reader path (briefing collector, lifecycle
+ * seeding, etc.) cannot drift onto different slugs for the same bundle.
+ *
+ * Resolution per ref shape:
+ *   - `name:`  → `ref.name` is the canonical manifest name by contract.
+ *                No disk read needed.
+ *   - `path:`  → reads `<path>/manifest.json` and uses `manifest.name`.
+ *                Falls back to a path-derived slug + warn only when the
+ *                manifest can't be read (bundle source missing/broken).
+ *   - `url:`   → uses persisted `ref.serverName` (the slugified
+ *                canonical name set at install time from
+ *                `ServerDetail.name`). Remote bundles have no on-disk
+ *                manifest; this is the stable identity we hold.
+ *
+ * Synchronous on purpose: path-bundle manifests are local files and
+ * boot already does a lot of sync fs work. Making this async would
+ * push `Promise<>` through the inventory build for no real win.
  */
-export function resolveBundleDataDir(workspacePath: string, bundleName: string): string {
-  return join(workspacePath, "data", deriveBundleDataDir(bundleName));
+export function resolveBundleDataDirForRef(
+  workDir: string,
+  wsId: string,
+  ref: BundleRef,
+  configDir?: string,
+): string {
+  const slugSource = readBundleSlugSource(ref, configDir);
+  return new WorkspaceContext({ wsId, workDir }).getDataPath(
+    "data",
+    deriveBundleDataDir(slugSource),
+  );
+}
+
+function readBundleSlugSource(ref: BundleRef, configDir: string | undefined): string {
+  if ("name" in ref) return ref.name;
+  if ("path" in ref) {
+    const bundleDir = resolveLocalBundle(ref.path, configDir);
+    if (bundleDir) {
+      try {
+        const raw = JSON.parse(readFileSync(join(bundleDir, "manifest.json"), "utf-8")) as {
+          name?: unknown;
+        };
+        if (typeof raw.name === "string" && raw.name.length > 0) return raw.name;
+      } catch (err) {
+        log.warn(
+          `[bundles] Failed to read manifest from ${ref.path}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+    log.warn(
+      `[bundles] Falling back to path-derived dataDir slug for ${ref.path} ` +
+        `(manifest unreadable — bundle subprocess will likely fail to start)`,
+    );
+    return ref.path;
+  }
+  return ref.serverName ?? ref.url;
 }

--- a/src/bundles/paths.ts
+++ b/src/bundles/paths.ts
@@ -1,9 +1,26 @@
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 import { log } from "../cli/log.ts";
 import { WorkspaceContext } from "../workspace/context.ts";
 import { resolveLocalBundle } from "./resolve.ts";
 import type { BundleRef } from "./types.ts";
+
+/**
+ * Resolved default workDir for callers that don't have the RuntimeConfig in
+ * hand. Reads `NB_WORK_DIR` from env, falls back to `~/.nimblebrain`, then
+ * `resolve()`s the result so the value crossing a process boundary (as
+ * `MPAK_WORKSPACE` / `UPJACK_ROOT`) is absolute and cwd-independent.
+ *
+ * The cli config-load path absolutizes its workDir at the same boundary;
+ * this is the env-only fallback for the bundle lifecycle methods that
+ * don't receive the config-derived value. Keep them aligned: if a future
+ * change shifts the contract (e.g. relative paths get a different anchor),
+ * change both sites.
+ */
+export function defaultWorkDir(): string {
+  return resolve(process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain"));
+}
 
 /** Prefixes reserved for system tools — bundles must not use these as source names. */
 const RESERVED_TOOL_PREFIXES = new Set(["nb"]);
@@ -143,24 +160,36 @@ function readBundleSlugSource(ref: BundleRef, configDir: string | undefined): st
   if ("name" in ref) return ref.name;
   if ("path" in ref) {
     const bundleDir = resolveLocalBundle(ref.path, configDir);
-    if (bundleDir) {
-      try {
-        const raw = JSON.parse(readFileSync(join(bundleDir, "manifest.json"), "utf-8")) as {
-          name?: unknown;
-        };
-        if (typeof raw.name === "string" && raw.name.length > 0) return raw.name;
-      } catch (err) {
-        log.warn(
-          `[bundles] Failed to read manifest from ${ref.path}: ${
+    if (!bundleDir) {
+      // Bundle path doesn't resolve at all (missing / moved / typo). Distinct
+      // failure mode from "found the dir but its manifest is broken", so it
+      // gets its own single message — no double-warn.
+      log.warn(
+        `[bundles] Local bundle path not found: ${ref.path} ` +
+          `(falling back to path-derived dataDir slug — subprocess will fail to start)`,
+      );
+      return ref.path;
+    }
+    try {
+      const raw = JSON.parse(readFileSync(join(bundleDir, "manifest.json"), "utf-8")) as {
+        name?: unknown;
+      };
+      if (typeof raw.name === "string" && raw.name.length > 0) return raw.name;
+      log.warn(
+        `[bundles] Manifest at ${ref.path} has no usable "name" field — ` +
+          `falling back to path-derived dataDir slug`,
+      );
+    } catch (err) {
+      // Single, fully-attributed message: include the error AND the
+      // fallback decision in one line so the operator gets the whole story
+      // without scanning two adjacent warns to correlate them.
+      log.warn(
+        `[bundles] Failed to read manifest from ${ref.path} — ` +
+          `falling back to path-derived dataDir slug (bundle subprocess will likely fail to start): ${
             err instanceof Error ? err.message : String(err)
           }`,
-        );
-      }
+      );
     }
-    log.warn(
-      `[bundles] Falling back to path-derived dataDir slug for ${ref.path} ` +
-        `(manifest unreadable — bundle subprocess will likely fail to start)`,
-    );
     return ref.path;
   }
   return ref.serverName ?? ref.url;

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -641,12 +641,22 @@ function buildLocalSource(
     spawnEnv.NB_HOST_URL = internalEnv.NB_HOST_URL;
   }
 
-  // Per-bundle data isolation — each bundle gets its own directory under data/
-  const nbWorkDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
-  const bundleDataDir =
-    dataDirOverride ?? join(nbWorkDir, "data", deriveBundleDataDir(manifest.name));
-  spawnEnv.MPAK_WORKSPACE = bundleDataDir;
-  spawnEnv.UPJACK_ROOT = bundleDataDir;
+  // Per-bundle data isolation. Callers (lifecycle install*, workspace-ops,
+  // buildProcessInventory) always pass `dataDir` via
+  // `resolveBundleDataDirForRef`, which keys the slug on `manifest.name` and
+  // anchors on the workspace prefix — the single source of truth that keeps
+  // the subprocess's write location aligned with what the briefing collector
+  // and seedInstance read from. A missing override here means a new caller
+  // skipped the helper; fail loudly rather than silently splitting onto a
+  // workspace-agnostic fallback.
+  if (!dataDirOverride) {
+    throw new Error(
+      `[bundles] buildLocalSource: dataDir override required for bundle ${manifest.name} ` +
+        `(missing caller — route through resolveBundleDataDirForRef)`,
+    );
+  }
+  spawnEnv.MPAK_WORKSPACE = dataDirOverride;
+  spawnEnv.UPJACK_ROOT = dataDirOverride;
 
   Object.assign(
     spawnEnv,

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -20,7 +20,12 @@ import { extractBundleMeta } from "./defaults.ts";
 import { filterEnvForBundle } from "./env-filter.ts";
 import { validateManifest } from "./manifest.ts";
 import { getMpak } from "./mpak.ts";
-import { deriveBundleDataDir, deriveServerName, validateServerName } from "./paths.ts";
+import {
+  defaultWorkDir,
+  deriveBundleDataDir,
+  deriveServerName,
+  validateServerName,
+} from "./paths.ts";
 import { notifyConnectionRunning } from "./pending-auth-buffer.ts";
 import { resolveLocalBundle } from "./resolve.ts";
 import type {
@@ -135,7 +140,7 @@ function resolveWorkspaceContext(
     return opts.workspaceContext;
   }
   if (opts.wsId) {
-    const workDir = opts.workDir ?? process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+    const workDir = opts.workDir ?? defaultWorkDir();
     return new WorkspaceContext({ wsId: opts.wsId, workDir });
   }
   return undefined;

--- a/src/bundles/workspace-ops.ts
+++ b/src/bundles/workspace-ops.ts
@@ -4,11 +4,9 @@
  * These are consumed by system tools for hot bundle management within workspaces.
  */
 
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type { ToolRegistry } from "../tools/registry.ts";
 import { WorkspaceContext } from "../workspace/context.ts";
-import { resolveBundleDataDirForRef, serverNameFromRef } from "./paths.ts";
+import { defaultWorkDir, resolveBundleDataDirForRef, serverNameFromRef } from "./paths.ts";
 import { startBundleSource } from "./startup.ts";
 import type { BundleRef } from "./types.ts";
 
@@ -47,7 +45,7 @@ export async function installBundleInWorkspace(
   // entry point. A caller that explicitly passes `workDir: ""` now
   // hits the `WorkspaceContext` constructor's empty-string rejection
   // (deliberate — relative paths in this code path were never correct).
-  const workDir = opts?.workDir ?? process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+  const workDir = opts?.workDir ?? defaultWorkDir();
   const wsContext = new WorkspaceContext({ wsId, workDir });
   const serverName = serverNameFromRef(bundleRef);
   // Slug source is `manifest.name`, resolved via the canonical helper so the
@@ -107,7 +105,7 @@ export async function uninstallBundleFromWorkspace(
 
   // Best-effort credential cleanup — don't fail uninstall if it errors.
   // Credentials are config, not data: they should not persist across uninstalls.
-  const workDir = opts?.workDir ?? process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+  const workDir = opts?.workDir ?? defaultWorkDir();
   try {
     await new WorkspaceContext({ wsId, workDir }).getCredentialStore().clearAll(bundleName);
   } catch (err) {

--- a/src/bundles/workspace-ops.ts
+++ b/src/bundles/workspace-ops.ts
@@ -8,7 +8,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ToolRegistry } from "../tools/registry.ts";
 import { WorkspaceContext } from "../workspace/context.ts";
-import { bundleNameFromRef, deriveBundleDataDir, serverNameFromRef } from "./paths.ts";
+import { resolveBundleDataDirForRef, serverNameFromRef } from "./paths.ts";
 import { startBundleSource } from "./startup.ts";
 import type { BundleRef } from "./types.ts";
 
@@ -50,8 +50,9 @@ export async function installBundleInWorkspace(
   const workDir = opts?.workDir ?? process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
   const wsContext = new WorkspaceContext({ wsId, workDir });
   const serverName = serverNameFromRef(bundleRef);
-  const bundleName = bundleNameFromRef(bundleRef);
-  const dataDir = wsContext.getDataPath("data", deriveBundleDataDir(bundleName));
+  // Slug source is `manifest.name`, resolved via the canonical helper so the
+  // launch-path data dir agrees with the seedInstance / briefing reader path.
+  const dataDir = resolveBundleDataDirForRef(workDir, wsId, bundleRef, configDir);
 
   // Check for existing registration
   if (registry.hasSource(serverName)) {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -182,8 +182,18 @@ export function loadConfig(flags: CliFlags = {}): RuntimeConfig {
     // Pass config path for bundle install/uninstall persistence
     configPath,
     configOverridePath,
-    workDir:
-      process.env.NB_WORK_DIR ?? (fileConfig.workDir as string | undefined) ?? flags.defaultWorkDir,
+    // Absolutize at load so the value can be passed across process boundaries
+    // (e.g. as `MPAK_WORKSPACE` to bundle subprocesses with a different cwd)
+    // without the two ends resolving against different bases. The undefined
+    // case is preserved — `resolveWorkDir(config)` in runtime.ts falls back to
+    // `DEFAULT_WORK_DIR`, which is already absolute.
+    workDir: ((): string | undefined => {
+      const raw =
+        process.env.NB_WORK_DIR ??
+        (fileConfig.workDir as string | undefined) ??
+        flags.defaultWorkDir;
+      return raw === undefined ? undefined : resolve(raw);
+    })(),
     telemetry: fileConfig.telemetry as RuntimeConfig["telemetry"],
   };
 

--- a/src/runtime/workspace-runtime.ts
+++ b/src/runtime/workspace-runtime.ts
@@ -9,14 +9,13 @@
 import { join } from "node:path";
 import { hasPersistedComposioConnection } from "../bundles/composio-connection.ts";
 import { hasPersistedWorkspaceOAuthTokens } from "../bundles/oauth-tokens.ts";
-import { bundleNameFromRef, deriveBundleDataDir, serverNameFromRef } from "../bundles/paths.ts";
+import { resolveBundleDataDirForRef, serverNameFromRef } from "../bundles/paths.ts";
 import { setPendingAuth } from "../bundles/pending-auth-buffer.ts";
 import { startBundleSource } from "../bundles/startup.ts";
 import type { BundleRef, LocalBundleMeta } from "../bundles/types.ts";
 import { log } from "../cli/log.ts";
 import { ToolRegistry } from "../tools/registry.ts";
 import type { ToolSource } from "../tools/types.ts";
-import { WorkspaceContext } from "../workspace/context.ts";
 import type { Workspace } from "../workspace/types.ts";
 import type { WorkspaceStore } from "../workspace/workspace-store.ts";
 
@@ -47,21 +46,23 @@ export interface ProcessInventoryEntry {
  *
  * For each workspace, iterates its declared bundles and produces one
  * ProcessInventoryEntry per (workspace, bundle) pair. The `dataDir`
- * is workspace-scoped via `WorkspaceContext.getDataPath("data", ...)`.
+ * is workspace-scoped via `resolveBundleDataDirForRef` (which keys the
+ * slug on `manifest.name`, reading it from disk for path bundles).
  */
 export function buildProcessInventory(
   workspaces: Workspace[],
   workDir: string,
+  configDir?: string,
 ): ProcessInventoryEntry[] {
   const entries: ProcessInventoryEntry[] = [];
 
   for (const ws of workspaces) {
-    const wsContext = new WorkspaceContext({ wsId: ws.id, workDir });
-
     for (const bundle of ws.bundles) {
       const serverName = serverNameFromRef(bundle);
-      const bundleName = bundleNameFromRef(bundle);
-      const dataDir = wsContext.getDataPath("data", deriveBundleDataDir(bundleName));
+      // Slug is keyed on `manifest.name` (read here for path bundles) so the
+      // launch-path data dir and the seedInstance / briefing reader-path
+      // data dir cannot disagree.
+      const dataDir = resolveBundleDataDirForRef(workDir, ws.id, bundle, configDir);
 
       entries.push({
         wsId: ws.id,
@@ -138,7 +139,7 @@ export async function startWorkspaceBundles(
 ): Promise<{ registries: Map<string, ToolRegistry>; entries: ProcessInventoryEntry[] }> {
   const workDir = opts?.workDir ?? join(process.env.NB_WORK_DIR ?? "", ".nimblebrain");
   const workspaces = await workspaceStore.list();
-  const inventory = buildProcessInventory(workspaces, workDir);
+  const inventory = buildProcessInventory(workspaces, workDir, configDir);
 
   // Group inventory by workspace
   const byWorkspace = new Map<string, ProcessInventoryEntry[]>();

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -37,7 +37,10 @@ function eventTypes(collector: { events: EngineEvent[] }): string[] {
 }
 
 /** Create a minimal echo MCP server bundle on disk with a valid MCPB manifest. */
-function createEchoBundleOnDisk(dir: string, opts?: { withUiMeta?: boolean; withUpjack?: boolean }): string {
+function createEchoBundleOnDisk(
+	dir: string,
+	opts?: { withUiMeta?: boolean; withUpjack?: boolean; upjackNamespace?: string },
+): string {
 	mkdirSync(dir, { recursive: true });
 
 	const nodeModulesPath = join(import.meta.dir, "../..", "node_modules");
@@ -76,7 +79,9 @@ main();
 		};
 	}
 	if (opts?.withUpjack) {
-		meta["ai.nimblebrain/upjack"] = { entities: [] };
+		const upjack: Record<string, unknown> = { entities: [] };
+		if (opts.upjackNamespace) upjack.namespace = opts.upjackNamespace;
+		meta["ai.nimblebrain/upjack"] = upjack;
 	}
 
 	const manifest = {
@@ -187,6 +192,48 @@ describe("BundleLifecycleManager — install local bundle", () => {
 
 		await registry.removeSource(instance.serverName);
 	}, 15_000);
+
+	it(
+		"installLocal lands the bundle's entityDataRoot at workspaces/<wsId>/data/<manifest-slug>/<namespace>/data (end-to-end)",
+		async () => {
+			// The regression we're guarding: installLocal previously didn't pass
+			// dataDir to startBundleSource, so buildLocalSource fell back to
+			// `<workDir>/data/<slug>` (workspace-agnostic) using a path-derived
+			// slug. After this PR, installLocal must produce a workspace-scoped
+			// directory keyed on `manifest.name`.
+			const bundleDir = createEchoBundleOnDisk(join(testDir, "echo-upjack-e2e"), {
+				withUpjack: true,
+				upjackNamespace: "apps/echo",
+			});
+			const configPath = join(testDir, "nimblebrain-upjack-e2e.json");
+			writeFileSync(configPath, JSON.stringify({ bundles: [] }, null, 2));
+
+			// Pin the workdir to the test tree so the assertion is host-agnostic
+			// and the test doesn't pollute the dev workdir at ~/.nimblebrain.
+			const prevWorkDir = process.env.NB_WORK_DIR;
+			process.env.NB_WORK_DIR = testDir;
+			try {
+				const registry = new ToolRegistry();
+				const sink = makeEventCollector();
+				const lifecycle = new BundleLifecycleManager(sink, configPath);
+
+				const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
+				try {
+					// Manifest name is `@test/echo` → slug `test-echo` (NOT
+					// path-derived, NOT under a workspace-agnostic /data/ root).
+					expect(instance.entityDataRoot).toBe(
+						join(testDir, "workspaces", "ws_test", "data", "test-echo", "apps/echo", "data"),
+					);
+				} finally {
+					await registry.removeSource(instance.serverName);
+				}
+			} finally {
+				if (prevWorkDir === undefined) delete process.env.NB_WORK_DIR;
+				else process.env.NB_WORK_DIR = prevWorkDir;
+			}
+		},
+		15_000,
+	);
 });
 
 // ---------------------------------------------------------------------------

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -632,21 +632,19 @@ describe("BundleLifecycleManager — instance tracking", () => {
 		expect(instance.entityDataRoot).toBeUndefined();
 	});
 
-	it("seedInstance rebuilds entityDataRoot from manifestName for path bundles", () => {
-		// Repro of the path-bundle bug fixed by 6e31dcf. `deriveBundleDataDir`
-		// only replaces the first `/`, so a `path:` install of
-		// `/Users/foo/Code/hq/synapse-apps/synapse-crm` produces a
-		// multi-segment broken dataDir like
-		// `<wsData>/-Users/foo/Code/hq/synapse-apps/synapse-crm`. The bundle
-		// process actually writes data using its manifest name, so
-		// seedInstance must anchor on `/workspaces/<ws>/data/` and rebuild
-		// entityDataRoot from the manifest name. Without this fix, the
-		// briefing collector reads from the junk path and reports "no data."
+	it("seedInstance composes entityDataRoot by trusting the caller's dataDir (no re-derivation)", () => {
+		// The previous incarnation of this test locked in a workaround:
+		// seedInstance used to receive a wrong `dataDir` (a path-bundle slug
+		// produced by `bundleNameFromRef(ref.path)`) and silently rebuild
+		// `entityDataRoot` from `manifestName` to compensate. That workaround
+		// is gone — every caller now routes through `resolveBundleDataDirForRef`,
+		// which keys the slug on `manifest.name` directly, so the input dataDir
+		// is already correct. The contract here is just: append the upjack
+		// namespace and `data/` to whatever the caller passed. No magic.
 		const sink = makeEventCollector();
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
-		const brokenDataDir =
-			"/data/workspaces/ws_eng/data/-Users/foo/Code/hq/synapse-apps/synapse-crm";
+		const correctDataDir = "/data/workspaces/ws_eng/data/nimblebraininc-synapse-crm";
 
 		lifecycle.seedInstance(
 			"synapse-crm",
@@ -665,16 +663,13 @@ describe("BundleLifecycleManager — instance tracking", () => {
 				upjackNamespace: "apps/crm",
 			},
 			"ws_eng",
-			brokenDataDir,
+			correctDataDir,
 		);
 
 		const instance = lifecycle.getInstance("synapse-crm", "ws_eng")!;
 		expect(instance.entityDataRoot).toBe(
 			"/data/workspaces/ws_eng/data/nimblebraininc-synapse-crm/apps/crm/data",
 		);
-		// And critically NOT the broken path the install dataDir would
-		// have produced.
-		expect(instance.entityDataRoot).not.toContain("/-Users/");
 	});
 });
 

--- a/test/integration/startup-credentials.test.ts
+++ b/test/integration/startup-credentials.test.ts
@@ -606,4 +606,24 @@ main();
     },
     20_000,
   );
+
+  test(
+    "throws if a path-bundle caller forgets to pass dataDir (canary on the helper-routing contract)",
+    async () => {
+      // `buildLocalSource` asserts `dataDir` is supplied because every
+      // production caller now routes through `resolveBundleDataDirForRef`.
+      // If a future change reintroduces the silent workspace-agnostic
+      // fallback, this test fails — it's the only thing protecting that
+      // contract from regressing.
+      const registry = new ToolRegistry();
+      let caught: Error | null = null;
+      try {
+        await startBundleSource({ path: bundleDir }, registry, new NoopEventSink());
+      } catch (err) {
+        caught = err instanceof Error ? err : new Error(String(err));
+      }
+      expect(caught).not.toBeNull();
+      expect(caught?.message).toMatch(/dataDir override required/i);
+    },
+  );
 });

--- a/test/integration/startup-credentials.test.ts
+++ b/test/integration/startup-credentials.test.ts
@@ -24,6 +24,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { resolveBundleDataDirForRef } from "../../src/bundles/paths.ts";
 import { startBundleSource } from "../../src/bundles/startup.ts";
 import { saveWorkspaceCredential } from "../../src/config/workspace-credentials.ts";
 import { ToolRegistry } from "../../src/tools/registry.ts";
@@ -411,6 +412,8 @@ describe("startBundleSource — local-path credential resolution", () => {
           { path: bundleDir },
           registry,
           new NoopEventSink(),
+          undefined,
+          { dataDir: resolveBundleDataDirForRef(rootDir, "ws_test", { path: bundleDir }) },
         );
         expect(result.sourceName).toBe(LOCAL_BUNDLE_SLUG);
 
@@ -448,6 +451,8 @@ describe("startBundleSource — local-path credential resolution", () => {
           { path: bundleDir },
           registry,
           new NoopEventSink(),
+          undefined,
+          { dataDir: resolveBundleDataDirForRef(rootDir, "ws_test", { path: bundleDir }) },
         );
 
         const callResult = await registry.execute({
@@ -485,6 +490,8 @@ describe("startBundleSource — local-path credential resolution", () => {
           { path: bundleDir },
           registry,
           new NoopEventSink(),
+          undefined,
+          { dataDir: resolveBundleDataDirForRef(rootDir, "ws_test", { path: bundleDir }) },
         );
 
         const callResult = await registry.execute({
@@ -575,6 +582,10 @@ main();
           { path: misconfiguredDir },
           registry,
           new NoopEventSink(),
+          undefined,
+          {
+            dataDir: resolveBundleDataDirForRef(rootDir, "ws_test", { path: misconfiguredDir }),
+          },
         );
 
         const callResult = await registry.execute({

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -130,6 +130,33 @@ describe("loadConfig", () => {
     });
   });
 
+  it("absolutizes a relative workDir from the config file", () => {
+    const configPath = writeTestConfig("rel-workdir.json", { workDir: ".nimblebrain" });
+    const config = loadConfig({ config: configPath });
+    expect(config.workDir).toBeDefined();
+    expect(config.workDir!.startsWith("/")).toBe(true);
+    expect(config.workDir!.endsWith(".nimblebrain")).toBe(true);
+  });
+
+  it("leaves an absolute workDir untouched", () => {
+    const abs = join(testDir, "abs-workdir-fixture");
+    const configPath = writeTestConfig("abs-workdir.json", { workDir: abs });
+    const config = loadConfig({ config: configPath });
+    expect(config.workDir).toBe(abs);
+  });
+
+  it("leaves workDir undefined when no source supplies one", () => {
+    const configPath = writeTestConfig("no-workdir.json", {});
+    const prev = process.env.NB_WORK_DIR;
+    delete process.env.NB_WORK_DIR;
+    try {
+      const config = loadConfig({ config: configPath });
+      expect(config.workDir).toBeUndefined();
+    } finally {
+      if (prev !== undefined) process.env.NB_WORK_DIR = prev;
+    }
+  });
+
   it("CLI flags override file config", () => {
     const configPath = writeTestConfig("override.json", {
       defaultModel: "claude-sonnet-4-5-20250929",

--- a/test/unit/runtime/bundles-workspace.test.ts
+++ b/test/unit/runtime/bundles-workspace.test.ts
@@ -1,46 +1,85 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { deriveBundleDataDir, resolveBundleDataDir } from "../../../src/bundles/paths.ts";
+import { deriveBundleDataDir, resolveBundleDataDirForRef } from "../../../src/bundles/paths.ts";
 
-describe("resolveBundleDataDir", () => {
-  it("combines workspace path with derived bundle data dir", () => {
-    const result = resolveBundleDataDir("workspaces/ws_eng", "@nimblebraininc/crm");
-    expect(result).toBe(join("workspaces/ws_eng", "data", "nimblebraininc-crm"));
+const tmpRoots: string[] = [];
+afterAll(() => {
+  for (const dir of tmpRoots) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function makeBundleDir(manifestName: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "nb-bundle-fixture-"));
+  tmpRoots.push(dir);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "manifest.json"), JSON.stringify({ name: manifestName, version: "0.0.0" }));
+  return dir;
+}
+
+describe("resolveBundleDataDirForRef", () => {
+  const workDir = "/home/user/.nimblebrain";
+
+  it("named ref: slug from ref.name (which is the canonical manifest name)", () => {
+    const dir = resolveBundleDataDirForRef(workDir, "ws_eng", { name: "@nimblebraininc/crm" });
+    expect(dir).toBe(`${workDir}/workspaces/ws_eng/data/nimblebraininc-crm`);
+  });
+
+  it("path ref: slug from manifest.name on disk, NOT from the path string", () => {
+    const bundleDir = makeBundleDir("@nimblebraininc/synapse-crm");
+    const dir = resolveBundleDataDirForRef(workDir, "ws_mat", { path: bundleDir });
+    expect(dir).toBe(`${workDir}/workspaces/ws_mat/data/nimblebraininc-synapse-crm`);
+  });
+
+  it(
+    "regression: a path ref and a name ref for the SAME bundle produce the SAME slug " +
+      "(this is the contract that keeps the launch-write path aligned with the seedInstance / " +
+      "briefing-read path; before this it diverged because the launch path slugified the " +
+      "filesystem path while the reader slugified the manifest name)",
+    () => {
+      const bundleDir = makeBundleDir("@nimblebraininc/synapse-crm");
+      const fromPath = resolveBundleDataDirForRef(workDir, "ws_mat", { path: bundleDir });
+      const fromName = resolveBundleDataDirForRef(workDir, "ws_mat", {
+        name: "@nimblebraininc/synapse-crm",
+      });
+      expect(fromPath).toBe(fromName);
+    },
+  );
+
+  it("url ref: slug from persisted ref.serverName (the install-time canonical slug)", () => {
+    const dir = resolveBundleDataDirForRef(workDir, "ws_eng", {
+      url: "https://mcp.example.com/sse",
+      serverName: "example-mcp",
+    });
+    expect(dir).toBe(`${workDir}/workspaces/ws_eng/data/example-mcp`);
+  });
+
+  it("url ref without serverName: falls back to deriving the slug from the URL", () => {
+    const dir = resolveBundleDataDirForRef(workDir, "ws_eng", { url: "https://mcp.example.com/sse" });
+    expect(dir.startsWith(`${workDir}/workspaces/ws_eng/data/`)).toBe(true);
   });
 
   it("two workspaces with the same bundle get separate directories", () => {
-    const ws1 = resolveBundleDataDir("/home/user/.nimblebrain/workspaces/ws_eng", "@nimblebraininc/crm");
-    const ws2 = resolveBundleDataDir("/home/user/.nimblebrain/workspaces/ws_sales", "@nimblebraininc/crm");
+    const ws1 = resolveBundleDataDirForRef(workDir, "ws_eng", { name: "@nimblebraininc/crm" });
+    const ws2 = resolveBundleDataDirForRef(workDir, "ws_sales", { name: "@nimblebraininc/crm" });
     expect(ws1).not.toBe(ws2);
-    expect(ws1).toBe("/home/user/.nimblebrain/workspaces/ws_eng/data/nimblebraininc-crm");
-    expect(ws2).toBe("/home/user/.nimblebrain/workspaces/ws_sales/data/nimblebraininc-crm");
   });
 
-  it("handles unscoped bundle names", () => {
-    const result = resolveBundleDataDir("/workspaces/default", "simple-bundle");
-    expect(result).toBe("/workspaces/default/data/simple-bundle");
-  });
-
-  it("handles absolute workspace paths", () => {
-    const result = resolveBundleDataDir("/home/user/.nimblebrain/workspaces/ws_abc", "@acme/tasks");
-    expect(result).toBe("/home/user/.nimblebrain/workspaces/ws_abc/data/acme-tasks");
-  });
-
-  it("keeps absolute path bundle refs inside one data directory", () => {
-    const result = resolveBundleDataDir(
-      "/home/user/.nimblebrain/workspaces/ws_abc",
-      "/Users/dev/Code/synapse-apps/synapse-crm",
-    );
-    expect(result).toBe(
-      "/home/user/.nimblebrain/workspaces/ws_abc/data/Users-dev-Code-synapse-apps-synapse-crm",
-    );
-  });
-
-  it("default workspace resolves correctly for backward compat", () => {
-    // Default workspace path is simply the workDir itself
-    const workDir = "/home/user/.nimblebrain";
-    const result = resolveBundleDataDir(workDir, "@nimblebraininc/crm");
-    expect(result).toBe(join(workDir, "data", "nimblebraininc-crm"));
+  it("path ref with a broken manifest: falls back to path-derived slug + warn (bundle will fail to start anyway)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nb-bundle-fixture-broken-"));
+    tmpRoots.push(dir);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "manifest.json"), "{ not valid json");
+    const out = resolveBundleDataDirForRef(workDir, "ws_eng", { path: dir });
+    // Fallback slug is path-derived — the exact form doesn't matter for callers, only that
+    // it's a string (not a throw) so inventory build proceeds.
+    expect(out.startsWith(`${workDir}/workspaces/ws_eng/data/`)).toBe(true);
   });
 });
 

--- a/test/unit/runtime/workspace-runtime.test.ts
+++ b/test/unit/runtime/workspace-runtime.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { BundleRef } from "../../../src/bundles/types.ts";
 import type { Workspace } from "../../../src/workspace/types.ts";
@@ -8,6 +10,25 @@ import {
   type ProcessInventoryEntry,
   resolveBundleStartConcurrency,
 } from "../../../src/runtime/workspace-runtime.ts";
+
+const tmpFixtures: string[] = [];
+afterAll(() => {
+  for (const dir of tmpFixtures) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function makeBundleFixture(manifestName: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "nb-ws-runtime-bundle-"));
+  tmpFixtures.push(dir);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "manifest.json"), JSON.stringify({ name: manifestName, version: "0.0.0" }));
+  return dir;
+}
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -94,13 +115,29 @@ describe("buildProcessInventory", () => {
     expect(entries[1].dataDir).toContain("ws_sales");
   });
 
-  it("handles path-based bundle refs", () => {
-    const bundles: BundleRef[] = [{ path: "../mcp-servers/echo" }];
-    const ws = makeWorkspace("ws_dev", "Dev", bundles);
+  it("path bundle: dataDir slug comes from manifest.name on disk, NOT from the path", () => {
+    const fixture = makeBundleFixture("@nimblebraininc/synapse-crm");
+    const ws = makeWorkspace("ws_dev", "Dev", [{ path: fixture }]);
 
     const entries = buildProcessInventory([ws], WORK_DIR);
     expect(entries).toHaveLength(1);
-    expect(entries[0].serverName).toBe("echo");
+    // Regression: the launch-path dataDir used to slug the path string
+    // (`Users-...-synapse-crm`), while seedInstance / the briefing collector
+    // slugged the manifest name (`nimblebraininc-synapse-crm`). They MUST
+    // agree now — both go through `resolveBundleDataDirForRef`.
+    expect(entries[0].dataDir).toBe(
+      join(WORK_DIR, "workspaces", "ws_dev", "data", "nimblebraininc-synapse-crm"),
+    );
+  });
+
+  it("path bundle + name bundle with the same manifest.name produce the same dataDir", () => {
+    const fixture = makeBundleFixture("@nimblebraininc/synapse-crm");
+    const wsPath = makeWorkspace("ws_dev", "Dev", [{ path: fixture }]);
+    const wsName = makeWorkspace("ws_dev", "Dev", [{ name: "@nimblebraininc/synapse-crm" }]);
+
+    const [pathEntry] = buildProcessInventory([wsPath], WORK_DIR);
+    const [nameEntry] = buildProcessInventory([wsName], WORK_DIR);
+    expect(pathEntry.dataDir).toBe(nameEntry.dataDir);
   });
 
   it("handles url-based bundle refs with explicit serverName", () => {


### PR DESCRIPTION
## Summary

Two stacked bugs caused bundle subprocesses to write entity data to a different directory than the daily-briefing reader and \`seedInstance\` looked at — for path bundles specifically, the launch path and the reader path slugged the bundle's data dir from different inputs. Result: a CRM with seed data fully populated but invisible to the UI, and a daily-briefing that confidently reported items that had no corresponding workspace state.

This PR makes the contract a single line: a bundle's data lives at \`\<workDir\>/workspaces/\<wsId\>/data/\<slug-of-manifest.name\>/\`. One resolver, called from every site that needs to know where a bundle's data is.

## The bugs

**1. Path-bundle slug divergence.** Two derivation rules in the tree, both alive:

- Launch path (\`buildProcessInventory\`, \`installBundleInWorkspace\`, \`installLocal\`) called \`deriveBundleDataDir(bundleNameFromRef(ref))\`. For \`path:\` refs that slugs the filesystem path (\`Users-mgolds02-Code-hq-synapse-apps-synapse-crm\`).
- Reader path (\`seedInstance\` → \`entityDataRoot\`, then \`briefing-collector\`) had a 20-line workaround block that recovered the manifest name and slugged that (\`nimblebraininc-synapse-crm\`).

Same bundle, same workspace, two different directories. The MCP subprocess wrote to one, the briefing read from the other.

**2. Relative \`workDir\` crossing the process boundary.** Config could declare \`\"workDir\": \".nimblebrain\"\`. \`cli/config.ts\` passed it through verbatim. \`MPAK_WORKSPACE\` was then handed to a subprocess whose cwd differs from the parent's, so the two ends resolved the relative path against different bases. A bundle ended up writing to \`\<bundle-source\>/.nimblebrain/...\` instead of \`\<dev-workdir\>/.nimblebrain/...\`.

The two bugs together produced a four-way fan-out of possible directories per bundle.

## The fix

- \`cli/config.ts\` — \`resolve()\` workDir at config load. Absolute by construction across the process boundary.
- \`bundles/paths.ts\` — delete \`bundleNameFromRef\` (only mis-uses) and the unused 2-arg \`resolveBundleDataDir\`. Add \`resolveBundleDataDirForRef(workDir, wsId, ref, configDir?)\` as the single entry point: keys the slug on \`manifest.name\` (read from \`\<path\>/manifest.json\` for path bundles; \`ref.name\` for named; \`ref.serverName ?? ref.url\` for URL), routed through \`WorkspaceContext.getDataPath\`.
- \`runtime/workspace-runtime.ts:buildProcessInventory\` — uses the helper; threads \`configDir\` from \`startWorkspaceBundles\`.
- \`bundles/workspace-ops.ts:installBundleInWorkspace\` — uses the helper.
- \`bundles/lifecycle.ts:installLocal\` — now computes and passes \`dataDir\` (previously passed nothing, hitting the workspace-agnostic fallback).
- \`bundles/lifecycle.ts:installNamed\` — uses the helper for symmetry.
- \`bundles/lifecycle.ts:seedInstance\` — deletes the \`bundleDataParent\` workaround that anchored on \`/workspaces/\<wsId\>/data/\` and re-derived the slug. With every caller routing through the same helper, \`seedInstance\` just trusts its \`dataDir\`.
- \`bundles/startup.ts:buildLocalSource\` — promotes the silent path-bundle fallback to a throw so a future caller can't skip the helper without it being obvious.

## Tests

- \`test/unit/cli.test.ts\` — regression tests for workDir absolutization (relative → absolute, absolute → unchanged, undefined → undefined).
- \`test/unit/runtime/bundles-workspace.test.ts\` — rewritten for the new API + regression test asserting \`{ path }\` and \`{ name }\` for the same manifest produce the same slug.
- \`test/unit/runtime/workspace-runtime.test.ts\` — path-bundle slug regression for \`buildProcessInventory\`.
- \`test/integration/lifecycle.test.ts\` — replaces the test that locked in the deleted workaround with one that locks in the new contract (\`seedInstance\` trusts its \`dataDir\`).
- \`test/integration/startup-credentials.test.ts\` — four \`startBundleSource({ path })\` call sites updated to pass \`dataDir\` per the new requirement.

## ⚠️ Deploy note

Tenants with \`path:\` bundles in their \`workspace.json\` have data at the old path-derived-slug location. The moment this lands, the subprocess writes to the manifest-name slug and the existing data is orphaned. **For the \`hq\` tenant specifically**, three renames are needed before rolling the new image:

\`\`\`bash
NS=tenant-hq
POD=\$(kubectl --context nimblebrain-platform-production -n \$NS get pods -l app=tenant-hq-platform -o jsonpath='{.items[0].metadata.name}')

kubectl --context nimblebrain-platform-production -n \$NS exec \$POD -- bash -c '
  set -e
  cd /data/workspaces
  mv ws_01kp730nhbcj3ck2/data/data-apps-local-synapse-dominos-intel ws_01kp730nhbcj3ck2/data/nimblebraininc-synapse-dominos-intel
  mv ws_nimblebrain_shared/data/data-apps-local-synapse-dominos-intel ws_nimblebrain_shared/data/nimblebraininc-synapse-dominos-intel
  mv ws_consortium_equity/data/data-apps-local-synapse-consortium ws_consortium_equity/data/nimblebraininc-synapse-consortium
  echo migration complete
'
\`\`\`

Volumes affected for \`hq\`: ~576 MB across the two dominos-intel renames + 24 KB for consortium. Best run after scaling the platform pod to 0 (no in-flight writes) and before rolling the new image — or as a one-shot k8s Job that holds the deploy gate.

**Other production tenants were not audited in this PR** — scan every namespace for the \`data-*\` / \`Users-*\` slug pattern under \`/data/workspaces/\*/data/\` before rolling. (The unrelated legacy \`/data/data/nimblebraininc-*\` location predates this fix and is already orphaned by #240; \`rm -rf\` whenever convenient.)

## Test plan

- [x] \`bun run verify\` green locally (static + unit + integration + smoke + web).
- [ ] Manually verify on dev: restart \`bun run dev\`, confirm CRM UI and daily briefing read from the same directory and report consistent counts.
- [ ] Pre-deploy: run the hq migration block above; verify the three target directories exist and the four source directories are gone.
- [ ] Pre-deploy: scan other production namespaces for \`data-*\` / \`Users-*\` slug dirs and add their renames to the migration block.
- [ ] Post-deploy: \`kubectl exec\` into the \`hq\` platform pod and confirm \`ls /data/workspaces/\*/data/\` shows only \`nimblebraininc-\*\` slugs.