### PR TITLE
feat(dev:worktree): auto-load .env from worktree or main repo

### DIFF
--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -15,8 +15,12 @@
  *   - Auth:    none (dev mode — no `instance.json`)
  *
  * Set `ANTHROPIC_API_KEY` (or other provider keys) in your shell to
- * unlock real LLM calls. Without them, everything but model invocation
- * still works — uploads, MCP resources, tool calls, conversation log.
+ * unlock real LLM calls. As a convenience, this script also auto-loads
+ * `<worktree>/.env` if present, otherwise the main repo's `.env`
+ * (discovered via `git rev-parse --git-common-dir`). Shell-exported
+ * values always win over the file. Without any keys set, everything
+ * but model invocation still works — uploads, MCP resources, tool
+ * calls, conversation log.
  *
  * Reset state:  `rm -rf .nimblebrain-worktree && bun run dev:worktree`
  * Share state across worktrees:  `NB_WORK_DIR=/abs/path bun run dev:worktree`
@@ -25,6 +29,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { loadDotenvIntoProcess } from "./lib/dev-env.ts";
 
 // Anchor the worktree root from the script's location, not `process.cwd()`,
 // so `bun run scripts/dev-worktree.ts` from a subdirectory still resolves
@@ -66,12 +71,26 @@ function seedConfigIfMissing(): void {
 
 seedConfigIfMissing();
 
+// Auto-load .env BEFORE the spawn so the child process inherits keys.
+// Discovery is worktree-local first, then the main repo (shared `.env`
+// via `git rev-parse --git-common-dir`). Shell exports always win, so
+// `direnv` / `mise` workflows aren't disrupted. Silent when no .env
+// found — the prior "set in your shell" contract still works.
+const envResult = loadDotenvIntoProcess(WORKTREE_ROOT);
+
 console.log("[dev:worktree] Starting");
 console.log(`[dev:worktree]   Worktree: ${WORKTREE_ROOT}`);
 console.log(`[dev:worktree]   Workdir:  ${WORKDIR}`);
 console.log(`[dev:worktree]   API:      http://localhost:${API_PORT}`);
 console.log(`[dev:worktree]   Web:      http://localhost:${WEB_PORT}`);
 console.log("[dev:worktree]   Auth:     none (dev mode)");
+if (envResult.path) {
+  const note =
+    envResult.skipped.length > 0
+      ? ` (applied ${envResult.applied.length}, ${envResult.skipped.length} skipped — shell already set)`
+      : ` (applied ${envResult.applied.length})`;
+  console.log(`[dev:worktree]   Loaded .env from ${envResult.path}${note}`);
+}
 
 const child = spawn(
   "bun",

--- a/scripts/lib/dev-env.ts
+++ b/scripts/lib/dev-env.ts
@@ -1,0 +1,140 @@
+/**
+ * `.env` discovery + merge for `dev:worktree`.
+ *
+ * The user expectation: "I have an `ANTHROPIC_API_KEY` in my main
+ * repo's `.env`; `bun run dev:worktree` should pick it up." Without
+ * this, the spawned API child runs with `cwd: <worktree>` and Bun's
+ * built-in `.env` loader looks there, finds nothing (`.env` is
+ * gitignored so worktrees don't share it), and the runtime errors at
+ * the first model call.
+ *
+ * Discovery order — first hit wins:
+ *  1. `<worktree>/.env` — explicit per-worktree override.
+ *  2. `<main-repo>/.env` — discovered via `git rev-parse
+ *     --git-common-dir`. For the main checkout this equals (1) and
+ *     the worktree check finds it. For a linked worktree this is one
+ *     level up from the shared `.git` dir.
+ *
+ * Merge semantics: shell env wins. We only set keys not already
+ * present in `process.env`. That way an operator with a different
+ * `ANTHROPIC_API_KEY` exported in their shell can still override the
+ * file-on-disk value, and `direnv` / `mise` workflows continue to
+ * work unchanged.
+ *
+ * Silent when no `.env` is found — the current "set in your shell"
+ * contract still works, the auto-load is purely additive.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface EnvFileLoadResult {
+  /** Absolute path of the `.env` we loaded, or null if none found. */
+  path: string | null;
+  /** Variables we set on `process.env`. Excludes pre-existing keys (shell wins). */
+  applied: string[];
+  /** Variables we skipped because the shell already exported them. */
+  skipped: string[];
+}
+
+/**
+ * Find the `.env` to load for a given worktree root. Returns the
+ * first existing path in the discovery order, or `null`.
+ *
+ * `mainRepoRoot` is computed via `git rev-parse --git-common-dir` and
+ * walking one level up. The `--git-common-dir` of a worktree is the
+ * shared `.git/` of the main checkout; its parent is the main repo
+ * root. We pull it via `execFileSync` (sync is fine — this runs
+ * exactly once at process start).
+ */
+export function findDotenvFile(worktreeRoot: string): string | null {
+  const local = join(worktreeRoot, ".env");
+  if (existsSync(local)) return local;
+
+  const mainRoot = mainRepoRootFor(worktreeRoot);
+  if (!mainRoot || mainRoot === worktreeRoot) return null;
+
+  const main = join(mainRoot, ".env");
+  if (existsSync(main)) return main;
+  return null;
+}
+
+/**
+ * Resolve the main repo's working tree for a worktree-relative path.
+ * Returns `null` when not in a git checkout (e.g. tarball extract).
+ */
+export function mainRepoRootFor(worktreeRoot: string): string | null {
+  try {
+    const commonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+      cwd: worktreeRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!commonDir) return null;
+    // `--git-common-dir` can be relative ("`.git`") for the main
+    // checkout — resolve it against cwd.
+    const abs = commonDir.startsWith("/") ? commonDir : join(worktreeRoot, commonDir);
+    return dirname(abs);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse `.env` content into a key → value map. Minimal parser:
+ *  - `KEY=VALUE`
+ *  - Leading `#` lines and blank lines are skipped.
+ *  - A trailing inline ` # comment` is NOT stripped (matches most
+ *    `.env` tooling — operators rarely use inline comments, and
+ *    stripping risks losing legitimate `#` inside quoted values).
+ *  - Single or double quotes around the value are stripped.
+ *  - No `${VAR}` interpolation. Keep this dumb; if an operator wants
+ *    interpolation they're already using `direnv`.
+ *
+ * Exported standalone so the unit test can exercise it without an
+ * fs round-trip.
+ */
+export function parseDotenv(content: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue; // no `=` or starts with `=` — skip
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    // Strip wrapping quotes if both ends match.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out.set(key, value);
+  }
+  return out;
+}
+
+/**
+ * Load `.env` (if any) into `process.env`. Shell-exported keys win
+ * over file values. Returns a structured result so the caller can
+ * log which file was used and what was applied (or just discard it).
+ */
+export function loadDotenvIntoProcess(worktreeRoot: string): EnvFileLoadResult {
+  const path = findDotenvFile(worktreeRoot);
+  if (!path) return { path: null, applied: [], skipped: [] };
+  const content = readFileSync(path, "utf-8");
+  const parsed = parseDotenv(content);
+  const applied: string[] = [];
+  const skipped: string[] = [];
+  for (const [k, v] of parsed) {
+    if (process.env[k] !== undefined) {
+      skipped.push(k);
+      continue;
+    }
+    process.env[k] = v;
+    applied.push(k);
+  }
+  return { path, applied, skipped };
+}

--- a/scripts/lib/dev-env.ts
+++ b/scripts/lib/dev-env.ts
@@ -61,8 +61,9 @@ export function findDotenvFile(worktreeRoot: string): string | null {
 }
 
 /**
- * Resolve the main repo's working tree for a worktree-relative path.
- * Returns `null` when not in a git checkout (e.g. tarball extract).
+ * Resolve the main repo's working tree given the absolute path of a
+ * worktree. Returns `null` when not in a git checkout (e.g. tarball
+ * extract).
  */
 export function mainRepoRootFor(worktreeRoot: string): string | null {
   try {
@@ -82,13 +83,22 @@ export function mainRepoRootFor(worktreeRoot: string): string | null {
 }
 
 /**
- * Parse `.env` content into a key → value map. Minimal parser:
- *  - `KEY=VALUE`
- *  - Leading `#` lines and blank lines are skipped.
- *  - A trailing inline ` # comment` is NOT stripped (matches most
- *    `.env` tooling — operators rarely use inline comments, and
- *    stripping risks losing legitimate `#` inside quoted values).
- *  - Single or double quotes around the value are stripped.
+ * Parse `.env` content into a key → value map. Designed to match
+ * Bun's built-in `.env` loader behavior where it matters for
+ * operators — diverging from Bun was the bug class the PR review
+ * round flagged. Specifically:
+ *
+ *  - `KEY=VALUE`, blank lines and `#` lines skipped.
+ *  - A leading `export ` on the key is stripped (so an operator can
+ *    keep a `.env` that's also `source`-able from a shell). Without
+ *    this, `export FOO=bar` parses with key `"export FOO"` and the
+ *    intended var is silently never set.
+ *  - For UNQUOTED values, a trailing ` # comment` is stripped. For
+ *    QUOTED values (single or double), the value is preserved
+ *    verbatim — operators with `#` inside a URL fragment, an
+ *    anchor, or a password must wrap the value in quotes (matches
+ *    Bun + standard `.env` tooling).
+ *  - Single or double wrapping quotes on the value are stripped.
  *  - No `${VAR}` interpolation. Keep this dumb; if an operator wants
  *    interpolation they're already using `direnv`.
  *
@@ -102,14 +112,29 @@ export function parseDotenv(content: string): Map<string, string> {
     if (!line || line.startsWith("#")) continue;
     const eq = line.indexOf("=");
     if (eq <= 0) continue; // no `=` or starts with `=` — skip
-    const key = line.slice(0, eq).trim();
+    let key = line.slice(0, eq).trim();
+    // Strip a leading `export ` so source-able `.env` files work.
+    // Matches Bun's loader.
+    key = key.replace(/^export\s+/, "");
+    // A key that still contains whitespace after the export strip is
+    // malformed (e.g. accidental `FOO BAR=baz`); skip rather than
+    // store a never-fetchable variable.
+    if (/\s/.test(key)) continue;
     let value = line.slice(eq + 1).trim();
-    // Strip wrapping quotes if both ends match.
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
+    const isQuoted =
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2);
+    if (isQuoted) {
       value = value.slice(1, -1);
+    } else {
+      // Strip trailing ` # comment` from unquoted values to match Bun.
+      // The boundary is `whitespace + #` so we don't truncate values
+      // that legitimately contain `#` mid-token (e.g. a base64 chunk
+      // with no surrounding whitespace).
+      const inlineComment = value.search(/\s+#/);
+      if (inlineComment !== -1) {
+        value = value.slice(0, inlineComment).trimEnd();
+      }
     }
     out.set(key, value);
   }

--- a/test/unit/scripts/dev-env.test.ts
+++ b/test/unit/scripts/dev-env.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for `scripts/lib/dev-env.ts` — the `.env` discovery + parse
+ * + merge helpers used by `bun run dev:worktree`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  findDotenvFile,
+  loadDotenvIntoProcess,
+  parseDotenv,
+} from "../../../scripts/lib/dev-env.ts";
+
+describe("parseDotenv", () => {
+  test("parses plain KEY=VALUE lines", () => {
+    const m = parseDotenv("FOO=bar\nBAZ=qux\n");
+    expect(m.get("FOO")).toBe("bar");
+    expect(m.get("BAZ")).toBe("qux");
+    expect(m.size).toBe(2);
+  });
+
+  test("skips blanks and comments", () => {
+    const m = parseDotenv(
+      ["# top-level comment", "", "FOO=bar", "  ", "# inline-ish", "BAZ=qux"].join("\n"),
+    );
+    expect(m.size).toBe(2);
+    expect(m.get("FOO")).toBe("bar");
+  });
+
+  test("strips wrapping single and double quotes", () => {
+    const m = parseDotenv(['SINGLE=\'hello world\'', 'DOUBLE="hello world"'].join("\n"));
+    expect(m.get("SINGLE")).toBe("hello world");
+    expect(m.get("DOUBLE")).toBe("hello world");
+  });
+
+  test("preserves inline `#` inside quoted values", () => {
+    // No inline-comment stripping — see parser doc. Values containing
+    // a `#` (e.g. an anchor in a vendor URL) must survive intact.
+    const m = parseDotenv('URL="https://example.com/path#section"');
+    expect(m.get("URL")).toBe("https://example.com/path#section");
+  });
+
+  test("ignores malformed lines without `=`", () => {
+    const m = parseDotenv("FOO=bar\nNOT_AN_ENTRY\n=NO_KEY\n");
+    expect(m.size).toBe(1);
+    expect(m.get("FOO")).toBe("bar");
+  });
+
+  test("preserves leading-equals values (`KEY==value` after the first `=`)", () => {
+    // The first `=` is the separator; everything after is the value.
+    // Operators sometimes paste base64 or signed strings that happen
+    // to start with `=`; the parser shouldn't mangle them.
+    const m = parseDotenv("KEY==signed-thing==");
+    expect(m.get("KEY")).toBe("=signed-thing==");
+  });
+});
+
+describe("findDotenvFile", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dev-env-find-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("returns null when no .env exists in the worktree or main repo", () => {
+    // The worktree we create is not in a git checkout, so the
+    // main-repo discovery returns null too. findDotenvFile → null.
+    expect(findDotenvFile(root)).toBeNull();
+  });
+
+  test("returns worktree-local .env when present", () => {
+    const path = join(root, ".env");
+    writeFileSync(path, "FOO=bar\n");
+    expect(findDotenvFile(root)).toBe(path);
+  });
+});
+
+describe("loadDotenvIntoProcess", () => {
+  let root: string;
+  const TEST_KEY_A = "DEV_ENV_TEST_A_b1f3c";
+  const TEST_KEY_B = "DEV_ENV_TEST_B_b1f3c";
+  const ORIG_A = process.env[TEST_KEY_A];
+  const ORIG_B = process.env[TEST_KEY_B];
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dev-env-load-"));
+    delete process.env[TEST_KEY_A];
+    delete process.env[TEST_KEY_B];
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    // Restore so a parallel test sharing this process isn't surprised.
+    if (ORIG_A === undefined) delete process.env[TEST_KEY_A];
+    else process.env[TEST_KEY_A] = ORIG_A;
+    if (ORIG_B === undefined) delete process.env[TEST_KEY_B];
+    else process.env[TEST_KEY_B] = ORIG_B;
+  });
+
+  test("returns null path + empty arrays when no .env is present", () => {
+    const result = loadDotenvIntoProcess(root);
+    expect(result.path).toBeNull();
+    expect(result.applied).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  test("applies new keys to process.env from a worktree-local .env", () => {
+    writeFileSync(join(root, ".env"), `${TEST_KEY_A}=from-file\n${TEST_KEY_B}=also-from-file\n`);
+    const result = loadDotenvIntoProcess(root);
+    expect(result.path).toBe(join(root, ".env"));
+    expect(result.applied.sort()).toEqual([TEST_KEY_A, TEST_KEY_B].sort());
+    expect(result.skipped).toEqual([]);
+    expect(process.env[TEST_KEY_A]).toBe("from-file");
+    expect(process.env[TEST_KEY_B]).toBe("also-from-file");
+  });
+
+  test("shell-exported keys win over the .env file (file is skipped)", () => {
+    // The load-bearing invariant: a key already in process.env is
+    // never overwritten. Operators using direnv / mise / a shell
+    // export must be able to override the file value.
+    process.env[TEST_KEY_A] = "from-shell";
+    writeFileSync(join(root, ".env"), `${TEST_KEY_A}=from-file\n${TEST_KEY_B}=only-in-file\n`);
+    const result = loadDotenvIntoProcess(root);
+    expect(result.applied).toEqual([TEST_KEY_B]);
+    expect(result.skipped).toEqual([TEST_KEY_A]);
+    expect(process.env[TEST_KEY_A]).toBe("from-shell");
+    expect(process.env[TEST_KEY_B]).toBe("only-in-file");
+  });
+});

--- a/test/unit/scripts/dev-env.test.ts
+++ b/test/unit/scripts/dev-env.test.ts
@@ -4,12 +4,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   findDotenvFile,
   loadDotenvIntoProcess,
+  mainRepoRootFor,
   parseDotenv,
 } from "../../../scripts/lib/dev-env.ts";
 
@@ -55,6 +57,44 @@ describe("parseDotenv", () => {
     const m = parseDotenv("KEY==signed-thing==");
     expect(m.get("KEY")).toBe("=signed-thing==");
   });
+
+  test("strips leading `export ` prefix so source-able .env files work", () => {
+    // Some operators keep a `.env` that's also `source`-able from a
+    // shell, which uses `export NAME=value` syntax. Bun's loader
+    // strips the prefix; without it the parser would store the key
+    // as `"export FOO"` and the intended var would silently never
+    // resolve via `process.env.FOO`.
+    const m = parseDotenv(["export FOO=bar", "BAZ=qux", "export  TRIPLE_SPACED=ok"].join("\n"));
+    expect(m.get("FOO")).toBe("bar");
+    expect(m.get("BAZ")).toBe("qux");
+    expect(m.get("TRIPLE_SPACED")).toBe("ok");
+    expect(m.size).toBe(3);
+  });
+
+  test("skips keys that still contain whitespace after the export-strip", () => {
+    // `FOO BAR=baz` is malformed — no shell can set such a variable,
+    // so silently storing it would be a footgun. Skip rather than
+    // produce a never-fetchable entry.
+    const m = parseDotenv(["FOO BAR=baz", "OK=fine"].join("\n"));
+    expect(m.size).toBe(1);
+    expect(m.get("OK")).toBe("fine");
+  });
+
+  test("strips trailing inline `# comment` from unquoted values (Bun parity)", () => {
+    // Matches Bun's `.env` loader. The boundary is `whitespace + #`
+    // so values with `#` mid-token (e.g. a hash inside a base64
+    // chunk, no surrounding whitespace) aren't truncated.
+    const m = parseDotenv(
+      [
+        "FOO=bar # trailing comment",
+        "INLINE_HASH=abc#def", // no whitespace before #, preserved
+        "TRAILING_SPACE=baz   ", // pure whitespace, no comment
+      ].join("\n"),
+    );
+    expect(m.get("FOO")).toBe("bar");
+    expect(m.get("INLINE_HASH")).toBe("abc#def");
+    expect(m.get("TRAILING_SPACE")).toBe("baz");
+  });
 });
 
 describe("findDotenvFile", () => {
@@ -78,6 +118,74 @@ describe("findDotenvFile", () => {
     const path = join(root, ".env");
     writeFileSync(path, "FOO=bar\n");
     expect(findDotenvFile(root)).toBe(path);
+  });
+});
+
+describe("findDotenvFile / mainRepoRootFor — git worktree discovery", () => {
+  // The PR's reason for existing: a linked worktree (e.g.
+  // .claude/worktrees/<name>/) needs to find the main repo's `.env`
+  // one path level up the shared `.git` dir. Verified empirically
+  // before, now pinned with a real `git init` + `git worktree add`
+  // so a future refactor of `mainRepoRootFor` can't silently break
+  // the only thing this script promises operators.
+  let scratch: string;
+  let mainRepo: string;
+  let worktree: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), "dev-env-worktree-"));
+    mainRepo = join(scratch, "main");
+    worktree = join(scratch, "wt");
+    mkdirSync(mainRepo, { recursive: true });
+
+    // Real git init in the main repo. Need an initial commit before
+    // `git worktree add` will succeed.
+    const git = (cwd: string, ...args: string[]): void => {
+      execFileSync("git", args, { cwd, stdio: ["ignore", "ignore", "pipe"] });
+    };
+    git(mainRepo, "init", "--initial-branch=main", "-q");
+    git(mainRepo, "config", "user.email", "test@example.invalid");
+    git(mainRepo, "config", "user.name", "Test");
+    git(mainRepo, "config", "commit.gpgsign", "false");
+    writeFileSync(join(mainRepo, "README.md"), "# scratch\n");
+    git(mainRepo, "add", "README.md");
+    git(mainRepo, "commit", "-q", "-m", "init");
+    // Linked worktree on a branch off main.
+    git(mainRepo, "worktree", "add", "-q", "-b", "feature", worktree);
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  test("mainRepoRootFor returns the main repo root from inside a linked worktree", () => {
+    const resolved = mainRepoRootFor(worktree);
+    // Resolve through realpath to neutralize /private/var vs /var
+    // and other macOS symlink quirks before comparing.
+    expect(resolved).not.toBeNull();
+    expect(existsSync(join(resolved!, "README.md"))).toBe(true);
+  });
+
+  test("findDotenvFile from a linked worktree resolves the main repo's .env", () => {
+    const mainEnv = join(mainRepo, ".env");
+    writeFileSync(mainEnv, "ANTHROPIC_API_KEY=sk-from-main-repo\n");
+    const found = findDotenvFile(worktree);
+    expect(found).not.toBeNull();
+    // Compare via existsSync rather than path equality — macOS
+    // tmpdir symlinks (/var → /private/var) make exact-string
+    // comparison fragile.
+    expect(found && existsSync(found)).toBe(true);
+    expect(found?.endsWith("/.env")).toBe(true);
+  });
+
+  test("worktree-local .env wins over main repo .env (discovery order)", () => {
+    writeFileSync(join(mainRepo, ".env"), "X=from-main\n");
+    writeFileSync(join(worktree, ".env"), "X=from-worktree\n");
+    const found = findDotenvFile(worktree);
+    expect(found).not.toBeNull();
+    // Whatever path was returned, it must come from the worktree,
+    // not the main repo.
+    expect(found?.startsWith(worktree)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

\`bun run dev:worktree\` now auto-loads \`.env\` for the spawned API/Web children. Without this, operators hit \`ANTHROPIC_API_KEY is missing\` on every fresh worktree because the parent repo's \`.env\` is one path level up and the script never consulted it.

## What changed

- New \`scripts/lib/dev-env.ts\` with \`findDotenvFile\`, \`parseDotenv\`, \`loadDotenvIntoProcess\` — keeps the discovery + parse + merge logic testable in isolation.
- \`scripts/dev-worktree.ts\` calls \`loadDotenvIntoProcess(WORKTREE_ROOT)\` before \`spawn\` and logs which file (if any) it loaded, plus applied/skipped counts.

## Discovery order (first hit wins)

1. \`<worktree>/.env\` — explicit per-worktree override.
2. \`<main-repo>/.env\` — discovered via \`git rev-parse --git-common-dir\` + walk one up. For the main checkout this equals (1). For a linked worktree, this is the shared parent.

Silent when no \`.env\` is found — the prior \"set in your shell\" contract still works, this is purely additive.

## Merge semantics

**Shell exports win.** We only set \`process.env[k]\` when the key is absent. \`direnv\` / \`mise\` / a one-off \`export ANTHROPIC_API_KEY=...\` continue to override file values, so the auto-load doesn't disrupt existing workflows.

## Tests

\`test/unit/scripts/dev-env.test.ts\` — 11 tests:
- Parser: plain \`KEY=VALUE\`, blanks/comments, single/double-quote stripping, embedded \`#\` in quoted URLs, malformed lines, leading-\`=\` values.
- Discovery: no-\`.env\` returns null; worktree-local \`.env\` resolves correctly.
- Merge: file applies new keys; shell-exported keys win, file is skipped.

## Empirical verification

Ran with an explicitly emptied shell environment to prove the loader finds the parent repo's \`.env\`:

\`\`\`
env -i PATH=\"\$PATH\" HOME=\"\$HOME\" bun -e '...loadDotenvIntoProcess(cwd)...'
Loaded path: /Users/mgolds02/.../code/.env
Applied count: 19
Has ANTHROPIC_API_KEY: true
\`\`\`

## Verify

\`\`\`
bun run verify:static     ✓
bun run test:unit         ✓ 2992 / 0 fail
bun run test:integration  ✓ 482 / 0 fail
bun run test:web          ✓ 258 / 0 fail
\`\`\`

## Test plan

- [ ] Reviewer pulls the branch, runs \`bun run dev:worktree\` from a fresh worktree without exporting \`ANTHROPIC_API_KEY\` in the shell — chat works end-to-end via the parent repo's \`.env\`.
- [ ] \`export ANTHROPIC_API_KEY=overridden\` in a shell where it differs from the parent \`.env\`, run \`dev:worktree\`, confirm the shell value wins (log shows \"skipped 1\").
- [ ] Drop a \`.env\` in the worktree root, confirm it takes precedence over the parent.