### PR TITLE
refactor(skills): shared output types via schemas, eliminate web↔server drift

### DIFF
--- a/src/tools/platform/AGENTS.md
+++ b/src/tools/platform/AGENTS.md
@@ -209,6 +209,41 @@ catch a future shape change. Narrow via `"run" in data` (or `data.status ===
 "dispatched"`) — the type system then forces every consumer to handle every
 branch.
 
+### In-process platform-tool variant
+
+`src/bundles/automations/src/server.ts`-style handlers return their
+domain object directly (`Promise<AutomationsRunOutput>`) and the
+framework wraps them as MCP `ToolResult` at registration time. That's
+the simplest §2.1 shape — the handler's return type IS the contract.
+
+In-process platform tools registered via `defineInProcessApp` return
+`Promise<ToolResult>` directly because they build the MCP-boundary
+shape themselves (`content` for the human summary, `structuredContent`
+for the typed payload, `isError` for the error flag). To still get
+compile-time drift coverage:
+
+```ts
+handler: async (input): Promise<ToolResult> => {
+  const list = await listSkills(...);
+  const out: SkillsListOutput = { skills: list };  // ← shape pinned here
+  return {
+    content: textContent(summarizeList(list)),
+    // Wire-format cast: `structuredContent` is `Record<string, unknown>`
+    // and TS doesn't structurally widen interfaces into it. The named
+    // `out` declaration above is the load-bearing assertion.
+    structuredContent: out as unknown as Record<string, unknown>,
+    isError: false,
+  };
+},
+```
+
+The discipline is the same — a named `XxxOutput` from `schemas/` —
+just expressed at the construction site rather than the handler
+signature. Either form satisfies §2.1; pick by which layer authored
+the handler. See `src/tools/platform/skills.ts` for the
+platform-tool reference; `src/bundles/automations/src/server.ts`
+for the bundle reference.
+
 ### Output schemas vs input schemas
 
 Output types are typically **type-only** exports — no TypeBox runtime

--- a/src/tools/platform/schemas/skills.ts
+++ b/src/tools/platform/schemas/skills.ts
@@ -184,3 +184,104 @@ export const SkillsMoveScopeInput = Type.Object(
   { required: ["id", "target_scope"] },
 );
 export type SkillsMoveScopeInput = Static<typeof SkillsMoveScopeInput>;
+
+// ── Tool output types ────────────────────────────────────────────────────
+//
+// Same convention as `automations.ts` §2.1 in `tools/platform/AGENTS.md`:
+// type-only exports, the handler's return type IS the contract, web and
+// server both import from here. Skills is a cleaner case than
+// automations — the read-side shapes lived nowhere canonical before
+// (both server's `tools/platform/skills.ts` AND web's
+// `pages/settings/SkillsTab.tsx` / `components/SkillsPopover.tsx`
+// hand-rolled identical interfaces). This file becomes the source of
+// truth; both sides import it, drift becomes structurally impossible.
+
+/** Tier a skill lives in. */
+export type SkillScope = "org" | "workspace" | "user" | "bundle";
+
+/** Skill layer per the loading-strategy spec. */
+export type SkillLayer = 1 | 3;
+
+/** Per-skill lifecycle status. */
+export type SkillStatus = "active" | "draft" | "disabled" | "archived";
+
+/**
+ * Source provenance for a skill — where it came from on disk or via
+ * a bundle. Optional fields; at least one is populated.
+ */
+export interface SkillSource {
+  bundle?: string;
+  bundleVersion?: string;
+  path?: string;
+  uri?: string;
+}
+
+/**
+ * Row returned per skill by `skills__list`. The summary surface for the
+ * settings UI and the agent's `skills__list` enumeration.
+ */
+export interface SkillSummary {
+  id: string;
+  name: string;
+  layer: SkillLayer;
+  scope: SkillScope;
+  status: SkillStatus;
+  type?: string;
+  tokens: number;
+  source: SkillSource;
+  description?: string;
+  modifiedAt?: string;
+  loadingStrategy?: string;
+  appliesToTools?: string[];
+  priority?: number;
+}
+
+export interface SkillsListOutput {
+  skills: SkillSummary[];
+}
+
+/**
+ * Full skill detail returned by `skills__read` — includes the markdown
+ * body and the full manifest metadata block.
+ */
+export interface SkillDetail {
+  id: string;
+  content: string;
+  layer: SkillLayer;
+  scope: SkillScope;
+  source: SkillSource;
+  metadata: {
+    name: string;
+    description?: string;
+    type?: string;
+    priority?: number;
+    loadingStrategy?: string;
+    appliesToTools?: string[];
+    status?: string;
+    overrides?: Array<{ bundle?: string; skill?: string; reason: string }>;
+    derivedFrom?: string;
+  };
+  modifiedAt?: string;
+}
+
+/** `SkillsReadOutput` is the detail itself — no wrapper envelope. */
+export type SkillsReadOutput = SkillDetail;
+
+/**
+ * Single entry in the `skills__active_for` response — one currently-
+ * active layer-3 skill for the named conversation, with provenance for
+ * why it loaded.
+ */
+export interface ActiveSkillEntry {
+  id: string;
+  layer: 3;
+  scope: SkillScope;
+  tokens: number;
+  loadedBy: "always" | "tool_affinity";
+  reason: string;
+}
+
+export interface SkillsActiveForOutput {
+  active: ActiveSkillEntry[];
+  conversationId: string;
+}

