### PR TITLE
fix(prompt): source the chat briefing from the focused workspace

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1337,16 +1337,10 @@ async function parseChatBody(
   }
   const parsed = body as ChatRequestBody;
 
-  // Stage 2 (T006): `/v1/chat` is identity-bound. The body's `workspaceId`
-  // and the `X-Workspace-Id` header are accepted-but-ignored for the chat
-  // path so existing clients (web composer, automations executor) keep
-  // working without a flag day. The header still resolves through
-  // `requireWorkspace` middleware for OTHER routes that consume it
-  // (handleResourceProxy, handleFileServe, handleReadResource); we just
-  // don't thread it into `ChatRequest`. A debug log on every call would
-  // be too noisy; the warning lives in the schema description and the
-  // ChatRequest doc comment.
-  void workspaceId;
+  // The validated `X-Workspace-Id` (focused workspace) threads into
+  // `ChatRequest.workspaceId`: it drives the deterministic per-workspace
+  // briefing (apps + overlays), NOT the tool list (still the identity's
+  // cross-workspace union). See the `ChatRequest.workspaceId` doc comment.
 
   return {
     message: parsed.message,
@@ -1355,6 +1349,7 @@ async function parseChatBody(
     ...(parsed.appContext !== undefined ? { appContext: parsed.appContext } : {}),
     ...(parsed.metadata !== undefined ? { metadata: parsed.metadata } : {}),
     ...(parsed.allowedTools !== undefined ? { allowedTools: parsed.allowedTools } : {}),
+    ...(workspaceId !== undefined ? { workspaceId } : {}),
     ...(identity ? { identity } : {}),
   };
 }
