### PR TITLE
feat(home): force briefing refresh via ?force=1 query param

### DIFF
--- a/src/bundles/home/ui/src/App.tsx
+++ b/src/bundles/home/ui/src/App.tsx
@@ -4,7 +4,7 @@ import {
   useHostContext,
   useSynapse,
 } from "@nimblebrain/synapse/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /* ---------- types ---------- */
 
@@ -201,8 +201,15 @@ function Dashboard() {
   // refetches the (workspace-scoped) briefing without remounting this iframe.
   // Narrow to both id and name even though only id drives refetch — keeps
   // future briefing copy ("Switched to Acme") cheap to wire up.
-  const { workspace } = useHostContext<{ workspace?: { id: string; name: string } }>();
+  // `forceRefresh` arrives in the `ui/initialize` host context when the
+  // host-shell URL carried `?force=1`. Consumed once by the briefing effect
+  // below — a one-shot cache-bust, not a persistent mode.
+  const { workspace, forceRefresh } = useHostContext<{
+    workspace?: { id: string; name: string };
+    forceRefresh?: boolean;
+  }>();
   const workspaceId = workspace?.id;
+  const forceConsumedRef = useRef(false);
   const [briefing, setBriefing] = useState<BriefingOutput | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -237,10 +244,15 @@ function Dashboard() {
   // `useHostContext` value lands on the next render after the handshake
   // resolves. Without the guard we'd fire one wasted briefing fetch in the
   // handshake-window, then immediately fire again with the real id.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: workspaceId is the refetch trigger; loadBriefing is stable
+  // biome-ignore lint/correctness/useExhaustiveDependencies: workspaceId is the refetch trigger; loadBriefing is stable; forceRefresh is read once and must not retrigger
   useEffect(() => {
     if (!workspaceId) return;
-    loadBriefing();
+    // `?force=1` is a one-shot cache-bust: honor it on the first briefing
+    // fetch, then fall back to the cache for later workspace switches even
+    // if the host keeps the flag in context.
+    const force = forceRefresh === true && !forceConsumedRef.current;
+    if (force) forceConsumedRef.current = true;
+    loadBriefing(force);
   }, [workspaceId]);
 
   // Show refresh banner on data changes

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ import {
 } from "./api/client";
 import { AppWithChat } from "./components/AppWithChat";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { HomeAppRoute } from "./components/HomeAppRoute";
 import { Login } from "./components/Login";
 import { RouteGuard } from "./components/RouteGuard";
 import { ShellLayout } from "./components/ShellLayout";
@@ -311,7 +312,7 @@ function AuthenticatedAppContent({
               {homePlacement ? (
                 <Route
                   index
-                  element={<AppWithChat placement={homePlacement} onNavigate={handleNavigate} />}
+                  element={<HomeAppRoute placement={homePlacement} onNavigate={handleNavigate} />}
                 />
               ) : (
                 <Route
@@ -535,7 +536,11 @@ function RedirectAppPanel() {
 }
 
 /** Redirect "/" to "/w/<active-workspace-slug>/" */
-function WorkspaceRedirect() {
+export function WorkspaceRedirect() {
+  // Carry the query string + hash through the `/` → `/w/<slug>/` redirect.
+  // Dropping it would kill params meant for the home route — e.g. `?force=1`,
+  // which `HomeAppRoute` reads — for anyone hitting the bare root URL.
+  const { search, hash } = useLocation();
   const { activeWorkspace, workspaces, loading } = useWorkspaceContext();
   if (loading)
     return (
@@ -545,7 +550,7 @@ function WorkspaceRedirect() {
     );
   const ws = activeWorkspace ?? workspaces[0];
   if (!ws) return <Navigate to="/settings" replace />;
-  return <Navigate to={`/w/${toSlug(ws.id)}/`} replace />;
+  return <Navigate to={{ pathname: `/w/${toSlug(ws.id)}/`, search, hash }} replace />;
 }
 
 export function App() {

--- a/web/src/bridge/host-extensions.ts
+++ b/web/src/bridge/host-extensions.ts
@@ -23,9 +23,20 @@ export type WorkspaceForHostContext = { id: string; name: string } | null;
  * Non-spec extension keys to merge into the `ui/initialize` hostContext
  * response. Bridge merges these alongside theme/styles; spec fields win
  * on key collisions.
+ *
+ * `forceRefresh` is delivered only here (initialize), never in
+ * `host-context-changed`, so an app reads it once at handshake and treats
+ * later workspace switches as normal cache-backed loads.
  */
-export function buildHostExtensions(workspace: WorkspaceForHostContext): Record<string, unknown> {
-  return workspace ? { workspace: { id: workspace.id, name: workspace.name } } : {};
+export function buildHostExtensions(
+  workspace: WorkspaceForHostContext,
+  forceRefresh = false,
+): Record<string, unknown> {
+  const ext: Record<string, unknown> = workspace
+    ? { workspace: { id: workspace.id, name: workspace.name } }
+    : {};
+  if (forceRefresh) ext.forceRefresh = true;
+  return ext;
 }
 
 /**

--- a/web/src/components/AppWithChat.tsx
+++ b/web/src/components/AppWithChat.tsx
@@ -27,6 +27,8 @@ function useIsMobile(): boolean {
 interface AppWithChatProps {
   placement: PlacementEntry;
   onNavigate: (route: string) => void;
+  /** One-shot `?force=1` cache-bust — only the home route passes this. */
+  forceRefresh?: boolean;
 }
 
 const DEFAULT_WIDTH = 380;
@@ -34,7 +36,7 @@ const RESIZE_HANDLE_WIDTH = 4; // px — matches ResizeHandle's w-1 at 16px root
 const TRANSITION_STANDARD = "300ms cubic-bezier(0.33, 1, 0.68, 1)";
 const TRANSITION_FULLSCREEN = "350ms cubic-bezier(0.4, 0, 0.2, 1)";
 
-export function AppWithChat({ placement, onNavigate }: AppWithChatProps) {
+export function AppWithChat({ placement, onNavigate, forceRefresh }: AppWithChatProps) {
   const { panelState, panelWidth, setPanelWidth, openPanel, closePanel, toggleFullscreen } =
     useChatPanelContext();
   const [isDragging, setIsDragging] = useState(false);
@@ -248,6 +250,7 @@ export function AppWithChat({ placement, onNavigate }: AppWithChatProps) {
               onChat={handleChat}
               onNavigate={onNavigate}
               onPromptAction={handlePromptAction}
+              forceRefresh={forceRefresh}
             />
           </div>
         </div>

--- a/web/src/components/HomeAppRoute.tsx
+++ b/web/src/components/HomeAppRoute.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { PlacementEntry } from "../types";
+import { AppWithChat } from "./AppWithChat";
+
+/**
+ * Home-route wrapper: reads the one-shot `?force=1` query param and relays
+ * it to the home app as `forceRefresh`. Lives here — not in `AppWithChat`
+ * or `SlotRenderer` — so this query-param code runs only while the home
+ * route is mounted. App iframes are `srcdoc` and can't read the host URL
+ * themselves, so the shell has to relay it.
+ */
+export function HomeAppRoute({
+  placement,
+  onNavigate,
+}: {
+  placement: PlacementEntry;
+  onNavigate: (route: string) => void;
+}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const forceRefreshRef = useRef(searchParams.get("force") === "1");
+  // Strip `?force=1` after the first read — it's a one-shot cache-bust, not
+  // a persistent mode, so it must not survive a reload or workspace switch.
+  useEffect(() => {
+    if (!forceRefreshRef.current) return;
+    setSearchParams(
+      (prev) => {
+        prev.delete("force");
+        return prev;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+  return (
+    <AppWithChat
+      placement={placement}
+      onNavigate={onNavigate}
+      forceRefresh={forceRefreshRef.current}
+    />
+  );
+}

--- a/web/src/components/SlotRenderer.tsx
+++ b/web/src/components/SlotRenderer.tsx
@@ -17,6 +17,11 @@ interface SlotRendererProps {
   onChat?: (message: string, context?: UiChatContext) => void;
   onNavigate?: (route: string) => void;
   onPromptAction?: (prompt: string) => void;
+  /**
+   * One-shot: force a cache-bypassing data load on first handshake.
+   * Only the home route sets this (from `?force=1`); inert elsewhere.
+   */
+  forceRefresh?: boolean;
 }
 
 export function SlotRenderer({
@@ -26,6 +31,7 @@ export function SlotRenderer({
   onChat,
   onNavigate,
   onPromptAction,
+  forceRefresh = false,
 }: SlotRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const bridgesRef = useRef<BridgeHandle[]>([]);
@@ -49,6 +55,11 @@ export function SlotRenderer({
   onNavigateRef.current = onNavigate;
   const onPromptActionRef = useRef(onPromptAction);
   onPromptActionRef.current = onPromptAction;
+
+  // Mirror `forceRefresh` into a ref so `getHostExtensions` reads it at
+  // handshake time — the same reason `workspaceRef`/`modeRef` exist.
+  const forceRefreshRef = useRef(forceRefresh);
+  forceRefreshRef.current = forceRefresh;
 
   const filtered = routeFilter ? placements.filter((p) => p.route === routeFilter) : placements;
 
@@ -99,7 +110,8 @@ export function SlotRenderer({
             onChat: (...args) => onChatRef.current?.(...args),
             onNavigate: (...args) => onNavigateRef.current?.(...args),
             onPromptAction: (...args) => onPromptActionRef.current?.(...args),
-            getHostExtensions: () => buildHostExtensions(workspaceRef.current),
+            getHostExtensions: () =>
+              buildHostExtensions(workspaceRef.current, forceRefreshRef.current),
           });
           bridges.push(bridge);
         } catch (err) {

--- a/web/test/HomeAppRoute.test.tsx
+++ b/web/test/HomeAppRoute.test.tsx
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------------
+// HomeAppRoute — `?force=1` query-param contract.
+//
+// Pins the home-route force-refresh behavior:
+//   1. `?force=1` → the home app receives `forceRefresh: true`.
+//   2. No param  → `forceRefresh: false`.
+//   3. The param is stripped after the first read (one-shot cache-bust,
+//      not a persistent mode — must not survive a reload/workspace switch).
+//   4. The strip removes ONLY `force`; other query params survive.
+//
+// Case 4 is the load-bearing one: the strip uses a functional
+// `setSearchParams` updater, and a refactor that replaces it with a
+// whole-object set would silently drop unrelated params (e.g. `?tab=`).
+//
+// Same plumbing as connector-sections.test.tsx: bun:test + react-dom/client
+// + happy-dom (via web/test/setup.ts), no @testing-library/react.
+// AppWithChat is stubbed — unmocked it mounts SlotRenderer → app iframes →
+// resource fetches, none of which work or matter under happy-dom.
+// ---------------------------------------------------------------------------
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { PlacementEntry } from "../src/types";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Stub AppWithChat down to a probe that records the `forceRefresh` prop.
+let receivedForce: boolean | undefined;
+mock.module("../src/components/AppWithChat", () => ({
+  AppWithChat: (props: { forceRefresh?: boolean }) => {
+    receivedForce = props.forceRefresh;
+    return null;
+  },
+}));
+
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { MemoryRouter, useLocation } = await import("react-router-dom");
+const { HomeAppRoute } = await import("../src/components/HomeAppRoute");
+
+const fakePlacement: PlacementEntry = {
+  serverName: "home",
+  slot: "main",
+  resourceUri: "ui://home/main",
+  priority: 0,
+  route: "/",
+};
+
+// `useLocation().search` after the strip effect settles. A render-time
+// probe is enough — `setSearchParams` re-renders all router consumers.
+let currentSearch = "";
+function LocationProbe() {
+  currentSearch = useLocation().search;
+  return null;
+}
+
+let active: { unmount(): void } | null = null;
+afterEach(() => {
+  active?.unmount();
+  active = null;
+  receivedForce = undefined;
+  currentSearch = "";
+});
+
+async function renderAt(url: string): Promise<void> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[url]}>
+        <LocationProbe />
+        <HomeAppRoute placement={fakePlacement} onNavigate={() => {}} />
+      </MemoryRouter>,
+    );
+  });
+  // Flush the strip effect and the re-render it triggers.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  active = {
+    unmount() {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+describe("HomeAppRoute", () => {
+  test("?force=1 → app receives forceRefresh true", async () => {
+    await renderAt("/?force=1");
+    expect(receivedForce).toBe(true);
+  });
+
+  test("no force param → app receives forceRefresh false", async () => {
+    await renderAt("/");
+    expect(receivedForce).toBe(false);
+  });
+
+  test("strips ?force=1 from the URL after mount (one-shot)", async () => {
+    await renderAt("/?force=1");
+    expect(currentSearch).toBe("");
+  });
+
+  test("strips only force, preserves other query params", async () => {
+    await renderAt("/?force=1&tab=activity");
+    expect(currentSearch).toBe("?tab=activity");
+  });
+});

--- a/web/test/WorkspaceRedirect.test.tsx
+++ b/web/test/WorkspaceRedirect.test.tsx
@@ -1,0 +1,113 @@
+// ---------------------------------------------------------------------------
+// WorkspaceRedirect — `/` → `/w/<slug>/` redirect, query/hash passthrough.
+//
+// Pins the redirect contract:
+//   1. Query string survives the redirect — `?force=1` must reach the home
+//      route, which `HomeAppRoute` reads. Dropping it kills the force-refresh
+//      param for anyone hitting the bare root URL.
+//   2. Hash survives the redirect.
+//   3. Multiple params survive intact (whole query string, not just `force`).
+//   4. No query/hash → clean `/w/<slug>/` with nothing trailing.
+//   5. No workspace → redirect to `/settings` instead.
+//
+// Same plumbing as HomeAppRoute.test.tsx: bun:test + react-dom/client +
+// happy-dom (via web/test/setup.ts), no @testing-library/react.
+// ---------------------------------------------------------------------------
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { WorkspaceInfo } from "../src/context/WorkspaceContext";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { MemoryRouter, Route, Routes, useLocation } = await import("react-router-dom");
+const { WorkspaceProvider } = await import("../src/context/WorkspaceContext");
+const { WorkspaceRedirect } = await import("../src/App");
+
+const fakeWorkspace: WorkspaceInfo = {
+  id: "ws_eng",
+  name: "Engineering",
+  memberCount: 1,
+  bundles: [],
+};
+
+// Redirect destination is read from a probe mounted outside <Routes>, so it
+// sees the new location regardless of whether a route matches it.
+let current: { pathname: string; search: string; hash: string } = {
+  pathname: "",
+  search: "",
+  hash: "",
+};
+function LocationProbe() {
+  const loc = useLocation();
+  current = { pathname: loc.pathname, search: loc.search, hash: loc.hash };
+  return null;
+}
+
+let active: { unmount(): void } | null = null;
+afterEach(() => {
+  active?.unmount();
+  active = null;
+  current = { pathname: "", search: "", hash: "" };
+});
+
+async function renderAt(url: string, workspaces: WorkspaceInfo[]): Promise<void> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[url]}>
+        <WorkspaceProvider initialWorkspaces={workspaces}>
+          <LocationProbe />
+          <Routes>
+            <Route path="/" element={<WorkspaceRedirect />} />
+          </Routes>
+        </WorkspaceProvider>
+      </MemoryRouter>,
+    );
+  });
+  // Flush the <Navigate> re-render.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  active = {
+    unmount() {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+describe("WorkspaceRedirect", () => {
+  test("carries ?force=1 through the redirect to the home route", async () => {
+    await renderAt("/?force=1", [fakeWorkspace]);
+    expect(current.pathname).toBe("/w/eng/");
+    expect(current.search).toBe("?force=1");
+  });
+
+  test("carries the hash through the redirect", async () => {
+    await renderAt("/#section", [fakeWorkspace]);
+    expect(current.pathname).toBe("/w/eng/");
+    expect(current.hash).toBe("#section");
+  });
+
+  test("carries the whole query string, not just force", async () => {
+    await renderAt("/?force=1&tab=activity", [fakeWorkspace]);
+    expect(current.pathname).toBe("/w/eng/");
+    expect(current.search).toBe("?force=1&tab=activity");
+  });
+
+  test("no query/hash → clean /w/<slug>/ redirect", async () => {
+    await renderAt("/", [fakeWorkspace]);
+    expect(current.pathname).toBe("/w/eng/");
+    expect(current.search).toBe("");
+    expect(current.hash).toBe("");
+  });
+
+  test("no workspace → redirect to /settings", async () => {
+    await renderAt("/?force=1", []);
+    expect(current.pathname).toBe("/settings");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `?force=1` query param on the home dashboard URL that bypasses the
briefing cache on the next load — for dev iteration and ops triage ("the
briefing on $tenant looks stale, append `?force=1`"). Closes #226.

The issue's suggested 3-line fix (`window.location.search` read inside the
bundle) does not work: app iframes are mounted via `srcdoc`, so the bundle's
`window.location` is `about:srcdoc` and never sees the host URL. The shell
relays the flag instead:

- **`HomeAppRoute`** (home route only) reads `?force=1` via `useSearchParams`,
  strips it (one-shot — not a persistent mode), and passes `forceRefresh` down.
- **`SlotRenderer`** forwards it into the `ui/initialize` host context via
  `buildHostExtensions` — initialize only, never `host-context-changed`, so
  it is first-load-only by construction.
- The **home bundle** reads `useHostContext().forceRefresh` and consumes it
  once in the briefing effect; later workspace switches use the cache.
- **`WorkspaceRedirect`** now carries the query string + hash through the
  `/` -> `/w/<slug>/` redirect, so the bare root URL (`/?force=1`) works — not
  just the workspace-scoped URL.

## Test plan

- [x] `bun run verify:static` — format, lint, tsc, cycles, bundle-transport, codegen
- [x] `bun run verify:test-unit` — 2884 unit + 258 web tests pass
- [x] `HomeAppRoute.test.tsx` (new) — param read, one-shot strip, other-param preservation
- [x] `WorkspaceRedirect.test.tsx` (new) — query/hash passthrough through the root redirect
- [x] Manual: `/?force=1` regenerates the briefing and strips the param; plain reload serves cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)