### PR TITLE
feat(scripts): heal-truncated-personal-workspaces — Stage 1 follow-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,14 @@ When adding a new code path that touches workspace-scoped credentials or identit
 
 **Conversations are user-scoped, not workspace-scoped.** Post-Stage-1, every conversation lives at `{workDir}/conversations/{convId}.jsonl` and is authorized by ownership (`Conversation.ownerId === access.userId`). Look up via `runtime.findConversation(convId, { userId })`; write via `runtime.findConversationStore()`. `workspaceId` on conversation metadata is a tool-scoping breadcrumb — it tells the runtime which workspace's tools the chat had access to when a turn ran, NOT where the file lives. Hand-building per-workspace conversation paths (`join(workDir, "workspaces", wsId, "conversations", ...)`) is a regression caught by `check:conversation-paths`. **Personal workspace ids** go through `personalWorkspaceIdFor(userId)` from `src/workspace/workspace-store.ts` — no hand-built `"ws_user_" + userId` or `` `ws_user_${userId}` `` outside that helper (`check:personal-workspace-id` enforces).
 
+### Stage 1 follow-ups — tenant migration order
+
+When migrating a tenant onto Stage 1, run the scripts in this order, all during a maintenance window with the platform scaled to zero:
+
+1. `bun run migrate:personal-workspaces` — renames each user's personal workspace to `ws_user_<userId>` and stamps `isPersonal` / `ownerUserId`.
+2. `bun run migrate:conversations-to-top-level` — moves per-workspace conversations to `{workDir}/conversations/`.
+3. `bun run scripts/heal-truncated-personal-workspaces.ts` — **only if needed.** Some legacy tenants (notably hq) used a 16-char-truncated slug for personal workspaces that step 1 doesn't recognize. Heuristic: step 1's output shows `no personal workspace found (will be created on next login)` for users who actually do have a workspace named `<displayName>'s Workspace` at a short-slug id. If you see that pattern, run this heal script (dry-run first). Idempotent — safe to run on any tenant; it exits cleanly with `no truncated workspace` when nothing matches. All three scripts share the same `.migration-lock` PID file, so they're serialized by construction.
+
 ## Debug Logging
 
 Hot-path diagnostics are gated behind namespace flags so they're available when you need them without editing source. Use for tracing across the runtime ↔ SSE ↔ browser ↔ iframe chain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ When migrating a tenant onto Stage 1, run the scripts in this order, all during 
 
 1. `bun run migrate:personal-workspaces` — renames each user's personal workspace to `ws_user_<userId>` and stamps `isPersonal` / `ownerUserId`.
 2. `bun run migrate:conversations-to-top-level` — moves per-workspace conversations to `{workDir}/conversations/`.
-3. `bun run scripts/heal-truncated-personal-workspaces.ts` — **only if needed.** Some legacy tenants (notably hq) used a 16-char-truncated slug for personal workspaces that step 1 doesn't recognize. Heuristic: step 1's output shows `no personal workspace found (will be created on next login)` for users who actually do have a workspace named `<displayName>'s Workspace` at a short-slug id. If you see that pattern, run this heal script (dry-run first). Idempotent — safe to run on any tenant; it exits cleanly with `no truncated workspace` when nothing matches. All three scripts share the same `.migration-lock` PID file, so they're serialized by construction.
+3. `bun run heal:truncated-personal-workspaces` — **only if needed.** Some legacy tenants (notably hq) used a 16-char-truncated slug for personal workspaces that step 1 doesn't recognize. Heuristic: step 1's output shows `no personal workspace found (will be created on next login)` for users who actually do have a workspace named `<displayName>'s Workspace` at a short-slug id. If you see that pattern, run this heal script (dry-run first). Idempotent — safe to run on any tenant; it exits cleanly with `no truncated workspace` when nothing matches. All three scripts share the same `.migration-lock` PID file, so they're serialized by construction.
 
 ## Debug Logging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 
 ### Fixed
 
