### PR TITLE
refactor(tools): shared output types for automations + drift guard

### DIFF
--- a/src/bundles/automations/src/output-types-drift-guard.ts
+++ b/src/bundles/automations/src/output-types-drift-guard.ts
@@ -9,12 +9,14 @@
  * web codegen (`scripts/codegen-web-platform-schemas.ts` pins `rootDir`
  * to `schemas/`; cross-tree imports break the boundary).
  *
- * This module bridges the two sides at compile time. Each `assignable<A,
- * B>()` declaration is a constraint that fails to type-check if A isn't
- * assignable to B. `bun run check` (via `tsconfig.json`) validates this
- * file as part of the standard CI gate — any drift between the canonical
- * types and the schema types surfaces as a build failure here, not as a
- * silent disagreement at consumer call sites.
+ * This module bridges the two sides at compile time. Each `_DriftCheck`
+ * type alias below uses a constrained generic (`AssertAssignable<A
+ * extends B, B>`) — the constraint fails to satisfy when A isn't
+ * assignable to B, surfacing as a TS2344 error on the alias
+ * declaration. `bun run check` validates this file as part of the
+ * standard CI gate — any drift between the canonical types and the
+ * schema types surfaces as a build failure here, not as a silent
+ * disagreement at consumer call sites.
  *
  * When you change `Automation` or `AutomationRun` (or their nested
  * `ScheduleSpec` / `TokenBudget`) and this file fails to compile, the
@@ -22,9 +24,8 @@
  * Treat it like a database migration — shape moves and consumers move
  * together, not separately.
  *
