### PR TITLE
fix(runtime): preserve OpenAI and Gemini reasoning replay

### DIFF
--- a/src/conversation/window.ts
+++ b/src/conversation/window.ts
@@ -120,6 +120,21 @@ export function stripOlderReasoning(messages: LanguageModelV3Message[]): Languag
 }
 
 /**
+ * Apply provider-specific replay policy for reasoning blocks.
+ *
+ * The historical stripping optimization is Anthropic-specific: older thinking
+ * signatures are safe to omit and otherwise grow the prompt quickly. OpenAI
+ * Responses API and Gemini can require reasoning/thought metadata to remain
+ * paired with replayed tool calls, so preserve those providers' history intact.
+ */
+export function applyReasoningReplayPolicy(
+  messages: LanguageModelV3Message[],
+  provider: string,
+): LanguageModelV3Message[] {
+  return provider === "anthropic" ? stripOlderReasoning(messages) : messages;
+}
+
+/**
  * Limit conversation history by message group count.
  * Keeps the first message (initial user request) plus the most recent
  * `maxGroups` message groups. Tool call/result pairs count as one group.

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -22,7 +22,11 @@ import type {
   ConversationStore,
   ParticipantInfo,
 } from "../conversation/types.ts";
-import { sliceHistory, stripOlderReasoning, windowMessages } from "../conversation/window.ts";
+import {
+  applyReasoningReplayPolicy,
+  sliceHistory,
+  windowMessages,
+} from "../conversation/window.ts";
 import { AgentEngine } from "../engine/engine.ts";
 import { estimateMessageTokens, estimateToolDescriptionTokens } from "../engine/token-estimate.ts";
 import type {
@@ -46,6 +50,7 @@ import { createIdentityProvider } from "../identity/provider.ts";
 import { DEV_IDENTITY } from "../identity/providers/dev.ts";
 import { UserStore } from "../identity/user.ts";
 import { InstructionsStore } from "../instructions/index.ts";
+import { getProviderFromModel } from "../model/catalog.ts";
 import { buildModelResolver, resolveModelString } from "../model/registry.ts";
 import { PermissionStore } from "../permissions/permission-store.ts";
 import type { Layer3SkillEntry, PromptAppInfo } from "../prompt/compose.ts";
@@ -963,9 +968,10 @@ export class Runtime {
 
     // Per-request hooks: inherit `beforeToolCall` from the runtime-level
     // hooks; compose `transformContext` here so the windowing budget is
-    // the one we just resolved for THIS call. The order (slice → strip
-    // older reasoning → window by token budget) is preserved.
+    // the one we just resolved for THIS call. The order (slice → apply
+    // provider replay policy → window by token budget) is preserved.
     const maxHistoryMessages = this.config.maxHistoryMessages ?? DEFAULT_MAX_HISTORY_MESSAGES;
+    const replayProvider = getProviderFromModel(resolvedModelString);
     const perRequestHooks: EngineHooks = {
       ...this.hooks,
       transformContext: (historyMessages, opts) => {
@@ -977,8 +983,8 @@ export class Runtime {
         const budget =
           attempt > 0 ? Math.floor(messageBudget.budget / (1 << attempt)) : messageBudget.budget;
         const sliced = sliceHistory(historyMessages, maxHistoryMessages);
-        const reasoningStripped = stripOlderReasoning(sliced);
-        return windowMessages(reasoningStripped, budget);
+        const replayReady = applyReasoningReplayPolicy(sliced, replayProvider);
+        return windowMessages(replayReady, budget);
       },
     };
 

--- a/test/unit/window.test.ts
+++ b/test/unit/window.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { LanguageModelV3Message } from "@ai-sdk/provider";
 import {
+	applyReasoningReplayPolicy,
 	sliceHistory,
 	stripOlderReasoning,
 	windowMessages,
@@ -458,5 +459,64 @@ describe("stripOlderReasoning", () => {
 		];
 		const result = stripOlderReasoning(msgs);
 		expect(result).toBe(msgs);
+	});
+});
+
+describe("applyReasoningReplayPolicy", () => {
+	const replayHistoryWithToolCall = (): LanguageModelV3Message[] => [
+		textMsg("user", "do something"),
+		{
+			role: "assistant",
+			content: [
+				{ type: "reasoning" as const, text: "considering options" },
+				{
+					type: "tool-call" as const,
+					toolCallId: "call_1",
+					toolName: "search",
+					input: { q: "x" },
+					providerOptions: {
+						google: { thoughtSignature: "opaque-signature" },
+					},
+				},
+			],
+		},
+		toolResultMsg("call_1"),
+		assistantWithReasoning("now reasoning again", "done"),
+	];
+
+	it("uses Anthropic's older-reasoning stripping policy", () => {
+		const msgs = replayHistoryWithToolCall();
+		const result = applyReasoningReplayPolicy(msgs, "anthropic");
+
+		expect(result[1]).toEqual({
+			role: "assistant",
+			content: [
+				{
+					type: "tool-call",
+					toolCallId: "call_1",
+					toolName: "search",
+					input: { q: "x" },
+					providerOptions: {
+						google: { thoughtSignature: "opaque-signature" },
+					},
+				},
+			],
+		});
+	});
+
+	it("preserves OpenAI reasoning paired with replayed tool calls", () => {
+		const msgs = replayHistoryWithToolCall();
+		const result = applyReasoningReplayPolicy(msgs, "openai");
+
+		expect(result).toBe(msgs);
+		expect(result[1]).toEqual(msgs[1]!);
+	});
+
+	it("preserves Gemini reasoning and thought metadata paired with replayed tool calls", () => {
+		const msgs = replayHistoryWithToolCall();
+		const result = applyReasoningReplayPolicy(msgs, "google");
+
+		expect(result).toBe(msgs);
+		expect(result[1]).toEqual(msgs[1]!);
 	});
 });


### PR DESCRIPTION
## Summary
[Fixes #257.](https://github.com/NimbleBrainInc/nimblebrain/issues/257)
OpenAI reasoning models can reject multi-tool replay when a prior `function_call` is replayed without its paired `reasoning` item. NimbleBrain was applying the older-reasoning stripping optimization globally, even though that behavior was only intended for Anthropic thinking/signature bloat.
This PR makes reasoning replay policy provider-aware:
- Anthropic keeps the existing older-reasoning stripping behavior.
- OpenAI preserves reasoning history so Responses API tool-call replay remains valid.
- Gemini preserves reasoning/thought metadata so replay-sensitive `thoughtSignature` data stays intact.
## Testing
- `bun test test/unit/window.test.ts`
- `bun run check`
- `bun run format:check`
- `bun run lint`