### PR TITLE
fix(docker): bundle scripts/ into platform image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production --ignore-scripts
 
 COPY src/ src/
+COPY scripts/ scripts/
 
 # Build bundle UIs (dist/ is gitignored, must build in container)
 RUN for ui in src/bundles/*/ui; do \


### PR DESCRIPTION
## Summary

Operational scripts (`migrate-personal-workspaces`, `migrate-conversations-to-top-level`, future `heal-*` scripts) live in `scripts/` and import from `src/`, but the Dockerfile only copies `src/`. Result: `kubectl exec` into a deployed pod can't run any of them — discovered while rolling Stage 1 out to hq production.

Single-line change: `COPY scripts/ scripts/` after the existing `COPY src/ src/`. Makefile migration targets in `deployments/nimblebrain/` now resolve correctly on a fresh pod, no `kubectl cp` workaround needed.

## Trade-off acknowledged

A malicious bundle running in the platform pod gains slightly easier access to invoke migration logic — but the underlying surface (bundle FS access to `/data`, ability to spawn subprocesses, ability to read `/app/src/` and reconstruct migration logic from scratch) is unchanged. The proper defense is bundle sandboxing + K8s Job pattern for migrations, not hiding the script files. That's a separate workstream worth tracking but not blocking this fix.

## Test plan

- [x] Local `bun run verify` — no TS/runtime changes, just Dockerfile
- [ ] Next platform image build will include `scripts/` at `/app/scripts/`
- [ ] After deploy, `kubectl exec deploy/tenant-<client>-platform -- ls /app/scripts/` shows the migration scripts
- [ ] `make migrate-personal-workspaces CLIENT=<client> ENV=<env>` runs without the `kubectl cp` workaround