### PR TITLE
feat(web): restore workspace briefing + Workspace settings link

### DIFF
--- a/src/services/home-types.ts
+++ b/src/services/home-types.ts
@@ -1,44 +1,18 @@
-/** Briefing input — passed to home__briefing tool. */
+// The briefing output contract lives in the platform schema — the single
+// source of truth, codegen'd to the web shell. Import for local use below and
+// re-export so backend callers keep importing from `../services/home-types.ts`.
+import type {
+  BriefingAction,
+  BriefingOutput,
+  BriefingSection,
+  BriefingState,
+} from "../tools/platform/schemas/home.ts";
+
+export type { BriefingAction, BriefingOutput, BriefingSection, BriefingState };
+
+/** Briefing input — passed to the `nb__briefing` tool. */
 export interface BriefingInput {
   force_refresh?: boolean;
-}
-
-/** Complete briefing output returned by home__briefing. */
-export interface BriefingOutput {
-  greeting: string;
-  date: string;
-  lede: string;
-  sections: BriefingSection[];
-  state: BriefingState;
-  generated_at: string;
-  cached: boolean;
-}
-
-/** Dashboard state derived from briefing content. */
-export type BriefingState = "empty" | "quiet" | "all-clear" | "normal" | "attention";
-
-/** Individual briefing section (e.g., "Your stock updates showed..."). */
-export interface BriefingSection {
-  id: string;
-  text: string;
-  type: "positive" | "neutral" | "warning";
-  category: "recent" | "upcoming" | "attention";
-  action?: BriefingAction;
-}
-
-/** Action attached to a briefing section. `type` discriminates which
- * field carries the payload — navigate uses `route`, startChat uses
- * `prompt` — but both fields are present in the wire shape (nullable
- * for the unused variant) because Anthropic structured-output requires
- * all schema properties to appear in `required`. Consumers check
- * `action.type` before reading the relevant field. */
-export interface BriefingAction {
-  type: "navigate" | "startChat";
-  label: string;
-  /** Set on navigate actions; null on startChat. */
-  route: string | null;
-  /** Set on startChat actions; null on navigate. */
-  prompt: string | null;
 }
 
 /** In-memory cache entry for a generated briefing. */

--- a/src/tools/platform/schemas/home.ts
+++ b/src/tools/platform/schemas/home.ts
@@ -12,3 +12,50 @@ export const HomeActivityInput = Type.Object({
   limit: Type.Optional(Type.Number({ description: "Max items per category. Default: 50." })),
 });
 export type HomeActivityInput = Static<typeof HomeActivityInput>;
+
+// ── Briefing output ────────────────────────────────────────────────────────
+//
+// Canonical contract for the `nb__briefing` tool's structured output. Per the
+// output-schema convention these are type-only (we don't wire-validate
+// outputs): `src/services/home-types.ts` re-exports them for the backend
+// (generator, cache, core-source), and `bun run codegen` emits them to
+// `web/src/_generated/platform-schemas/home.ts` for the web briefing surface.
+// Single source of truth — do not hand-redeclare on either side.
+
+/** Dashboard state derived from briefing content. */
+export type BriefingState = "empty" | "quiet" | "all-clear" | "normal" | "attention";
+
+/**
+ * Action attached to a briefing section. `type` discriminates the payload —
+ * `navigate` uses `route`, `startChat` uses `prompt` — but both fields are
+ * always present (null for the unused variant) because the LLM structured-
+ * output schema requires every property. Consumers check `type` first.
+ */
+export interface BriefingAction {
+  type: "navigate" | "startChat";
+  label: string;
+  /** Set on navigate actions; null on startChat. */
+  route: string | null;
+  /** Set on startChat actions; null on navigate. */
+  prompt: string | null;
+}
+
+/** Individual briefing section — one line item under a category heading. */
+export interface BriefingSection {
+  id: string;
+  text: string;
+  type: "positive" | "neutral" | "warning";
+  category: "recent" | "upcoming" | "attention";
+  action?: BriefingAction;
+}
+
+/** Complete briefing output returned by `nb__briefing`. */
+export interface BriefingOutput {
+  greeting: string;
+  date: string;
+  lede: string;
+  sections: BriefingSection[];
+  state: BriefingState;
+  generated_at: string;
+  cached: boolean;
+}