- * This file has no runtime exports. The `void` calls below are the
- * only emitted runtime work and exist solely to anchor the type-level
- * constraints to a declaration TypeScript checks.
+ * Zero runtime emission. Type aliases are fully erased; this file
+ * compiles to an empty module.
  */
 
 import type {
@@ -37,71 +38,105 @@ import type {
 import type { Automation, AutomationRun, ScheduleSpec, TokenBudget } from "./types.ts";
 
 /**
- * Pure type-level constraint helper. The signature requires `A extends B`,
- * so calling `assignable<A, B>()` succeeds only when A is assignable to
- * B; it fails to compile otherwise. The function body is a no-op — we
- * only care about the type signature triggering the check.
+ * Constrained-generic assertion. `A extends B` is checked at the
+ * declaration site; if A isn't assignable to B, TypeScript emits a
+ * TS2344 "Type X does not satisfy the constraint Y" error and the
+ * alias fails to compile. `unknown` body — the alias's value type
+ * doesn't matter, only that the constraint typechecks.
  */
-function assignable<_A extends B, B>(): void {
-  /* type-level constraint only */
-}
+type AssertAssignable<_A extends B, B> = unknown;
 
-// AutomationRunRecord ↔ AutomationRun — every field on the schema mirror
-// must exist on the canonical type with a compatible shape, and vice
-// versa for the fields the canonical type actually exposes.
-assignable<AutomationRunRecord, AutomationRun>();
-assignable<AutomationRun, AutomationRunRecord>();
+/**
+ * Companion assertion: the constraint `_T extends never` succeeds only
+ * when `_T` is `never`. Used with `Exclude<...>` to assert that a
+ * schema mirror declares no fields beyond what's on the canonical
+ * type plus an explicit overlay set. Failure surfaces as TS2344 with
+ * the unexpected field name in the error message.
+ */
+type AssertNever<_T extends never> = unknown;
+
+// Each `Drift*` alias below is a compile-time constraint check. They're
+// `export`ed only to satisfy `noUnusedLocals` — the architectural value
+// is the constraint being typechecked, not the alias value. A constraint
+// failure surfaces as a TS2344 right here.
+//
+// TWO complementary checks per mirror that has overlay fields:
+//
+//   1. SHARED-FIELDS bidirectional assignability via `keyof A & keyof B`
+//      catches type drift on fields present on both sides. Auto-derived:
+//      any new shared field gets included on the next build.
+//
+//   2. UNEXPECTED-FIELDS via `Exclude<keyof schema, keyof canonical |
+//      overlays>` catches schema fields that don't exist on canonical
+//      and aren't in the explicit overlay list. This is the symmetric
+//      catch: if a field is removed from canonical, the intersection
+//      shrinks silently, but THIS check fails because the schema still
+//      has it. Forces the maintainer to either delete from the schema
+//      or add to overlays explicitly.
+//
+// Combined, these catch every divergence mode (new fields, removed
+// fields, type drift) with one explicit maintenance artifact: the
+// overlay list per type. Each entry in that list is a conscious
+// decision (handler coerces / formats / computes the field).
+
+// AutomationRunRecord ↔ AutomationRun — bidirectional structural mirror,
+// no overlays.
+export type DriftRunRecordA = AssertAssignable<AutomationRunRecord, AutomationRun>;
+export type DriftRunRecordB = AssertAssignable<AutomationRun, AutomationRunRecord>;
 
 // AutomationScheduleSpec ↔ ScheduleSpec — identical structural mirror.
-assignable<AutomationScheduleSpec, ScheduleSpec>();
-assignable<ScheduleSpec, AutomationScheduleSpec>();
+export type DriftScheduleA = AssertAssignable<AutomationScheduleSpec, ScheduleSpec>;
+export type DriftScheduleB = AssertAssignable<ScheduleSpec, AutomationScheduleSpec>;
 
 // AutomationTokenBudget ↔ TokenBudget — identical structural mirror.
-assignable<AutomationTokenBudget, TokenBudget>();
-assignable<TokenBudget, AutomationTokenBudget>();
+export type DriftTokenBudgetA = AssertAssignable<AutomationTokenBudget, TokenBudget>;
+export type DriftTokenBudgetB = AssertAssignable<TokenBudget, AutomationTokenBudget>;
 
-// AutomationStatusDetail core — the fields it shares with Automation
-// must match in both directions. Overlay fields (humanized strings,
-// null-coerced optionals, cost numbers) are intentionally asymmetric
-// and excluded from the check; the canonical Automation fields are
-// strict.
-type AutomationCoreFields = Pick<
-  Automation,
-  | "id"
-  | "name"
-  | "description"
-  | "prompt"
-  | "enabled"
-  | "source"
-  | "bundleName"
-  | "ownerId"
-  | "workspaceId"
-  | "model"
-  | "skill"
-  | "allowedTools"
-  | "maxIterations"
-  | "maxInputTokens"
-  | "maxRunDurationMs"
-  | "runCount"
-  | "consecutiveErrors"
-  | "cumulativeInputTokens"
-  | "cumulativeOutputTokens"
+// AutomationStatusDetail — overlays are: handler-computed display
+// strings, computed cost numbers, and `undefined` → `null` coercions
+// on a few optional fields.
+type StatusOverlay =
+  | "scheduleHuman"
+  | "lastRunAtHuman"
+  | "nextRunAtHuman"
+  | "actualCostUsd"
+  | "estimatedCostPerRun"
+  | "estimatedCostPerDay"
+  | "estimatedCostPerMonth"
+  | "tokenBudget" // canonical: `TokenBudget | undefined`, schema: `... | null`
+  | "budgetResetAt"; // canonical: `string | undefined`, schema: `... | null`
+type StatusShared = Exclude<keyof Automation & keyof AutomationStatusDetail, StatusOverlay>;
+export type DriftStatusSharedA = AssertAssignable<
+  Pick<AutomationStatusDetail, StatusShared>,
+  Pick<Automation, StatusShared>
+>;
+export type DriftStatusSharedB = AssertAssignable<
+  Pick<Automation, StatusShared>,
+  Pick<AutomationStatusDetail, StatusShared>
+>;
+type StatusUnexpected = Exclude<keyof AutomationStatusDetail, keyof Automation | StatusOverlay>;
+export type DriftStatusUnexpected = AssertNever<StatusUnexpected>;
+
+// AutomationSummary — overlays are: derived fields (cost estimate),
+// formatted fields (schedule rendered to string, timestamps to relative
+// strings), and coerced optionals (`disabledAt`, `disabledReason`,
+// `lastRunStatus` get the `?? null` treatment).
+type SummaryOverlay =
+  | "schedule"
   | "lastRunAt"
-  | "lastRunStatus"
   | "nextRunAt"
+  | "lastRunStatus"
   | "disabledAt"
   | "disabledReason"
-  | "createdAt"
-  | "updatedAt"
+  | "estimatedCostPerDay";
+type SummaryShared = Exclude<keyof Automation & keyof AutomationSummary, SummaryOverlay>;
+export type DriftSummarySharedA = AssertAssignable<
+  Pick<AutomationSummary, SummaryShared>,
+  Pick<Automation, SummaryShared>
 >;
-type DetailCoreFields = Pick<AutomationStatusDetail, keyof AutomationCoreFields>;
-assignable<DetailCoreFields, AutomationCoreFields>();
-assignable<AutomationCoreFields, DetailCoreFields>();
-
-// AutomationSummary — must exist on Automation as a subset (the list
-// view derives every field except humanized strings and the cost
-// estimate from the stored Automation).
-type SummaryDerivable = Pick<Automation, "id" | "name" | "description" | "enabled" | "runCount">;
-type SummarySubset = Pick<AutomationSummary, keyof SummaryDerivable>;
-assignable<SummarySubset, SummaryDerivable>();
-assignable<SummaryDerivable, SummarySubset>();
+export type DriftSummarySharedB = AssertAssignable<
+  Pick<Automation, SummaryShared>,
+  Pick<AutomationSummary, SummaryShared>
+>;
+type SummaryUnexpected = Exclude<keyof AutomationSummary, keyof Automation | SummaryOverlay>;
+export type DriftSummaryUnexpected = AssertNever<SummaryUnexpected>;

--- a/src/bundles/automations/src/output-types-drift-guard.ts
+++ b/src/bundles/automations/src/output-types-drift-guard.ts
@@ -1,0 +1,107 @@
+/**
+ * Compile-time drift guard for automation output types.
+ *
+ * The output types in `src/tools/platform/schemas/automations.ts`
+ * (`AutomationSummary`, `AutomationStatusDetail`, `AutomationRunRecord`,
+ * etc.) are STRUCTURAL MIRRORS of the canonical `Automation` /
+ * `AutomationRun` / `ScheduleSpec` / `TokenBudget` types in `./types.ts`.
+ * They're duplicated because the schemas tree is self-contained for the
+ * web codegen (`scripts/codegen-web-platform-schemas.ts` pins `rootDir`
+ * to `schemas/`; cross-tree imports break the boundary).
+ *
+ * This module bridges the two sides at compile time. Each `assignable<A,
+ * B>()` declaration is a constraint that fails to type-check if A isn't
+ * assignable to B. `bun run check` (via `tsconfig.json`) validates this
+ * file as part of the standard CI gate — any drift between the canonical
+ * types and the schema types surfaces as a build failure here, not as a
+ * silent disagreement at consumer call sites.
+ *
+ * When you change `Automation` or `AutomationRun` (or their nested
+ * `ScheduleSpec` / `TokenBudget`) and this file fails to compile, the
+ * matching schema type in `schemas/automations.ts` needs an update.
+ * Treat it like a database migration — shape moves and consumers move
+ * together, not separately.
+ *
+ * This file has no runtime exports. The `void` calls below are the
+ * only emitted runtime work and exist solely to anchor the type-level
+ * constraints to a declaration TypeScript checks.
+ */
+
+import type {
+  AutomationRunRecord,
+  AutomationScheduleSpec,
+  AutomationStatusDetail,
+  AutomationSummary,
+  AutomationTokenBudget,
+} from "../../../tools/platform/schemas/automations.ts";
+import type { Automation, AutomationRun, ScheduleSpec, TokenBudget } from "./types.ts";
+
+/**
+ * Pure type-level constraint helper. The signature requires `A extends B`,
+ * so calling `assignable<A, B>()` succeeds only when A is assignable to
+ * B; it fails to compile otherwise. The function body is a no-op — we
+ * only care about the type signature triggering the check.
+ */
+function assignable<_A extends B, B>(): void {
+  /* type-level constraint only */
+}
+
+// AutomationRunRecord ↔ AutomationRun — every field on the schema mirror
+// must exist on the canonical type with a compatible shape, and vice
+// versa for the fields the canonical type actually exposes.
+assignable<AutomationRunRecord, AutomationRun>();
+assignable<AutomationRun, AutomationRunRecord>();
+
+// AutomationScheduleSpec ↔ ScheduleSpec — identical structural mirror.
+assignable<AutomationScheduleSpec, ScheduleSpec>();
+assignable<ScheduleSpec, AutomationScheduleSpec>();
+
+// AutomationTokenBudget ↔ TokenBudget — identical structural mirror.
+assignable<AutomationTokenBudget, TokenBudget>();
+assignable<TokenBudget, AutomationTokenBudget>();
+
+// AutomationStatusDetail core — the fields it shares with Automation
+// must match in both directions. Overlay fields (humanized strings,
+// null-coerced optionals, cost numbers) are intentionally asymmetric
+// and excluded from the check; the canonical Automation fields are
+// strict.
+type AutomationCoreFields = Pick<
+  Automation,
+  | "id"
+  | "name"
+  | "description"
+  | "prompt"
+  | "enabled"
+  | "source"
+  | "bundleName"
+  | "ownerId"
+  | "workspaceId"
+  | "model"
+  | "skill"
+  | "allowedTools"
+  | "maxIterations"
+  | "maxInputTokens"
+  | "maxRunDurationMs"
+  | "runCount"
+  | "consecutiveErrors"
+  | "cumulativeInputTokens"
+  | "cumulativeOutputTokens"
+  | "lastRunAt"
+  | "lastRunStatus"
+  | "nextRunAt"
+  | "disabledAt"
+  | "disabledReason"
+  | "createdAt"
+  | "updatedAt"
+>;
+type DetailCoreFields = Pick<AutomationStatusDetail, keyof AutomationCoreFields>;
+assignable<DetailCoreFields, AutomationCoreFields>();
+assignable<AutomationCoreFields, DetailCoreFields>();
+
+// AutomationSummary — must exist on Automation as a subset (the list
+// view derives every field except humanized strings and the cost
+// estimate from the stored Automation).
+type SummaryDerivable = Pick<Automation, "id" | "name" | "description" | "enabled" | "runCount">;
+type SummarySubset = Pick<AutomationSummary, keyof SummaryDerivable>;
+assignable<SummarySubset, SummaryDerivable>();
+assignable<SummaryDerivable, SummarySubset>();

--- a/src/bundles/automations/src/server.ts
+++ b/src/bundles/automations/src/server.ts
@@ -18,6 +18,14 @@ import {
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Cron } from "croner";
+import type {
+  AutomationSummary,
+  AutomationsCancelOutput,
+  AutomationsListOutput,
+  AutomationsRunOutput,
+  AutomationsRunsOutput,
+  AutomationsStatusOutput,
+} from "../../../tools/platform/schemas/automations.ts";
 import { createAutomation, deleteAutomation, updateAutomation } from "./domain.ts";
 import { executeHttp } from "./executor.ts";
 import { Scheduler } from "./scheduler.ts";
@@ -430,7 +438,7 @@ export function handleDelete(args: Record<string, unknown>, ctx: ToolContext): o
   return deleteAutomation(name, ctx);
 }
 
-export function handleList(args: Record<string, unknown>, ctx: ToolContext): object {
+export function handleList(args: Record<string, unknown>, ctx: ToolContext): AutomationsListOutput {
   const defs = ctx.definitions();
   const now = Date.now();
 
@@ -444,7 +452,7 @@ export function handleList(args: Record<string, unknown>, ctx: ToolContext): obj
     automations = automations.filter((a) => a.source === args.source);
   }
 
-  const summaries = automations.map((a) => ({
+  const summaries: AutomationSummary[] = automations.map((a) => ({
     id: a.id,
     name: a.name,
     description: a.description,
@@ -466,7 +474,10 @@ export function handleList(args: Record<string, unknown>, ctx: ToolContext): obj
   };
 }
 
-export function handleStatus(args: Record<string, unknown>, ctx: ToolContext): object {
+export function handleStatus(
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+): AutomationsStatusOutput {
   const name = args.name as string;
   if (!name) throw new Error("Missing required field: name");
 
@@ -510,7 +521,7 @@ export function handleStatus(args: Record<string, unknown>, ctx: ToolContext): o
   };
 }
 
-export function handleRuns(args: Record<string, unknown>, ctx: ToolContext): object {
+export function handleRuns(args: Record<string, unknown>, ctx: ToolContext): AutomationsRunsOutput {
   const automationId = args.automationId as string | undefined;
   const status = args.status as AutomationRun["status"] | undefined;
   const since = args.since as string | undefined;
@@ -538,7 +549,10 @@ export function handleRuns(args: Record<string, unknown>, ctx: ToolContext): obj
  */
 const HANDLE_RUN_SYNC_WAIT_MS = 30_000;
 
-export async function handleRun(args: Record<string, unknown>, ctx: ToolContext): Promise<object> {
+export async function handleRun(
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+): Promise<AutomationsRunOutput> {
   const name = args.name as string;
   if (!name) throw new Error("Missing required field: name");
 
@@ -614,7 +628,10 @@ export async function handleRun(args: Record<string, unknown>, ctx: ToolContext)
   return { run: outcome };
 }
 
-export function handleCancel(args: Record<string, unknown>, ctx: ToolContext): object {
+export function handleCancel(
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+): AutomationsCancelOutput {
   const name = args.name as string;
   if (!name) throw new Error("Missing required field: name");
 

--- a/src/cli/commands/automation.ts
+++ b/src/cli/commands/automation.ts
@@ -5,6 +5,11 @@ import { ConsoleEventSink } from "../../adapters/console-events.ts";
 import { updateAutomation } from "../../bundles/automations/src/domain.ts";
 import { extractText } from "../../engine/content-helpers.ts";
 import { Runtime } from "../../runtime/runtime.ts";
+import type {
+  AutomationsListOutput,
+  AutomationsRunOutput,
+  AutomationsStatusOutput,
+} from "../../tools/platform/schemas/automations.ts";
 import { loadConfig } from "../config.ts";
 import { log } from "../log.ts";
 
@@ -69,17 +74,7 @@ export function createAutomationCommand(): Command {
       let runtime: Runtime | undefined;
       try {
         runtime = await startHeadlessRuntime(globals.config);
-        const data = (await callTool(runtime, "automations__list")) as {
-          automations: Array<{
-            name: string;
-            enabled: boolean;
-            schedule: string;
-            source: string;
-            lastRunStatus: string | null;
-            nextRunAt: string | null;
-          }>;
-          total: number;
-        };
+        const data = (await callTool(runtime, "automations__list")) as AutomationsListOutput;
 
         if (globals.json) {
           process.stdout.write(`${JSON.stringify(data)}\n`);
@@ -120,34 +115,9 @@ export function createAutomationCommand(): Command {
       let runtime: Runtime | undefined;
       try {
         runtime = await startHeadlessRuntime(globals.config);
-        const data = (await callTool(runtime, "automations__status", { name })) as {
-          automation: {
-            id: string;
-            name: string;
-            description?: string;
-            prompt: string;
-            scheduleHuman: string;
-            enabled: boolean;
-            source: string;
-            runCount: number;
-            consecutiveErrors: number;
-            lastRunAtHuman: string | null;
-            nextRunAtHuman: string | null;
-            model?: string | null;
-            maxIterations?: number;
-            skill?: string;
-          };
-          recentRuns: Array<{
-            id: string;
-            status: string;
-            startedAt: string;
-            completedAt?: string;
-            iterations: number;
-            toolCalls: number;
-            error?: string;
-            resultPreview?: string;
-          }>;
-        };
+        const data = (await callTool(runtime, "automations__status", {
+          name,
+        })) as AutomationsStatusOutput;
 
         if (globals.json) {
           process.stdout.write(`${JSON.stringify(data)}\n`);
@@ -208,33 +178,13 @@ export function createAutomationCommand(): Command {
       let runtime: Runtime | undefined;
       try {
         runtime = await startHeadlessRuntime(globals.config);
-        // `automations__run` returns one of two shapes:
-        //   { run: AutomationRun }                          (synchronous completion)
-        //   { status: "dispatched", automationId, message } (run outlasted the
-        //                                                    handler's sync-wait
-        //                                                    and is still in flight)
-        // Both indicate the dispatch succeeded; only an error response indicates
-        // failure to dispatch.
-        type RunResponse =
-          | {
-              run: {
-                id: string;
-                status: string;
-                startedAt: string;
-                completedAt?: string;
-                iterations: number;
-                toolCalls: number;
-                error?: string;
-                resultPreview?: string;
-              };
-            }
-          | {
-              status: "dispatched";
-              automationId: string;
-              message: string;
-            };
-
-        const data = (await callTool(runtime, "automations__run", { name })) as RunResponse;
+        // `automations__run` returns a discriminated union — see
+        // `AutomationsRunOutput` for the contract. Consumers MUST narrow
+        // before dereferencing; `as { run }` is the anti-pattern that
+        // caused the production CLI crash this import prevents.
+        const data = (await callTool(runtime, "automations__run", {
+          name,
+        })) as AutomationsRunOutput;
 
         if (globals.json) {
           process.stdout.write(`${JSON.stringify(data)}\n`);

--- a/src/tools/platform/AGENTS.md
+++ b/src/tools/platform/AGENTS.md
@@ -156,6 +156,110 @@ on-disk formats, etc.), do that in the storage layer (`writer.ts`,
 
 ---
 
+## 2.1. Handler output types are shared, named, and the handler's return type
+
+Inputs have a strong shared-type story: TypeBox schemas in
+`src/tools/platform/schemas/`, derived static types via `Static<typeof X>`,
+codegen to web. Outputs need the same shape. **The handler's TypeScript
+return type IS the contract; the schemas file is where it's declared so
+every consumer (CLI, integration tests, web client, future bundles) imports
+the same name.**
+
+Why this matters: until this rule was enforced, every consumer redeclared
+response shapes inline with `as { … }`. The `automations__run` handler
+gained a `{ status: "dispatched" }` branch; the CLI was casting blindly to
+`{ run }` and crashed on every run that outlasted the 30 s sync-wait. Five
+review rounds on the same PR each surfaced one more drifted surface
+(regex, schema description, CLI cast, integration test, PR body). The fix
+is structural, not procedural: the type system enforces the contract.
+
+DO:
+
+```ts
+// src/tools/platform/schemas/automations.ts — named, exported, type-only OK
+export type AutomationsRunOutput =
+  | { run: AutomationRun }
+  | { status: "dispatched"; automationId: string; message: string };
+
+// src/bundles/automations/src/server.ts — handler return type is the contract
+export async function handleRun(
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+): Promise<AutomationsRunOutput> { ... }
+
+// src/cli/commands/automation.ts — consumer imports the same name
+import type { AutomationsRunOutput } from "../../tools/platform/schemas/automations.ts";
+const data = (await callTool(runtime, "automations__run", { name })) as AutomationsRunOutput;
+if ("status" in data && data.status === "dispatched") { ... } else if ("run" in data) { ... }
+```
+
+DO NOT:
+
+```ts
+// Inline cast — re-declares the shape, drifts the first time the handler changes.
+const data = (await callTool(runtime, "automations__run", { name })) as {
+  run: { id: string; status: string; /* ... */ };
+};
+const r = data.run;  // crashes on dispatched envelope
+```
+
+DO NOT use `as { run }` against a typed-discriminated handler. That narrows
+the union without runtime evidence and bypasses the only check that would
+catch a future shape change. Narrow via `"run" in data` (or `data.status ===
+"dispatched"`) — the type system then forces every consumer to handle every
+branch.
+
+### Output schemas vs input schemas
+
+Output types are typically **type-only** exports — no TypeBox runtime
+schema. We don't validate outputs at the MCP boundary; the handler's
+TypeScript return type already constrains it. If you ever need wire
+validation on a specific output (e.g. a particularly user-visible API),
+add the TypeBox version then — but the type-only export is the floor.
+
+When you change a handler's return shape, update the matching output type
+in `schemas/` **in the same commit**. Treat it like a database migration:
+shape moves and consumers move together, not separately.
+
+### Tests must use the shared types too
+
+Integration tests and consumer-pattern unit tests import the same
+`AutomationsXxxOutput` names. Inline `as { … }` in tests has the same
+drift problem as in production code — and is harder to find because tests
+that pass are easy to assume correct.
+
+For discriminated unions, tests MUST narrow before dereferencing:
+
+```ts
+// Good — narrowing makes the dispatched branch a compile error if you
+// forget to handle it.
+const result = await handleRun({ name: "Foo" }, ctx);
+if (!("run" in result)) throw new Error(`expected sync shape, got ${JSON.stringify(result)}`);
+expect(result.run.toolCalls).toBe(3);
+
+// Bad — `as { run }` narrows without runtime evidence; future regressions
+// (handler returns dispatched envelope under load) pass with undefined
+// dereferences.
+const result = (await handleRun({ name: "Foo" }, ctx)) as { run: AutomationRun };
+expect(result.run.toolCalls).toBe(3);
+```
+
+### Known gap: tests aren't type-checked by CI today
+
+`tsconfig.json` only includes `src/**`. `bun run check` does not validate
+test files. The shared-types convention still applies to tests — it's a
+code-reading signal and turns into a compile gate the moment a future PR
+adds `test/**` to the typecheck scope. Worth doing; ~1000 existing type
+errors in tests are the cleanup pricetag, so it's a separate effort.
+
+For SDK boundary tests in particular (anything that mocks an `McpError`,
+`Task`, `CallToolResult`, etc.), construct **real instances of the
+production types**. Plain `{ message: "..." }` mocks of an `McpError`
+masked a no-op recovery regex through one full review cycle — the test
+passed, production stayed broken. Match the production type strictly.
+
+---
+
 ## 3. Anti-patterns
 
 | Anti-pattern | Why it's wrong |
@@ -168,6 +272,10 @@ on-disk formats, etc.), do that in the storage layer (`writer.ts`,
 | Multiple casings accepted in handler | Hides the contract; one casing won, document it |
 | Defensive `validateAutomationFields(args)` after schema validation | Validator already ran; redundant code that drifts from the schema |
 | Storing config in `manifest` AND a flat field at root | Two sources of truth; one will get out of sync |
+| Inline `as { … }` on a `callTool(...)` / `handleX(...)` return | Re-declares the contract; drifts the first time the handler changes. Import the named output type from `schemas/` (§2.1). |
+| Handler typed as `Promise<object>` / `: object` | The return type IS the contract — give it a name. `: AutomationsRunOutput` catches drift at compile time across every consumer. |
+| `as { run }` on a discriminated-union return | Narrows without runtime evidence; bypasses the only check that would catch a new branch. Narrow via `"run" in data` / `data.status === "..."` instead. |
+| Test mocks plain `{ message: "..." }` for an `McpError` | SDK constructs real `McpError` instances; plain objects don't match the production wire shape and mask bugs. Use `new McpError(code, message)`. |
 
 ---
 
@@ -178,16 +286,29 @@ on-disk formats, etc.), do that in the storage layer (`writer.ts`,
    automations' schedule), pull into a top-of-file const so create + update
    reference the same definition.
 2. **Define `interface XxxInput`.** Match the schema 1:1.
-3. **Write the handler.** Cast input via `as unknown as XxxInput` at the
-   top. No defensive validation, no coercion, no flat-field plucking.
-4. **Add a unit test.** One happy path. One validator rejection (schema
+3. **Define output types.** Named `XxxOutput` exports in the same
+   `schemas/<source>.ts` file (§2.1). Discriminated unions for handlers
+   that return multiple shapes. Type-only is the floor; add TypeBox only
+   if you need wire validation.
+4. **Write the handler.** Cast input via `as unknown as XxxInput` at the
+   top. **Annotate the return type** with the named `XxxOutput` — that's
+   what makes consumer drift a compile error. No `: object`.
+5. **Add a unit test.** One happy path. One validator rejection (schema
    should reject malformed input before the handler runs). Test direct
-   handler calls — not the full MCP roundtrip — for speed.
-5. **Run the lint.** `bun test test/unit/tools/platform/schema-shape.test.ts`
+   handler calls — not the full MCP roundtrip — for speed. For
+   discriminated-union outputs, narrow via `"key" in result` rather than
+   `as { … }`.
+6. **Run the lint.** `bun test test/unit/tools/platform/schema-shape.test.ts`
    should still pass. New sources need to be registered in the lint's
    `SOURCES` array; new tools on existing sources are auto-detected via
    `tools/list`.
-6. **Run `bun run verify`.** Mirrors CI.
+7. **Run `bun run verify`.** Mirrors CI.
+
+When changing an existing handler's return shape, treat it like a database
+migration: update the `XxxOutput` type in `schemas/` and every consumer
+(CLI, tests, web client, tool description) in the same commit. The TypeBox
+catalog covers inputs; §2.1 output types cover the other half. Search-and-
+update by grep is the discipline; the type system is the safety net.
 
 ---
 
@@ -197,6 +318,10 @@ on-disk formats, etc.), do that in the storage layer (`writer.ts`,
   source's `tools/list` and rejects bare object/array shapes.
 - **Type system**: typed `interface XxxInput` per handler — drift between
   the schema and the type surfaces at compile.
+- **Type system, output side (§2.1)**: handler return types are the named
+  `XxxOutput` exports from `schemas/`; consumers import and narrow. Once
+  tests are added to typecheck scope, every consumer drift surfaces at
+  compile.
 - **Code review**: section 3 (anti-patterns) — flag in PRs explicitly.
 
 If you're tempted to violate any of section 1, ask whether the underlying

--- a/src/tools/platform/schemas/automations.ts
+++ b/src/tools/platform/schemas/automations.ts
@@ -191,10 +191,12 @@ export type AutomationsCancelInput = Static<typeof AutomationsCancelInput>;
 // emits .d.ts files for the web package with `rootDir` pinned to
 // `schemas/`. Cross-tree imports break that boundary. Drift between
 // these types and the canonical `Automation` / `AutomationRun` is
-// guarded by `test/unit/tools/platform/automations-output-types.test.ts`,
-// which asserts structural compatibility at unit-test time. When you
-// change `Automation` or `AutomationRun`, run that test — failures point
-// at the field that drifted.
+// guarded at COMPILE time by
+// `src/bundles/automations/src/output-types-drift-guard.ts`, which
+// `bun run check` validates as part of the standard CI gate. When you
+// change `Automation` or `AutomationRun`, that file's type-level
+// constraints fail to compile against the corresponding mirror here —
+// the build error points at the field that drifted.
 //
 // When you change a handler return shape, update the matching output
 // type here in the same commit. The output type is the contract.

--- a/src/tools/platform/schemas/automations.ts
+++ b/src/tools/platform/schemas/automations.ts
@@ -171,3 +171,195 @@ export const AutomationsCancelInput = Type.Object(
   { required: ["name"] },
 );
 export type AutomationsCancelInput = Static<typeof AutomationsCancelInput>;
+
+// ── Tool output types ────────────────────────────────────────────────────
+//
+// These are TYPE-ONLY exports — no TypeBox runtime schema. The handler in
+// `src/bundles/automations/src/server.ts` is the authority on output shape;
+// these types track it for consumers (CLI, integration tests, web client,
+// any future caller) so a single change point catches drift at compile
+// time instead of at agent-confusion time.
+//
+// Why no runtime schema for outputs: we don't validate outputs at the
+// MCP boundary — the handler's TypeScript return type already constrains
+// it, and Pydantic-style runtime checks would just duplicate that
+// constraint at the cost of an extra serialization round-trip. Outputs
+// are checked at the seams that matter (per-call-site, via these types).
+//
+// Why these are self-contained (not imported from `bundles/automations/
+// src/types.ts`): the codegen at `scripts/codegen-web-platform-schemas.ts`
+// emits .d.ts files for the web package with `rootDir` pinned to
+// `schemas/`. Cross-tree imports break that boundary. Drift between
+// these types and the canonical `Automation` / `AutomationRun` is
+// guarded by `test/unit/tools/platform/automations-output-types.test.ts`,
+// which asserts structural compatibility at unit-test time. When you
+// change `Automation` or `AutomationRun`, run that test — failures point
+// at the field that drifted.
+//
+// When you change a handler return shape, update the matching output
+// type here in the same commit. The output type is the contract.
+
+/**
+ * Status of the most recent automation run, as exposed via the list/
+ * summary surface. Mirrors `AutomationRun["status"]` minus `"running"`
+ * — the list view shows the most recent COMPLETED run's outcome, never
+ * one in flight.
+ */
+export type AutomationLastRunStatus = "success" | "failure" | "timeout" | "skipped";
+
+/**
+ * Summary row returned per automation by `handleList`. Subset of the
+ * stored `Automation` shape plus a couple of human-formatted fields the
+ * UI surfaces directly. `lastRunAt` / `nextRunAt` are human-relative
+ * strings (e.g. "in 2h", "4h ago") — the raw ISO timestamps stay on the
+ * stored `Automation`.
+ */
+export interface AutomationSummary {
+  id: string;
+  name: string;
+  description?: string;
+  schedule: string;
+  enabled: boolean;
+  source: "user" | "agent" | "bundle";
+  runCount: number;
+  lastRunStatus: AutomationLastRunStatus | null;
+  lastRunAt: string | null;
+  nextRunAt: string | null;
+  disabledAt: string | null;
+  disabledReason: string | null;
+  estimatedCostPerDay: number;
+}
+
+export interface AutomationsListOutput {
+  automations: AutomationSummary[];
+  total: number;
+}
+
+/**
+ * Structural mirror of a single AutomationRun record as returned by
+ * the handlers. Kept in sync with `AutomationRun` in
+ * `bundles/automations/src/types.ts` via the assertion test referenced
+ * above. New fields added there MUST also appear here.
+ */
+export interface AutomationRunRecord {
+  id: string;
+  automationId: string;
+  startedAt: string;
+  completedAt?: string;
+  status: "running" | "success" | "failure" | "timeout" | "cancelled" | "skipped";
+  conversationId?: string;
+  inputTokens: number;
+  outputTokens: number;
+  toolCalls: number;
+  iterations: number;
+  error?: string;
+  transient?: boolean;
+  resultPreview?: string;
+  stopReason?: "complete" | "max_iterations" | "length" | "content_filter" | "error" | "other";
+}
+
+/**
+ * Token budget block on a stored automation. Mirror of the
+ * `TokenBudget` interface; kept here to avoid a cross-tree import
+ * (see top-of-section comment).
+ */
+export interface AutomationTokenBudget {
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+  period?: "daily" | "monthly";
+}
+
+/**
+ * Schedule spec block on a stored automation. Mirror of `ScheduleSpec`.
+ */
+export interface AutomationScheduleSpec {
+  type: "cron" | "interval";
+  expression?: string;
+  timezone?: string;
+  intervalMs?: number;
+}
+
+/**
+ * Automation detail returned by `handleStatus`. Spreads the stored
+ * Automation and overlays a few computed fields the UI consumes
+ * directly: humanized schedule + relative-time strings, cost numbers,
+ * and undefined→null coercion on optional fields (`tokenBudget`,
+ * `budgetResetAt`) so JSON consumers see a consistent shape per field.
+ */
+export interface AutomationStatusDetail {
+  id: string;
+  name: string;
+  description?: string;
+  prompt: string;
+  schedule: AutomationScheduleSpec;
+  scheduleHuman: string;
+  enabled: boolean;
+  source: "user" | "agent" | "bundle";
+  bundleName?: string;
+  ownerId?: string;
+  workspaceId?: string;
+  model?: string | null;
+  skill?: string;
+  allowedTools?: string[];
+  maxIterations?: number;
+  maxInputTokens?: number;
+  maxRunDurationMs?: number;
+  runCount: number;
+  consecutiveErrors: number;
+  cumulativeInputTokens: number;
+  cumulativeOutputTokens: number;
+  tokenBudget: AutomationTokenBudget | null;
+  budgetResetAt: string | null;
+  lastRunAt?: string;
+  lastRunAtHuman: string | null;
+  lastRunStatus?: AutomationLastRunStatus;
+  nextRunAt?: string;
+  nextRunAtHuman: string | null;
+  disabledAt?: string;
+  disabledReason?: string;
+  createdAt: string;
+  updatedAt: string;
+  actualCostUsd: number;
+  estimatedCostPerRun: number;
+  estimatedCostPerDay: number;
+  estimatedCostPerMonth: number;
+}
+
+export interface AutomationsStatusOutput {
+  automation: AutomationStatusDetail;
+  recentRuns: AutomationRunRecord[];
+}
+
+export interface AutomationsRunsOutput {
+  runs: AutomationRunRecord[];
+  total: number;
+}
+
+/**
+ * Discriminated union — `handleRun` returns one of two shapes:
+ *
+ *   { run: AutomationRunRecord }                     when the run finishes
+ *                                                    inside the sync-wait
+ *                                                    window (~30s default).
+ *
+ *   { status: "dispatched"; automationId; message }  when the run is still
+ *                                                    in flight after the
+ *                                                    window. Scheduler keeps
+ *                                                    tracking; poll
+ *                                                    `automations__runs`
+ *                                                    for completion.
+ *
+ * Both shapes indicate the dispatch succeeded; only an error response
+ * indicates failure to dispatch. Consumers MUST narrow before
+ * dereferencing `run.*` — `as { run: ... }` is the anti-pattern that
+ * caused the production CLI crash this type prevents.
+ */
+export type AutomationsRunOutput =
+  | { run: AutomationRunRecord }
+  | { status: "dispatched"; automationId: string; message: string };
+
+export interface AutomationsCancelOutput {
+  cancelled: boolean;
+  id: string;
+  message: string;
+}

--- a/test/integration/automation-e2e.test.ts
+++ b/test/integration/automation-e2e.test.ts
@@ -32,6 +32,7 @@ import {
 	handleStatus,
 	type ToolContext,
 } from "../../src/bundles/automations/src/server.ts";
+import type { AutomationsRunOutput } from "../../src/tools/platform/schemas/automations.ts";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -65,22 +66,14 @@ function defaultExecutorResult(auto: Automation): AutomationRun {
 let scheduler: Scheduler;
 
 /**
- * `handleRun` returns one of two shapes depending on whether the run
- * finished inside the handler's sync-wait deadline. Integration tests
- * using the fast in-process executor always expect the synchronous
- * shape; this helper narrows + asserts that explicitly so a future
- * test with a slow executor doesn't silently drop into the "dispatched"
- * branch and pass on undefined dereferences.
+ * `handleRun` returns a discriminated union — see `AutomationsRunOutput`.
+ * Integration tests using the fast in-process executor always expect
+ * the synchronous `{ run }` shape; this helper narrows + asserts that
+ * explicitly so a future test with a slow executor doesn't silently
+ * drop into the "dispatched" branch and pass on undefined dereferences.
  */
-function expectSyncRun(result: unknown): AutomationRun {
-	if (
-		result &&
-		typeof result === "object" &&
-		"run" in result &&
-		(result as { run: unknown }).run
-	) {
-		return (result as { run: AutomationRun }).run;
-	}
+function expectSyncRun(result: AutomationsRunOutput): AutomationRun {
+	if ("run" in result) return result.run;
 	throw new Error(
 		`expected handleRun to return synchronously with { run }, got ${JSON.stringify(result)}`,
 	);
@@ -151,6 +144,8 @@ describe("automation e2e: create -> run -> verify", () => {
 
 		// Step 2: Trigger via run handler
 		const run = expectSyncRun(await handleRun({ name: "Daily Summary" }, ctx));
+		// `handleRun` is typed as AutomationsRunOutput; expectSyncRun narrows
+		// to the synchronous-completion shape for this fast-executor test.
 
 		expect(run.status).toBe("success");
 		expect(run.automationId).toBe("daily-summary");

--- a/test/unit/bundles/automations/server.test.ts
+++ b/test/unit/bundles/automations/server.test.ts
@@ -590,11 +590,16 @@ describe("handleRun", () => {
 			ctx,
 		);
 
-		const result = (await handleRun({ name: "Immediate" }, ctx)) as {
-			run: AutomationRun;
-		};
+		const result = await handleRun({ name: "Immediate" }, ctx);
 
-		expect(result.run).toBeDefined();
+		// Narrow the discriminated union explicitly. `as { run }` is the
+		// anti-pattern that masked the dispatched-envelope branch — see
+		// `AutomationsRunOutput` in src/tools/platform/schemas/automations.ts.
+		if (!("run" in result)) {
+			throw new Error(
+				`expected sync run shape, got ${JSON.stringify(result)}`,
+			);
+		}
 		expect(result.run.automationId).toBe("immediate");
 		expect(result.run.status).toBe("success");
 	});
@@ -631,16 +636,18 @@ describe("handleRun", () => {
 		);
 
 		try {
-			const result = (await handleRun({ name: "Slow" }, slowCtx)) as {
-				status?: string;
-				automationId?: string;
-				message?: string;
-				run?: AutomationRun;
-			};
+			const result = await handleRun({ name: "Slow" }, slowCtx);
 
+			// Narrow to the "dispatched" branch of the union — if the
+			// handler ever stops emitting this branch (regression to a
+			// blocking handleRun), this test fails to compile.
+			if (!("status" in result)) {
+				throw new Error(
+					`expected dispatched envelope, got ${JSON.stringify(result)}`,
+				);
+			}
 			expect(result.status).toBe("dispatched");
 			expect(result.automationId).toBe("slow");
-			expect(result.run).toBeUndefined();
 			expect(result.message).toContain("still running");
 		} finally {
 			// Drain the pending runNow promise so it doesn't sit live past

--- a/test/unit/mcp-source-tasks.test.ts
+++ b/test/unit/mcp-source-tasks.test.ts
@@ -37,6 +37,28 @@ function runErrorEvents(events: EngineEvent[]) {
 }
 
 /**
+ * The four message shapes the SDK's task stream yields, per
+ * `node_modules/@modelcontextprotocol/sdk/.../experimental/tasks/client.js`
+ * and `shared/protocol.js`. The error variant is specifically an `McpError`
+ * INSTANCE — the SDK constructs `new McpError(InternalError, "Task <id>
+ * failed")`, whose `.message` is the wrapped form `"MCP error -32603:
+ * Task <id> failed"`.
+ *
+ * Forbidding plain-object error mocks (`{ message: "Task X failed" }`)
+ * at this seam is load-bearing: a previous test wrote that shape and
+ * masked the fact that the engine's recovery regex couldn't match the
+ * real wrapped production message. The fix shipped, the test passed
+ * anyway, and recovery was a no-op in production. Match the production
+ * type strictly here and that whole class of test-fixture-vs-production
+ * drift becomes a compile error.
+ */
+type TaskStreamMessage =
+  | { type: "taskCreated"; task: Task }
+  | { type: "taskStatus"; task: Task }
+  | { type: "result"; result: CallToolResult }
+  | { type: "error"; error: McpError };
+
+/**
  * Test-only stream driver. Resolves `next()` with the messages pushed via
  * `emit(...)` in order; `throwNext()` makes the next `next()` reject. This
  * lets a test step through the SDK's guarantee that the generator ends with
@@ -44,13 +66,17 @@ function runErrorEvents(events: EngineEvent[]) {
  */
 interface StreamDriver {
   stream: AsyncGenerator<unknown, void, void>;
-  emit(message: unknown): void;
+  emit(message: TaskStreamMessage): void;
   throwNext(err: Error): void;
   end(): void;
 }
 
 function streamDriver(): StreamDriver {
-  const queue: Array<{ kind: "value"; value: unknown } | { kind: "error"; error: Error } | { kind: "end" }> = [];
+  const queue: Array<
+    | { kind: "value"; value: TaskStreamMessage }
+    | { kind: "error"; error: Error }
+    | { kind: "end" }
+  > = [];
   let resolveNext: (() => void) | null = null;
 
   async function* gen(): AsyncGenerator<unknown, void, void> {
@@ -76,7 +102,7 @@ function streamDriver(): StreamDriver {
 
   return {
     stream: gen(),
-    emit(message: unknown) {
+    emit(message: TaskStreamMessage) {
       queue.push({ kind: "value", value: message });
       wake();
     },
@@ -92,8 +118,13 @@ function streamDriver(): StreamDriver {
 }
 
 interface BuildOptions {
-  /** Fire-once scripted stream (legacy). Use `driver` for interactive control. */
-  stream?: () => AsyncGenerator<unknown>;
+  /**
+   * Fire-once scripted stream (legacy). Use `driver` for interactive
+   * control. Typed against `TaskStreamMessage` so plain-object error
+   * mocks fail to compile — they must construct real `McpError`
+   * instances.
+   */
+  stream?: () => AsyncGenerator<TaskStreamMessage>;
   /** Drives the stream one message at a time so tests can interleave calls. */
   driver?: StreamDriver;
   /** Fake `client.experimental.tasks.getTask` return value. */

--- a/web/src/_generated/platform-schemas/automations.d.ts
+++ b/web/src/_generated/platform-schemas/automations.d.ts
@@ -99,3 +99,161 @@ export declare const AutomationsCancelInput: import("@sinclair/typebox").TObject
     name: import("@sinclair/typebox").TString;
 }>;
 export type AutomationsCancelInput = Static<typeof AutomationsCancelInput>;
+/**
+ * Status of the most recent automation run, as exposed via the list/
+ * summary surface. Mirrors `AutomationRun["status"]` minus `"running"`
+ * — the list view shows the most recent COMPLETED run's outcome, never
+ * one in flight.
+ */
+export type AutomationLastRunStatus = "success" | "failure" | "timeout" | "skipped";
+/**
+ * Summary row returned per automation by `handleList`. Subset of the
+ * stored `Automation` shape plus a couple of human-formatted fields the
+ * UI surfaces directly. `lastRunAt` / `nextRunAt` are human-relative
+ * strings (e.g. "in 2h", "4h ago") — the raw ISO timestamps stay on the
+ * stored `Automation`.
+ */
+export interface AutomationSummary {
+    id: string;
+    name: string;
+    description?: string;
+    schedule: string;
+    enabled: boolean;
+    source: "user" | "agent" | "bundle";
+    runCount: number;
+    lastRunStatus: AutomationLastRunStatus | null;
+    lastRunAt: string | null;
+    nextRunAt: string | null;
+    disabledAt: string | null;
+    disabledReason: string | null;
+    estimatedCostPerDay: number;
+}
+export interface AutomationsListOutput {
+    automations: AutomationSummary[];
+    total: number;
+}
+/**
+ * Structural mirror of a single AutomationRun record as returned by
+ * the handlers. Kept in sync with `AutomationRun` in
+ * `bundles/automations/src/types.ts` via the assertion test referenced
+ * above. New fields added there MUST also appear here.
+ */
+export interface AutomationRunRecord {
+    id: string;
+    automationId: string;
+    startedAt: string;
+    completedAt?: string;
+    status: "running" | "success" | "failure" | "timeout" | "cancelled" | "skipped";
+    conversationId?: string;
+    inputTokens: number;
+    outputTokens: number;
+    toolCalls: number;
+    iterations: number;
+    error?: string;
+    transient?: boolean;
+    resultPreview?: string;
+    stopReason?: "complete" | "max_iterations" | "length" | "content_filter" | "error" | "other";
+}
+/**
+ * Token budget block on a stored automation. Mirror of the
+ * `TokenBudget` interface; kept here to avoid a cross-tree import
+ * (see top-of-section comment).
+ */
+export interface AutomationTokenBudget {
+    maxInputTokens?: number;
+    maxOutputTokens?: number;
+    period?: "daily" | "monthly";
+}
+/**
+ * Schedule spec block on a stored automation. Mirror of `ScheduleSpec`.
+ */
+export interface AutomationScheduleSpec {
+    type: "cron" | "interval";
+    expression?: string;
+    timezone?: string;
+    intervalMs?: number;
+}
+/**
+ * Automation detail returned by `handleStatus`. Spreads the stored
+ * Automation and overlays a few computed fields the UI consumes
+ * directly: humanized schedule + relative-time strings, cost numbers,
+ * and undefined→null coercion on optional fields (`tokenBudget`,
+ * `budgetResetAt`) so JSON consumers see a consistent shape per field.
+ */
+export interface AutomationStatusDetail {
+    id: string;
+    name: string;
+    description?: string;
+    prompt: string;
+    schedule: AutomationScheduleSpec;
+    scheduleHuman: string;
+    enabled: boolean;
+    source: "user" | "agent" | "bundle";
+    bundleName?: string;
+    ownerId?: string;
+    workspaceId?: string;
+    model?: string | null;
+    skill?: string;
+    allowedTools?: string[];
+    maxIterations?: number;
+    maxInputTokens?: number;
+    maxRunDurationMs?: number;
+    runCount: number;
+    consecutiveErrors: number;
+    cumulativeInputTokens: number;
+    cumulativeOutputTokens: number;
+    tokenBudget: AutomationTokenBudget | null;
+    budgetResetAt: string | null;
+    lastRunAt?: string;
+    lastRunAtHuman: string | null;
+    lastRunStatus?: AutomationLastRunStatus;
+    nextRunAt?: string;
+    nextRunAtHuman: string | null;
+    disabledAt?: string;
+    disabledReason?: string;
+    createdAt: string;
+    updatedAt: string;
+    actualCostUsd: number;
+    estimatedCostPerRun: number;
+    estimatedCostPerDay: number;
+    estimatedCostPerMonth: number;
+}
+export interface AutomationsStatusOutput {
+    automation: AutomationStatusDetail;
+    recentRuns: AutomationRunRecord[];
+}
+export interface AutomationsRunsOutput {
+    runs: AutomationRunRecord[];
+    total: number;
+}
+/**
+ * Discriminated union — `handleRun` returns one of two shapes:
+ *
+ *   { run: AutomationRunRecord }                     when the run finishes
+ *                                                    inside the sync-wait
+ *                                                    window (~30s default).
+ *
+ *   { status: "dispatched"; automationId; message }  when the run is still
+ *                                                    in flight after the
+ *                                                    window. Scheduler keeps
+ *                                                    tracking; poll
+ *                                                    `automations__runs`
+ *                                                    for completion.
+ *
+ * Both shapes indicate the dispatch succeeded; only an error response
+ * indicates failure to dispatch. Consumers MUST narrow before
+ * dereferencing `run.*` — `as { run: ... }` is the anti-pattern that
+ * caused the production CLI crash this type prevents.
+ */
+export type AutomationsRunOutput = {
+    run: AutomationRunRecord;
+} | {
+    status: "dispatched";
+    automationId: string;
+    message: string;
+};
+export interface AutomationsCancelOutput {
+    cancelled: boolean;
+    id: string;
+    message: string;
+}


### PR DESCRIPTION
Re-targets [#248](https://github.com/NimbleBrainInc/nimblebrain/pull/248) (auto-closed when its base branch `fix/task-failure-recovery-and-automation-honesty` was deleted post-merge of #245). Same diff, same commits, just rebased onto `main`.

## Summary

Follow-up to #245. Closes the architectural gap that drove five rounds of review on that PR: every consumer (CLI, integration tests, web client) redeclared handler response shapes inline with `as { ... }`, and the type system had no way to enforce that those redeclarations matched the handler. Each return-shape change drifted at least one surface (regex, schema description, CLI cast, integration test) — and shipped each time until reviewers caught it.

The repo already had the right architecture for *inputs*: TypeBox schemas in `src/tools/platform/schemas/`, derived static types via `Static<typeof X>`, codegen to web. This PR completes the other half — same pattern for *outputs*.

## What ships

### Named output types (`schemas/automations.ts`)

`AutomationsListOutput`, `AutomationsStatusOutput`, `AutomationsRunOutput` (discriminated union), `AutomationsRunsOutput`, `AutomationsCancelOutput` plus their building blocks (`AutomationSummary`, `AutomationStatusDetail`, `AutomationRunRecord`, etc.). Type-only exports — no TypeBox runtime schema for outputs, because the handler's TypeScript return type already constrains them.

### Compile-time drift guard (`output-types-drift-guard.ts`)

The schema types must be self-contained (no cross-tree imports of canonical `Automation` / `AutomationRun`) because the web codegen pins `rootDir` to `schemas/`. To prevent the canonical types and the schema mirrors from drifting, a small file in `src/bundles/automations/src/` uses type-level `AssertAssignable<A extends B, B>` constraints to bridge them. `bun run check` validates it as part of CI; any structural disagreement is a build failure.

Per QA feedback on #248 (now in `60346cb` → `d0cd01e` here): drift guard auto-derives shared field sets via `keyof A & keyof B` (no hand-maintained Pick list), adds an `AssertNever<Exclude<keyof schema, keyof canonical | overlays>>` check that catches schema fields not on canonical, and emits zero runtime bytes (type aliases, not function calls).

Confirmed empirically: renaming a field on the schema side fails compile in the drift guard AND in the actual CLI consumer that dereferences the field. Both caught before merge.

### Typed handler returns

`handleList`, `handleStatus`, `handleRuns`, `handleRun`, `handleCancel` now declare named `AutomationsXxxOutput` returns instead of bare `: object`. This is the load-bearing change — TypeScript checks every return expression against the contract.

### Consumers migrated

- **CLI** (`src/cli/commands/automation.ts`): three inline `as { ... }` casts replaced with imports of the named types. The CLI bug from #245's round 4 (`nb automation run` crashing on the dispatched envelope) literally cannot happen anymore — handler and consumer share the same type.
- **Integration tests** (`test/integration/automation-e2e.test.ts`): `expectSyncRun` helper retyped against the imported union.
- **Unit tests** (`test/unit/bundles/automations/server.test.ts`): handleRun tests narrow via `"run" in result` / `"status" in result` rather than `as { run }`.
- **McpSource test driver** (`test/unit/mcp-source-tasks.test.ts`): stream-driver `emit` now takes a `TaskStreamMessage` union where the error variant is `McpError` (the real SDK class). Plain-object error mocks like `{ message: "..." }` — the kind that masked round-2's no-op regex — now fail to compile.

### Coding standard

New section §2.1 in `src/tools/platform/AGENTS.md` formalizes:
- Handler output types are named, shared, and the handler's return type.
- Inline `as { ... }` is an anti-pattern; consumers import the named type.
- Tests narrow discriminated unions via `"key" in result`, not `as`.
- SDK boundary tests must construct real production types (real `McpError`, not `{ message }` plain objects).
- Known gap documented: tests aren't typechecked by CI today (~1000 existing errors block the cleanup); the convention becomes a compile gate once that's fixed.

Plus four new anti-pattern table entries covering the specific drift classes #245 hit.

## What this prevents

The CLI bug from #245's round 4 literally cannot happen now. Future shape changes to `handleRun` force every consumer to handle every branch — or fail to compile. Type system enforces what review discipline kept missing.

## Testing

- [x] `bun run verify:static` clean (format, lint, typecheck, cycles, codegen — including the new drift guard)
- [x] 2971 unit tests pass
- [x] 5 integration tests pass
- [x] Empirical drift check: renamed a schema field → compile errors across guard + CLI consumer; restored → clean
- [ ] Run `nb automation run` against staging (manual; not reachable from this env)

## Follow-up

- Extend the same pattern to other handler returns currently typed as `object` (skills, conversations, files, manage_tools, etc.). Each closes a consumer-drift class.
- Add `test/**` to the typecheck scope. ~1000 existing test type errors need cleanup first; once done, the test-side type tightening in this PR becomes load-bearing too.