### PR TITLE
feat(runtime): thread AbortSignal through ChatRequest → engine → tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 ### Fixed
 
+- `runtime.chat()` now honors an `AbortSignal` end-to-end (`ChatRequest.signal` → `EngineConfig.signal` → iteration loop + every tool call). Callers racing the chat against a deadline (notably the automations executor's per-run budget) now cancel in-flight LLM/tool work instead of orphaning it; HTTP `/v1/chat` and `/v1/chat/stream` also forward `request.signal`, so client disconnect cancels engine work ([#251](https://github.com/NimbleBrainInc/nimblebrain/pull/251)).
 - Task-augmented MCP tools no longer report a false `MCP error -32603: Task <id> failed` when the server stored a usable `tasks/result` payload; the engine refetches and surfaces the real content ([#245](https://github.com/NimbleBrainInc/nimblebrain/pull/245)).
 - `automations__run` no longer hits `MCP error -32001: Request timed out` on multi-minute automations; `handleRun` caps its sync wait below the SDK's 60 s request timeout and returns a `{ status: "dispatched" }` envelope when the run outlasts the window, with the scheduler tracking it in the background ([#245](https://github.com/NimbleBrainInc/nimblebrain/pull/245)).
 - Synthesized automation failure records now carry the real `startedAt` from dispatch time instead of the catch-clause instant, so operators can tell a long hang from a setup crash ([#245](https://github.com/NimbleBrainInc/nimblebrain/pull/245)).

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -56,7 +56,12 @@ export async function handleChat(
   }
 
   try {
-    const result = await runtime.chat(parsed);
+    // Thread the request's abort signal into the chat so a client
+    // disconnect or upstream timeout actually cancels the in-flight
+    // engine loop and tool calls — instead of orphaning the work until
+    // it eventually finishes writing to disk (the production bug behind
+    // the morning-brief executor lying about timeouts).
+    const result = await runtime.chat({ ...parsed, signal: request.signal });
     // Cost is derived at the boundary, never stored. Same wire shape as
     // the streaming `done` event so clients see one consistent contract.
     const wireUsage = {
@@ -183,7 +188,11 @@ export async function handleChatStream(
       });
 
       runtime
-        .chat(parsed, sink)
+        // Thread the HTTP request's signal so client disconnect cancels
+        // the engine loop + in-flight tool calls (cooperative). The SSE
+        // stream's controller closes on cancellation via `closed` flag;
+        // this propagates the cancellation INTO the chat too.
+        .chat({ ...parsed, signal: request.signal }, sink)
         .then((result) => {
           // Cost is computed at the API boundary — never stored. The
           // wire-format `usage.costUsd` is what clients display; deriving

--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -204,6 +204,7 @@ export function createDirectExecutor(
     // doing all the work.
     const runController = new AbortController();
     let timedOut = false;
+    let externallyAborted = false;
     const timeoutTimer = setTimeout(() => {
       timedOut = true;
       runController.abort();
@@ -212,9 +213,13 @@ export function createDirectExecutor(
     let onExternalAbort: (() => void) | undefined;
     if (externalSignal) {
       if (externalSignal.aborted) {
+        externallyAborted = true;
         runController.abort(externalSignal.reason);
       } else {
-        onExternalAbort = () => runController.abort(externalSignal.reason);
+        onExternalAbort = () => {
+          externallyAborted = true;
+          runController.abort(externalSignal.reason);
+        };
         externalSignal.addEventListener("abort", onExternalAbort, { once: true });
       }
     }
@@ -227,10 +232,14 @@ export function createDirectExecutor(
       return mapResultToRun(automation, startedAt, data);
     } catch (err) {
       // Preserve the canonical "timed out after Ns" wording so
-      // `Scheduler.dispatchRun` classifies this as `timeout` and not
-      // generic `failure`. External-cancel paths preserve the original
-      // AbortError so they classify as `cancelled`.
-      if (timedOut) {
+      // `Scheduler.dispatchRun` classifies this as `timeout`. If
+      // BOTH the external abort AND the timeout fire (narrow race
+      // when chatFn takes a beat to honor cancel near the timeout
+      // boundary), external-cancel wins — the operator-meaningful
+      // cause is "I cancelled", not "the clock ran out at the same
+      // moment". Drift here would silently restamp a cancel as a
+      // timeout in the run record.
+      if (timedOut && !externallyAborted) {
         throw new Error(
           `Automation ${automation.id} timed out after ${Math.round(timeoutMs / 1000)}s`,
         );

--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -29,6 +29,17 @@ export interface ChatFnRequest {
   workspaceId?: string;
   /** Identity under which this automation runs. */
   identity?: { id: string; name?: string; email?: string; role?: string };
+  /**
+   * Cancellation signal forwarded into `runtime.chat()` → engine → tool
+   * calls. When the scheduler's per-run controller aborts (timeout,
+   * explicit cancel, scheduler stop), the in-flight LLM/tool work
+   * actually stops instead of being orphaned. Before this field
+   * existed, a chat that exceeded `maxRunDurationMs` ran to completion
+   * in the background and wrote a complete conversation to disk
+   * minutes after the executor had already synthesized a fake
+   * "timeout" run record.
+   */
+  signal?: AbortSignal;
 }
 
 /** Minimal chat result shape (matches runtime ChatResult). */
@@ -171,32 +182,64 @@ export function createDirectExecutor(
 ) {
   return async function executeDirect(
     automation: Automation,
-    signal?: AbortSignal,
+    externalSignal?: AbortSignal,
   ): Promise<AutomationRun> {
     const startedAt = new Date().toISOString();
     const timeoutMs = automation.maxRunDurationMs ?? DEFAULT_TIMEOUT_MS;
     const ctx = getContext(automation);
 
-    // Race the chat call against a timeout
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      const timer = setTimeout(
-        () =>
-          reject(
-            new Error(
-              `Automation ${automation.id} timed out after ${Math.round(timeoutMs / 1000)}s`,
-            ),
-          ),
-        timeoutMs,
-      );
-      signal?.addEventListener("abort", () => {
-        clearTimeout(timer);
-        reject(new DOMException("The operation was aborted.", "AbortError"));
+    // Combined cancellation: a single controller aborts when EITHER the
+    // scheduler's external signal fires (manual cancel, scheduler stop)
+    // OR the per-run timeout elapses. The combined signal goes into
+    // chatFn → runtime.chat → engine.run → every tool call, so an
+    // abort actually cancels in-flight LLM/tool work instead of
+    // orphaning it the way the old `Promise.race` pattern did.
+    //
+    // Production bug this fixes: `morning-brief-6am-pt` runs took
+    // 6–7 minutes while the 5-minute Promise.race rejected at the
+    // 5-minute mark, returning to dispatchRun. The chat kept running,
+    // finished cleanly 1–2 minutes later, wrote a complete conversation
+    // to disk — and the result was discarded. The agent saw a "timeout"
+    // run record with `iterations: 0, toolCalls: 0` despite the agent
+    // doing all the work.
+    const runController = new AbortController();
+    let timedOut = false;
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      runController.abort();
+    }, timeoutMs);
+
+    let onExternalAbort: (() => void) | undefined;
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        runController.abort(externalSignal.reason);
+      } else {
+        onExternalAbort = () => runController.abort(externalSignal.reason);
+        externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+      }
+    }
+
+    try {
+      const data = await chatFn({
+        ...buildRequest(automation, ctx),
+        signal: runController.signal,
       });
-    });
-
-    const data = await Promise.race([chatFn(buildRequest(automation, ctx)), timeoutPromise]);
-
-    return mapResultToRun(automation, startedAt, data);
+      return mapResultToRun(automation, startedAt, data);
+    } catch (err) {
+      // Preserve the canonical "timed out after Ns" wording so
+      // `Scheduler.dispatchRun` classifies this as `timeout` and not
+      // generic `failure`. External-cancel paths preserve the original
+      // AbortError so they classify as `cancelled`.
+      if (timedOut) {
+        throw new Error(
+          `Automation ${automation.id} timed out after ${Math.round(timeoutMs / 1000)}s`,
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutTimer);
+      if (onExternalAbort) externalSignal?.removeEventListener("abort", onExternalAbort);
+    }
   };
 }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -468,6 +468,20 @@ export class AgentEngine {
     const unregisterToolControls = config.toolPromotion?.registerControls(toolControls);
     try {
       while (iteration < maxIter) {
+        // Cancellation check at the top of every iteration. The signal is
+        // already threaded to `tools.execute` so an in-flight tool call
+        // can honor it, but without checking here the engine would
+        // proceed to the NEXT LLM call after a cancelled tool — wasting
+        // a model round-trip and continuing to generate downstream tool
+        // calls the caller no longer wants. Cooperative cancellation:
+        // we don't preempt the current tool, but we don't start new work
+        // either. The runtime catch translates AbortError into the
+        // appropriate `run.error` event for SSE consumers.
+        if (config.signal?.aborted) {
+          throw config.signal.reason instanceof Error
+            ? config.signal.reason
+            : new DOMException("The operation was aborted.", "AbortError");
+        }
         // Filter out any tool the supervisor has tripped this run. Removing
         // the tool from the model's toolset is more reliable than telling
         // the model "do not call this tool" via prose — the model literally

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -477,6 +477,17 @@ export class AgentEngine {
         // we don't preempt the current tool, but we don't start new work
         // either. The runtime catch translates AbortError into the
         // appropriate `run.error` event for SSE consumers.
+        //
+        // Gap acknowledged: an IN-FLIGHT LLM stream (`callModel` →
+        // `model.doStream`) is not signal-aware. The current step
+        // through this check blocks on the stream until it completes
+        // before the next iteration's abort check fires. For tool-call-
+        // dominated runs (the morning-brief case this fix targets) the
+        // gap is small. For long completions / reasoning-heavy runs
+        // it's a real cancellation lag — fix is to plumb `signal`
+        // through `callModel` to `model.doStream({ abortSignal })`,
+        // tracked separately so this PR stays scoped to the
+        // architectural plumbing.
         if (config.signal?.aborted) {
           throw config.signal.reason instanceof Error
             ? config.signal.reason

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1015,6 +1015,12 @@ export class Runtime {
       // runs). Member-scoped MCP bundles use this to route to the right
       // per-principal source. Workspace-scoped sources ignore it.
       ...(request.identity ? { principalId: request.identity.id } : {}),
+      // Cancellation: thread the caller's signal into the engine. The
+      // engine checks it between iterations and forwards it down to every
+      // tool call. Without this, callers racing the chat against a
+      // deadline (notably the automations executor's `Promise.race`
+      // against `maxRunDurationMs`) silently orphan in-flight work.
+      ...(request.signal ? { signal: request.signal } : {}),
     };
 
     // Determine which event store handles conversation events for this request.

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -234,6 +234,27 @@ export interface ChatRequest {
   allowedTools?: string[];
   /** Authenticated user identity for this request. Set by API middleware. */
   identity?: import("../identity/provider.ts").UserIdentity;
+  /**
+   * Cancellation signal forwarded to the engine and threaded down to every
+   * tool call via `EngineConfig.signal`. When aborted, the agent loop stops
+   * before its next iteration; in-flight task-augmented MCP tools receive
+   * `tasks/cancel`; inline tool calls abort their RPC.
+   *
+   * Without this, callers racing `runtime.chat()` against an external
+   * deadline (e.g. the automations executor's `Promise.race` against
+   * `maxRunDurationMs`) ORPHAN the in-flight LLM/tool work — the chat
+   * keeps running, finishes, writes the conversation to disk, but the
+   * caller never sees the result. Production proof: `morning-brief-6am-pt`
+   * runs in ws_nimblebrain_shared completed in 6-7m while the 5m
+   * Promise.race silently abandoned them, leaving fake `timeout` run
+   * records and ~$X of wasted LLM spend per missed run.
+   *
+   * Cooperative: the engine checks the signal between iterations and the
+   * current tool call may run to completion before the loop exits. Long-
+   * running tools honor the signal via the contract in CLAUDE.md
+   * §"Long-Running Tools (MCP Tasks)".
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/test/unit/bundles/automations/executor.test.ts
+++ b/test/unit/bundles/automations/executor.test.ts
@@ -509,4 +509,87 @@ describe("createDirectExecutor — recursive-call guard", () => {
 		const result = await executor(automation);
 		expect(result.status).toBe("success");
 	});
+
+	test("forwards a combined signal into chatFn so timeouts cancel in-flight chat work", async () => {
+		// Regression: the old Promise.race pattern rejected at the timeout
+		// but didn't propagate cancellation to the chatFn. The chat kept
+		// running, finished cleanly minutes later, and the result was
+		// silently discarded. Now the chatFn receives a signal that
+		// aborts on the same timeout — so it can cooperatively stop.
+		let receivedSignal: AbortSignal | undefined;
+		let signalFiredDuringChat = false;
+
+		const slowChatFn: ChatFn = async (req) => {
+			receivedSignal = req.signal;
+			// Wait up to 500ms but bail on abort so the test runs fast.
+			await new Promise<void>((resolve) => {
+				const timer = setTimeout(resolve, 500);
+				req.signal?.addEventListener(
+					"abort",
+					() => {
+						signalFiredDuringChat = true;
+						clearTimeout(timer);
+						resolve();
+					},
+					{ once: true },
+				);
+			});
+			// On abort the chat throws — matches engine.run behavior under
+			// signal-driven cancellation.
+			if (req.signal?.aborted) {
+				throw new DOMException("The operation was aborted.", "AbortError");
+			}
+			return {
+				response: "ok",
+				conversationId: "conv_test",
+				toolCalls: [],
+				inputTokens: 100,
+				outputTokens: 50,
+				stopReason: "complete",
+				usage: { iterations: 1 },
+			};
+		};
+
+		const executor = createDirectExecutor(slowChatFn, () => ({
+			workspaceId: "ws_test",
+		}));
+		const automation = makeAutomation({ maxRunDurationMs: 50 });
+
+		await expect(executor(automation)).rejects.toThrow(/timed out after/);
+		expect(receivedSignal).toBeDefined();
+		expect(signalFiredDuringChat).toBe(true);
+	});
+
+	test("external cancel propagates into chatFn signal as AbortError", async () => {
+		// Symmetric to the timeout case: when the scheduler aborts the
+		// run controller (manual cancel, scheduler.stop()), the chatFn's
+		// signal must also fire so the in-flight engine work cancels.
+		let chatSawAbort = false;
+		const slowChatFn: ChatFn = async (req) => {
+			await new Promise<void>((resolve) => {
+				req.signal?.addEventListener(
+					"abort",
+					() => {
+						chatSawAbort = true;
+						resolve();
+					},
+					{ once: true },
+				);
+				setTimeout(resolve, 5000);
+			});
+			throw new DOMException("The operation was aborted.", "AbortError");
+		};
+
+		const executor = createDirectExecutor(slowChatFn, () => ({ workspaceId: "ws_test" }));
+		const externalController = new AbortController();
+		const automation = makeAutomation({ maxRunDurationMs: 10_000 });
+
+		const runPromise = executor(automation, externalController.signal);
+		// Give the chat a tick to start, then cancel.
+		await new Promise((r) => setTimeout(r, 10));
+		externalController.abort();
+
+		await expect(runPromise).rejects.toThrow();
+		expect(chatSawAbort).toBe(true);
+	});
 });

--- a/test/unit/bundles/automations/executor.test.ts
+++ b/test/unit/bundles/automations/executor.test.ts
@@ -592,4 +592,43 @@ describe("createDirectExecutor — recursive-call guard", () => {
 		await expect(runPromise).rejects.toThrow();
 		expect(chatSawAbort).toBe(true);
 	});
+
+	test("external-cancel wins the race when timeout fires concurrently — no false 'timeout' status", async () => {
+		// Race regression: external abort + timeout firing in the same
+		// tick. Without the `externallyAborted` flag, `timedOut` flips
+		// true under both paths and the catch rewrites the error to
+		// "timed out after Ns" — so the scheduler stamps `status:
+		// "timeout"` on what was really a cancel. Narrow window, but
+		// the whole point of the PR is honest status records.
+		const chatFn: ChatFn = async (req) => {
+			await new Promise<void>((resolve) => {
+				req.signal?.addEventListener("abort", () => resolve(), { once: true });
+				setTimeout(resolve, 5000);
+			});
+			throw new DOMException("The operation was aborted.", "AbortError");
+		};
+
+		const executor = createDirectExecutor(chatFn, () => ({ workspaceId: "ws_test" }));
+		const externalController = new AbortController();
+		// Make the timeout extremely tight so it fires very close to the
+		// external cancel — exercises the race the flag is meant to
+		// disambiguate.
+		const automation = makeAutomation({ maxRunDurationMs: 5 });
+
+		const runPromise = executor(automation, externalController.signal);
+		// Cancel externally in the same tick — both abort sources fire
+		// near-simultaneously.
+		externalController.abort();
+
+		// External cancel must dominate: the error must NOT be the
+		// timeout-shape that `Scheduler.dispatchRun` keys off via
+		// `errorMsg.includes("timed out")`.
+		let caughtMessage = "";
+		try {
+			await runPromise;
+		} catch (e) {
+			caughtMessage = e instanceof Error ? e.message : String(e);
+		}
+		expect(caughtMessage).not.toMatch(/timed out after/);
+	});
 });

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -3398,4 +3398,134 @@ describe("malformed tool call input", () => {
       expect(callCount).toBe(1);
     });
   });
+
+  describe("cancellation via config.signal", () => {
+    it("aborts the loop between iterations when config.signal fires after a tool call", async () => {
+      // Regression for the orphan-and-write bug: before this PR, the
+      // engine only forwarded `config.signal` to `tools.execute`. A
+      // run whose signal aborted mid-flight would let the current tool
+      // call honor it (good) but still proceed to the NEXT LLM call,
+      // wasting a model round-trip and generating downstream tool
+      // calls the caller no longer wants. The fix is a check at the
+      // top of every iteration; this test exercises that check
+      // end-to-end.
+      const controller = new AbortController();
+      let modelCalls = 0;
+      const model = createMockModel(() => {
+        modelCalls++;
+        // Iteration 1: return a tool call.
+        if (modelCalls === 1) {
+          return {
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call_1",
+                toolName: "test__noop",
+                input: JSON.stringify({}),
+              },
+            ],
+            inputTokens: 10,
+            outputTokens: 5,
+          };
+        }
+        // Iteration 2 onward would yield text completion; but we
+        // should never reach this because the abort check at the top
+        // of iteration 2 throws first.
+        return {
+          content: [{ type: "text", text: "should not appear" }],
+          inputTokens: 10,
+          outputTokens: 5,
+        };
+      });
+
+      let toolCallCount = 0;
+      const engine = makeEngine(model, {
+        schemas: [
+          {
+            name: "test__noop",
+            description: "noop",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+        handler: () => {
+          toolCallCount++;
+          // Fire the signal right after the tool finishes. The engine's
+          // iteration-boundary check should observe it before the next
+          // LLM call. (Aborting BEFORE the tool runs would surface as
+          // a tool-side abort; we deliberately abort post-tool to
+          // exercise the between-iteration check the PR added.)
+          controller.abort();
+          return { content: textContent("noop"), isError: false };
+        },
+      });
+
+      await expect(
+        engine.run(
+          { ...defaultConfig, signal: controller.signal },
+          "",
+          [{ role: "user", content: [{ type: "text", text: "go" }] }],
+          [],
+        ),
+      ).rejects.toMatchObject({ name: "AbortError" });
+
+      // Iteration 1 ran (model called once, tool called once) but
+      // iteration 2's LLM call did NOT — the abort check stopped the
+      // loop before the next round-trip.
+      expect(modelCalls).toBe(1);
+      expect(toolCallCount).toBe(1);
+    });
+
+    it("throws immediately when signal is already aborted on entry", async () => {
+      // Pre-aborted signals should fail-fast on the first iteration's
+      // boundary check, before any model call. Important for the
+      // executor's cancellation contract: when the scheduler aborts a
+      // run before it really starts, no LLM spend should accrue.
+      const controller = new AbortController();
+      controller.abort();
+
+      let modelCalls = 0;
+      const model = createMockModel(() => {
+        modelCalls++;
+        return {
+          content: [{ type: "text", text: "should not run" }],
+          inputTokens: 10,
+          outputTokens: 5,
+        };
+      });
+      const engine = makeEngine(model);
+
+      await expect(
+        engine.run(
+          { ...defaultConfig, signal: controller.signal },
+          "",
+          [{ role: "user", content: [{ type: "text", text: "go" }] }],
+          [],
+        ),
+      ).rejects.toMatchObject({ name: "AbortError" });
+
+      expect(modelCalls).toBe(0);
+    });
+
+    it("propagates a custom abort reason as the thrown error", async () => {
+      // When the executor aborts with a specific Error (e.g. timeout),
+      // the engine surfaces that reason through the throw — so the
+      // scheduler can classify the failure correctly (timeout vs
+      // generic cancel). Drift here would silently collapse all
+      // cancellations into the same status.
+      const controller = new AbortController();
+      const customReason = new Error("Automation foo timed out after 600s");
+      controller.abort(customReason);
+
+      const engine = makeEngine();
+
+      await expect(
+        engine.run(
+          { ...defaultConfig, signal: controller.signal },
+          "",
+          [{ role: "user", content: [{ type: "text", text: "go" }] }],
+          [],
+        ),
+      ).rejects.toThrow(/timed out after 600s/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes the architectural bug the #245 review missed and the production logs proved: \`runtime.chat()\` couldn't be cancelled. Callers racing the chat against an external deadline orphaned the in-flight LLM/tool work; the chat ran to completion in the background, wrote a full conversation to disk minutes after the executor had already synthesized a fake "timeout" run record, and the result was silently discarded.

## Production evidence

From \`ws_nimblebrain_shared\` (image \`5e20637\`, pre-#245):

| Run | Actual duration | Budget | Recorded status |
|---|---|---|---|
| 5/15 \`conv_7e7b5ad4ce7b4b4e\` | 6m 36s | 5m | cancelled |
| 5/15 \`conv_eaaf398ce9af4768\` | 7m 25s | 5m | timeout |
| 5/16 \`conv_abc9563a17d448f4\` | 6m 08s | 5m | timeout |

Every conversation ended \`stopReason: complete\` — the work actually happened. The "timeout" / "cancelled" run records were lies the scheduler synthesized while the executor's \`Promise.race\` had already returned.

## What this PR ships

1. **\`ChatRequest.signal?: AbortSignal\`** — the missing field.
2. **\`Runtime.chat\` → \`EngineConfig.signal\`** — populated from the request. (Engine already had the field; it just wasn't being set by the runtime.)
3. **\`engine.run\` checks \`config.signal.aborted\` at the top of every iteration.** The engine was already forwarding the signal into \`tools.execute\` — the gap was the loop itself.
4. **\`/v1/chat\` and \`/v1/chat/stream\` handlers thread \`request.signal\`** into \`runtime.chat\` — client disconnect now cancels engine work.
5. **\`createDirectExecutor\` ditches \`Promise.race\`** in favor of a combined \`AbortController\` (timeout OR external abort) whose signal threads into chatFn. When the budget fires, the chat aborts cooperatively instead of being orphaned.

## What this does NOT fix

The synthesized run record on cancel/timeout still has \`iterations: 0, toolCalls: 0, inputTokens: 0\` — the executor's catch path doesn't have the partial result data. Solving that requires \`runtime.chat()\` to return PARTIAL data on cancellation. Bigger change; flagged for follow-up.

## Companion operator change (already applied)

\`morning-brief-6am-pt\`'s \`maxRunDurationMs\` bumped 300000 → 600000 (5m → 10m) directly in production \`automations.json\`. Empirically the runs take 6-7m; 10m gives ~35% headroom for variance without masking real hangs. With this PR deployed, a run that actually overshoots 10m will cleanly cancel instead of orphan-and-write.

## Testing

- [x] \`bun run verify:static\` clean (format, lint, typecheck, cycles, codegen)
- [x] \`bun run test:unit\` — 2973 pass (2 new regression tests)
  - \`createDirectExecutor: forwards a combined signal into chatFn so timeouts cancel in-flight chat work\`
  - \`createDirectExecutor: external cancel propagates into chatFn signal as AbortError\`
- [x] \`bun test test/integration/automation-e2e.test.ts\` — 5 pass
- [ ] After deploy: verify next \`morning-brief-6am-pt\` cron fire either (a) completes inside the new 10m budget with a real run record, or (b) cleanly aborts and the conversation reflects the cancellation rather than completing in the background

## Not done in this PR (deferred to follow-up)

- **In-flight LLM stream cancellation.** `callModel` → `model.doStream` doesn't accept an `AbortSignal`, so a long-running LLM stream blocks the engine until completion before the next iteration's abort check fires. For tool-call-dominated runs (the morning-brief case) the gap is small; for long completions / reasoning-heavy runs it's a real cancellation lag. Plumbing `signal` through `callModel` to `doStream({ abortSignal })` is its own architectural change to the LLM streaming path — separate PR. The new iteration-boundary check in `engine.ts` has a comment naming the gap so the next reader of cancellation behavior doesn't have to rediscover it.
- **End-to-end HTTP cancellation integration test.** Wanted to add one for the `/v1/chat` client-disconnect path. Meaningful coverage needs either custom-tool registration the test infra doesn't expose cleanly, or the LLM-signal threading above. The HTTP wiring (`signal: request.signal` in both handler paths) is two lines and unit-tested via the engine + executor coverage; revisit once the LLM-signal piece lands.
