### PR TITLE
fix(registries): drop runtime URL editing — URL is deployment config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - `InlineSource`, `ResourceReader`, `isResourceReader`. External callers should switch to `defineInProcessApp` (returns an `McpSource`); `InlineToolDef` becomes `InProcessTool` with the same shape.
 - `bridgeUseMcp` feature flag and its scaffolding (`web/src/features.ts`, `getBridgeUseMcp` / `setBridgeUseMcp`, the schema entry, the resolver field). The MCP transport is the only path; legacy REST branches in the bridge are deleted.
 - Skill create/edit form no longer surfaces "Loading strategy" and "Tool affinity (comma-separated globs)" inputs. These fields exist on the on-disk `SkillManifest` but were never in the LLM-facing tool schema and were silently dropped by `skills__create` / `skills__update`. Operators who need them today should edit the skill markdown file directly under `~/.nimblebrain/{skills,workspaces/<wsId>/skills,users/<userId>/skills}/`; a future operator-only API may surface them.
+- Registry URL editing on the Org → Registries settings page (and the `manage_registries set_url` action). URL overrides (e.g. self-hosted mpak) are deployment config — set via `NB_REGISTRIES` or `registries.json`. The UI now shows the configured URL or "(using default)" as read-only.
 
 ### Operator notes
 

