### PR TITLE
feat(engine): forward signal as abortSignal into model.doStream

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -540,39 +540,48 @@ export class AgentEngine {
         const callProviderOptions = buildThinkingProviderOptions(config.model, config.thinking);
 
         const callOnce = (msgs: LanguageModelV3Message[]) =>
-          withRetry(() =>
-            callModel(
-              this.model,
-              {
-                prompt: [
-                  {
-                    role: "system",
-                    content: callPrompt,
-                    providerOptions: {
-                      anthropic: { cacheControl: { type: "ephemeral" } },
+          withRetry(
+            () =>
+              callModel(
+                this.model,
+                {
+                  prompt: [
+                    {
+                      role: "system",
+                      content: callPrompt,
+                      providerOptions: {
+                        anthropic: { cacheControl: { type: "ephemeral" } },
+                      },
                     },
-                  },
-                  ...addCacheBreakpoint(msgs),
-                ],
-                tools: modelTools,
-                maxOutputTokens: config.maxOutputTokens,
-                // Forward the run-scoped signal into the model call. AI
-                // SDK V3 providers honor `abortSignal` by aborting the
-                // underlying fetch, so an in-flight stream cancels at
-                // the network layer instead of blocking the engine
-                // until the model finishes. Pairs with the iteration-
-                // boundary check above: that handles between-step
-                // cancellation, this handles in-step.
-                ...(config.signal ? { abortSignal: config.signal } : {}),
-                ...(Object.keys(callProviderOptions).length > 0
-                  ? { providerOptions: callProviderOptions }
-                  : {}),
-              },
-              (text) => this.events.emit({ type: "text.delta", data: { runId, text } }),
-              (text) => this.events.emit({ type: "reasoning.delta", data: { runId, text } }),
-              (id, name) => this.events.emit({ type: "tool.preparing", data: { runId, id, name } }),
-              (id) => this.events.emit({ type: "tool.preparing.done", data: { runId, id } }),
-            ),
+                    ...addCacheBreakpoint(msgs),
+                  ],
+                  tools: modelTools,
+                  maxOutputTokens: config.maxOutputTokens,
+                  // Forward the run-scoped signal into the model call. AI
+                  // SDK V3 providers honor `abortSignal` by aborting the
+                  // underlying fetch, so an in-flight stream cancels at
+                  // the network layer instead of blocking the engine
+                  // until the model finishes. Pairs with the iteration-
+                  // boundary check above: that handles between-step
+                  // cancellation, this handles in-step.
+                  ...(config.signal ? { abortSignal: config.signal } : {}),
+                  ...(Object.keys(callProviderOptions).length > 0
+                    ? { providerOptions: callProviderOptions }
+                    : {}),
+                },
+                (text) => this.events.emit({ type: "text.delta", data: { runId, text } }),
+                (text) => this.events.emit({ type: "reasoning.delta", data: { runId, text } }),
+                (id, name) =>
+                  this.events.emit({ type: "tool.preparing", data: { runId, id, name } }),
+                (id) => this.events.emit({ type: "tool.preparing.done", data: { runId, id } }),
+              ),
+            // Defaults preserved; only the new fourth arg matters here.
+            // The retry backoff sleep aborts on `config.signal` so a
+            // cancel during backoff bites within the abort tick instead
+            // of after the full delay (up to ~8.5s on attempt 3).
+            3,
+            1000,
+            config.signal,
           );
 
         const llmStart = performance.now();

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -468,26 +468,26 @@ export class AgentEngine {
     const unregisterToolControls = config.toolPromotion?.registerControls(toolControls);
     try {
       while (iteration < maxIter) {
-        // Cancellation check at the top of every iteration. The signal is
-        // already threaded to `tools.execute` so an in-flight tool call
-        // can honor it, but without checking here the engine would
-        // proceed to the NEXT LLM call after a cancelled tool — wasting
-        // a model round-trip and continuing to generate downstream tool
-        // calls the caller no longer wants. Cooperative cancellation:
-        // we don't preempt the current tool, but we don't start new work
-        // either. The runtime catch translates AbortError into the
-        // appropriate `run.error` event for SSE consumers.
+        // Cancellation check at the top of every iteration. Three signal
+        // propagation paths now cover the full agent loop:
         //
-        // Gap acknowledged: an IN-FLIGHT LLM stream (`callModel` →
-        // `model.doStream`) is not signal-aware. The current step
-        // through this check blocks on the stream until it completes
-        // before the next iteration's abort check fires. For tool-call-
-        // dominated runs (the morning-brief case this fix targets) the
-        // gap is small. For long completions / reasoning-heavy runs
-        // it's a real cancellation lag — fix is to plumb `signal`
-        // through `callModel` to `model.doStream({ abortSignal })`,
-        // tracked separately so this PR stays scoped to the
-        // architectural plumbing.
+        //   1. THIS check — between iterations. Catches a cancel that
+        //      fires during a tool call (e.g. an external timeout that
+        //      fires mid-tool); without it, the engine would proceed to
+        //      the next LLM round-trip after the cancelled tool.
+        //   2. `tools.execute(call, config.signal)` — in-flight tool.
+        //      Task-augmented MCP tools get `tasks/cancel`; inline ones
+        //      abort their RPC.
+        //   3. `callModel(..., { abortSignal: config.signal })` below —
+        //      in-flight LLM stream. The provider aborts the underlying
+        //      fetch on signal, so a long completion or reasoning-heavy
+        //      run cancels at the network layer instead of blocking
+        //      until the model finishes.
+        //
+        // Cooperative throughout: we never preempt running work, just
+        // stop starting new work. The runtime catch translates the
+        // thrown AbortError into the appropriate `run.error` event for
+        // SSE consumers.
         if (config.signal?.aborted) {
           throw config.signal.reason instanceof Error
             ? config.signal.reason
@@ -556,6 +556,14 @@ export class AgentEngine {
                 ],
                 tools: modelTools,
                 maxOutputTokens: config.maxOutputTokens,
+                // Forward the run-scoped signal into the model call. AI
+                // SDK V3 providers honor `abortSignal` by aborting the
+                // underlying fetch, so an in-flight stream cancels at
+                // the network layer instead of blocking the engine
+                // until the model finishes. Pairs with the iteration-
+                // boundary check above: that handles between-step
+                // cancellation, this handles in-step.
+                ...(config.signal ? { abortSignal: config.signal } : {}),
                 ...(Object.keys(callProviderOptions).length > 0
                   ? { providerOptions: callProviderOptions }
                   : {}),

--- a/src/engine/retry.ts
+++ b/src/engine/retry.ts
@@ -19,17 +19,52 @@ export function isRetryable(err: unknown): boolean {
 }
 
 /**
+ * Sleep that resolves after `ms` or rejects when `signal` aborts —
+ * whichever fires first. Used by `withRetry` so a cancel during the
+ * backoff window doesn't have to wait the full delay (up to ~8.5s on
+ * attempt 3) for the signal to bite. Pre-aborted signal rejects
+ * synchronously without arming a timer.
+ */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const reasonError = (): Error =>
+      signal?.reason instanceof Error
+        ? signal.reason
+        : new DOMException("The operation was aborted.", "AbortError");
+    if (signal?.aborted) {
+      reject(reasonError());
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(reasonError());
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
  * Retry wrapper with exponential backoff and jitter.
  *
  * - Retries on 429 (rate limit) and 529 (overload).
  * - Fails immediately on 401 (auth) with a clear message.
  * - Fails immediately on all other errors.
  * - Backoff: baseDelay * 2^attempt + random(0, 500ms).
+ * - Optional `signal` interrupts the backoff sleep so a cancel during
+ *   backoff bites within the abort tick instead of after the full
+ *   delay. The signal also propagates into `fn()` calls if those
+ *   honor it (the engine threads `config.signal` to AI SDK
+ *   `doStream({ abortSignal })`).
  */
 export async function withRetry<T>(
   fn: () => Promise<T>,
   maxRetries = 3,
   baseDelayMs = 1000,
+  signal?: AbortSignal,
 ): Promise<T> {
   for (let attempt = 0; ; attempt++) {
     try {
@@ -46,7 +81,7 @@ export async function withRetry<T>(
       }
 
       const delay = baseDelayMs * 2 ** attempt + Math.random() * 500;
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await abortableSleep(delay, signal);
     }
   }
 }

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -3506,6 +3506,61 @@ describe("malformed tool call input", () => {
       expect(modelCalls).toBe(0);
     });
 
+    it("forwards config.signal as abortSignal into model.doStream", async () => {
+      // Regression for the in-flight LLM stream cancellation gap: a
+      // signal threaded through `config.signal` must reach the model
+      // call as `options.abortSignal`, or AI SDK providers can't
+      // abort the underlying fetch and a long completion blocks the
+      // engine until the model finishes.
+      const controller = new AbortController();
+      let receivedSignal: AbortSignal | undefined;
+      const model = createMockModel((options) => {
+        receivedSignal = options.abortSignal;
+        return {
+          content: [{ type: "text", text: "ok" }],
+          inputTokens: 5,
+          outputTokens: 5,
+        };
+      });
+      const engine = makeEngine(model);
+
+      await engine.run(
+        { ...defaultConfig, signal: controller.signal },
+        "",
+        [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        [],
+      );
+
+      expect(receivedSignal).toBe(controller.signal);
+    });
+
+    it("omits abortSignal from doStream options when config.signal is undefined", async () => {
+      // Symmetric check: don't synthesize an empty signal when the
+      // caller didn't pass one. Providers behave differently on
+      // `abortSignal: undefined` vs the field being absent; keep
+      // the shape clean.
+      let optionsSeen: { abortSignal?: AbortSignal } | undefined;
+      const model = createMockModel((options) => {
+        optionsSeen = options;
+        return {
+          content: [{ type: "text", text: "ok" }],
+          inputTokens: 5,
+          outputTokens: 5,
+        };
+      });
+      const engine = makeEngine(model);
+
+      await engine.run(
+        defaultConfig,
+        "",
+        [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        [],
+      );
+
+      expect(optionsSeen).toBeDefined();
+      expect("abortSignal" in (optionsSeen ?? {})).toBe(false);
+    });
+
     it("propagates a custom abort reason as the thrown error", async () => {
       // When the executor aborts with a specific Error (e.g. timeout),
       // the engine surfaces that reason through the throw — so the

--- a/test/unit/retry.test.ts
+++ b/test/unit/retry.test.ts
@@ -118,4 +118,67 @@ describe("withRetry", () => {
     ).rejects.toThrow(err);
     expect(calls).toBe(1);
   });
+
+  it("interrupts backoff when signal aborts mid-sleep", async () => {
+    // Pre-existing gap closed: if the signal aborted during the
+    // backoff window, the engine had to wait the full delay (up to
+    // ~8.5s on attempt 3) before the next retry attempt observed
+    // the abort. Now the sleep is abort-aware — cancellation bites
+    // within the abort tick.
+    const controller = new AbortController();
+    let calls = 0;
+    const err = { status: 429 };
+    const start = Date.now();
+
+    const runPromise = withRetry(
+      async () => {
+        calls++;
+        throw err;
+      },
+      3,
+      // 5-second base delay — without the abort, attempt 1's
+      // backoff alone would block this test for 5s+.
+      5_000,
+      controller.signal,
+    );
+
+    // Let attempt 1 fail and the backoff timer arm.
+    await new Promise((r) => setTimeout(r, 20));
+    controller.abort();
+
+    await expect(runPromise).rejects.toMatchObject({ name: "AbortError" });
+
+    const elapsed = Date.now() - start;
+    // Way under the 5-second backoff that would have held us
+    // without the abort. A generous ceiling that still catches
+    // any regression to "wait the full delay first".
+    expect(elapsed).toBeLessThan(500);
+    // Exactly one attempt fired before the abort interrupted backoff.
+    expect(calls).toBe(1);
+  });
+
+  it("rejects synchronously when called with a pre-aborted signal during backoff", async () => {
+    // Symmetric coverage: a signal that's already aborted when the
+    // backoff sleep starts must reject immediately, not arm a timer
+    // it then has to clean up. Matters for the engine's iteration
+    // path where the abort may have fired during the prior attempt.
+    const controller = new AbortController();
+    let calls = 0;
+    const err = { status: 429 };
+
+    const fn = async () => {
+      calls++;
+      // Abort BEFORE we throw — backoff observes a pre-aborted
+      // signal when it tries to sleep.
+      if (calls === 1) controller.abort();
+      throw err;
+    };
+
+    const start = Date.now();
+    await expect(withRetry(fn, 3, 5_000, controller.signal)).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    expect(Date.now() - start).toBeLessThan(100);
+    expect(calls).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the cancellation gap acknowledged in [#251](https://github.com/NimbleBrainInc/nimblebrain/pull/251): an in-flight LLM stream blocked the engine until the model finished regardless of signal state. The iteration-boundary check fired only AFTER the stream completed, so a 30-second completion couldn't be interrupted even if the caller had already aborted.

## The fix

One field forwarded into \`callModel\`'s \`LanguageModelV3CallOptions\`:

\`\`\`ts
...(config.signal ? { abortSignal: config.signal } : {}),
\`\`\`

AI SDK V3's \`LanguageModelV3CallOptions.abortSignal\` is the canonical field — every V3 provider aborts the underlying fetch when it fires, so a long completion or reasoning-heavy stream cancels at the network layer instead of blocking the engine.

## The triangle is now closed

\`runtime.chat()\` cancellation now propagates along three independent paths:

| # | Path | PR |
|---|---|---|
| 1 | Iteration boundary — next LLM call doesn't start | #251 |
| 2 | Tool execution — in-flight tool aborts via \`tasks/cancel\` (task-augmented) or RPC abort (inline) | #245, #251 |
| 3 | LLM stream — in-flight \`model.doStream\` aborts via provider fetch | **THIS PR** |

Cooperative throughout: running work isn't preempted, but new work doesn't start. Comment at the iteration-boundary check in \`engine.ts\` updated to reflect the full picture (the comment flagging the gap in #251 is now replaced).

## Why omit instead of pass undefined

The omission guard (\`config.signal ? {...} : {}\`) matters because AI SDK providers behave differently on \`abortSignal: undefined\` vs the field being absent. A regression test pins this contract so a future refactor that drops the omission breaks loudly instead of silently changing provider behavior on no-signal runs.

## Testing

- [x] \`bun run verify:static\` clean (format, lint, typecheck, cycles, codegen)
- [x] \`bun run test:unit\` — 2979 pass (2 new)
  - \`forwards config.signal as abortSignal into model.doStream\` — the load-bearing assertion
  - \`omits abortSignal from doStream options when config.signal is undefined\` — pins the omission contract

## Operational impact

This change lights up cancellation for the workloads #251 explicitly flagged as still-blocking: long completions (large outputs), reasoning models, and any agent run that spends significant wall-clock time in a single LLM round-trip. Combined with #251 + the production \`maxRunDurationMs\` bump, a morning-brief-style automation that overshoots its budget now cancels cleanly across all three paths instead of orphaning work.

---

## Follow-up included (per #252 review)

A second commit on this branch closes the retry-backoff gap the reviewer flagged: a cancel that fires during the exponential-backoff sleep used to wait the full delay (up to ~8.5s on attempt 3) before the next retry attempt observed the abort. Now the sleep races the timer against the abort listener; whichever fires first wins. Pre-aborted signals reject synchronously without arming a timer.

The cancellation triangle is now genuinely tight: there is no path through the agent loop where an aborted signal sits idle for more than an abort-listener tick.

Adds 2 more regression tests in `test/unit/retry.test.ts`. Total: 2981 unit tests pass.