--- a/src/tools/platform/schemas/home.ts
+++ b/src/tools/platform/schemas/home.ts
@@ -19,7 +19,7 @@ export type HomeActivityInput = Static<typeof HomeActivityInput>;
 // output-schema convention these are type-only (we don't wire-validate
 // outputs): `src/services/home-types.ts` re-exports them for the backend
 // (generator, cache, core-source), and `bun run codegen` emits them to
-// `web/src/_generated/platform-schemas/home.ts` for the web briefing surface.
+// `web/src/_generated/platform-schemas/home.d.ts` for the web briefing surface.
 // Single source of truth — do not hand-redeclare on either side.
 
 /** Dashboard state derived from briefing content. */

--- a/web/src/_generated/platform-schemas/home.d.ts
+++ b/web/src/_generated/platform-schemas/home.d.ts
@@ -10,3 +10,37 @@ export declare const HomeActivityInput: import("@sinclair/typebox").TObject<{
     limit: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TNumber>;
 }>;
 export type HomeActivityInput = Static<typeof HomeActivityInput>;
+/** Dashboard state derived from briefing content. */
+export type BriefingState = "empty" | "quiet" | "all-clear" | "normal" | "attention";
+/**
+ * Action attached to a briefing section. `type` discriminates the payload —
+ * `navigate` uses `route`, `startChat` uses `prompt` — but both fields are
+ * always present (null for the unused variant) because the LLM structured-
+ * output schema requires every property. Consumers check `type` first.
+ */
+export interface BriefingAction {
+    type: "navigate" | "startChat";
+    label: string;
+    /** Set on navigate actions; null on startChat. */
+    route: string | null;
+    /** Set on startChat actions; null on navigate. */
+    prompt: string | null;
+}
+/** Individual briefing section — one line item under a category heading. */
+export interface BriefingSection {
+    id: string;
+    text: string;
+    type: "positive" | "neutral" | "warning";
+    category: "recent" | "upcoming" | "attention";
+    action?: BriefingAction;
+}
+/** Complete briefing output returned by `nb__briefing`. */
+export interface BriefingOutput {
+    greeting: string;
+    date: string;
+    lede: string;
+    sections: BriefingSection[];
+    state: BriefingState;
+    generated_at: string;
+    cached: boolean;
+}

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { ChevronUp, LogOut, UserCog } from "lucide-react";
+import { ChevronUp, LogOut, Settings, UserCog } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSession } from "../context/SessionContext";
@@ -101,6 +101,11 @@ export const UserMenu = memo(function UserMenu({
     navigate("/profile");
   }, [navigate]);
 
+  const goToWorkspaceSettings = useCallback(() => {
+    setOpen(false);
+    navigate("/settings/workspace/general");
+  }, [navigate]);
+
   const handleLogout = useCallback(() => {
     setOpen(false);
     onLogout();
@@ -189,6 +194,14 @@ export const UserMenu = memo(function UserMenu({
             >
               <UserCog className="w-4 h-4 text-sidebar-foreground/60" />
               <span>Profile settings</span>
+            </button>
+            <button
+              type="button"
+              onClick={goToWorkspaceSettings}
+              className="flex items-center gap-2.5 w-full rounded-md px-2 py-2 text-sm text-left transition-all duration-150 text-sidebar-foreground hover:bg-sidebar-foreground/5"
+            >
+              <Settings className="w-4 h-4 text-sidebar-foreground/60" />
+              <span>Workspace settings</span>
             </button>
             <button
               type="button"

--- a/web/src/components/briefing/BriefingView.tsx
+++ b/web/src/components/briefing/BriefingView.tsx
@@ -1,0 +1,193 @@
+// ---------------------------------------------------------------------------
+// BriefingView — presentational render of a workspace activity briefing.
+//
+// Pure: it takes a `BriefingOutput` (the `nb__briefing` tool's structured
+// result) plus loading/error/action callbacks and renders. No data fetching,
+// no transport — the workspace dashboard wires it to `useWorkspaceBriefing`,
+// and the future home control panel can reuse it against a cross-workspace
+// source. The briefing is LLM-generated from each installed app's declared
+// facets; this component is the surface the workspace reorg dropped.
+// ---------------------------------------------------------------------------
+
+import type { ReactNode } from "react";
+import type {
+  BriefingAction,
+  BriefingOutput,
+  BriefingSection,
+} from "../../_generated/platform-schemas/home";
+import { cn } from "../../lib/utils";
+
+interface BriefingViewProps {
+  briefing: BriefingOutput | null;
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+  /** Invoked when a section's action is clicked (navigate / startChat). */
+  onAction?: (action: BriefingAction) => void;
+}
+
+// Render order: anything needing attention first, then what happened, then
+// what's ahead.
+const CATEGORIES: { key: BriefingSection["category"]; label: string }[] = [
+  { key: "attention", label: "Needs attention" },
+  { key: "recent", label: "Recent" },
+  { key: "upcoming", label: "Coming up" },
+];
+
+/** Sentiment → dot color. Positive reads calm, warning reads urgent. */
+function dotClass(type: BriefingSection["type"]): string {
+  if (type === "positive") return "bg-emerald-500";
+  if (type === "warning") return "bg-red-500";
+  return "bg-amber-500";
+}
+
+/**
+ * Minimal inline markdown — `**bold**` and `` `code` `` — rendered as React
+ * nodes, never injected HTML. Briefing text is platform-generated, but we
+ * still render structurally so there's no `dangerouslySetInnerHTML` surface.
+ */
+function formatInline(text: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  const re = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  let last = 0;
+  let key = 0;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) out.push(text.slice(last, m.index));
+    const token = m[0];
+    if (token.startsWith("**")) {
+      out.push(
+        <strong key={key++} className="font-semibold text-foreground">
+          {token.slice(2, -2)}
+        </strong>,
+      );
+    } else {
+      out.push(
+        <code key={key++} className="rounded bg-muted px-1 py-0.5 text-[0.85em] font-mono">
+          {token.slice(1, -1)}
+        </code>,
+      );
+    }
+    last = m.index + token.length;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out;
+}
+
+function Eyebrow() {
+  return (
+    <div className="text-[11px] font-bold tracking-[0.08em] uppercase text-muted-foreground">
+      Briefing
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div className="mt-3 space-y-2.5" aria-hidden>
+      <div className="h-3 w-2/3 rounded bg-muted animate-pulse" />
+      <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
+      <div className="h-3 w-3/5 rounded bg-muted animate-pulse" />
+    </div>
+  );
+}
+
+function SectionGroup({
+  label,
+  items,
+  onAction,
+}: {
+  label: string;
+  items: BriefingSection[];
+  onAction?: (action: BriefingAction) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="mt-4 first:mt-3">
+      <div className="text-[11px] font-semibold tracking-[0.06em] uppercase text-muted-foreground/70">
+        {label}
+      </div>
+      <ul className="mt-1.5 space-y-1.5">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-start gap-2.5 text-sm text-foreground/90">
+            <span
+              className={cn("mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full", dotClass(item.type))}
+              aria-hidden
+            />
+            <span className="flex-1 leading-relaxed">{formatInline(item.text)}</span>
+            {/* v1 renders navigate actions (router-routable). `startChat`
+                actions need the chat composer, which a shell page can't reach
+                without subscribing to ChatContext (re-renders the shell every
+                token); they render as text-only until an isolated handler
+                lands. */}
+            {item.action?.type === "navigate" && onAction && (
+              <button
+                type="button"
+                onClick={() => onAction(item.action!)}
+                className="shrink-0 text-xs font-medium text-primary hover:underline"
+              >
+                {item.action.label || "View"} &rarr;
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function BriefingView({ briefing, loading, error, onRetry, onAction }: BriefingViewProps) {
+  const hasSections = (briefing?.sections.length ?? 0) > 0;
+
+  return (
+    <section data-testid="workspace-briefing">
+      <Eyebrow />
+
+      {loading && !briefing && <Skeleton />}
+
+      {error && (
+        <div
+          className="mt-3 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+          data-testid="workspace-briefing-error"
+        >
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-2 text-xs font-medium text-destructive hover:underline"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {briefing && (
+        <>
+          {briefing.lede && (
+            <p className="mt-1.5 text-sm text-muted-foreground italic leading-relaxed">
+              {briefing.lede}
+            </p>
+          )}
+          {hasSections ? (
+            CATEGORIES.map(({ key, label }) => (
+              <SectionGroup
+                key={key}
+                label={label}
+                items={briefing.sections.filter((s) => s.category === key)}
+                onAction={onAction}
+              />
+            ))
+          ) : (
+            <p
+              className="mt-2 text-sm text-muted-foreground"
+              data-testid="workspace-briefing-empty"
+            >
+              Nothing needs your attention right now.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/src/hooks/useWorkspaceBriefing.ts
+++ b/web/src/hooks/useWorkspaceBriefing.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { BriefingOutput } from "../_generated/platform-schemas/home";
+import { callTool } from "../api/client";
+import { parseToolResult } from "../api/tool-result";
+
+export interface UseWorkspaceBriefing {
+  briefing: BriefingOutput | null;
+  loading: boolean;
+  error: string | null;
+  /** Force a cache-bypassing regeneration. */
+  refresh: () => void;
+}
+
+/**
+ * Fetch the workspace activity briefing (`nb__briefing`) for the active
+ * workspace.
+ *
+ * The briefing is workspace-scoped server-side via the `X-Workspace-Id`
+ * header, which the REST client derives from the active workspace. We key the
+ * fetch on `workspaceId` — and the caller must pass the *active* workspace id
+ * (not the route slug's), because `WorkspaceContext.setActiveWorkspace` sets
+ * the React state and the request header together. Keying on the active id
+ * therefore guarantees the header matches the workspace we're fetching for,
+ * with no stale-header race (the page mounts before the route guard's sync
+ * effect, so the slug-derived id could briefly lead the header).
+ *
+ * Transport is REST (`callTool`), not the MCP iframe bridge — this is
+ * first-party shell code per the API-audiences split in `CLAUDE.md`.
+ */
+export function useWorkspaceBriefing(workspaceId: string | undefined): UseWorkspaceBriefing {
+  const [briefing, setBriefing] = useState<BriefingOutput | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Monotonic request id — drops responses that resolve after a newer fetch
+  // (workspace switched, or a refresh raced the initial load).
+  const reqRef = useRef(0);
+
+  const load = useCallback(
+    async (forceRefresh: boolean) => {
+      if (!workspaceId) return;
+      const seq = ++reqRef.current;
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await callTool(
+          "nb",
+          "briefing",
+          forceRefresh ? { force_refresh: true } : {},
+        );
+        const out = parseToolResult<BriefingOutput>(result);
+        if (seq === reqRef.current) setBriefing(out);
+      } catch (err) {
+        if (seq === reqRef.current) {
+          setError(err instanceof Error ? err.message : "Failed to load briefing");
+        }
+      } finally {
+        if (seq === reqRef.current) setLoading(false);
+      }
+    },
+    [workspaceId],
+  );
+
+  // Refetch when the active workspace lands or changes. Clear immediately so a
+  // switch never flashes the previous workspace's briefing under the new
+  // header.
+  useEffect(() => {
+    setBriefing(null);
+    setError(null);
+    if (workspaceId) void load(false);
+  }, [workspaceId, load]);
+
+  const refresh = useCallback(() => {
+    void load(true);
+  }, [load]);
+
+  return { briefing, loading, error, refresh };
+}

--- a/web/src/pages/WorkspaceOverviewPage.tsx
+++ b/web/src/pages/WorkspaceOverviewPage.tsx
@@ -18,12 +18,16 @@
 // the same data that used to feed the bottom `APPS` group.
 // ---------------------------------------------------------------------------
 
+import { useCallback } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import type { BriefingAction } from "../_generated/platform-schemas/home";
+import { BriefingView } from "../components/briefing/BriefingView";
 import { useShellContext } from "../context/ShellContext";
 import { useWorkspaceContext, type WorkspaceInfo } from "../context/WorkspaceContext";
+import { useWorkspaceBriefing } from "../hooks/useWorkspaceBriefing";
 import { resolveIcon } from "../lib/icons";
-import { toSlug } from "../lib/workspace-slug";
 import { cn } from "../lib/utils";
+import { toSlug } from "../lib/workspace-slug";
 import type { PlacementEntry } from "../types";
 
 export function WorkspaceOverviewPage() {
@@ -33,6 +37,26 @@ export function WorkspaceOverviewPage() {
   const navigate = useNavigate();
 
   const workspace = slug ? wsCtx.workspaces.find((w) => toSlug(w.id) === slug) : undefined;
+
+  // The briefing is workspace-scoped server-side via X-Workspace-Id (= the
+  // active workspace). Key the fetch on the active workspace id so the header
+  // and the fetch stay in lockstep (see useWorkspaceBriefing for the rationale).
+  const {
+    briefing,
+    loading: briefingLoading,
+    error: briefingError,
+    refresh: refreshBriefing,
+  } = useWorkspaceBriefing(wsCtx.activeWorkspace?.id);
+
+  const handleBriefingAction = useCallback(
+    (action: BriefingAction) => {
+      if (action.type !== "navigate" || !action.route) return;
+      // Facet navigate actions carry the app's route (e.g. "@scope/name").
+      // Absolute paths pass through; bare routes open the app in this workspace.
+      navigate(action.route.startsWith("/") ? action.route : `/w/${slug}/app/${action.route}`);
+    },
+    [navigate, slug],
+  );
 
   if (wsCtx.loading) {
     return (
@@ -78,6 +102,22 @@ export function WorkspaceOverviewPage() {
           </p>
         </header>
 
+        {/* Briefing — LLM summary of recent workspace activity, generated from
+            the installed apps' declared facets. Restored from the pre-reorg
+            home surface. */}
+        <div className="mb-10">
+          <BriefingView
+            briefing={briefing}
+            loading={briefingLoading}
+            error={briefingError}
+            onRetry={refreshBriefing}
+            onAction={handleBriefingAction}
+          />
+        </div>
+
+        <div className="text-[11px] font-bold tracking-[0.08em] uppercase text-muted-foreground mb-3">
+          Available apps
+        </div>
         {apps.length === 0 ? (
           <div
             className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground"

--- a/web/test/BriefingView.test.tsx
+++ b/web/test/BriefingView.test.tsx
@@ -1,0 +1,193 @@
+// BriefingView — render contract for the restored workspace briefing surface.
+// Uses the container/createRoot harness (happy-dom + testing-library's
+// `screen.getByText` don't mix); query via container.textContent + testids.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { BriefingOutput } from "../src/_generated/platform-schemas/home";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { BriefingView } = await import("../src/components/briefing/BriefingView");
+
+interface Mounted {
+  container: HTMLDivElement;
+  unmount(): void;
+}
+
+let mounted: Mounted | null = null;
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+});
+
+async function mount(element: React.ReactElement): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return {
+    container,
+    unmount() {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+function findByTestId(c: HTMLElement, id: string): HTMLElement | null {
+  for (const el of Array.from(c.getElementsByTagName("*"))) {
+    if (el.getAttribute("data-testid") === id) return el as HTMLElement;
+  }
+  return null;
+}
+
+function findButton(c: HTMLElement, text: string): HTMLButtonElement | null {
+  for (const el of Array.from(c.getElementsByTagName("button"))) {
+    if ((el.textContent ?? "").includes(text)) return el as HTMLButtonElement;
+  }
+  return null;
+}
+
+function makeBriefing(overrides: Partial<BriefingOutput> = {}): BriefingOutput {
+  return {
+    greeting: "Good morning",
+    date: "Monday, May 25, 2026",
+    lede: "Two things need a look; everything else is quiet.",
+    state: "attention",
+    generated_at: "2026-05-25T08:00:00.000Z",
+    cached: false,
+    sections: [
+      {
+        id: "s-recent",
+        text: "Closed **3 deals** yesterday.",
+        type: "positive",
+        category: "recent",
+      },
+      {
+        id: "s-attention",
+        text: "2 follow-ups are overdue.",
+        type: "warning",
+        category: "attention",
+        action: { type: "navigate", label: "View deals", route: "@acme/crm", prompt: null },
+      },
+      {
+        id: "s-upcoming",
+        text: "A renewal is due Friday.",
+        type: "neutral",
+        category: "upcoming",
+        action: {
+          type: "startChat",
+          label: "Draft outreach",
+          route: null,
+          prompt: "Draft a renewal email",
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("BriefingView", () => {
+  test("renders the lede and section texts, inline markdown as <strong>", async () => {
+    mounted = await mount(
+      <BriefingView briefing={makeBriefing()} loading={false} error={null} onRetry={() => {}} />,
+    );
+    const text = mounted.container.textContent ?? "";
+    expect(text).toContain("Two things need a look");
+    expect(text).toContain("follow-ups are overdue");
+    expect(text).toContain("renewal is due Friday");
+    // getElementsByTagName, not querySelector — happy-dom's querySelector
+    // throws under bun in this setup (see the other web component tests).
+    const strongs = Array.from(mounted.container.getElementsByTagName("strong"));
+    expect(strongs.some((s) => s.textContent === "3 deals")).toBe(true);
+  });
+
+  test("orders categories attention → recent → upcoming", async () => {
+    mounted = await mount(
+      <BriefingView briefing={makeBriefing()} loading={false} error={null} onRetry={() => {}} />,
+    );
+    const text = mounted.container.textContent ?? "";
+    const attention = text.indexOf("Needs attention");
+    const recent = text.indexOf("Recent");
+    const upcoming = text.indexOf("Coming up");
+    expect(attention).toBeGreaterThanOrEqual(0);
+    expect(attention).toBeLessThan(recent);
+    expect(recent).toBeLessThan(upcoming);
+  });
+
+  test("renders a button for navigate actions and fires onAction", async () => {
+    let calls = 0;
+    mounted = await mount(
+      <BriefingView
+        briefing={makeBriefing()}
+        loading={false}
+        error={null}
+        onRetry={() => {}}
+        onAction={() => {
+          calls++;
+        }}
+      />,
+    );
+    const btn = findButton(mounted.container, "View deals");
+    expect(btn).not.toBeNull();
+    await act(async () => {
+      btn?.click();
+    });
+    expect(calls).toBe(1);
+  });
+
+  test("does NOT render a button for startChat actions (v1)", async () => {
+    mounted = await mount(
+      <BriefingView
+        briefing={makeBriefing()}
+        loading={false}
+        error={null}
+        onRetry={() => {}}
+        onAction={() => {}}
+      />,
+    );
+    expect(mounted.container.textContent ?? "").toContain("renewal is due Friday");
+    expect(findButton(mounted.container, "Draft outreach")).toBeNull();
+  });
+
+  test("shows an empty state when there are no sections", async () => {
+    mounted = await mount(
+      <BriefingView
+        briefing={makeBriefing({ sections: [], state: "all-clear", lede: "" })}
+        loading={false}
+        error={null}
+        onRetry={() => {}}
+      />,
+    );
+    expect(findByTestId(mounted.container, "workspace-briefing-empty")).not.toBeNull();
+  });
+
+  test("renders an error with a working Retry", async () => {
+    let calls = 0;
+    mounted = await mount(
+      <BriefingView
+        briefing={null}
+        loading={false}
+        error="boom"
+        onRetry={() => {
+          calls++;
+        }}
+      />,
+    );
+    expect(mounted.container.textContent ?? "").toContain("boom");
+    const retry = findButton(mounted.container, "Retry");
+    expect(retry).not.toBeNull();
+    await act(async () => {
+      retry?.click();
+    });
+    expect(calls).toBe(1);
+  });
+});

--- a/web/test/useWorkspaceBriefing.test.ts
+++ b/web/test/useWorkspaceBriefing.test.ts
@@ -1,0 +1,124 @@
+// useWorkspaceBriefing — the logic-heavy half of the briefing restore: the
+// monotonic stale-response guard, clear-on-workspace-switch, and force_refresh
+// routing. callTool is mocked with manually-resolvable deferreds so we can
+// control response ordering (the whole point of the reqRef guard).
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface Deferred {
+  resolve: (v: unknown) => void;
+  reject: (e: unknown) => void;
+  args: Record<string, unknown> | undefined;
+}
+
+let calls: Deferred[] = [];
+
+mock.module("../src/api/client", () => ({
+  callTool: (_server: string, _tool: string, args?: Record<string, unknown>) =>
+    new Promise((resolve, reject) => {
+      calls.push({ resolve, reject, args });
+    }),
+}));
+
+const { useWorkspaceBriefing } = await import("../src/hooks/useWorkspaceBriefing");
+
+/** Resolve the Nth callTool with a briefing whose greeting tags its origin. */
+function resolveCall(i: number, greeting: string): void {
+  calls[i]?.resolve({
+    isError: false,
+    structuredContent: {
+      greeting,
+      date: "",
+      lede: "",
+      sections: [],
+      state: "quiet",
+      generated_at: "",
+      cached: false,
+    },
+  });
+}
+
+const flush = () => act(async () => { await Promise.resolve(); });
+
+beforeEach(() => {
+  calls = [];
+});
+afterEach(() => {
+  calls = [];
+});
+
+describe("useWorkspaceBriefing", () => {
+  test("fetches on mount and exposes the briefing", async () => {
+    const { result } = renderHook(() => useWorkspaceBriefing("ws_a"));
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.args).toEqual({}); // initial load is not a force-refresh
+    await act(async () => {
+      resolveCall(0, "alpha");
+    });
+    expect(result.current.briefing?.greeting).toBe("alpha");
+    expect(result.current.loading).toBe(false);
+  });
+
+  test("refresh() sends force_refresh: true", async () => {
+    const { result } = renderHook(() => useWorkspaceBriefing("ws_a"));
+    await act(async () => {
+      resolveCall(0, "alpha");
+    });
+    await act(async () => {
+      result.current.refresh();
+    });
+    expect(calls.length).toBe(2);
+    expect(calls[1]?.args).toEqual({ force_refresh: true });
+  });
+
+  test("switching workspace clears the briefing before the refetch resolves", async () => {
+    const { result, rerender } = renderHook(({ ws }: { ws: string }) => useWorkspaceBriefing(ws), {
+      initialProps: { ws: "ws_a" },
+    });
+    await act(async () => {
+      resolveCall(0, "alpha");
+    });
+    expect(result.current.briefing?.greeting).toBe("alpha");
+
+    await act(async () => {
+      rerender({ ws: "ws_b" });
+    });
+    // Cleared immediately so the old workspace's briefing never shows under
+    // the new X-Workspace-Id header; ws_b's fetch is now in flight.
+    expect(result.current.briefing).toBeNull();
+    expect(calls.length).toBe(2);
+  });
+
+  test("drops a stale response superseded by a workspace switch", async () => {
+    const { result, rerender } = renderHook(({ ws }: { ws: string }) => useWorkspaceBriefing(ws), {
+      initialProps: { ws: "ws_a" },
+    });
+    // call 0 = ws_a (left pending — the slow one)
+    await act(async () => {
+      rerender({ ws: "ws_b" });
+    });
+    expect(calls.length).toBe(2); // call 1 = ws_b
+
+    // ws_b resolves first and wins.
+    await act(async () => {
+      resolveCall(1, "bravo");
+    });
+    expect(result.current.briefing?.greeting).toBe("bravo");
+
+    // The slow ws_a now resolves LATE — the monotonic reqRef guard must drop
+    // it so it can't clobber the current (ws_b) briefing.
+    await act(async () => {
+      resolveCall(0, "alpha-stale");
+    });
+    await flush();
+    expect(result.current.briefing?.greeting).toBe("bravo");
+  });
+
+  test("does not fetch when there is no active workspace", () => {
+    renderHook(() => useWorkspaceBriefing(undefined));
+    expect(calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Restores two surfaces the Stage 2 workspace reorg dropped. Both backends were intact; the reorg replaced the home-bundle iframe with native React pages and never carried these over.

## 1. Workspace briefing on the dashboard (`f8d37e5`)

The `nb__briefing` tool — which collects each installed app's declared **facets** + recent activity and generates an LLM summary — kept working, but nothing displayed it after the reorg. Restored on `WorkspaceOverviewPage`, above the app grid.

**Architecture (first-principles):**
- **Single source of truth for the contract.** `BriefingOutput`/`Section`/`Action` move into the platform schema (`src/tools/platform/schemas/home.ts`); `home-types.ts` re-exports them for the backend (generator, cache, core-source) and `bun run codegen` emits them to the web shell. No hand-maintained copy (the old home-bundle UI had re-declared them) — drift is caught by `check:codegen`.
- **Clean separation, correct transport.** `BriefingView` is a pure presentational component (reusable by the future home control panel); `useWorkspaceBriefing` fetches via REST `callTool` — not the iframe MCP bridge — because this is first-party shell code, keyed on the active workspace so the `X-Workspace-Id` header and the fetch stay in lockstep (race-guarded).
- **XSS-safe rendering.** Inline markdown (`**bold**`, `` `code` ``) renders as React nodes, no `dangerouslySetInnerHTML`.
- Sections group **Needs attention / Recent / Coming up** with sentiment dots; loading / error+retry / empty states. `navigate` actions route via the router; `startChat` actions render text-only for now (a shell page can't reach the chat composer without subscribing to `ChatContext`, which re-renders the shell every token — follow-up via an isolated handler).

## 2. Workspace settings link in the user menu (`a98b195`)

The bottom-left `UserMenu` lost its workspace-settings entry. Added back beneath "Profile settings" → `/settings/workspace/general`.

## Tests
`verify:static` green (codegen / cycles / tsc / lint) · unit **3079/0** · web **349/0** (incl. new `BriefingView.test`).

The 3 `instructions-rework` integration failures on this branch are pre-existing on `main` and fixed by #275 — not introduced here. They clear once #275 merges (or this rebases onto a main that has it).

## Follow-ups
- `startChat` briefing actions via an isolated chat-action handler.
- The home `/` control panel (cross-workspace, deterministic action items) — its own effort; `BriefingView` is built to be reused there.