--- a/src/registries/registry-store.ts
+++ b/src/registries/registry-store.ts
@@ -126,13 +126,17 @@ export class RegistryStore {
    * (intentionally not exposed through the admin tool — kept here for
    * tests / future migration paths).
    *
+   * `url` is intentionally NOT patchable here. Registry URLs are
+   * deployment configuration — set via `NB_REGISTRIES` or by editing
+   * `registries.json` directly — not a runtime mutation surface.
+   *
    * When env overrides are active, persistent mutation is rejected —
    * the env value is the source of truth and we don't want to silently
    * shadow it with a `registries.json` write.
    */
   async update(
     id: string,
-    patch: Partial<Pick<RegistryConfig, "enabled" | "url" | "name">>,
+    patch: Partial<Pick<RegistryConfig, "enabled" | "name">>,
     opts: { force?: boolean } = {},
   ): Promise<RegistryConfig> {
     if (this.envOverride) {

--- a/src/tools/registry-tools.ts
+++ b/src/tools/registry-tools.ts
@@ -13,8 +13,12 @@ import type { InProcessTool } from "./in-process-app.ts";
  *
  * The two seeded registries are:
  *   - "curated"  — locked, always on
- *   - "mpak"     — toggleable; admin can override the URL to point
- *     at a private mpak instance
+ *   - "mpak"     — toggleable
+ *
+ * Registry URLs (e.g., a self-hosted mpak) are deployment configuration,
+ * not runtime state — set via the `NB_REGISTRIES` env var or by editing
+ * `registries.json` directly. This tool intentionally has no `set_url`
+ * action.
  */
 
 export interface ManageRegistriesContext {
@@ -32,11 +36,10 @@ export function createManageRegistriesTool(ctx: ManageRegistriesContext): InProc
       properties: {
         action: {
           type: "string",
-          enum: ["list", "enable", "disable", "set_url", "rename"],
+          enum: ["list", "enable", "disable", "rename"],
           description: "Action to perform.",
         },
         id: { type: "string", description: "Registry id (required for non-list actions)." },
-        url: { type: "string", description: "New registry URL (set_url only)." },
         name: { type: "string", description: "New display name (rename only)." },
       },
       required: ["action"],
@@ -84,39 +87,6 @@ export function createManageRegistriesTool(ctx: ManageRegistriesContext): InProc
             const next = await store.update(id, { enabled: false });
             return {
               content: textContent(`Disabled "${next.name}".`),
-              structuredContent: { ok: true, registry: next },
-              isError: false,
-            };
-          }
-          case "set_url": {
-            const url = String(input.url ?? "");
-            if (!url) return { content: textContent("`url` is required."), isError: true };
-            // Cheap shape check — full URL parsing happens at registry
-            // load time. This guards against pasting a server name
-            // without a scheme. Restrict to http(s) — registry URLs
-            // only ever contact remote endpoints; `javascript:` /
-            // `file:` / `data:` schemes have no business here, even
-            // org-admin gated.
-            let parsed: URL;
-            try {
-              parsed = new URL(url);
-            } catch {
-              return {
-                content: textContent(`Invalid URL: ${url}`),
-                isError: true,
-              };
-            }
-            if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-              return {
-                content: textContent(
-                  `Registry URL must use http or https — got "${parsed.protocol}".`,
-                ),
-                isError: true,
-              };
-            }
-            const next = await store.update(id, { url });
-            return {
-              content: textContent(`Updated "${next.name}" URL to ${url}.`),
               structuredContent: { ok: true, registry: next },
               isError: false,
             };

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -931,14 +931,6 @@ export async function setRegistryEnabled(
   return unwrapStructured(result, enabled ? "enable" : "disable");
 }
 
-export async function setRegistryUrl(
-  id: string,
-  url: string,
-): Promise<{ ok: boolean; registry: RegistryConfig }> {
-  const result = await callTool("nb", "manage_registries", { action: "set_url", id, url });
-  return unwrapStructured(result, "set_url");
-}
-
 export type ToolPolicy = "allow" | "disallow";
 
 /**

--- a/web/src/pages/settings/OrgRegistriesTab.tsx
+++ b/web/src/pages/settings/OrgRegistriesTab.tsx
@@ -1,18 +1,14 @@
 import { useEffect, useState } from "react";
-import {
-  listRegistries,
-  type RegistryConfig,
-  setRegistryEnabled,
-  setRegistryUrl,
-} from "../../api/client";
+import { listRegistries, type RegistryConfig, setRegistryEnabled } from "../../api/client";
 import { SettingsPageHeader } from "./components";
 
 /**
  * Admin surface for connector registries — the sources Browse pulls
  * from. Locked registries (curated) render a disabled toggle so it's
- * obvious they're permanent. Other registries can be enabled / disabled
- * and, when applicable, have their URL overridden (e.g., point mpak
- * at a private mpak instance).
+ * obvious they're permanent. Other registries can be enabled or
+ * disabled here. Registry URLs (e.g., pointing mpak at a self-hosted
+ * instance) are deployment configuration — set via the `NB_REGISTRIES`
+ * env var or `registries.json` — not a runtime UI knob.
  */
 export function OrgRegistriesTab() {
   const [registries, setRegistries] = useState<RegistryConfig[]>([]);
@@ -48,21 +44,11 @@ export function OrgRegistriesTab() {
     }
   };
 
-  const onUrlSubmit = async (id: string, url: string) => {
-    setError(null);
-    try {
-      await setRegistryUrl(id, url);
-      refresh();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    }
-  };
-
   return (
     <div className="max-w-3xl mx-auto space-y-6">
       <SettingsPageHeader
         title="Registries"
-        description="Sources the Browse page pulls connectors from. Curated services are always available; mpak.dev and future registries can be enabled, disabled, or pointed elsewhere."
+        description="Sources the Browse page pulls connectors from. Curated services are always available; mpak.dev and future registries can be enabled or disabled here. URL overrides (e.g., a self-hosted mpak) are deployment config — set via NB_REGISTRIES."
       />
 
       {error && <p className="text-sm text-destructive">{error}</p>}
@@ -72,12 +58,7 @@ export function OrgRegistriesTab() {
       ) : (
         <div className="border-t border-border">
           {registries.map((r) => (
-            <RegistryRow
-              key={r.id}
-              registry={r}
-              onToggle={(next) => onToggle(r.id, next)}
-              onUrlSubmit={(url) => onUrlSubmit(r.id, url)}
-            />
+            <RegistryRow key={r.id} registry={r} onToggle={(next) => onToggle(r.id, next)} />
           ))}
         </div>
       )}
@@ -88,22 +69,11 @@ export function OrgRegistriesTab() {
 function RegistryRow({
   registry,
   onToggle,
-  onUrlSubmit,
 }: {
   registry: RegistryConfig;
   onToggle: (next: boolean) => void;
-  onUrlSubmit: (url: string) => void;
 }) {
-  const [editingUrl, setEditingUrl] = useState(false);
-  const [draftUrl, setDraftUrl] = useState(registry.url ?? "");
   const supportsUrl = registry.type === "mpak";
-
-  const submit = () => {
-    if (draftUrl.trim() && draftUrl !== registry.url) {
-      onUrlSubmit(draftUrl.trim());
-    }
-    setEditingUrl(false);
-  };
 
   return (
     <div className="flex items-start gap-4 py-4 border-b border-border">
@@ -116,36 +86,8 @@ function RegistryRow({
           {registry.locked && <span className="text-[10px] text-muted-foreground">locked</span>}
         </div>
         {supportsUrl && (
-          <div className="mt-1 text-xs text-muted-foreground">
-            {editingUrl ? (
-              <span className="flex items-center gap-2">
-                <input
-                  type="url"
-                  value={draftUrl}
-                  onChange={(e) => setDraftUrl(e.target.value)}
-                  onBlur={submit}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") submit();
-                    if (e.key === "Escape") {
-                      setDraftUrl(registry.url ?? "");
-                      setEditingUrl(false);
-                    }
-                  }}
-                  className="font-mono text-xs px-2 py-0.5 rounded border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-              </span>
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setDraftUrl(registry.url ?? "");
-                  setEditingUrl(true);
-                }}
-                className="font-mono text-xs hover:underline underline-offset-4"
-              >
-                {registry.url ?? "(no URL set — click to add)"}
-              </button>
-            )}
+          <div className="mt-1 font-mono text-xs text-muted-foreground">
+            {registry.url ?? "(using default)"}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

The mpak row on **Settings → Org → Registries** was editable, but rendered `"(no URL set — click to add)"` whenever no override was persisted — even though the mpak SDK has a working default (`registry.mpak.dev`). The empty state read like the registry was broken when it was actually operating off the SDK default.

Two write paths for the same setting (UI vs `NB_REGISTRIES` / `registries.json`) was the underlying confusion. URL overrides (e.g. pointing mpak at a self-hosted instance) are deployment config — they should not be a runtime UI knob.

## Changes

- **web** (`OrgRegistriesTab.tsx`): replaced click-to-edit URL with read-only display — shows the configured URL when one is set, `"(using default)"` otherwise. Updated page description.
- **web** (`api/client.ts`): removed `setRegistryUrl` REST helper.
- **server** (`registry-tools.ts`): removed `set_url` action from `manage_registries` tool.
- **server** (`registry-store.ts`): dropped `url` from `RegistryStore.update()`'s patch type.
- **CHANGELOG**: one-line entry under Unreleased → Removed.

Net: 5 files, +22 / −113.

## Test plan

- [x] `bun run verify:static` (format, lint, tsc, cycles, codegen)
- [x] `bun run test:unit` — 2965 pass
- [ ] Manual: load `/settings/org/registries`, confirm mpak row reads `"(using default)"` instead of `"(no URL set — click to add)"`
- [ ] Manual: with `NB_REGISTRIES` set to override the mpak URL, confirm the override URL displays read-only
- [ ] Manual: enable/disable toggle still works on the mpak row