@@ -1421,12 +1416,12 @@ async function parseMultipartChatBody(
   // Stage 2 (T006): no `workspaceId` on the chat envelope — see
   // `parseChatBody`'s comment.
   if (uploadedFiles.length === 0) {
-    void workspaceId;
     return {
       message,
       conversationId: typeof conversationId === "string" ? conversationId : undefined,
       model: typeof model === "string" ? model : undefined,
       appContext,
+      ...(workspaceId !== undefined ? { workspaceId } : {}),
       ...(identity ? { identity } : {}),
     };
   }
@@ -1443,7 +1438,6 @@ async function parseMultipartChatBody(
   // don't break, but the chat path no longer routes by it.
   // Cross-workspace ingest is a Stage 6 concern (files would need to
   // be tagged with their target workspace at upload).
-  void workspaceId;
   const ingestWsId = identity?.id ? personalWorkspaceIdFor(identity.id) : workspaceId;
   const store = createFileStore(join(runtime.getWorkspaceScopedDir(ingestWsId), "files"));
   const filesConfig = runtime.getFilesConfig();
@@ -1463,6 +1457,7 @@ async function parseMultipartChatBody(
     appContext,
     contentParts: ingestResult.contentParts,
     fileRefs: ingestResult.fileRefs,
+    ...(workspaceId !== undefined ? { workspaceId } : {}),
     ...(identity ? { identity } : {}),
   };
 }

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -80,11 +80,12 @@ export async function handleChat(
       ...result.usage,
       costUsd: estimateCost(result.usage.model, result.usage),
     };
-    // Stage 2 (T006): chat is identity-bound. `ChatRequest.workspaceId` is
-    // gone, and `ChatResult.workspaceId` with it — per-tool-call workspace
-    // attribution lives on each `tool.done` event's `workspaceId` field
-    // (stamped from the orchestrator's resolved namespace), not on the
-    // response envelope.
+    // Stage 2: chat is identity-bound, so there is no `ChatResult.workspaceId`
+    // — per-tool-call workspace attribution lives on each `tool.done` event's
+    // `workspaceId` field (stamped from the orchestrator's resolved
+    // namespace), not on the response envelope. (`ChatRequest.workspaceId`
+    // exists as the focused workspace for prompt scoping, but it's an input,
+    // not part of the result.)
     const responseBody = {
       ...result,
       inputTokens: result.usage.inputTokens,
@@ -1412,9 +1413,9 @@ async function parseMultipartChatBody(
     return apiError(400, "bad_request", "message or file attachment is required");
   }
 
-  // If no files, treat as a plain text request (no ingest needed).
-  // Stage 2 (T006): no `workspaceId` on the chat envelope — see
-  // `parseChatBody`'s comment.
+  // If no files, treat as a plain text request (no ingest needed). The
+  // focused workspace (`X-Workspace-Id`) threads into `ChatRequest.workspaceId`
+  // for prompt scoping — see `parseChatBody`.
   if (uploadedFiles.length === 0) {
     return {
       message,
@@ -1428,15 +1429,13 @@ async function parseMultipartChatBody(
 
   // Ingest files: validate, store, extract text, build content parts.
   //
-  // Stage 2 (T006): the chat surface is identity-bound, so the file
-  // store must be too. `runtime.chat()` reads files from
-  // `getWorkspaceScopedDir(personalWorkspaceIdFor(identity.id))/files`;
-  // ingest writes to the SAME location here, ignoring any
-  // `X-Workspace-Id` header (which the chat path also ignores). The
-  // `workspaceId` parameter is intentionally void'd — kept on the
-  // signature so other callers of `parseMultipartChatBody` (if any)
-  // don't break, but the chat path no longer routes by it.
-  // Cross-workspace ingest is a Stage 6 concern (files would need to
+  // Stage 2: the file store is identity-bound. `runtime.chat()` reads files
+  // from `getWorkspaceScopedDir(personalWorkspaceIdFor(identity.id))/files`;
+  // ingest writes to the SAME location here, ignoring `X-Workspace-Id` for
+  // FILE STORAGE (files are identity-scoped — Phase B moves them fully). The
+  // `workspaceId` parameter still threads into `ChatRequest.workspaceId` (the
+  // focused workspace, for prompt scoping) — it just doesn't route file
+  // storage. Cross-workspace ingest is a later concern (files would need to
   // be tagged with their target workspace at upload).
   const ingestWsId = identity?.id ? personalWorkspaceIdFor(identity.id) : workspaceId;
   const store = createFileStore(join(runtime.getWorkspaceScopedDir(ingestWsId), "files"));

--- a/src/api/routes/chat.ts
+++ b/src/api/routes/chat.ts
@@ -15,15 +15,14 @@ export function chatRoutes(ctx: AppContext) {
   const chatBodyLimit = bodyLimit(1_048_576, {
     multipart: ctx.runtime.getFilesConfig().maxTotalSize,
   });
-  // Stage 2 (T006): `/v1/chat` is identity-bound. We use the optional
-  // workspace middleware so an `X-Workspace-Id` header (sent by web
-  // composer and existing automations clients) still validates against
-  // membership (`400/403` on a malformed or cross-tenant header), but
-  // its value never reaches the chat handler — `handleChat` discards
-  // it. The chat session's tool list comes from
+  // Stage 2: `/v1/chat` is identity-bound — the tool list comes from
   // `aggregateToolList(identityId)` and each call routes via the
-  // orchestrator. See `handlers.ts::parseChatBody` for the
-  // accept-but-ignore docstring.
+  // orchestrator, not from a single session workspace. The optional
+  // workspace middleware validates the `X-Workspace-Id` header against
+  // membership (`400/403` on a malformed or cross-tenant header); its
+  // value flows through `handleChat` into `ChatRequest.workspaceId` as the
+  // *focused* workspace, scoping the prompt briefing (installed apps +
+  // house rules). See `handlers.ts::parseChatBody`.
   return new Hono<AppEnv>()
     .use("*", requireAuth(ctx.authOptions))
     .use("*", optionalWorkspace(ctx.workspaceStore))

--- a/src/api/schemas/rest.ts
+++ b/src/api/schemas/rest.ts
@@ -75,7 +75,7 @@ export const ChatRequestBody = Type.Object(
     workspaceId: Type.Optional(
       Type.String({
         description:
-          "DEPRECATED (Stage 2 / T006): the chat surface is identity-bound; tools come from every workspace the caller can see and each call routes by namespace prefix. This field and the X-Workspace-Id header are accepted-but-ignored on /v1/chat so existing clients keep working. Per-tool-call workspace attribution lives on each tool.done event's `workspaceId` field.",
+          "DEPRECATED: the chat surface is identity-bound; tools come from every workspace the caller can see and each call routes by namespace prefix, so this body field is ignored on /v1/chat (kept for client compatibility). The focused workspace comes from the X-Workspace-Id header instead, which scopes the prompt briefing (installed apps + house rules) — not this field. Per-tool-call workspace attribution lives on each tool.done event's `workspaceId` field.",
       }),
     ),
     appContext: Type.Optional(

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -930,8 +930,14 @@ export class Runtime {
     // pass the session (personal) workspace so personal-scope overlays
     // surface; the cross-workspace tools are still in the aggregated list
     // below.
-    const apps = await this.buildAppsList(sessionWsId);
-    const liveOverlays = await this.readPromptOverlays(sessionWsId);
+    // The briefing (Installed Apps + org/workspace overlays) reflects the
+    // workspace the chat is FOCUSED on, not the tool union. `request.workspaceId`
+    // is the focused workspace (from X-Workspace-Id); absent → personal
+    // workspace as a temporary bridge until the home control panel exists.
+    // Both reads are deterministic + workspace-scoped (same for every member).
+    const activeWsId = request.workspaceId ?? sessionWsId;
+    const apps = await this.buildAppsList(activeWsId);
+    const liveOverlays = await this.readPromptOverlays(activeWsId);
 
     // Build focusedApp when the request is scoped to a specific app (§7 app-aware chat).
     // Pre-Stage-2 this searched the request's single workspace; post-T006

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -925,16 +925,13 @@ export class Runtime {
     }
 
     // `buildAppsList` populates each app's `customInstructions` from the
-    // bundle's `app://instructions` resource (when published);
-    // org and workspace overlays come from platform-owned storage. We
-    // pass the session (personal) workspace so personal-scope overlays
-    // surface; the cross-workspace tools are still in the aggregated list
-    // below.
-    // The briefing (Installed Apps + org/workspace overlays) reflects the
-    // workspace the chat is FOCUSED on, not the tool union. `request.workspaceId`
-    // is the focused workspace (from X-Workspace-Id); absent → personal
-    // workspace as a temporary bridge until the home control panel exists.
-    // Both reads are deterministic + workspace-scoped (same for every member).
+    // bundle's `app://instructions` resource (when published); org and
+    // workspace overlays come from platform-owned storage. Both reflect the
+    // workspace the chat is FOCUSED on (`request.workspaceId`, from
+    // `X-Workspace-Id`) — not the cross-workspace tool union. Absent, they
+    // fall back to the personal workspace as a temporary bridge until the
+    // home control panel exists. Deterministic + workspace-scoped (same for
+    // every member).
     const activeWsId = request.workspaceId ?? sessionWsId;
     const apps = await this.buildAppsList(activeWsId);
     const liveOverlays = await this.readPromptOverlays(activeWsId);
@@ -1034,18 +1031,19 @@ export class Runtime {
       locale: requestIdentity.preferences?.locale ?? "en-US",
     };
 
-    // The displayed workspace context in the prompt is the session
-    // (personal) workspace — what the user is "in" for legacy single-
-    // workspace UX. Cross-workspace tool calls still execute against
-    // their own namespace-prefixed workspace; this is just the prose
-    // identity the prompt narrates.
-    const workspaceContext = sessionWorkspace
-      ? { id: sessionWorkspace.id, name: sessionWorkspace.name }
-      : { id: sessionWsId };
+    // The prompt narrates the FOCUSED workspace — the same one whose apps +
+    // house rules the briefing above describes — so the prose, the app list,
+    // and the persona all agree. Reuse the already-loaded session workspace
+    // when it's the focused one; otherwise load the focused workspace.
+    const activeWorkspace =
+      activeWsId === sessionWsId ? sessionWorkspace : await this._workspaceStore.get(activeWsId);
+    const workspaceContext = activeWorkspace
+      ? { id: activeWorkspace.id, name: activeWorkspace.name }
+      : { id: activeWsId };
 
-    // Build per-request context skills with workspace identity override
-    const identityOverride = sessionWorkspace?.identity
-      ? makeIdentitySkill(sessionWorkspace.identity)
+    // Workspace identity/persona override — follows the focused workspace too.
+    const identityOverride = activeWorkspace?.identity
+      ? makeIdentitySkill(activeWorkspace.identity)
       : null;
     const requestContextSkills = identityOverride
       ? [...this.contextSkills, identityOverride]

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -222,17 +222,31 @@ export interface ChatRequest {
   model?: string;
   maxIterations?: number;
   /**
+   * The workspace the chat is *focused* on (the `/w/:slug` the user is
+   * viewing, plumbed from the `X-Workspace-Id` header). Drives the
+   * deterministic, workspace-scoped **briefing**: the Installed Apps
+   * section and the org/workspace instruction overlays reflect THIS
+   * workspace, identical for every member (no per-user generation).
+   *
+   * NOT tool scope. Tools remain the cross-workspace union
+   * (`aggregateToolList(identityId)`); re-introducing this field does not
+   * re-narrow tools to one workspace (what T006 removed). Absent → the
+   * chat isn't focused on a workspace (e.g. the future home control
+   * panel); for now it falls back to the personal workspace as a
+   * temporary bridge, NOT a claim that home == the personal workspace.
+   */
+  workspaceId?: string;
+  /**
    * When set, the chat is scoped to a specific app.
    *
    * Stage 2 (cross-workspace): the chat surface is identity-bound, not
    * workspace-bound. Tools come from the cross-workspace aggregator
    * (`orchestrator.aggregateToolList(identityId)`) and each tool call
-   * routes through the orchestrator's parsed-namespace path. There is no
-   * session-level `workspaceId` — `ChatRequest.workspaceId` was removed
-   * by T006. The session's "default workspace" for legacy single-
-   * workspace reads (overlays, file store, app skills) is the
-   * identity's personal workspace at `personalWorkspaceIdFor(identity.id)`.
-   * Per-call workspace attribution lives on the tool's namespace prefix.
+   * routes through the orchestrator's parsed-namespace path. The
+   * `workspaceId` field above is the *focused* workspace for the
+   * deterministic briefing (apps + overlays) only — it does NOT narrow
+   * the tool list. Per-call workspace attribution lives on the tool's
+   * namespace prefix.
    */
   appContext?: AppContext;
   /** Additional content parts from file uploads (text extracts, images). */

--- a/test/integration/stage-1-cross-workspace-conversation.test.ts
+++ b/test/integration/stage-1-cross-workspace-conversation.test.ts
@@ -183,8 +183,8 @@ describe("Stage 1 — conversations outlive their workspace context", () => {
     expect(loaded?.ownerId).toBe(ALICE.id);
     // Stage 2 (T006): the chat surface is identity-bound; the metadata
     // `workspaceId` is the session (personal) workspace, NOT the value
-    // of `X-Workspace-Id`. The header is accepted-but-ignored on the
-    // chat path; per-call workspace attribution lives on each tool.done
+    // of `X-Workspace-Id`. The header now scopes the prompt briefing, not
+    // this metadata field; per-call workspace attribution lives on each tool.done
     // event's payload.
     expect(loaded?.workspaceId).toBe(`ws_user_${ALICE.id}`);
 
@@ -241,8 +241,9 @@ describe("Stage 1 — conversations outlive their workspace context", () => {
     //    sharedA-flavored context (pre-removal), one in sharedB-flavored
     //    (post-removal). Per Stage 2 (T006) the metadata `workspaceId`
     //    records the session (personal) workspace, NOT the `X-Workspace-Id`
-    //    of the request. Tool scoping for cross-workspace calls now
-    //    happens at dispatch time via the orchestrator's parsed namespace
+    //    of the request (which now scopes the prompt briefing, not this
+    //    metadata). Tool scoping for cross-workspace calls happens at
+    //    dispatch time via the orchestrator's parsed namespace
     //    — the metadata field is only a UI breadcrumb for the legacy
     //    single-workspace overlays/file-store reads.
     const store = runtime.findConversationStore();


### PR DESCRIPTION
## What

Fixes the 3 long-parked `instructions-rework` integration failures — and they were a real bug, not stale tests.

**Root cause:** Stage 2 made the *tool list* a cross-workspace union but left the prompt's **briefing** — the Installed Apps section + org/workspace instruction overlays — pinned to the identity's *personal* workspace (`sessionWsId`). So a chat focused on workspace X showed X's tools but none of X's apps or house rules. `ChatRequest.workspaceId` was removed by T006 and the `X-Workspace-Id` header was validated-then-discarded.

## The model

A workspace's briefing is a fact about the **workspace, not the viewer** — its apps + house rules, read deterministically from what's installed and what's stored, identical for every member (no per-user generation). When a chat is focused on a workspace, the briefing reflects *that* workspace.

## Change

Re-introduce `ChatRequest.workspaceId` with **focused-workspace** semantics — explicitly *not* the tool-scoping field T006 removed:

- `handlers.ts` — thread the already-validated `X-Workspace-Id` (focused workspace) into the request across all three `ChatRequest` build paths (JSON + both multipart returns), instead of discarding it.
- `runtime.ts` — `activeWsId = request.workspaceId ?? sessionWsId` drives `buildAppsList` + `readPromptOverlays`.
- `types.ts` — re-add the field, documented as briefing-focus, not tool scope.

Tools stay the cross-workspace union; conversations stay identity-owned; files stay put (Phase B moves them to identity scope). Absent → personal workspace as a **temporary bridge** until the home control-panel surface exists (home is its own surface, not a workspace).

## Tests

`verify:static` green · unit **3097/0** · integration **615/0** (the 3 reds + their neighbor now pass).

## Follow-ups (not in this PR)

- **Prompt narration coherence:** the prose "current workspace" (`workspaceContext`) still names the personal workspace; for full coherence it should name the focused workspace too. Small, separable, user-visible — worth a deliberate call.
- **Home control panel:** a standalone system surface (deterministic cross-workspace action items), part of the identity/root work.