--- a/src/tools/platform/skills.ts
+++ b/src/tools/platform/skills.ts
@@ -43,7 +43,14 @@ import { validateSkill } from "../../skills/validator.ts";
 import { deleteSkill, updateSkill, writeSkill } from "../../skills/writer.ts";
 import { defineInProcessApp, type InProcessTool } from "../in-process-app.ts";
 import type { McpSource } from "../mcp-source.ts";
-import type { ActiveSkillEntry, SkillDetail, SkillSummary } from "./schemas/skills.ts";
+import type {
+  ActiveSkillEntry,
+  SkillDetail,
+  SkillSummary,
+  SkillsActiveForOutput,
+  SkillsListOutput,
+  SkillsReadOutput,
+} from "./schemas/skills.ts";
 import {
   SkillsActivateInput,
   SkillsActiveForInput,
@@ -170,9 +177,16 @@ export function createSkillsSource(runtime: Runtime, eventSink: EventSink): McpS
       handler: async (input: Record<string, unknown>): Promise<ToolResult> => {
         try {
           const list = await listSkills(runtime, authoringGuidePath, input);
+          // Construct via the canonical envelope so a shape drift on
+          // either side surfaces at compile time. The cast at the
+          // boundary is needed because `structuredContent`'s wire type
+          // is `Record<string, unknown>`, which TS doesn't infer
+          // structural interfaces into; validation still happens on
+          // `out`'s declaration.
+          const out: SkillsListOutput = { skills: list };
           return {
             content: textContent(summarizeList(list)),
-            structuredContent: { skills: list },
+            structuredContent: out as unknown as Record<string, unknown>,
             isError: false,
           };
         } catch (err) {
@@ -252,9 +266,13 @@ export function createSkillsSource(runtime: Runtime, eventSink: EventSink): McpS
               isError: true,
             };
           }
+          // Compile-time drift coverage on the read shape: `out`'s type
+          // pins it to the canonical `SkillsReadOutput`. Wire cast is
+          // the same shim explained in the `list` handler.
+          const out: SkillsReadOutput = result;
           return {
             content: textContent(summarizeRead(result)),
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: out as unknown as Record<string, unknown>,
             isError: false,
           };
         } catch (err) {
@@ -294,9 +312,10 @@ export function createSkillsSource(runtime: Runtime, eventSink: EventSink): McpS
               isError: true,
             };
           }