+- Heal script for tenants whose legacy personal-workspace slugs use the 16-char truncated form unrecognized by `migrate-personal-workspaces.ts` — run `scripts/heal-truncated-personal-workspaces.ts` after the Stage 1 migrations to rename truncated personal workspaces to the canonical form, stamp identity fields, delete empty canonical stubs, and rewrite conversation `workspaceId` refs.
 - `runtime.chat()` now honors an `AbortSignal` end-to-end (`ChatRequest.signal` → `EngineConfig.signal` → iteration loop + every tool call). Callers racing the chat against a deadline (notably the automations executor's per-run budget) now cancel in-flight LLM/tool work instead of orphaning it; HTTP `/v1/chat` and `/v1/chat/stream` also forward `request.signal`, so client disconnect cancels engine work ([#251](https://github.com/NimbleBrainInc/nimblebrain/pull/251)).
 - Task-augmented MCP tools no longer report a false `MCP error -32603: Task <id> failed` when the server stored a usable `tasks/result` payload; the engine refetches and surfaces the real content ([#245](https://github.com/NimbleBrainInc/nimblebrain/pull/245)).
 - `automations__run` no longer hits `MCP error -32001: Request timed out` on multi-minute automations; `handleRun` caps its sync wait below the SDK's 60 s request timeout and returns a `{ status: "dispatched" }` envelope when the run outlasts the window, with the scheduler tracking it in the background ([#245](https://github.com/NimbleBrainInc/nimblebrain/pull/245)).

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "smoke": "bun test test/smoke/",
     "migrate:personal-workspaces": "bun run scripts/migrate-personal-workspaces.ts",
     "migrate:conversations-to-top-level": "bun run scripts/migrate-conversations-to-top-level.ts",
+    "heal:truncated-personal-workspaces": "bun run scripts/heal-truncated-personal-workspaces.ts",
     "check:cycles": "bun run scripts/check-cycles.ts",
     "check:bundle-transport": "bun run scripts/check-bundle-transport.ts",
     "check:workspace-paths": "bun run scripts/check-workspace-paths.ts",

--- a/scripts/heal-truncated-personal-workspaces.ts
+++ b/scripts/heal-truncated-personal-workspaces.ts
@@ -39,7 +39,7 @@
 import { existsSync } from "node:fs";
 import { readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { UserStore } from "../src/identity/user.ts";
 import { writeJsonAtomic } from "../src/util/atomic-json.ts";
 import type { Workspace } from "../src/workspace/types.ts";
@@ -57,6 +57,7 @@ interface Args {
 interface Stats {
   usersScanned: number;
   healed: number;
+  partialRenameHealed: number;
   alreadyCanonical: number;
   noTruncatedWorkspace: number;
   skippedNameMismatch: number;
@@ -133,6 +134,12 @@ function isAdminOf(ws: Workspace, userId: string): boolean {
  * Count top-level conversation JSONL files whose metadata's
  * `workspaceId` equals `id`. Conversations are stored at
  * `{workDir}/conversations/*.jsonl` post-Stage-1.
+ *
+ * O(N) scan of the conversations dir per call. Acceptable for a
+ * maintenance script that runs during a window — small tenants spend
+ * milliseconds, large tenants spend seconds. If a future tenant has
+ * a per-user count high enough to make this hot, build a single
+ * `Map<workspaceId, count>` once in main and pass it in.
  */
 async function countConversationRefs(
   conversationsDir: string,
@@ -146,6 +153,78 @@ async function countConversationRefs(
     if (meta && meta.workspaceId === id) n++;
   }
   return n;
+}
+
+/**
+ * Recursively walk `dir`, returning the relative path of the first file
+ * that ISN'T an expected sentinel. Used to detect canonical-stub content
+ * a bundles+convRefs check alone misses — populated data/credentials/
+ * skills/files/ subdirs, a legacy conversations/ subdir, or any other
+ * file an `rm -rf` would silently destroy.
+ *
+ * Allowed:
+ *  - `workspace.json` at the root.
+ *  - Any `.gitkeep` (scaffolding sentinel for empty subdirs).
+ *  - Any directory itself (recursion descends into it).
+ *
+ * Returns null when the tree contains only allowed entries.
+ */
+async function findUnexpectedContent(
+  dir: string,
+  root: string = dir,
+): Promise<string | null> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isFile()) {
+      const rel = relative(root, full);
+      if (rel === "workspace.json") continue;
+      if (entry.name === ".gitkeep") continue;
+      return rel;
+    }
+    if (entry.isDirectory()) {
+      const inside = await findUnexpectedContent(full, root);
+      if (inside) return inside;
+    }
+  }
+  return null;
+}
+
+/**
+ * Return the first populated optional `workspace.json` field whose
+ * contents would be lost if this canonical stub is rm'd. The minimum
+ * shape for a "truly empty" canonical stub is: exactly the owner as
+ * a sole admin member, zero bundles, no agents/skillDirs/models/
+ * identity/connectorsAllowList/oauthOperatorApps populated. Anything
+ * else means the stub holds real state and the operator must
+ * reconcile.
+ */
+function findPopulatedWorkspaceField(
+  ws: Workspace,
+  ownerUserId: string,
+): string | null {
+  if ((ws.bundles ?? []).length > 0) return `bundles (${ws.bundles.length})`;
+
+  const members = ws.members ?? [];
+  if (members.length !== 1) {
+    return `members (${members.length} — expected exactly the owner as sole admin)`;
+  }
+  const sole = members[0];
+  if (!sole || sole.userId !== ownerUserId || sole.role !== "admin") {
+    return `members[0] (expected ${ownerUserId} as admin, got ${sole?.userId} as ${sole?.role})`;
+  }
+
+  if (ws.agents && Object.keys(ws.agents).length > 0) return "agents";
+  if (ws.skillDirs && ws.skillDirs.length > 0) return "skillDirs";
+  if (ws.models && Object.keys(ws.models).length > 0) return "models";
+  if (ws.identity) return "identity";
+  if (ws.connectorsAllowList && ws.connectorsAllowList.length > 0) {
+    return "connectorsAllowList";
+  }
+  if (ws.oauthOperatorApps && Object.keys(ws.oauthOperatorApps).length > 0) {
+    return "oauthOperatorApps";
+  }
+  return null;
 }
 
 /**
@@ -224,32 +303,57 @@ async function healOne(opts: {
   const canonicalDir = join(workspacesDir, canonicalId);
 
   // Stub-handling on the canonical id.
+  //
+  // Three layers of "is this stub truly empty?" gate the `rm -rf`. Any
+  // populated workspace.json field, any reference from a top-level
+  // conversation, or any unexpected file under the canonical dir flips
+  // to a hard-error — the script never auto-merges or silently
+  // destroys real state. Operator must reconcile.
   if (existsSync(canonicalDir)) {
     const canonicalWsPath = join(canonicalDir, "workspace.json");
+
     if (existsSync(canonicalWsPath)) {
       const canonicalWs = JSON.parse(
         await readFile(canonicalWsPath, "utf-8"),
       ) as Workspace;
-      const bundleCount = canonicalWs.bundles?.length ?? 0;
-      const refCount = await countConversationRefs(conversationsDir, canonicalId);
-      if (bundleCount > 0 || refCount > 0) {
+
+      const populatedField = findPopulatedWorkspaceField(canonicalWs, userId);
+      if (populatedField) {
         return {
           error:
-            `canonical stub ${canonicalId} holds state ` +
-            `(bundles=${bundleCount}, convRefs=${refCount}) — ` +
-            "manual reconciliation required",
+            `canonical stub ${canonicalId} workspace.json is populated ` +
+            `(${populatedField}) — manual reconciliation required`,
         };
       }
-      console.error(
-        `[heal] ${userId}: ${dryRun ? "[dry-run] would " : ""}delete empty canonical stub ${canonicalId}`,
-      );
-      if (!dryRun) await rm(canonicalDir, { recursive: true, force: true });
-    } else {
-      console.error(
-        `[heal] ${userId}: ${dryRun ? "[dry-run] would " : ""}delete stub dir ${canonicalId} (no workspace.json)`,
-      );
-      if (!dryRun) await rm(canonicalDir, { recursive: true, force: true });
+
+      const refCount = await countConversationRefs(conversationsDir, canonicalId);
+      if (refCount > 0) {
+        return {
+          error:
+            `canonical stub ${canonicalId} is referenced by ${refCount} ` +
+            "top-level conversation(s) — manual reconciliation required",
+        };
+      }
     }
+
+    // Recursive content walk. Catches:
+    //  - populated data/credentials/skills/files/ subdirs (anything
+    //    beyond their `.gitkeep` sentinels)
+    //  - legacy `conversations/` subdir from Stage-0 stubs
+    //  - any other unanticipated file
+    const extra = await findUnexpectedContent(canonicalDir);
+    if (extra) {
+      return {
+        error:
+          `canonical stub ${canonicalId} has unexpected content (${extra}) — ` +
+          "manual reconciliation required",
+      };
+    }
+
+    console.error(
+      `[heal] ${userId}: ${dryRun ? "[dry-run] would " : ""}delete empty canonical stub ${canonicalId}`,
+    );
+    if (!dryRun) await rm(canonicalDir, { recursive: true, force: true });
   }
 
   // Rename truncatedId → canonicalId.
@@ -324,6 +428,7 @@ async function main(): Promise<void> {
   const stats: Stats = {
     usersScanned: 0,
     healed: 0,
+    partialRenameHealed: 0,
     alreadyCanonical: 0,
     noTruncatedWorkspace: 0,
     skippedNameMismatch: 0,
@@ -348,6 +453,69 @@ async function main(): Promise<void> {
     try {
       const truncatedWs = await wsStore.get(truncatedId);
       if (!truncatedWs) {
+        // No truncated workspace. Common path: this user was always at
+        // the canonical id (Stage 0 lazy-create) — nothing to do.
+        //
+        // Less-common path: a previous heal crashed between
+        // `rename(truncated, canonical)` and the workspace.json rewrite,
+        // leaving the canonical dir on disk but its embedded `id` /
+        // `isPersonal` / `ownerUserId` still pointing at the pre-rename
+        // values. Detect and stamp on rerun — mirrors Stage 1's
+        // `migrate-personal-workspaces.ts` partial-rename heal.
+        const canonicalWs = await wsStore.get(canonicalId);
+        const needsStamp =
+          canonicalWs !== null &&
+          (canonicalWs.id !== canonicalId ||
+            canonicalWs.isPersonal !== true ||
+            canonicalWs.ownerUserId !== user.id);
+        if (canonicalWs && needsStamp) {
+          console.error(
+            `[heal] ${user.id}: ${args.dryRun ? "[dry-run] would " : ""}` +
+              `stamp identity on partial-rename canonical ${canonicalId} ` +
+              `(was id=${canonicalWs.id}, isPersonal=${canonicalWs.isPersonal}, ` +
+              `ownerUserId=${canonicalWs.ownerUserId})`,
+          );
+          if (!args.dryRun) {
+            const wsPath = join(workspacesDir, canonicalId, "workspace.json");
+            const updated: Workspace = {
+              ...canonicalWs,
+              id: canonicalId,
+              isPersonal: true,
+              ownerUserId: user.id,
+              about: canonicalWs.about ?? null,
+              updatedAt: new Date().toISOString(),
+            };
+            await writeJsonAtomic(wsPath, updated);
+          }
+          // Rewrite conversation refs that still point at the pre-rename
+          // truncated id. (If the partial run rewrote some but not all,
+          // remaining ones get fixed now; if it crashed before any
+          // rewrites, all get fixed.)
+          let rewrites = 0;
+          if (existsSync(conversationsDir)) {
+            for (const fname of await readdir(conversationsDir)) {
+              if (!fname.endsWith(".jsonl")) continue;
+              const cpath = join(conversationsDir, fname);
+              const meta = await readConversationMetadata(cpath);
+              if (!meta || meta.workspaceId !== truncatedId) continue;
+              if (args.dryRun) {
+                rewrites++;
+                continue;
+              }
+              if (
+                await rewriteConversationWorkspaceId(cpath, truncatedId, canonicalId)
+              ) {
+                rewrites++;
+              }
+            }
+          }
+          console.error(
+            `[heal] ${user.id}: ${args.dryRun ? "[dry-run] would " : ""}` +
+              `rewrite workspaceId on ${rewrites} conversation(s) referencing truncated id`,
+          );
+          stats.partialRenameHealed++;
+          continue;
+        }
         console.error(
           `[heal] ${user.id}: no truncated workspace ${truncatedId} — skip`,
         );
@@ -398,6 +566,7 @@ async function main(): Promise<void> {
   console.error(`[heal] summary${args.dryRun ? " (dry-run)" : ""}:`);
   console.error(`[heal]   users scanned:                 ${stats.usersScanned}`);
   console.error(`[heal]   healed users:                  ${stats.healed}`);
+  console.error(`[heal]   partial-rename healed:         ${stats.partialRenameHealed}`);
   console.error(`[heal]   already canonical (skipped):   ${stats.alreadyCanonical}`);
   console.error(`[heal]   no truncated workspace:        ${stats.noTruncatedWorkspace}`);
   console.error(`[heal]   skipped (name mismatch):       ${stats.skippedNameMismatch}`);

--- a/scripts/heal-truncated-personal-workspaces.ts
+++ b/scripts/heal-truncated-personal-workspaces.ts
@@ -37,7 +37,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { readdir, readFile, rename, rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, relative } from "node:path";
 import { UserStore } from "../src/identity/user.ts";
@@ -47,6 +47,10 @@ import {
   personalWorkspaceIdFor,
   WorkspaceStore,
 } from "../src/workspace/workspace-store.ts";
+import {
+  readConversationMetadata,
+  rewriteConversationWorkspaceId,
+} from "./lib/conversation-metadata.ts";
 import { acquireMigrationLock } from "./lib/migration-lock.ts";
 
 interface Args {
@@ -191,18 +195,59 @@ async function findUnexpectedContent(
 }
 
 /**
- * Return the first populated optional `workspace.json` field whose
- * contents would be lost if this canonical stub is rm'd. The minimum
- * shape for a "truly empty" canonical stub is: exactly the owner as
- * a sole admin member, zero bundles, no agents/skillDirs/models/
- * identity/connectorsAllowList/oauthOperatorApps populated. Anything
- * else means the stub holds real state and the operator must
- * reconcile.
+ * Keys allowed on a "truly empty" canonical stub. Anything outside
+ * this set is forbidden — new optional fields on `Workspace` default
+ * to forbidden, which is the safe direction (a denylist would silently
+ * allow new fields, e.g. `allowHttpProxy`, that the script doesn't
+ * know about yet).
+ *
+ * Members of this set still have value-level checks below — `bundles`
+ * must be empty, `members` must be exactly the owner-admin, etc.
+ */
+const ALLOWED_STUB_KEYS: ReadonlySet<string> = new Set([
+  "id",
+  "name",
+  "members",
+  "bundles",
+  "createdAt",
+  "updatedAt",
+  "about",
+  "isPersonal",
+  "ownerUserId",
+]);
+
+/**
+ * Return the first populated `workspace.json` field whose contents
+ * would be lost if this canonical stub is rm'd. The minimum shape for
+ * a "truly empty" canonical stub is:
+ *   - only structural keys present (allowlisted above)
+ *   - exactly the owner as sole admin member
+ *   - zero bundles
+ *   - `about` null or empty
+ *
+ * Inverted from the prior denylist style. The previous version
+ * enumerated `agents`/`skillDirs`/`models`/`identity`/
+ * `connectorsAllowList`/`oauthOperatorApps` explicitly and would have
+ * silently passed any new optional field added to `Workspace` later
+ * (round-2 QA caught `allowHttpProxy` missing from that list). Adding
+ * an unfamiliar field to the allowlist is now an explicit operator
+ * decision.
  */
 function findPopulatedWorkspaceField(
   ws: Workspace,
   ownerUserId: string,
 ): string | null {
+  // 1. Reject any field outside the allowlist — covers `agents`,
+  //    `skillDirs`, `models`, `identity`, `allowHttpProxy`,
+  //    `connectorsAllowList`, `oauthOperatorApps`, and anything added
+  //    to `Workspace` in the future.
+  for (const key of Object.keys(ws)) {
+    if (!ALLOWED_STUB_KEYS.has(key)) {
+      return `unexpected field: ${key}`;
+    }
+  }
+
+  // 2. Value-level checks on the allowlisted keys.
   if ((ws.bundles ?? []).length > 0) return `bundles (${ws.bundles.length})`;
 
   const members = ws.members ?? [];
@@ -214,67 +259,44 @@ function findPopulatedWorkspaceField(
     return `members[0] (expected ${ownerUserId} as admin, got ${sole?.userId} as ${sole?.role})`;
   }
 
-  if (ws.agents && Object.keys(ws.agents).length > 0) return "agents";
-  if (ws.skillDirs && ws.skillDirs.length > 0) return "skillDirs";
-  if (ws.models && Object.keys(ws.models).length > 0) return "models";
-  if (ws.identity) return "identity";
-  if (ws.connectorsAllowList && ws.connectorsAllowList.length > 0) {
-    return "connectorsAllowList";
+  if (typeof ws.about === "string" && ws.about.length > 0) {
+    return "about (non-empty)";
   }
-  if (ws.oauthOperatorApps && Object.keys(ws.oauthOperatorApps).length > 0) {
-    return "oauthOperatorApps";
+  if (ws.ownerUserId !== undefined && ws.ownerUserId !== ownerUserId) {
+    return `ownerUserId (got ${ws.ownerUserId}, expected ${ownerUserId})`;
   }
   return null;
 }
 
 /**
- * Read the metadata line (line 1) of a conversation JSONL. Returns null
- * if unreadable / unparseable — the file is left alone in that case.
+ * Walk `conversationsDir` and rewrite every top-level conversation
+ * JSONL whose metadata's `workspaceId` matches `oldId` to `newId`.
+ * Returns the count of files that were (or would be, in dry-run)
+ * rewritten. Used twice in main: the happy-path rename and the
+ * partial-rename heal.
  */
-async function readConversationMetadata(
-  filePath: string,
-): Promise<Record<string, unknown> | null> {
-  try {
-    const raw = await readFile(filePath, "utf-8");
-    const newlineIdx = raw.indexOf("\n");
-    const firstLine = newlineIdx < 0 ? raw : raw.slice(0, newlineIdx);
-    return JSON.parse(firstLine) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Rewrite the metadata line of a conversation JSONL so its
- * `workspaceId` reflects the renamed workspace. Returns true if
- * rewritten. Other lines pass through byte-identical.
- */
-async function rewriteConversationWorkspaceId(
-  filePath: string,
+async function rewriteConvRefs(
+  conversationsDir: string,
   oldId: string,
   newId: string,
-): Promise<boolean> {
-  const raw = await readFile(filePath, "utf-8");
-  const newlineIdx = raw.indexOf("\n");
-  if (newlineIdx < 0) return false;
-
-  const metadataLine = raw.slice(0, newlineIdx);
-  const rest = raw.slice(newlineIdx); // includes the leading \n
-
-  let meta: Record<string, unknown>;
-  try {
-    meta = JSON.parse(metadataLine);
-  } catch {
-    return false;
+  dryRun: boolean,
+): Promise<number> {
+  if (!existsSync(conversationsDir)) return 0;
+  let rewrites = 0;
+  for (const fname of await readdir(conversationsDir)) {
+    if (!fname.endsWith(".jsonl")) continue;
+    const cpath = join(conversationsDir, fname);
+    const meta = await readConversationMetadata(cpath);
+    if (!meta || meta.workspaceId !== oldId) continue;
+    if (dryRun) {
+      rewrites++;
+      continue;
+    }
+    if (await rewriteConversationWorkspaceId(cpath, oldId, newId)) {
+      rewrites++;
+    }
   }
-  if (meta.workspaceId !== oldId) return false;
-  meta.workspaceId = newId;
-  const newMetadata = JSON.stringify(meta);
-
-  const tmp = `${filePath}.tmp.${Date.now()}`;
-  await writeFile(tmp, `${newMetadata}${rest}`, { encoding: "utf-8", mode: 0o600 });
-  await rename(tmp, filePath);
-  return true;
+  return rewrites;
 }
 
 /**
@@ -378,22 +400,12 @@ async function healOne(opts: {
   }
 
   // Rewrite workspaceId on conversations that point at the truncated id.
-  let rewrites = 0;
-  if (existsSync(conversationsDir)) {
-    for (const fname of await readdir(conversationsDir)) {
-      if (!fname.endsWith(".jsonl")) continue;
-      const cpath = join(conversationsDir, fname);
-      const meta = await readConversationMetadata(cpath);
-      if (!meta || meta.workspaceId !== truncatedId) continue;
-      if (dryRun) {
-        rewrites++;
-        continue;
-      }
-      if (await rewriteConversationWorkspaceId(cpath, truncatedId, canonicalId)) {
-        rewrites++;
-      }
-    }
-  }
+  const rewrites = await rewriteConvRefs(
+    conversationsDir,
+    truncatedId,
+    canonicalId,
+    dryRun,
+  );
   console.error(
     `[heal] ${userId}: ${dryRun ? "[dry-run] would " : ""}rewrite workspaceId on ${rewrites} conversation(s)`,
   );
@@ -462,6 +474,16 @@ async function main(): Promise<void> {
         // `isPersonal` / `ownerUserId` still pointing at the pre-rename
         // values. Detect and stamp on rerun — mirrors Stage 1's
         // `migrate-personal-workspaces.ts` partial-rename heal.
+        //
+        // Two safety gates before stamping — the canonical might be an
+        // unrelated workspace that happens to share the id:
+        //   - name must match `<displayName>'s Workspace` (the rename
+        //     preserved name from the original truncated workspace)
+        //   - user must be an admin member (claims ownership)
+        // The empty-content gates that `healOne` applies to stubs do
+        // NOT apply here — a partially-renamed canonical legitimately
+        // carries the user's bundles, settings, and pre-PR-C extra
+        // collaborators. We're stamping identity, not deleting.
         const canonicalWs = await wsStore.get(canonicalId);
         const needsStamp =
           canonicalWs !== null &&
@@ -469,6 +491,32 @@ async function main(): Promise<void> {
             canonicalWs.isPersonal !== true ||
             canonicalWs.ownerUserId !== user.id);
         if (canonicalWs && needsStamp) {
+          const expectedName = `${user.displayName}'s Workspace`;
+          if (canonicalWs.name !== expectedName) {
+            console.error(
+              `[heal] ${user.id}: canonical ${canonicalId} exists with stale identity ` +
+                `but name ${JSON.stringify(canonicalWs.name)} != expected ${JSON.stringify(expectedName)} — ` +
+                "refuse to stamp (manual reconciliation required)",
+            );
+            stats.errors.push({
+              ctx: user.id,
+              message: `canonical ${canonicalId} has stale identity but unexpected name — operator must reconcile`,
+            });
+            continue;
+          }
+          if (!isAdminOf(canonicalWs, user.id)) {
+            console.error(
+              `[heal] ${user.id}: canonical ${canonicalId} exists with stale identity ` +
+                `but ${user.id} is not an admin member — refuse to stamp ` +
+                "(manual reconciliation required)",
+            );
+            stats.errors.push({
+              ctx: user.id,
+              message: `canonical ${canonicalId} has stale identity but ${user.id} is not an admin — operator must reconcile`,
+            });
+            continue;
+          }
+
           console.error(
             `[heal] ${user.id}: ${args.dryRun ? "[dry-run] would " : ""}` +
               `stamp identity on partial-rename canonical ${canonicalId} ` +
@@ -487,28 +535,12 @@ async function main(): Promise<void> {
             };
             await writeJsonAtomic(wsPath, updated);
           }
-          // Rewrite conversation refs that still point at the pre-rename
-          // truncated id. (If the partial run rewrote some but not all,
-          // remaining ones get fixed now; if it crashed before any
-          // rewrites, all get fixed.)
-          let rewrites = 0;
-          if (existsSync(conversationsDir)) {
-            for (const fname of await readdir(conversationsDir)) {
-              if (!fname.endsWith(".jsonl")) continue;
-              const cpath = join(conversationsDir, fname);
-              const meta = await readConversationMetadata(cpath);
-              if (!meta || meta.workspaceId !== truncatedId) continue;
-              if (args.dryRun) {
-                rewrites++;
-                continue;
-              }
-              if (
-                await rewriteConversationWorkspaceId(cpath, truncatedId, canonicalId)
-              ) {
-                rewrites++;
-              }
-            }
-          }
+          const rewrites = await rewriteConvRefs(
+            conversationsDir,
+            truncatedId,
+            canonicalId,
+            args.dryRun,
+          );
           console.error(
             `[heal] ${user.id}: ${args.dryRun ? "[dry-run] would " : ""}` +
               `rewrite workspaceId on ${rewrites} conversation(s) referencing truncated id`,

--- a/scripts/heal-truncated-personal-workspaces.ts
+++ b/scripts/heal-truncated-personal-workspaces.ts
@@ -1,0 +1,417 @@
+#!/usr/bin/env bun
+/**
+ * Stage 1 follow-up: heal personal workspaces whose legacy slug used
+ * the 16-char-truncated form (e.g. `ws_01kp730nhbcj3ck2`) instead of
+ * the full lowercased ULID (`ws_01kp730nhbcj3ck2hfhe3hmnf6`).
+ *
+ * `migrate-personal-workspaces.ts` assumed the pre-Stage-1 slug was the
+ * full `user.id` with the `user_` prefix stripped (`legacySlugForUserId`,
+ * 26 chars). Production tenants like hq turned out to use the 16-char
+ * truncation, so the migration didn't recognize those workspaces as
+ * personal: they ended up stamped `isPersonal: false` and, where Stage 0
+ * had backfilled it, an empty canonical-form stub holds the Personal
+ * slot at `ws_user_<userId>`.
+ *
+ * For each user:
+ *  - `truncatedId = "ws_" + userId.replace(/^user_/, "").toLowerCase().slice(0, 16)`
+ *  - `canonicalId = personalWorkspaceIdFor(userId)`
+ *  - If `truncatedId` directory exists AND `workspace.json.name` is
+ *    exactly `<displayName>'s Workspace` AND the user is an admin
+ *    member → eligible.
+ *  - If `canonicalId` exists too: it MUST be empty (0 bundles, 0
+ *    top-level conversations referencing it) to be deleted. If it has
+ *    bundles or referencing conversations, hard-error — operator
+ *    reconciles. Auto-merging a stub holding real state would be
+ *    silently destructive.
+ *  - Rename `truncatedId` → `canonicalId` atomically; rewrite
+ *    `workspace.json` (id, isPersonal, ownerUserId, about, updatedAt);
+ *    rewrite the metadata line of every `{workDir}/conversations/*.jsonl`
+ *    whose `workspaceId` equals `truncatedId`.
+ *
+ * Idempotent and one-phase. Designed to run during a maintenance window
+ * with the platform stopped, AFTER `migrate-personal-workspaces`. Holds
+ * the same `.migration-lock` PID file; concurrent runs refuse to start.
+ *
+ * Usage:
+ *     bun run scripts/heal-truncated-personal-workspaces.ts [--work-dir <path>] [--dry-run]
+ */
+
+import { existsSync } from "node:fs";
+import { readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { UserStore } from "../src/identity/user.ts";
+import { writeJsonAtomic } from "../src/util/atomic-json.ts";
+import type { Workspace } from "../src/workspace/types.ts";
+import {
+  personalWorkspaceIdFor,
+  WorkspaceStore,
+} from "../src/workspace/workspace-store.ts";
+import { acquireMigrationLock } from "./lib/migration-lock.ts";
+
+interface Args {
+  workDir: string;
+  dryRun: boolean;
+}
+
+interface Stats {
+  usersScanned: number;
+  healed: number;
+  alreadyCanonical: number;
+  noTruncatedWorkspace: number;
+  skippedNameMismatch: number;
+  skippedNotAdmin: number;
+  errors: { ctx: string; message: string }[];
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  let workDir = process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+  let dryRun = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--work-dir") {
+      workDir = argv[++i] ?? "";
+    } else if (arg?.startsWith("--work-dir=")) {
+      workDir = arg.slice("--work-dir=".length);
+    } else {
+      console.error(`[heal] unknown argument: ${arg}`);
+      printHelp();
+      process.exit(2);
+    }
+  }
+
+  if (!workDir) {
+    console.error("[heal] --work-dir is required (or set NB_WORK_DIR)");
+    process.exit(2);
+  }
+  return { workDir, dryRun };
+}
+
+function printHelp(): void {
+  console.log(`
+heal-truncated-personal-workspaces — Stage 1 follow-up
+
+Heals personal workspaces whose legacy slug used the 16-char-truncated
+form, which the original migrate-personal-workspaces did not recognize.
+
+Usage:
+  bun run scripts/heal-truncated-personal-workspaces.ts [options]
+
+Options:
+  --work-dir <path>   Override the work directory.
+                      Defaults to $NB_WORK_DIR or ~/.nimblebrain.
+  --dry-run           Report planned changes without writing.
+  -h, --help          This message.
+
+Run AFTER migrate-personal-workspaces. Idempotent: running twice produces
+no changes the second time. Run with --dry-run first to verify the plan.
+`);
+}
+
+/**
+ * Build the 16-char-truncated personal-workspace id this script targets.
+ * The truncation form was an artifact of pre-Stage-1 hq production — a
+ * legacy convention not used elsewhere and intentionally not exported.
+ */
+function truncatedPersonalIdFor(userId: string): string {
+  const slug = userId.replace(/^user_/, "").toLowerCase().slice(0, 16);
+  return `ws_${slug}`;
+}
+
+function isAdminOf(ws: Workspace, userId: string): boolean {
+  return ws.members.some((m) => m.userId === userId && m.role === "admin");
+}
+
+/**
+ * Count top-level conversation JSONL files whose metadata's
+ * `workspaceId` equals `id`. Conversations are stored at
+ * `{workDir}/conversations/*.jsonl` post-Stage-1.
+ */
+async function countConversationRefs(
+  conversationsDir: string,
+  id: string,
+): Promise<number> {
+  if (!existsSync(conversationsDir)) return 0;
+  let n = 0;
+  for (const fname of await readdir(conversationsDir)) {
+    if (!fname.endsWith(".jsonl")) continue;
+    const meta = await readConversationMetadata(join(conversationsDir, fname));
+    if (meta && meta.workspaceId === id) n++;
+  }
+  return n;
+}
+
+/**
+ * Read the metadata line (line 1) of a conversation JSONL. Returns null
+ * if unreadable / unparseable — the file is left alone in that case.
+ */
+async function readConversationMetadata(
+  filePath: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const newlineIdx = raw.indexOf("\n");
+    const firstLine = newlineIdx < 0 ? raw : raw.slice(0, newlineIdx);
+    return JSON.parse(firstLine) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rewrite the metadata line of a conversation JSONL so its
+ * `workspaceId` reflects the renamed workspace. Returns true if
+ * rewritten. Other lines pass through byte-identical.
+ */
+async function rewriteConversationWorkspaceId(
+  filePath: string,
+  oldId: string,
+  newId: string,
+): Promise<boolean> {
+  const raw = await readFile(filePath, "utf-8");
+  const newlineIdx = raw.indexOf("\n");
+  if (newlineIdx < 0) return false;
+
+  const metadataLine = raw.slice(0, newlineIdx);
+  const rest = raw.slice(newlineIdx); // includes the leading \n
+
+  let meta: Record<string, unknown>;
+  try {
+    meta = JSON.parse(metadataLine);
+  } catch {
+    return false;
+  }
+  if (meta.workspaceId !== oldId) return false;
+  meta.workspaceId = newId;
+  const newMetadata = JSON.stringify(meta);
+
+  const tmp = `${filePath}.tmp.${Date.now()}`;
+  await writeFile(tmp, `${newMetadata}${rest}`, { encoding: "utf-8", mode: 0o600 });
+  await rename(tmp, filePath);
+  return true;
+}
+
+/**
+ * Heal one user's truncated personal workspace. All filesystem mutations
+ * are confined to here; the caller composes pre-checks + stats.
+ */
+async function healOne(opts: {
+  workspacesDir: string;
+  conversationsDir: string;
+  truncatedId: string;
+  canonicalId: string;
+  userId: string;
+  truncatedWs: Workspace;
+  dryRun: boolean;
+}): Promise<{ ok: true } | { error: string }> {
+  const {
+    workspacesDir,
+    conversationsDir,
+    truncatedId,
+    canonicalId,
+    userId,
+    dryRun,
+  } = opts;
+
+  const truncatedDir = join(workspacesDir, truncatedId);
+  const canonicalDir = join(workspacesDir, canonicalId);
+
+  // Stub-handling on the canonical id.
+  if (existsSync(canonicalDir)) {
+    const canonicalWsPath = join(canonicalDir, "workspace.json");
+    if (existsSync(canonicalWsPath)) {
+      const canonicalWs = JSON.parse(
+        await readFile(canonicalWsPath, "utf-8"),
+      ) as Workspace;
+      const bundleCount = canonicalWs.bundles?.length ?? 0;
+      const refCount = await countConversationRefs(conversationsDir, canonicalId);
+      if (bundleCount > 0 || refCount > 0) {
+        return {
+          error:
+            `canonical stub ${canonicalId} holds state ` +
+            `(bundles=${bundleCount}, convRefs=${refCount}) — ` +
+            "manual reconciliation required",
+        };
+      }
+      console.error(
+        `[heal] ${userId}: ${dryRun ? "[dry-run] would " : ""}delete empty canonical stub ${canonicalId}`,
+      );
+      if (!dryRun) await rm(canonicalDir, { recursive: true, force: true });
+    } else {
+      console.error(
+        `[heal] ${userId}: ${dryRun ? "[dry-run] would " : ""}delete stub dir ${canonicalId} (no workspace.json)`,
+      );
+      if (!dryRun) await rm(canonicalDir, { recursive: true, force: true });
+    }
+  }
+
+  // Rename truncatedId → canonicalId.
+  console.error(
+    `[heal] ${userId}: ${dryRun ? "[dry-run] would " : ""}rename ${truncatedId} → ${canonicalId}`,
+  );
+  if (!dryRun) {
+    await rename(truncatedDir, canonicalDir);
+    // Rewrite workspace.json with identity stamps.
+    const wsPath = join(canonicalDir, "workspace.json");
+    const raw = await readFile(wsPath, "utf-8");
+    const ws = JSON.parse(raw) as Workspace;
+    const updated: Workspace = {
+      ...ws,
+      id: canonicalId,
+      isPersonal: true,
+      ownerUserId: userId,
+      about: ws.about ?? null,
+      updatedAt: new Date().toISOString(),
+    };
+    await writeJsonAtomic(wsPath, updated);
+  }
+
+  // Rewrite workspaceId on conversations that point at the truncated id.
+  let rewrites = 0;
+  if (existsSync(conversationsDir)) {
+    for (const fname of await readdir(conversationsDir)) {
+      if (!fname.endsWith(".jsonl")) continue;
+      const cpath = join(conversationsDir, fname);
+      const meta = await readConversationMetadata(cpath);
+      if (!meta || meta.workspaceId !== truncatedId) continue;
+      if (dryRun) {
+        rewrites++;
+        continue;
+      }
+      if (await rewriteConversationWorkspaceId(cpath, truncatedId, canonicalId)) {
+        rewrites++;
+      }
+    }
+  }
+  console.error(
+    `[heal] ${userId}: ${dryRun ? "[dry-run] would " : ""}rewrite workspaceId on ${rewrites} conversation(s)`,
+  );
+
+  return { ok: true };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  console.error(
+    `[heal] workDir=${args.workDir}${args.dryRun ? " (dry-run)" : ""}`,
+  );
+
+  const workspacesDir = join(args.workDir, "workspaces");
+  const usersDir = join(args.workDir, "users");
+  const conversationsDir = join(args.workDir, "conversations");
+
+  if (!existsSync(workspacesDir)) {
+    console.error(`[heal] no workspaces dir at ${workspacesDir} — nothing to do`);
+    return;
+  }
+  if (!existsSync(usersDir)) {
+    console.error(`[heal] no users dir at ${usersDir} — nothing to do`);
+    return;
+  }
+
+  // Same lock as the Stage 1 migrations. Auto-released on exit / signal.
+  acquireMigrationLock(args.workDir, "heal-truncated-personal-workspaces");
+
+  const userStore = new UserStore(args.workDir);
+  const wsStore = new WorkspaceStore(args.workDir);
+  const stats: Stats = {
+    usersScanned: 0,
+    healed: 0,
+    alreadyCanonical: 0,
+    noTruncatedWorkspace: 0,
+    skippedNameMismatch: 0,
+    skippedNotAdmin: 0,
+    errors: [],
+  };
+
+  const users = await userStore.list();
+  for (const user of users) {
+    stats.usersScanned++;
+    const canonicalId = personalWorkspaceIdFor(user.id);
+    const truncatedId = truncatedPersonalIdFor(user.id);
+
+    // The truncation only matters when the truncated form differs from
+    // the canonical form (it always will for real `user_<ULID>` ids, but
+    // synthetic / short test ids may collapse — skip those cleanly).
+    if (truncatedId === canonicalId) {
+      stats.alreadyCanonical++;
+      continue;
+    }
+
+    try {
+      const truncatedWs = await wsStore.get(truncatedId);
+      if (!truncatedWs) {
+        console.error(
+          `[heal] ${user.id}: no truncated workspace ${truncatedId} — skip`,
+        );
+        stats.noTruncatedWorkspace++;
+        continue;
+      }
+
+      const expectedName = `${user.displayName}'s Workspace`;
+      if (truncatedWs.name !== expectedName) {
+        console.error(
+          `[heal] ${user.id}: ${truncatedId} name ${JSON.stringify(truncatedWs.name)} != expected ${JSON.stringify(expectedName)} — skip (not a personal workspace)`,
+        );
+        stats.skippedNameMismatch++;
+        continue;
+      }
+
+      if (!isAdminOf(truncatedWs, user.id)) {
+        console.error(
+          `[heal] ${user.id}: not admin of ${truncatedId} — skip`,
+        );
+        stats.skippedNotAdmin++;
+        continue;
+      }
+
+      const result = await healOne({
+        workspacesDir,
+        conversationsDir,
+        truncatedId,
+        canonicalId,
+        userId: user.id,
+        truncatedWs,
+        dryRun: args.dryRun,
+      });
+      if ("error" in result) {
+        console.error(`[heal] ${user.id}: ERROR: ${result.error}`);
+        stats.errors.push({ ctx: user.id, message: result.error });
+        continue;
+      }
+      stats.healed++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[heal] ERROR for user ${user.id}: ${message}`);
+      stats.errors.push({ ctx: user.id, message });
+    }
+  }
+
+  console.error("");
+  console.error(`[heal] summary${args.dryRun ? " (dry-run)" : ""}:`);
+  console.error(`[heal]   users scanned:                 ${stats.usersScanned}`);
+  console.error(`[heal]   healed users:                  ${stats.healed}`);
+  console.error(`[heal]   already canonical (skipped):   ${stats.alreadyCanonical}`);
+  console.error(`[heal]   no truncated workspace:        ${stats.noTruncatedWorkspace}`);
+  console.error(`[heal]   skipped (name mismatch):       ${stats.skippedNameMismatch}`);
+  console.error(`[heal]   skipped (not admin):           ${stats.skippedNotAdmin}`);
+  console.error(`[heal]   errors:                        ${stats.errors.length}`);
+  if (stats.errors.length > 0) {
+    for (const e of stats.errors) {
+      console.error(`[heal]     [error] ${e.ctx}: ${e.message}`);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lib/conversation-metadata.ts
+++ b/scripts/lib/conversation-metadata.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared metadata-line helpers for top-level conversation JSONL files.
+ *
+ * Conversations are stored at `{workDir}/conversations/<convId>.jsonl`
+ * post-Stage-1. The first line is a JSON metadata object whose fields
+ * (id, ownerId, workspaceId, etc.) are read on every conversation
+ * lookup. Subsequent lines are the append-only event log and MUST be
+ * preserved byte-identical when the metadata is rewritten.
+ *
+ * Migrations and heals that rename workspace ids reach into the
+ * metadata line to update the `workspaceId` field. Three sites needed
+ * this logic prior to extraction (`migrate-personal-workspaces.ts` plus
+ * two copies in `heal-truncated-personal-workspaces.ts`). Future
+ * workspace-id-renaming migrations should reuse this helper.
+ */
+
+import { readFile, rename, writeFile } from "node:fs/promises";
+
+/**
+ * Read the metadata line (line 1) of a top-level conversation JSONL.
+ * Returns null if the file is unreadable, the metadata line is not
+ * valid JSON, or the file has no newline (single-line file is malformed
+ * — leave it alone). Callers treat null as "skip this file."
+ */
+export async function readConversationMetadata(
+  filePath: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const newlineIdx = raw.indexOf("\n");
+    const firstLine = newlineIdx < 0 ? raw : raw.slice(0, newlineIdx);
+    return JSON.parse(firstLine) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rewrite the metadata line of a conversation JSONL so its
+ * `workspaceId` field reflects a workspace id rename. Returns true if
+ * the file was rewritten, false if the metadata's `workspaceId`
+ * didn't match `oldId` (already migrated, different workspace, or
+ * malformed metadata). Other lines pass through byte-identical via
+ * tmp-file + atomic rename.
+ */
+export async function rewriteConversationWorkspaceId(
+  filePath: string,
+  oldId: string,
+  newId: string,
+): Promise<boolean> {
+  const raw = await readFile(filePath, "utf-8");
+  const newlineIdx = raw.indexOf("\n");
+  if (newlineIdx < 0) return false;
+
+  const metadataLine = raw.slice(0, newlineIdx);
+  const rest = raw.slice(newlineIdx); // includes the leading \n
+
+  let meta: Record<string, unknown>;
+  try {
+    meta = JSON.parse(metadataLine);
+  } catch {
+    return false;
+  }
+  if (meta.workspaceId !== oldId) return false;
+  meta.workspaceId = newId;
+  const newMetadata = JSON.stringify(meta);
+
+  const tmp = `${filePath}.tmp.${Date.now()}`;
+  await writeFile(tmp, `${newMetadata}${rest}`, { encoding: "utf-8", mode: 0o600 });
+  await rename(tmp, filePath);
+  return true;
+}

--- a/scripts/migrate-personal-workspaces.ts
+++ b/scripts/migrate-personal-workspaces.ts
@@ -27,7 +27,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { readdir, readFile, rename, writeFile } from "node:fs/promises";
+import { readdir, readFile, rename } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { UserStore } from "../src/identity/user.ts";
@@ -37,6 +37,7 @@ import {
   WorkspaceStore,
 } from "../src/workspace/workspace-store.ts";
 import type { Workspace } from "../src/workspace/types.ts";
+import { rewriteConversationWorkspaceId } from "./lib/conversation-metadata.ts";
 import { acquireMigrationLock } from "./lib/migration-lock.ts";
 
 interface Args {
@@ -182,40 +183,6 @@ async function renameWorkspace(
     if (!fname.endsWith(".jsonl")) continue;
     await rewriteConversationWorkspaceId(join(convDir, fname), oldId, newId);
   }
-}
-
-/**
- * Rewrite the metadata line (line 1) of a conversation JSONL so its
- * `workspaceId` reflects the renamed workspace. Other lines are passed
- * through byte-identical — never reparse run/llm/tool events here.
- */
-async function rewriteConversationWorkspaceId(
-  filePath: string,
-  oldId: string,
-  newId: string,
-): Promise<void> {
-  const raw = await readFile(filePath, "utf-8");
-  const newlineIdx = raw.indexOf("\n");
-  if (newlineIdx < 0) return;
-
-  const metadataLine = raw.slice(0, newlineIdx);
-  const rest = raw.slice(newlineIdx); // includes the leading \n
-
-  let meta: Record<string, unknown>;
-  try {
-    meta = JSON.parse(metadataLine);
-  } catch {
-    // Malformed metadata; leave the file alone. Operator can fix.
-    return;
-  }
-  if (meta.workspaceId !== oldId) return; // already migrated or different ws
-  meta.workspaceId = newId;
-  const newMetadata = JSON.stringify(meta);
-
-  // Atomic write: tmp file + rename.
-  const tmp = `${filePath}.tmp.${Date.now()}`;
-  await writeFile(tmp, `${newMetadata}${rest}`, { encoding: "utf-8", mode: 0o600 });
-  await rename(tmp, filePath);
 }
 
 /**

--- a/test/integration/heal-truncated-personal-workspaces.test.ts
+++ b/test/integration/heal-truncated-personal-workspaces.test.ts
@@ -431,6 +431,103 @@ describe("heal-truncated-personal-workspaces", () => {
     }
   });
 
+  test("adversarial: canonical stub has allowHttpProxy set → script refuses (allowlist catches non-enumerated field)", async () => {
+    // Round-2 QA finding: the original check was an explicit denylist
+    // of known unsafe fields and missed `allowHttpProxy`. The allowlist
+    // makes any field outside ALLOWED_STUB_KEYS forbidden by default.
+    // Pinning a specific field that wasn't in the original denylist
+    // proves the new approach catches them all — including ones that
+    // don't exist yet.
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Personal",
+      members: [{ userId: USER_ID, role: "admin" }],
+      bundles: [],
+      extra: { allowHttpProxy: false },
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("canonical stub");
+    expect(stderr).toContain("unexpected field: allowHttpProxy");
+    expect(stderr).toContain("manual reconciliation required");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("partial-rename adversarial: canonical name doesn't match → refuse to stamp", async () => {
+    // Round-2 QA finding: partial-rename branch must verify the
+    // canonical is actually the user's personal before stamping
+    // identity onto it. A workspace named something else that happens
+    // to live at ws_user_<userId> shouldn't be silently claimed.
+    await seedUser();
+    // No truncated workspace.
+    // Canonical exists but is a totally unrelated workspace.
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Some Team Project", // NOT "Alice's Workspace"
+      members: [{ userId: USER_ID, role: "admin" }],
+      bundles: [{ source: { type: "static", name: "fake" } } as unknown],
+      // Stale identity stamps (the trigger condition):
+      isPersonal: false,
+      extra: { id: TRUNCATED_WS_ID },
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain(`canonical ${CANONICAL_WS_ID} exists with stale identity`);
+    expect(stderr).toContain("unexpected name");
+    expect(stderr).toContain("manual reconciliation required");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("partial-rename adversarial: user is not admin of canonical → refuse to stamp", async () => {
+    await seedUser();
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: EXPECTED_NAME,
+      members: [
+        { userId: USER_ID, role: "member" },
+        { userId: "user_other", role: "admin" },
+      ],
+      isPersonal: false,
+      extra: { id: TRUNCATED_WS_ID },
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain(`canonical ${CANONICAL_WS_ID} exists with stale identity`);
+    expect(stderr).toContain(`${USER_ID} is not an admin`);
+    expect(stderr).toContain("manual reconciliation required");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
   test("partial-rename heal: canonical exists with stale id + no truncated → stamp identity + rewrite refs", async () => {
     // Simulates a prior heal run that crashed between the directory
     // rename and the workspace.json rewrite. On rerun, the truncated

--- a/test/integration/heal-truncated-personal-workspaces.test.ts
+++ b/test/integration/heal-truncated-personal-workspaces.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Exercises scripts/heal-truncated-personal-workspaces.ts against a
+ * fake work tree. Each test names the failure mode it pins — adversarial
+ * cases caught Stage 1 lessons (no silent auto-merging, no name guessing,
+ * no membership guessing).
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const SCRIPT = join(
+  import.meta.dirname ?? __dirname,
+  "..",
+  "..",
+  "scripts",
+  "heal-truncated-personal-workspaces.ts",
+);
+
+// A real-shaped userId so the 16-char truncation differs from the full
+// ULID. `user_<26-char-ULID>` is the canonical form.
+const USER_ID = "user_01kp730nhbcj3ck2hfhe3hmnf6";
+const DISPLAY_NAME = "Alice";
+// Truncated form: 16 chars of the ULID after stripping `user_`.
+const TRUNCATED_WS_ID = "ws_01kp730nhbcj3ck2";
+// Canonical form (personalWorkspaceIdFor): `ws_user_<userId>`.
+const CANONICAL_WS_ID = `ws_user_${USER_ID}`;
+const EXPECTED_NAME = `${DISPLAY_NAME}'s Workspace`;
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "nb-heal-trunc-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function seedUser(
+  id: string = USER_ID,
+  email = "alice@example.com",
+  displayName: string = DISPLAY_NAME,
+): Promise<void> {
+  const dir = join(workDir, "users", id);
+  await mkdir(dir, { recursive: true });
+  const now = new Date().toISOString();
+  await writeFile(
+    join(dir, "profile.json"),
+    `${JSON.stringify(
+      {
+        id,
+        email,
+        displayName,
+        orgRole: "member",
+        preferences: {},
+        createdAt: now,
+        updatedAt: now,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function seedWorkspace(opts: {
+  id: string;
+  name: string;
+  members: Array<{ userId: string; role: "admin" | "member" }>;
+  bundles?: unknown[];
+  isPersonal?: boolean;
+  ownerUserId?: string;
+  about?: string | null;
+}): Promise<void> {
+  const wsDir = join(workDir, "workspaces", opts.id);
+  await mkdir(wsDir, { recursive: true, mode: 0o700 });
+  const now = new Date().toISOString();
+  const ws: Record<string, unknown> = {
+    id: opts.id,
+    name: opts.name,
+    members: opts.members,
+    bundles: opts.bundles ?? [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  if (opts.isPersonal !== undefined) ws.isPersonal = opts.isPersonal;
+  if (opts.ownerUserId !== undefined) ws.ownerUserId = opts.ownerUserId;
+  if (opts.about !== undefined) ws.about = opts.about;
+  await writeFile(join(wsDir, "workspace.json"), `${JSON.stringify(ws, null, 2)}\n`);
+}
+
+async function seedTopLevelConversation(opts: {
+  convId: string;
+  workspaceId: string;
+  ownerId?: string;
+}): Promise<void> {
+  const dir = join(workDir, "conversations");
+  await mkdir(dir, { recursive: true });
+  const metadata = {
+    id: opts.convId,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    title: null,
+    lastModel: null,
+    ownerId: opts.ownerId ?? USER_ID,
+    workspaceId: opts.workspaceId,
+    format: "events",
+  };
+  const body =
+    `${JSON.stringify(metadata)}\n` +
+    `${JSON.stringify({ ts: new Date().toISOString(), type: "user.message", content: [{ type: "text", text: "hi" }] })}\n`;
+  await writeFile(join(dir, `${opts.convId}.jsonl`), body);
+}
+
+async function readWorkspace(id: string): Promise<Record<string, unknown>> {
+  const raw = await readFile(join(workDir, "workspaces", id, "workspace.json"), "utf-8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+async function readConvMetadata(convId: string): Promise<Record<string, unknown>> {
+  const raw = await readFile(
+    join(workDir, "conversations", `${convId}.jsonl`),
+    "utf-8",
+  );
+  const firstLine = raw.split("\n")[0] ?? "";
+  return JSON.parse(firstLine) as Record<string, unknown>;
+}
+
+async function runHeal(args: string[] = []): Promise<{ exitCode: number; stderr: string }> {
+  const proc = Bun.spawn({
+    cmd: ["bun", "run", SCRIPT, "--work-dir", workDir, ...args],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stderr };
+}
+
+/**
+ * Deep-snapshot the workdir: per-file relative-path → SHA-256 of bytes.
+ * Used to verify dry-run is byte-identical (no observable mutation).
+ */
+async function snapshotWorkdir(): Promise<Map<string, string>> {
+  const snap = new Map<string, string>();
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) {
+        await walk(full);
+      } else if (e.isFile()) {
+        const bytes = await readFile(full);
+        const hasher = new Bun.CryptoHasher("sha256");
+        hasher.update(bytes);
+        snap.set(relative(workDir, full), hasher.digest("hex"));
+      }
+    }
+  }
+  await walk(workDir);
+  return snap;
+}
+
+describe("heal-truncated-personal-workspaces", () => {
+  test("happy path: deletes empty canonical stub, renames truncated → canonical, stamps identity, rewrites conv refs", async () => {
+    await seedUser();
+    // Personal workspace at the truncated id with the correct name +
+    // admin membership.
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    // An empty canonical stub left by Stage 1's lazy-create or by a
+    // misclassified backfill.
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Personal",
+      members: [{ userId: USER_ID, role: "admin" }],
+      bundles: [],
+    });
+    // A conversation that still points at the truncated workspace id.
+    await seedTopLevelConversation({
+      convId: "conv_alpha",
+      workspaceId: TRUNCATED_WS_ID,
+    });
+
+    const { exitCode, stderr } = await runHeal();
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain(`delete empty canonical stub ${CANONICAL_WS_ID}`);
+    expect(stderr).toContain(`rename ${TRUNCATED_WS_ID} → ${CANONICAL_WS_ID}`);
+    expect(stderr).toContain("rewrite workspaceId on 1 conversation(s)");
+
+    // Truncated gone, canonical exists.
+    expect(existsSync(join(workDir, "workspaces", TRUNCATED_WS_ID))).toBe(false);
+    expect(existsSync(join(workDir, "workspaces", CANONICAL_WS_ID))).toBe(true);
+
+    // Identity stamps + id rewrite on the canonical workspace.json.
+    const ws = await readWorkspace(CANONICAL_WS_ID);
+    expect(ws.id).toBe(CANONICAL_WS_ID);
+    expect(ws.isPersonal).toBe(true);
+    expect(ws.ownerUserId).toBe(USER_ID);
+    expect(ws.about).toBeNull();
+    expect(ws.name).toBe(EXPECTED_NAME);
+
+    // Conversation metadata rewritten; other lines preserved.
+    const meta = await readConvMetadata("conv_alpha");
+    expect(meta.workspaceId).toBe(CANONICAL_WS_ID);
+    const raw = await readFile(
+      join(workDir, "conversations", "conv_alpha.jsonl"),
+      "utf-8",
+    );
+    expect(raw).toContain('"type":"user.message"');
+    expect(raw).toContain('"text":"hi"');
+  });
+
+  test("no canonical stub: just rename + stamp, no error", async () => {
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    expect(existsSync(join(workDir, "workspaces", CANONICAL_WS_ID))).toBe(false);
+
+    const { exitCode, stderr } = await runHeal();
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("delete empty canonical stub");
+    expect(stderr).toContain(`rename ${TRUNCATED_WS_ID} → ${CANONICAL_WS_ID}`);
+
+    expect(existsSync(join(workDir, "workspaces", TRUNCATED_WS_ID))).toBe(false);
+    const ws = await readWorkspace(CANONICAL_WS_ID);
+    expect(ws.id).toBe(CANONICAL_WS_ID);
+    expect(ws.isPersonal).toBe(true);
+    expect(ws.ownerUserId).toBe(USER_ID);
+  });
+
+  test("adversarial: canonical stub has bundles → script refuses, leaves both workspaces untouched", async () => {
+    // Pins the "don't silently clobber state" invariant. A naive port
+    // that rm-rf'd the canonical dir whenever it existed would lose
+    // an admin's app installs.
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Personal",
+      members: [{ userId: USER_ID, role: "admin" }],
+      bundles: [
+        { source: { type: "static", name: "fake-bundle" } } as unknown,
+      ],
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("canonical stub");
+    expect(stderr).toContain("manual reconciliation required");
+
+    // Both directories still present, bytes unchanged.
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("adversarial: name mismatch → that user is skipped", async () => {
+    // Pins the "don't guess the personal owner from id shape alone"
+    // invariant. A workspace at the truncated id whose name isn't
+    // `<displayName>'s Workspace` could be anything; do not assume.
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: "Shared Team Workspace", // NOT "Alice's Workspace"
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("not a personal workspace");
+    expect(stderr).toContain("skipped (name mismatch)");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("adversarial: user is not admin of the truncated workspace → skip", async () => {
+    // Pins "membership check is required". A user could be a plain
+    // member on a workspace that happens to live at their truncated
+    // id; healing it would steal it from its real owner.
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [
+        { userId: USER_ID, role: "member" },
+        { userId: "user_other", role: "admin" },
+      ],
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain(`not admin of ${TRUNCATED_WS_ID}`);
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("idempotent: a second --apply run after a successful first run is a no-op", async () => {
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    await seedTopLevelConversation({
+      convId: "conv_alpha",
+      workspaceId: TRUNCATED_WS_ID,
+    });
+
+    const first = await runHeal();
+    expect(first.exitCode).toBe(0);
+    expect(first.stderr).toContain(`rename ${TRUNCATED_WS_ID} → ${CANONICAL_WS_ID}`);
+
+    const afterFirst = await snapshotWorkdir();
+
+    // Mutate updatedAt to be detectable: but the script only writes if
+    // it identifies a truncated personal; second run finds none.
+    const second = await runHeal();
+    expect(second.exitCode).toBe(0);
+    expect(second.stderr).toContain("no truncated workspace");
+    expect(second.stderr).not.toContain("rename");
+
+    const afterSecond = await snapshotWorkdir();
+    expect(afterSecond.size).toBe(afterFirst.size);
+    for (const [path, hash] of afterFirst) {
+      expect(afterSecond.get(path)).toBe(hash);
+    }
+  });
+
+  test("dry-run: workdir is byte-identical before and after", async () => {
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Personal",
+      members: [{ userId: USER_ID, role: "admin" }],
+      bundles: [],
+    });
+    await seedTopLevelConversation({
+      convId: "conv_alpha",
+      workspaceId: TRUNCATED_WS_ID,
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal(["--dry-run"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("[dry-run] would rename");
+    expect(stderr).toContain("[dry-run] would delete empty canonical stub");
+    expect(stderr).toContain("[dry-run] would rewrite workspaceId on 1 conversation(s)");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("lock contention: second --apply while a first holds the lock fails fast with holder details", async () => {
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+
+    // Plant a live lock pointing at this test process (which is alive).
+    const lockPath = join(workDir, ".migration-lock");
+    await writeFile(
+      lockPath,
+      `${JSON.stringify(
+        {
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+          script: "migrate-personal-workspaces",
+        },
+        null,
+        2,
+      )}\n`,
+      { mode: 0o600 },
+    );
+
+    const { exitCode, stderr } = await runHeal();
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Another migration is already running");
+    expect(stderr).toContain("migrate-personal-workspaces");
+    expect(stderr).toContain(`pid=${process.pid}`);
+
+    // The truncated workspace was not touched.
+    expect(existsSync(join(workDir, "workspaces", TRUNCATED_WS_ID))).toBe(true);
+    expect(existsSync(join(workDir, "workspaces", CANONICAL_WS_ID))).toBe(false);
+
+    // Clean up the plant so afterEach doesn't trip on it (rm -rf would
+    // succeed regardless; this is just hygiene). Also confirms the lock
+    // still belongs to us — the failed run didn't take it over.
+    const cur = JSON.parse(await readFile(lockPath, "utf-8")) as { pid: number };
+    expect(cur.pid).toBe(process.pid);
+    await stat(lockPath); // throws if missing — sanity
+  });
+
+  test("--help exits 0 and prints usage", async () => {
+    const proc = Bun.spawn({
+      cmd: ["bun", "run", SCRIPT, "--help"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("heal-truncated-personal-workspaces");
+    expect(stdout).toContain("--work-dir");
+    expect(stdout).toContain("--dry-run");
+  });
+});

--- a/test/integration/heal-truncated-personal-workspaces.test.ts
+++ b/test/integration/heal-truncated-personal-workspaces.test.ts
@@ -73,6 +73,7 @@ async function seedWorkspace(opts: {
   isPersonal?: boolean;
   ownerUserId?: string;
   about?: string | null;
+  extra?: Record<string, unknown>;
 }): Promise<void> {
   const wsDir = join(workDir, "workspaces", opts.id);
   await mkdir(wsDir, { recursive: true, mode: 0o700 });
@@ -88,6 +89,7 @@ async function seedWorkspace(opts: {
   if (opts.isPersonal !== undefined) ws.isPersonal = opts.isPersonal;
   if (opts.ownerUserId !== undefined) ws.ownerUserId = opts.ownerUserId;
   if (opts.about !== undefined) ws.about = opts.about;
+  if (opts.extra) Object.assign(ws, opts.extra);
   await writeFile(join(wsDir, "workspace.json"), `${JSON.stringify(ws, null, 2)}\n`);
 }
 
@@ -273,6 +275,202 @@ describe("heal-truncated-personal-workspaces", () => {
     }
   });
 
+  test("adversarial: canonical stub has extra members → script refuses, leaves both workspaces untouched", async () => {
+    // Pre-PR-C, a personal workspace could carry multiple admins (the
+    // case we observed on hq production where Mat was admin on Mario's
+    // personal workspace). An rm -rf that ignored membership would
+    // strip those collaborators from the audit trail without warning.
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Personal",
+      members: [
+        { userId: USER_ID, role: "admin" },
+        { userId: "user_collaborator", role: "admin" },
+      ],
+      bundles: [],
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("canonical stub");
+    expect(stderr).toContain("workspace.json is populated");
+    expect(stderr).toContain("members");
+    expect(stderr).toContain("manual reconciliation required");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("adversarial: canonical stub has populated optional field (agents) → script refuses", async () => {
+    // workspace.json can carry agents/skillDirs/models/identity/
+    // connectorsAllowList/oauthOperatorApps. None of these were
+    // checked by the original bundle-count gate. Picking `agents` as
+    // a representative; the check is shape-driven and covers all.
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Personal",
+      members: [{ userId: USER_ID, role: "admin" }],
+      bundles: [],
+      extra: {
+        agents: {
+          assistant: { model: "anthropic:claude-sonnet-4-6", identity: null },
+        },
+      },
+    });
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("canonical stub");
+    expect(stderr).toContain("agents");
+    expect(stderr).toContain("manual reconciliation required");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("adversarial: canonical stub has populated subdir (data/) → script refuses", async () => {
+    // Stage 0 scaffolds data/, credentials/, skills/, files/ with
+    // .gitkeep sentinels. If a user ever wrote real content into any
+    // of them (a credentialed bundle wrote to data/X.json, a custom
+    // skill landed under skills/, etc.), an rm -rf would silently
+    // destroy it. The recursive walk catches this even when
+    // workspace.json is empty.
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Personal",
+      members: [{ userId: USER_ID, role: "admin" }],
+      bundles: [],
+    });
+    const stubDataDir = join(workDir, "workspaces", CANONICAL_WS_ID, "data");
+    await mkdir(stubDataDir, { recursive: true });
+    await writeFile(join(stubDataDir, ".gitkeep"), "");
+    await writeFile(join(stubDataDir, "real-content.json"), '{"x":1}');
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("canonical stub");
+    expect(stderr).toContain("unexpected content");
+    expect(stderr).toContain("real-content.json");
+    expect(stderr).toContain("manual reconciliation required");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("adversarial: canonical stub has legacy conversations/ subdir → script refuses", async () => {
+    // Stage 0 stubs predate the Stage 1 conversations move. A legacy
+    // per-workspace `conversations/*.jsonl` file inside the canonical
+    // dir would have been silently destroyed by an rm -rf — the
+    // top-level countConversationRefs check only scans
+    // {workDir}/conversations/, never the per-workspace subdir.
+    await seedUser();
+    await seedWorkspace({
+      id: TRUNCATED_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+    });
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: "Personal",
+      members: [{ userId: USER_ID, role: "admin" }],
+      bundles: [],
+    });
+    const stubConvDir = join(workDir, "workspaces", CANONICAL_WS_ID, "conversations");
+    await mkdir(stubConvDir, { recursive: true });
+    await writeFile(
+      join(stubConvDir, "conv_legacy.jsonl"),
+      `${JSON.stringify({ id: "conv_legacy", createdAt: new Date().toISOString() })}\n`,
+    );
+
+    const before = await snapshotWorkdir();
+    const { exitCode, stderr } = await runHeal();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("canonical stub");
+    expect(stderr).toContain("unexpected content");
+    expect(stderr).toContain("conv_legacy.jsonl");
+    expect(stderr).toContain("manual reconciliation required");
+
+    const after = await snapshotWorkdir();
+    expect(after.size).toBe(before.size);
+    for (const [path, hash] of before) {
+      expect(after.get(path)).toBe(hash);
+    }
+  });
+
+  test("partial-rename heal: canonical exists with stale id + no truncated → stamp identity + rewrite refs", async () => {
+    // Simulates a prior heal run that crashed between the directory
+    // rename and the workspace.json rewrite. On rerun, the truncated
+    // dir is gone, but the canonical dir's embedded `id`,
+    // `isPersonal`, `ownerUserId` still point at the pre-rename
+    // values. Detect-and-stamp on rerun — mirrors Stage 1's
+    // migrate-personal-workspaces partial-rename heal.
+    await seedUser();
+    // The canonical dir exists, but its workspace.json is in the
+    // pre-rename state.
+    await seedWorkspace({
+      id: CANONICAL_WS_ID,
+      name: EXPECTED_NAME,
+      members: [{ userId: USER_ID, role: "admin" }],
+      // Stale fields the crash left behind:
+      isPersonal: false,
+      // Note: ownerUserId intentionally absent.
+      extra: { id: TRUNCATED_WS_ID }, // overrides the seedWorkspace-set id
+    });
+    // A conversation that still references the pre-rename id.
+    await seedTopLevelConversation({
+      convId: "conv_alpha",
+      workspaceId: TRUNCATED_WS_ID,
+    });
+
+    const { exitCode, stderr } = await runHeal();
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain(`stamp identity on partial-rename canonical ${CANONICAL_WS_ID}`);
+    expect(stderr).toContain("rewrite workspaceId on 1 conversation(s) referencing truncated id");
+    expect(stderr).toContain("partial-rename healed:         1");
+
+    const ws = await readWorkspace(CANONICAL_WS_ID);
+    expect(ws.id).toBe(CANONICAL_WS_ID);
+    expect(ws.isPersonal).toBe(true);
+    expect(ws.ownerUserId).toBe(USER_ID);
+
+    const meta = await readConvMetadata("conv_alpha");
+    expect(meta.workspaceId).toBe(CANONICAL_WS_ID);
+  });
+
   test("adversarial: name mismatch → that user is skipped", async () => {
     // Pins the "don't guess the personal owner from id shape alone"
     // invariant. A workspace at the truncated id whose name isn't
@@ -323,7 +521,7 @@ describe("heal-truncated-personal-workspaces", () => {
     }
   });
 
-  test("idempotent: a second --apply run after a successful first run is a no-op", async () => {
+  test("idempotent: a second run after a successful first run is a no-op", async () => {
     await seedUser();
     await seedWorkspace({
       id: TRUNCATED_WS_ID,
@@ -346,7 +544,10 @@ describe("heal-truncated-personal-workspaces", () => {
     const second = await runHeal();
     expect(second.exitCode).toBe(0);
     expect(second.stderr).toContain("no truncated workspace");
-    expect(second.stderr).not.toContain("rename");
+    // No rename operation occurred — checking the verb specifically so
+    // the "partial-rename healed" stat label doesn't trigger the assertion.
+    expect(second.stderr).not.toContain("rename ws_");
+    expect(second.stderr).not.toContain("would rename");
 
     const afterSecond = await snapshotWorkdir();
     expect(afterSecond.size).toBe(afterFirst.size);
@@ -387,7 +588,7 @@ describe("heal-truncated-personal-workspaces", () => {
     }
   });
 
-  test("lock contention: second --apply while a first holds the lock fails fast with holder details", async () => {
+  test("lock contention: second run while a first holds the lock fails fast with holder details", async () => {
     await seedUser();
     await seedWorkspace({
       id: TRUNCATED_WS_ID,


### PR DESCRIPTION
## Summary

Stage 1 (PR #244) migrated personal workspaces to the canonical `ws_user_<userId>` form, but `migrate-personal-workspaces.ts` assumed the pre-Stage-1 slug was the full lowercased ULID (`user.id.replace(/^user_/, "").toLowerCase()` → 26 chars). Production tenants like hq used a 16-char-truncated slug (e.g. `ws_01kp730nhbcj3ck2` for `user_01kp730nhbcj3ck2hfhe3hmnf6`). The migration didn't recognize those workspaces as personal: it stamped them `isPersonal: false`, and an empty canonical-form stub (created lazily by `ensureUserWorkspace` or by a Stage 0 backfill) was left holding the Personal slot.

We hand-fixed hq production with a Python heal script. This PR codifies that heal as a TypeScript script matching the existing migration patterns, so future tenants don't need ad-hoc fixes.

## What it does

For each user:
- `truncatedId = "ws_" + userId.replace(/^user_/, "").toLowerCase().slice(0, 16)`
- `canonicalId = personalWorkspaceIdFor(userId)`

If the truncated workspace exists AND its name matches `<displayName>'s Workspace` AND the user is an admin member, the script enters the happy path:

- Three safety gates before deleting the canonical stub: workspace.json fields outside the allowlist (`id`, `name`, `members`, `bundles`, `createdAt`, `updatedAt`, `about`, `isPersonal`, `ownerUserId`), members not exactly the owner-admin, or any unexpected file on disk beyond `workspace.json` + `.gitkeep` sentinels → hard-error, both workspaces left byte-identical. Auto-merging would silently destroy state.
- Atomic FS rename `truncatedId` → `canonicalId`, then rewrite `workspace.json` (`id`, `isPersonal: true`, `ownerUserId`, `about`, `updatedAt`).
- Rewrite the metadata line of every `{workDir}/conversations/*.jsonl` whose `workspaceId` equals the truncated id.

If the truncated is absent but the canonical exists with stale identity stamps (the crash window between rename and json rewrite), the script enters the partial-rename heal path:

- Two safety gates: canonical name must match `<displayName>'s Workspace`, user must be an admin member. Either gate failing → hard-error (manual reconciliation required). The empty-content gates from the happy path do NOT apply here — a partially-renamed canonical legitimately carries the user's bundles and any pre-PR-C extra collaborators.
- Stamp identity on the canonical workspace.json; rewrite any conversation refs still pointing at the truncated id.

Idempotent: a second run finds nothing to heal and exits 0. Holds the same `.migration-lock` PID file as the Stage 1 migrations.

## When to run

After `migrate-personal-workspaces` for any tenant whose migrate output showed `no personal workspace found (will be created on next login)` for users who actually do have a workspace named `<displayName>'s Workspace` at a short-slug id. Safe to run as a no-op on tenants without truncated slugs.

```
bun run heal:truncated-personal-workspaces --work-dir /data --dry-run   # dry-run
bun run heal:truncated-personal-workspaces --work-dir /data             # apply
```

Inside a deployed platform pod:

```
kubectl --context nimblebrain-platform-production exec -n tenant-<client> deploy/tenant-<client>-platform -c platform -- bun run heal:truncated-personal-workspaces --work-dir /data --dry-run
```

A wrapping `make heal-truncated-personal-workspaces CLIENT=<client> ENV=<env>` Makefile target sits uncommitted in the `deployments/nimblebrain` submodule on an unrelated feature branch — will land as a separate submodule commit.

## Test plan

17 integration tests, all pass. Coverage:

**Happy path / structural**
- Happy path: stub deletion + rename + identity stamps + conversation rewrites.
- No canonical stub: just rename + stamp.
- Idempotent: second run is a no-op (byte-identical workdir via SHA-256 snapshot).
- Dry-run is byte-identical.
- Lock contention: planted live lock fails fast with holder pid + script name.
- `--help` exits 0.

**Empty-stub safety (6 adversarial cases — refuse + byte-identical)**
- Canonical stub has bundles → refuse.
- Canonical stub has extra members (pre-PR-C collaborators) → refuse.
- Canonical stub has populated optional field (`agents`) → refuse.
- Canonical stub has populated subdir (`data/X.json`) → refuse via recursive content walk.
- Canonical stub has legacy `conversations/` subdir → refuse.
- Canonical stub has `allowHttpProxy` set → refuse (proves the allowlist catches fields the original denylist missed).

**Eligibility gates (2 adversarial cases — skip)**
- Truncated workspace name mismatch → user skipped (not assumed to be personal).
- User is non-admin of truncated workspace → user skipped.

**Partial-rename heal (3 cases)**
- Happy path: stale-identity canonical + no truncated → stamp + rewrite refs.
- Adversarial: canonical name mismatch → refuse to stamp.
- Adversarial: user not admin of canonical → refuse to stamp.

### Verify state

- `bun run verify:static` — green.
- `bun run test:unit` — 2972 pass / 0 fail.
- `bun run test:web` — 258 pass / 0 fail.
- `bun run test:integration` — 559 pass / 0 fail / 12 skip (17 heal tests included).
- `bun run smoke` — 17 pass / 0 fail.

## Changes since initial PR

Two rounds of QA review have landed on this branch. Summary:

**Round 1 (commit `22e65c3`):**
- Broadened the empty-stub gate to catch populated workspace.json fields, multi-member stubs, populated scaffolding subdirs (`data/`, `credentials/`, `skills/`, `files/`), and legacy `conversations/` subdirs — the original `bundles > 0 || refs > 0` check would have silently `rm -rf`'d real state in any of those cases.
- Added partial-rename heal on rerun (mirrors Stage 1's `migrate-personal-workspaces.ts` pattern).
- Added `heal:truncated-personal-workspaces` script alias in `package.json`.
- Renamed misleading `--apply` references in test descriptions (the script's interface is `--dry-run` opt-in).

**Round 2 (this commit):**
- Inverted the workspace.json field check to an allowlist (`ALLOWED_STUB_KEYS`) — a new optional field on `Workspace` now defaults to forbidden in stubs, not silently allowed. Caught the missing `allowHttpProxy` check.
- Added safety gates to the partial-rename branch (name match + admin membership) so a workspace at the canonical id but unrelated to the user is refused, not silently claimed.
- Extracted `rewriteConversationWorkspaceId` and `readConversationMetadata` to `scripts/lib/conversation-metadata.ts`. `migrate-personal-workspaces.ts` now imports the shared helpers; the heal script's internal duplication is gone too.
- PR body refreshed to match the actual state (test count, invocation commands).

References PR #244 (Stage 1 origin).
