### PR TITLE
fix(tools): rank natural-language tool search

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -3,6 +3,7 @@ import { textContent } from "../engine/content-helpers.ts";
 import type { ToolCall, ToolResult, ToolRouter, ToolSchema } from "../engine/types.ts";
 import type { PermissionStore } from "../permissions/permission-store.ts";
 import type { McpSource } from "./mcp-source.ts";
+import { rankToolSearchResults } from "./search-ranking.ts";
 import type { Tool, ToolSource } from "./types.ts";
 
 /**
@@ -233,12 +234,10 @@ export class ToolRegistry implements ToolRouter {
     return source.execute(localName, call.input, signal);
   }
 
-  /** Search all tools by keyword (substring match on name + description). */
+  /** Search all tools by natural-language terms over name + description. */
   private async searchTools(query: string): Promise<Array<{ name: string; description: string }>> {
-    const q = query.toLowerCase();
     const all = await this.availableTools();
-    return all
-      .filter((t) => t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q))
+    return rankToolSearchResults(all, query)
       .slice(0, 5)
       .map((t) => ({ name: t.name, description: t.description }));
   }

--- a/src/tools/search-ranking.ts
+++ b/src/tools/search-ranking.ts
@@ -15,6 +15,12 @@ function tokenize(value: string): string[] {
     .filter(Boolean);
 }
 
+// Best-effort plural folding: a token longer than 3 chars ending in "s" also
+// matches its singular ("boards" → "board"). Applied symmetrically to both
+// query and corpus tokens, so an over-stripped junk variant ("status" →
+// "statu") only matches if some other real token stems to the same string —
+// which doesn't occur in the tool corpus. Intentionally naive; a real stemmer
+// isn't worth a dependency for discovery ranking.
 function tokenVariants(token: string): string[] {
   if (token.length > 3 && token.endsWith("s")) return [token, token.slice(0, -1)];
   return [token];
@@ -72,10 +78,12 @@ export function rankToolSearchResults<T extends ToolSearchResult>(tools: T[], qu
     }
 
     if (matchedTerms === 0 && !nameSubstringMatch && !descriptionSubstringMatch) continue;
-    const fullCoverage = matchedTerms === queryTerms.length;
-    score += matchedTerms * 1000;
-    if (fullCoverage) score += 500;
 
+    // `score` carries only the substring + per-term signal. Query-term
+    // *coverage* is the comparator's primary sort key (below), so it is
+    // deliberately not folded into `score` too — within any matchedTerms
+    // tie-group the coverage contribution is constant and cancels, so
+    // encoding it here would never change ordering.
     scored.push({ tool, score, matchedTerms });
   }
 

--- a/src/tools/search-ranking.ts
+++ b/src/tools/search-ranking.ts
@@ -1,0 +1,87 @@
+import type { ToolSchema } from "../engine/types.ts";
+
+export type ToolSearchResult = Pick<ToolSchema, "name" | "description">;
+
+interface ScoredTool<T extends ToolSearchResult> {
+  tool: T;
+  score: number;
+  matchedTerms: number;
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function tokenVariants(token: string): string[] {
+  if (token.length > 3 && token.endsWith("s")) return [token, token.slice(0, -1)];
+  return [token];
+}
+
+function tokenSet(value: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const token of tokenize(value)) {
+    for (const variant of tokenVariants(token)) tokens.add(variant);
+  }
+  return tokens;
+}
+
+function hasTerm(tokens: Set<string>, term: string): boolean {
+  for (const variant of tokenVariants(term)) {
+    if (tokens.has(variant)) return true;
+  }
+  return false;
+}
+
+/**
+ * Rank installed tools for natural-language discovery queries.
+ *
+ * Matching is deterministic and dependency-free: full-query substring matches
+ * still work, but multi-term queries also match tokenized source names, tool
+ * names, and descriptions. Full query-term coverage ranks above partial hits.
+ */
+export function rankToolSearchResults<T extends ToolSearchResult>(tools: T[], query: string): T[] {
+  const normalizedQuery = query.toLowerCase().trim();
+  const queryTerms = [...new Set(tokenize(normalizedQuery))];
+  if (queryTerms.length === 0) return tools;
+
+  const scored: ScoredTool<T>[] = [];
+  for (const tool of tools) {
+    const name = tool.name.toLowerCase();
+    const description = tool.description.toLowerCase();
+    const nameTokens = tokenSet(tool.name);
+    const descriptionTokens = tokenSet(tool.description);
+
+    let score = 0;
+    if (name.includes(normalizedQuery)) score += 200;
+    if (description.includes(normalizedQuery)) score += 100;
+
+    let matchedTerms = 0;
+    for (const term of queryTerms) {
+      const nameMatch = hasTerm(nameTokens, term);
+      const descriptionMatch = hasTerm(descriptionTokens, term);
+      if (!nameMatch && !descriptionMatch) continue;
+
+      matchedTerms++;
+      score += nameMatch ? 20 : 0;
+      score += descriptionMatch ? 10 : 0;
+    }
+
+    if (matchedTerms === 0) continue;
+    const fullCoverage = matchedTerms === queryTerms.length;
+    score += matchedTerms * 1000;
+    if (fullCoverage) score += 500;
+
+    scored.push({ tool, score, matchedTerms });
+  }
+
+  scored.sort((a, b) => {
+    if (b.matchedTerms !== a.matchedTerms) return b.matchedTerms - a.matchedTerms;
+    if (b.score !== a.score) return b.score - a.score;
+    return a.tool.name.localeCompare(b.tool.name);
+  });
+
+  return scored.map((s) => s.tool);
+}