+          const out: SkillsActiveForOutput = { active: result, conversationId: convId };
           return {
             content: textContent(summarizeActive(result)),
-            structuredContent: { active: result, conversationId: convId },
+            structuredContent: out as unknown as Record<string, unknown>,
             isError: false,
           };
         } catch (err) {

--- a/src/tools/platform/skills.ts
+++ b/src/tools/platform/skills.ts
@@ -43,6 +43,7 @@ import { validateSkill } from "../../skills/validator.ts";
 import { deleteSkill, updateSkill, writeSkill } from "../../skills/writer.ts";
 import { defineInProcessApp, type InProcessTool } from "../in-process-app.ts";
 import type { McpSource } from "../mcp-source.ts";
+import type { ActiveSkillEntry, SkillDetail, SkillSummary } from "./schemas/skills.ts";
 import {
   SkillsActivateInput,
   SkillsActiveForInput,
@@ -434,41 +435,11 @@ interface ListInput {
   modified_since?: string;
 }
 
-interface ListedSkill {
-  id: string;
-  name: string;
-  layer: 1 | 3;
-  scope: "org" | "workspace" | "user" | "bundle";
-  status: "active" | "draft" | "disabled" | "archived";
-  type?: string;
-  tokens: number;
-  source: { bundle?: string; bundleVersion?: string; path?: string; uri?: string };
-  description?: string;
-  modifiedAt?: string;
-  loadingStrategy?: string;
-  appliesToTools?: string[];
-  priority?: number;
-}
-
-interface ReadResult {
-  id: string;
-  content: string;
-  layer: 1 | 3;
-  scope: "org" | "workspace" | "user" | "bundle";
-  source: { bundle?: string; bundleVersion?: string; path?: string; uri?: string };
-  metadata: {
-    name: string;
-    description?: string;
-    type?: string;
-    priority?: number;
-    loadingStrategy?: string;
-    appliesToTools?: string[];
-    status?: string;
-    overrides?: Array<{ bundle?: string; skill?: string; reason: string }>;
-    derivedFrom?: string;
-  };
-  modifiedAt?: string;
-}
+// Local aliases for the canonical output shapes from `schemas/skills.ts`.
+// Server and web both import from there — this alias just keeps the
+// historical local name in this file's body so the diff stays small.
+type ListedSkill = SkillSummary;
+type ReadResult = SkillDetail;
 
 function skillToListed(skill: Skill): ListedSkill {
   const m = skill.manifest;
@@ -834,14 +805,8 @@ function inferScopeFromPath(
   return "bundle";
 }
 
-interface ActiveForEntry {
-  id: string;
-  layer: 3;
-  scope: "org" | "workspace" | "user" | "bundle";
-  tokens: number;
-  loadedBy: "always" | "tool_affinity";
-  reason: string;
-}
+// Local alias for the canonical shape from `schemas/skills.ts`.
+type ActiveForEntry = ActiveSkillEntry;
 
 /**
  * Find the most recent `skills.loaded` event for the conversation and

--- a/web/src/_generated/platform-schemas/skills.d.ts
+++ b/web/src/_generated/platform-schemas/skills.d.ts
@@ -81,3 +81,87 @@ export declare const SkillsMoveScopeInput: import("@sinclair/typebox").TObject<{
     target_scope: import("@sinclair/typebox").TUnsafe<"user" | "org" | "workspace">;
 }>;
 export type SkillsMoveScopeInput = Static<typeof SkillsMoveScopeInput>;
+/** Tier a skill lives in. */
+export type SkillScope = "org" | "workspace" | "user" | "bundle";
+/** Skill layer per the loading-strategy spec. */
+export type SkillLayer = 1 | 3;
+/** Per-skill lifecycle status. */
+export type SkillStatus = "active" | "draft" | "disabled" | "archived";
+/**
+ * Source provenance for a skill — where it came from on disk or via
+ * a bundle. Optional fields; at least one is populated.
+ */
+export interface SkillSource {
+    bundle?: string;
+    bundleVersion?: string;
+    path?: string;
+    uri?: string;
+}
+/**
+ * Row returned per skill by `skills__list`. The summary surface for the
+ * settings UI and the agent's `skills__list` enumeration.
+ */
+export interface SkillSummary {
+    id: string;
+    name: string;
+    layer: SkillLayer;
+    scope: SkillScope;
+    status: SkillStatus;
+    type?: string;
+    tokens: number;
+    source: SkillSource;
+    description?: string;
+    modifiedAt?: string;
+    loadingStrategy?: string;
+    appliesToTools?: string[];
+    priority?: number;
+}
+export interface SkillsListOutput {
+    skills: SkillSummary[];
+}
+/**
+ * Full skill detail returned by `skills__read` — includes the markdown
+ * body and the full manifest metadata block.
+ */
+export interface SkillDetail {
+    id: string;
+    content: string;
+    layer: SkillLayer;
+    scope: SkillScope;
+    source: SkillSource;
+    metadata: {
+        name: string;
+        description?: string;
+        type?: string;
+        priority?: number;
+        loadingStrategy?: string;
+        appliesToTools?: string[];
+        status?: string;
+        overrides?: Array<{
+            bundle?: string;
+            skill?: string;
+            reason: string;
+        }>;
+        derivedFrom?: string;
+    };
+    modifiedAt?: string;
+}
+/** `SkillsReadOutput` is the detail itself — no wrapper envelope. */
+export type SkillsReadOutput = SkillDetail;
+/**
+ * Single entry in the `skills__active_for` response — one currently-
+ * active layer-3 skill for the named conversation, with provenance for
+ * why it loaded.
+ */
+export interface ActiveSkillEntry {
+    id: string;
+    layer: 3;
+    scope: SkillScope;
+    tokens: number;
+    loadedBy: "always" | "tool_affinity";
+    reason: string;
+}
+export interface SkillsActiveForOutput {
+    active: ActiveSkillEntry[];
+    conversationId: string;
+}

--- a/web/src/components/SkillsPopover.tsx
+++ b/web/src/components/SkillsPopover.tsx
@@ -3,9 +3,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { callTool } from "../api/client";
 import { parseToolResponse } from "../lib/tool-response";
-// Canonical shape from `src/tools/platform/schemas/skills.ts`; mirrored
+// Canonical shapes from `src/tools/platform/schemas/skills.ts`; mirrored
 // here via codegen so server + web can't drift.
-import type { ActiveSkillEntry as ActiveSkill } from "../_generated/platform-schemas/skills";
+import type {
+  ActiveSkillEntry as ActiveSkill,
+  SkillsActiveForOutput,
+} from "../_generated/platform-schemas/skills";
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -51,7 +54,7 @@ export function SkillsPopover({ conversationId }: { conversationId: string | nul
     setError(null);
     try {
       const res = await callTool("skills", "active_for", { conversation_id: conversationId });
-      const data = parseToolResponse<{ active: ActiveSkill[] }>(res);
+      const data = parseToolResponse<SkillsActiveForOutput>(res);
       setSkills(data.active);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to load active skills.";

--- a/web/src/components/SkillsPopover.tsx
+++ b/web/src/components/SkillsPopover.tsx
@@ -3,17 +3,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { callTool } from "../api/client";
 import { parseToolResponse } from "../lib/tool-response";
-
-// ── Types ────────────────────────────────────────────────────────────────
-
-interface ActiveSkill {
-  id: string;
-  layer: 3;
-  scope: "org" | "workspace" | "user" | "bundle";
-  tokens: number;
-  loadedBy: "always" | "tool_affinity";
-  reason: string;
-}
+// Canonical shape from `src/tools/platform/schemas/skills.ts`; mirrored
+// here via codegen so server + web can't drift.
+import type { ActiveSkillEntry as ActiveSkill } from "../_generated/platform-schemas/skills";
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -13,24 +13,19 @@ import { RequireActiveWorkspace } from "./components/RequireActiveWorkspace";
 
 // ── Types ────────────────────────────────────────────────────────────────
 //
-// Mirror the shapes returned by the `nb__skills` source. We don't import
-// from the server-side TS to keep the web client decoupled — duplication
-// is acceptable here since these are stable contract types and any drift
-// surfaces immediately in the UI.
-
-type Scope = "org" | "workspace" | "user" | "bundle";
-type Status = "active" | "draft" | "disabled" | "archived";
-
-// `ListedSkill` / `ReadSkill` were duplicated declarations of the
-// server-side shapes from `src/tools/platform/skills.ts`. Both sides
-// now import the canonical types from `schemas/skills.ts` via the
-// generated platform-schemas tree, so a future shape change in one
-// place can't silently drift from the other.
+// Canonical shapes from `src/tools/platform/schemas/skills.ts`, mirrored
+// here via codegen at `web/src/_generated/platform-schemas/`. Server and
+// web both import from the same declarations so a shape change in one
+// place can't silently drift from the other (the pattern §2.1 in
+// `src/tools/platform/AGENTS.md` exists to enforce). Local aliases keep
+// the diff small for historical readers.
 import type {
   SkillDetail as ReadSkill,
+  SkillScope as Scope,
+  SkillsListOutput,
+  SkillStatus as Status,
   SkillSummary as ListedSkill,
 } from "../../_generated/platform-schemas/skills";
-export type { ListedSkill, ReadSkill };
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -86,7 +81,7 @@ function Inner() {
       if (scopeFilter !== "all") args.scope = scopeFilter;
       if (statusFilter !== "all") args.status = statusFilter;
       const res = await callTool("skills", "list", args);
-      const data = parseToolResponse<{ skills: ListedSkill[] }>(res);
+      const data = parseToolResponse<SkillsListOutput>(res);
       setSkills(data.skills);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to load skills.";

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -18,45 +18,19 @@ import { RequireActiveWorkspace } from "./components/RequireActiveWorkspace";
 // is acceptable here since these are stable contract types and any drift
 // surfaces immediately in the UI.
 
-type Layer = 1 | 3;
 type Scope = "org" | "workspace" | "user" | "bundle";
 type Status = "active" | "draft" | "disabled" | "archived";
 
-interface ListedSkill {
-  id: string;
-  name: string;
-  layer: Layer;
-  scope: Scope;
-  status: Status;
-  type?: string;
-  tokens: number;
-  source: { bundle?: string; bundleVersion?: string; path?: string; uri?: string };
-  description?: string;
-  modifiedAt?: string;
-  loadingStrategy?: string;
-  appliesToTools?: string[];
-  priority?: number;
-}
-
-interface ReadSkill {
-  id: string;
-  content: string;
-  layer: Layer;
-  scope: Scope;
-  source: ListedSkill["source"];
-  metadata: {
-    name: string;
-    description?: string;
-    type?: string;
-    priority?: number;
-    loadingStrategy?: string;
-    appliesToTools?: string[];
-    status?: string;
-    overrides?: Array<{ bundle?: string; skill?: string; reason: string }>;
-    derivedFrom?: string;
-  };
-  modifiedAt?: string;
-}
+// `ListedSkill` / `ReadSkill` were duplicated declarations of the
+// server-side shapes from `src/tools/platform/skills.ts`. Both sides
+// now import the canonical types from `schemas/skills.ts` via the
+// generated platform-schemas tree, so a future shape change in one
+// place can't silently drift from the other.
+import type {
+  SkillDetail as ReadSkill,
+  SkillSummary as ListedSkill,
+} from "../../_generated/platform-schemas/skills";
+export type { ListedSkill, ReadSkill };
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Applies the §2.1 pattern from [#249](https://github.com/NimbleBrainInc/nimblebrain/pull/249) to the \`skills\` namespace. Three read-side shapes (\`SkillSummary\`, \`SkillDetail\`, \`ActiveSkillEntry\`) were structurally identical declarations duplicated in BOTH \`src/tools/platform/skills.ts\` AND web's \`SkillsTab.tsx\` / \`SkillsPopover.tsx\`. The two sides could drift the moment one was edited without the other.

Moved the canonical declarations to \`src/tools/platform/schemas/skills.ts\` as type-only exports. Server imports directly; web imports from codegen'd \`_generated/platform-schemas/skills.d.ts\`. One source of truth.

## Why this is cleaner than #249

Skills is a simpler case than automations: the read-side types lived nowhere canonical before, so there's no \`Automation\`-equivalent for the schema mirror to drift from. The schemas file IS the canonical declaration; no drift guard needed. Future handlers / consumers import from it — that's the structural enforcement.

## Scope (kept tight on purpose)

Read-side handlers only: \`list\`, \`read\`, \`active_for\`. Mutations (\`create\`, \`update\`, \`delete\`, \`activate\`, \`deactivate\`, \`move_scope\`) keep their current ToolResult-returning shape. They have less consumer reach and can be migrated as a discrete follow-up when someone touches them. Pattern is validated; the rest is mechanical.

## Stats

**Net −90 lines** despite adding the canonical types. The web↔server duplication was costing real LOC.

## Test plan

- [x] \`bun run verify:static\` clean (format, lint, typecheck, cycles, codegen)
- [x] \`bun run test:unit\` — 2971 pass, 0 fail
- [ ] Smoke: load \`/settings/skills\` in web; \`SkillsPopover\` rendering inside a chat session