--- a/src/tools/search-ranking.ts
+++ b/src/tools/search-ranking.ts
@@ -51,12 +51,14 @@ export function rankToolSearchResults<T extends ToolSearchResult>(tools: T[], qu
   for (const tool of tools) {
     const name = tool.name.toLowerCase();
     const description = tool.description.toLowerCase();
+    const nameSubstringMatch = name.includes(normalizedQuery);
+    const descriptionSubstringMatch = description.includes(normalizedQuery);
     const nameTokens = tokenSet(tool.name);
     const descriptionTokens = tokenSet(tool.description);
 
     let score = 0;
-    if (name.includes(normalizedQuery)) score += 200;
-    if (description.includes(normalizedQuery)) score += 100;
+    if (nameSubstringMatch) score += 200;
+    if (descriptionSubstringMatch) score += 100;
 
     let matchedTerms = 0;
     for (const term of queryTerms) {
@@ -69,7 +71,7 @@ export function rankToolSearchResults<T extends ToolSearchResult>(tools: T[], qu
       score += descriptionMatch ? 10 : 0;
     }
 
-    if (matchedTerms === 0) continue;
+    if (matchedTerms === 0 && !nameSubstringMatch && !descriptionSubstringMatch) continue;
     const fullCoverage = matchedTerms === queryTerms.length;
     score += matchedTerms * 1000;
     if (fullCoverage) score += 500;

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -159,11 +159,13 @@ export async function createSystemTools(
         const matches = rankToolSearchResults(all, q);
         if (matches.length === 0)
           return { content: textContent(`No tools matched "${query}".`), isError: false };
-        const lines = [`Found ${matches.length} tool(s) for "${query}":\n`];
-        for (const t of matches) lines.push(`- **${t.name}**: ${t.description}`);
+        const shown = matches.slice(0, 25);
+        const suffix = matches.length > shown.length ? ` (showing top ${shown.length})` : "";
+        const lines = [`Found ${matches.length} tool(s) for "${query}"${suffix}:\n`];
+        for (const t of shown) lines.push(`- **${t.name}**: ${t.description}`);
         return {
           content: textContent(lines.join("\n")),
-          structuredContent: { tools: matches.map((t) => ({ name: t.name })) },
+          structuredContent: { tools: shown.map((t) => ({ name: t.name })) },
           isError: false,
         };
       },

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -21,6 +21,7 @@ import { McpSource } from "./mcp-source.ts";
 import { createManageToolsToolDefs } from "./platform/manage-tools.ts";
 import type { ToolRegistry } from "./registry.ts";
 import { createManageRegistriesTool } from "./registry-tools.ts";
+import { rankToolSearchResults } from "./search-ranking.ts";
 import { createManageUsersTool, type ManageUsersContext } from "./user-tools.ts";
 import {
   createManageWorkspacesTool,
@@ -97,7 +98,7 @@ export async function createSystemTools(
           query: {
             type: "string",
             description:
-              "Search query (substring match on name + description). Optional — omit to list everything in scope.",
+              "Search query (natural-language terms over name + description). Optional — omit to list everything in scope.",
           },
         },
         required: ["scope"],
@@ -138,7 +139,7 @@ export async function createSystemTools(
         }
 
         // scope === "tools" (default)
-        const q = query.toLowerCase();
+        const q = query.toLowerCase().trim();
         // Identity-level discovery: search the identity's full
         // cross-workspace tool union (the aggregator), not just the
         // calling workspace. The aggregator namespaces nb__search per
@@ -155,9 +156,7 @@ export async function createSystemTools(
             toolEligibilityCtx?.isToolEligible(t) ?? !t.annotations?.["ai.nimblebrain/internal"],
         );
         if (!q) return groupToolsBySource(all);
-        const matches = all.filter(
-          (t) => t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q),
-        );
+        const matches = rankToolSearchResults(all, q);
         if (matches.length === 0)
           return { content: textContent(`No tools matched "${query}".`), isError: false };
         const lines = [`Found ${matches.length} tool(s) for "${query}":\n`];

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -53,6 +53,35 @@ async function makeRegistry(): Promise<ToolRegistry> {
 	return registry;
 }
 
+async function makeTodoSearchRegistry(): Promise<ToolRegistry> {
+	const registry = new ToolRegistry();
+	const todoSource = await makeInProcessSource("synapse-todo-board", [
+		{
+			name: "create_board_task",
+			description: "Create a task on a specific board",
+			inputSchema: { type: "object", properties: {} },
+			handler: async () => ({ content: textContent("ok"), isError: false }),
+		},
+		{
+			name: "list_boards",
+			description: "List available boards",
+			inputSchema: { type: "object", properties: {} },
+			handler: async () => ({ content: textContent("ok"), isError: false }),
+		},
+	]);
+	const genericSource = await makeInProcessSource("scratch", [
+		{
+			name: "create_task_template",
+			description: "Create a reusable task template",
+			inputSchema: { type: "object", properties: {} },
+			handler: async () => ({ content: textContent("ok"), isError: false }),
+		},
+	]);
+	registry.addSource(todoSource);
+	registry.addSource(genericSource);
+	return registry;
+}
+
 function getStructured<T>(result: { structuredContent?: unknown }): T | undefined {
 	return result.structuredContent as T | undefined;
 }
@@ -70,6 +99,51 @@ describe("System Tools", () => {
 		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toEqual([
 			{ name: "test__greet" },
 		]);
+	});
+
+	it("search with scope=tools matches natural-language terms across source, name, and description", async () => {
+		const registry = await makeTodoSearchRegistry();
+		const systemTools = await createSystemTools(() => registry);
+		const result = await systemTools.execute("search", {
+			scope: "tools",
+			query: "todo task create",
+		});
+
+		expect(result.isError).toBe(false);
+		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools?.[0]).toEqual({
+			name: "synapse-todo-board__create_board_task",
+		});
+		expect(extractText(result.content)).toContain("synapse-todo-board__create_board_task");
+	});
+
+	it("search with scope=tools tokenizes hyphenated source names", async () => {
+		const registry = await makeTodoSearchRegistry();
+		const systemTools = await createSystemTools(() => registry);
+		const result = await systemTools.execute("search", {
+			scope: "tools",
+			query: "todo board",
+		});
+
+		expect(result.isError).toBe(false);
+		const names = getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools?.map(
+			(t) => t.name,
+		);
+		expect(names).toContain("synapse-todo-board__create_board_task");
+		expect(names).toContain("synapse-todo-board__list_boards");
+	});
+
+	it("search with scope=tools matches description terms", async () => {
+		const registry = await makeTodoSearchRegistry();
+		const systemTools = await createSystemTools(() => registry);
+		const result = await systemTools.execute("search", {
+			scope: "tools",
+			query: "specific board",
+		});
+
+		expect(result.isError).toBe(false);
+		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools?.[0]).toEqual({
+			name: "synapse-todo-board__create_board_task",
+		});
 	});
 
 	it("search with scope=tools and empty query returns all tools grouped", async () => {

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -82,6 +82,21 @@ async function makeTodoSearchRegistry(): Promise<ToolRegistry> {
 	return registry;
 }
 
+async function makeManyMatchingToolsRegistry(count: number): Promise<ToolRegistry> {
+	const registry = new ToolRegistry();
+	const source = await makeInProcessSource(
+		"many",
+		Array.from({ length: count }, (_, i) => ({
+			name: `common_tool_${String(i).padStart(2, "0")}`,
+			description: "Common searchable helper",
+			inputSchema: { type: "object", properties: {} },
+			handler: async () => ({ content: textContent("ok"), isError: false }),
+		})),
+	);
+	registry.addSource(source);
+	return registry;
+}
+
 function getStructured<T>(result: { structuredContent?: unknown }): T | undefined {
 	return result.structuredContent as T | undefined;
 }
@@ -98,6 +113,29 @@ describe("System Tools", () => {
 		expect(extractText(result.content)).toContain("test__greet");
 		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toEqual([
 			{ name: "test__greet" },
+		]);
+	});
+
+	it("search with scope=tools preserves single-word prefix substring matches", async () => {
+		const registry = new ToolRegistry();
+		const source = await makeInProcessSource("test", [
+			{
+				name: "greeting",
+				description: "Friendly salutation helper",
+				inputSchema: { type: "object", properties: {} },
+				handler: async () => ({ content: textContent("ok"), isError: false }),
+			},
+		]);
+		registry.addSource(source);
+		const systemTools = await createSystemTools(() => registry);
+		const result = await systemTools.execute("search", {
+			scope: "tools",
+			query: "greet",
+		});
+
+		expect(result.isError).toBe(false);
+		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toEqual([
+			{ name: "test__greeting" },
 		]);
 	});
 
@@ -144,6 +182,23 @@ describe("System Tools", () => {
 		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools?.[0]).toEqual({
 			name: "synapse-todo-board__create_board_task",
 		});
+	});
+
+	it("search with scope=tools caps broad matches at the top 25 results", async () => {
+		const registry = await makeManyMatchingToolsRegistry(30);
+		const systemTools = await createSystemTools(() => registry);
+		const result = await systemTools.execute("search", {
+			scope: "tools",
+			query: "common",
+		});
+
+		expect(result.isError).toBe(false);
+		expect(extractText(result.content)).toContain(
+			'Found 30 tool(s) for "common" (showing top 25):',
+		);
+		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toHaveLength(25);
+		expect(extractText(result.content)).toContain("many__common_tool_24");
+		expect(extractText(result.content)).not.toContain("many__common_tool_25");
 	});
 
 	it("search with scope=tools and empty query returns all tools grouped", async () => {

--- a/test/unit/tools/search-ranking.test.ts
+++ b/test/unit/tools/search-ranking.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { textContent } from "../../../src/engine/content-helpers.ts";
+import { ToolRegistry } from "../../../src/tools/registry.ts";
+import { rankToolSearchResults } from "../../../src/tools/search-ranking.ts";
+import { makeInProcessSource } from "../../helpers/in-process-source.ts";
+
+// Plain ToolSearchResult fixtures (name + description) — the ranker only
+// reads those two fields.
+const CANDIDATES = [
+  { name: "synapse-crm__create_contact", description: "Create a CRM contact" },
+  { name: "synapse-todo-board__create_board_task", description: "Create a task on a todo board" },
+  { name: "synapse-todo-board__list_boards", description: "List the todo boards in a workspace" },
+];
+
+describe("rankToolSearchResults", () => {
+  it("matches a multi-term natural-language query against a tokenized tool name", () => {
+    // The literal full-query substring "todo task create" appears in no name
+    // or description; tokenized matching is what surfaces the right tool.
+    const ranked = rankToolSearchResults(CANDIDATES, "todo task create");
+    expect(ranked[0]?.name).toBe("synapse-todo-board__create_board_task");
+  });
+
+  it("ranks full query-term coverage above partial coverage", () => {
+    // "create_board_task" covers all three terms; the other two candidates
+    // cover one each ("todo" / "create"), so the full-coverage tool must
+    // sort strictly ahead of both.
+    const ranked = rankToolSearchResults(CANDIDATES, "todo task create");
+    expect(ranked.length).toBe(3);
+    expect(ranked[0]?.name).toBe("synapse-todo-board__create_board_task");
+  });
+
+  it("folds simple plurals so a singular query matches a plural token", () => {
+    // "board" must reach "...__list_boards" via the plural variant.
+    const ranked = rankToolSearchResults(CANDIDATES, "board");
+    expect(ranked.some((t) => t.name === "synapse-todo-board__list_boards")).toBe(true);
+  });
+
+  it("excludes tools that match no query term", () => {
+    const ranked = rankToolSearchResults(CANDIDATES, "zzznomatch");
+    expect(ranked).toEqual([]);
+  });
+
+  it("returns the input unchanged for an empty query (browse passthrough)", () => {
+    const ranked = rankToolSearchResults(CANDIDATES, "   ");
+    expect(ranked).toBe(CANDIDATES);
+  });
+});
+
+describe("ToolRegistry invalid-tool-name suggestions", () => {
+  it("reuses ranked search to suggest the namespaced tool for a bare name", async () => {
+    // Exercises the "Did you mean?" path: a bare (prefix-less) name routes
+    // through searchTools → rankToolSearchResults and surfaces the correct
+    // namespaced suggestion. Locks the PR-body claim that invalid-name
+    // suggestions reuse the same ranked search.
+    const registry = new ToolRegistry();
+    registry.addSource(
+      await makeInProcessSource("synapse-todo-board", [
+        {
+          name: "create_board_task",
+          description: "Create a task on a todo board",
+          inputSchema: { type: "object", properties: {} },
+          handler: async () => ({ content: textContent("ok"), isError: false }),
+        },
+      ]),
+    );
+
+    const result = await registry.execute({
+      id: "t1",
+      name: "create_board_task",
+      input: {},
+    });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("Did you mean");
+    expect(text).toContain("synapse-todo-board__create_board_task");
+  });
+});

--- a/test/unit/tools/search-ranking.test.ts
+++ b/test/unit/tools/search-ranking.test.ts
@@ -7,72 +7,72 @@ import { makeInProcessSource } from "../../helpers/in-process-source.ts";
 // Plain ToolSearchResult fixtures (name + description) — the ranker only
 // reads those two fields.
 const CANDIDATES = [
-  { name: "synapse-crm__create_contact", description: "Create a CRM contact" },
-  { name: "synapse-todo-board__create_board_task", description: "Create a task on a todo board" },
-  { name: "synapse-todo-board__list_boards", description: "List the todo boards in a workspace" },
+	{ name: "synapse-crm__create_contact", description: "Create a CRM contact" },
+	{ name: "synapse-todo-board__create_board_task", description: "Create a task on a todo board" },
+	{ name: "synapse-todo-board__list_boards", description: "List the todo boards in a workspace" },
 ];
 
 describe("rankToolSearchResults", () => {
-  it("matches a multi-term natural-language query against a tokenized tool name", () => {
-    // The literal full-query substring "todo task create" appears in no name
-    // or description; tokenized matching is what surfaces the right tool.
-    const ranked = rankToolSearchResults(CANDIDATES, "todo task create");
-    expect(ranked[0]?.name).toBe("synapse-todo-board__create_board_task");
-  });
+	it("matches a multi-term natural-language query against a tokenized tool name", () => {
+		// The literal full-query substring "todo task create" appears in no name
+		// or description; tokenized matching is what surfaces the right tool.
+		const ranked = rankToolSearchResults(CANDIDATES, "todo task create");
+		expect(ranked[0]?.name).toBe("synapse-todo-board__create_board_task");
+	});
 
-  it("ranks full query-term coverage above partial coverage", () => {
-    // "create_board_task" covers all three terms; the other two candidates
-    // cover one each ("todo" / "create"), so the full-coverage tool must
-    // sort strictly ahead of both.
-    const ranked = rankToolSearchResults(CANDIDATES, "todo task create");
-    expect(ranked.length).toBe(3);
-    expect(ranked[0]?.name).toBe("synapse-todo-board__create_board_task");
-  });
+	it("ranks full query-term coverage above partial coverage", () => {
+		// "create_board_task" covers all three terms; the other two candidates
+		// cover one each ("todo" / "create"), so the full-coverage tool must
+		// sort strictly ahead of both.
+		const ranked = rankToolSearchResults(CANDIDATES, "todo task create");
+		expect(ranked.length).toBe(3);
+		expect(ranked[0]?.name).toBe("synapse-todo-board__create_board_task");
+	});
 
-  it("folds simple plurals so a singular query matches a plural token", () => {
-    // "board" must reach "...__list_boards" via the plural variant.
-    const ranked = rankToolSearchResults(CANDIDATES, "board");
-    expect(ranked.some((t) => t.name === "synapse-todo-board__list_boards")).toBe(true);
-  });
+	it("folds simple plurals so a singular query matches a plural token", () => {
+		// "board" must reach "...__list_boards" via the plural variant.
+		const ranked = rankToolSearchResults(CANDIDATES, "board");
+		expect(ranked.some((t) => t.name === "synapse-todo-board__list_boards")).toBe(true);
+	});
 
-  it("excludes tools that match no query term", () => {
-    const ranked = rankToolSearchResults(CANDIDATES, "zzznomatch");
-    expect(ranked).toEqual([]);
-  });
+	it("excludes tools that match no query term", () => {
+		const ranked = rankToolSearchResults(CANDIDATES, "zzznomatch");
+		expect(ranked).toEqual([]);
+	});
 
-  it("returns the input unchanged for an empty query (browse passthrough)", () => {
-    const ranked = rankToolSearchResults(CANDIDATES, "   ");
-    expect(ranked).toBe(CANDIDATES);
-  });
+	it("returns the input unchanged for an empty query (browse passthrough)", () => {
+		const ranked = rankToolSearchResults(CANDIDATES, "");
+		expect(ranked).toBe(CANDIDATES);
+	});
 });
 
 describe("ToolRegistry invalid-tool-name suggestions", () => {
-  it("reuses ranked search to suggest the namespaced tool for a bare name", async () => {
-    // Exercises the "Did you mean?" path: a bare (prefix-less) name routes
-    // through searchTools → rankToolSearchResults and surfaces the correct
-    // namespaced suggestion. Locks the PR-body claim that invalid-name
-    // suggestions reuse the same ranked search.
-    const registry = new ToolRegistry();
-    registry.addSource(
-      await makeInProcessSource("synapse-todo-board", [
-        {
-          name: "create_board_task",
-          description: "Create a task on a todo board",
-          inputSchema: { type: "object", properties: {} },
-          handler: async () => ({ content: textContent("ok"), isError: false }),
-        },
-      ]),
-    );
+	it("reuses ranked search to suggest the namespaced tool for a bare name", async () => {
+		// Exercises the "Did you mean?" path: a bare (prefix-less) name routes
+		// through searchTools → rankToolSearchResults and surfaces the correct
+		// namespaced suggestion. Locks the PR-body claim that invalid-name
+		// suggestions reuse the same ranked search.
+		const registry = new ToolRegistry();
+		registry.addSource(
+			await makeInProcessSource("synapse-todo-board", [
+				{
+					name: "create_board_task",
+					description: "Create a task on a todo board",
+					inputSchema: { type: "object", properties: {} },
+					handler: async () => ({ content: textContent("ok"), isError: false }),
+				},
+			]),
+		);
 
-    const result = await registry.execute({
-      id: "t1",
-      name: "create_board_task",
-      input: {},
-    });
+		const result = await registry.execute({
+			id: "t1",
+			name: "create_board_task",
+			input: {},
+		});
 
-    expect(result.isError).toBe(true);
-    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
-    expect(text).toContain("Did you mean");
-    expect(text).toContain("synapse-todo-board__create_board_task");
-  });
+		expect(result.isError).toBe(true);
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+		expect(text).toContain("Did you mean");
+		expect(text).toContain("synapse-todo-board__create_board_task");
+	});
 });


### PR DESCRIPTION
## Summary
Fixes #33.
`nb__search` previously used literal substring matching over the full query, so natural-language queries like `todo task create` failed unless that exact phrase appeared contiguously in a tool name or description.
This PR adds deterministic tokenized ranking for tool discovery:
- Tokenizes tool source/name/description on separators like `-`, `_`, and spaces.
- Matches multi-term queries across source names, tool names, and descriptions.
- Ranks fuller query-term coverage above partial matches.
- Preserves empty-query browse behavior.
- Reuses the same ranked search for invalid-tool-name suggestions.
This allows queries like `todo task create` and `todo board` to discover `synapse-todo-board__create_board_task`.
## Testing
- `bun test test/unit/system-tools.test.ts`
- `bun run check`
- `bun run format:check`
- `bun run lint`