### PR TITLE
fix(smoke): align cross-workspace test with global-scope contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
 
   smoke:
     name: Smoke Tests
-    if: github.ref == 'refs/heads/main'
+    # Runs on PRs and on main. Smoke hits the live mpak registry + downloads
+    # bundles (~15s, network); gating it to main-only previously let a stale
+    # smoke assertion merge green and turn main red post-merge.
     needs: [test-unit, test-integration]
     runs-on: ubuntu-latest
     steps:

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -691,11 +691,14 @@ function createServer(
 
     // ── Stage 2: parse the namespaced tool name + route via orchestrator
     //
-    // Strict invariant — no fallback to a "current workspace." A bare name
-    // like `crm.search` is a client bug we surface as `-32602 Invalid
-    // params` per MCP spec, with `error.data.reason: "invalid_tool_name"`
-    // so MCP clients can render a meaningful message. The orchestrator's
-    // four error classes each map to a distinct response shape.
+    // Strict invariant — no fallback to a "current workspace." A bare
+    // `<source>__<tool>` name (no `ws_<id>-` prefix) parses to global scope;
+    // until W3 wires global dispatch we surface it as `-32602 Invalid params`
+    // per MCP spec with `error.data.reason: "global_not_routable"`. Truly
+    // malformed names (empty, empty tool, bad `ws_` id) surface as
+    // `invalid_tool_name`. Either way the client gets a meaningful reason and
+    // the call never silently routes. The orchestrator's five error classes
+    // each map to a distinct response shape.
     let routed: Awaited<ReturnType<typeof routeToolCall>>;
     try {
       routed = await routeToolCall({

--- a/test/smoke/external-mcp-cross-workspace.test.ts
+++ b/test/smoke/external-mcp-cross-workspace.test.ts
@@ -260,14 +260,18 @@ describe("external MCP cross-workspace (Stage 2 T011 smoke)", () => {
   //
   // Pins: a defensive default that silently routes un-prefixed names
   // to the user's personal workspace makes a class of LLM mistakes
-  // succeed in the wrong place. The contract is fail-loud: JSON-RPC
-  // `-32602` with `data.reason: "invalid_tool_name"`.
+  // succeed in the wrong place. A bare `<source>__<tool>` name has no
+  // `ws_<id>-` prefix, so it parses to GLOBAL scope (see
+  // tools/namespace.ts). Global dispatch lands in W3; until then the
+  // orchestrator fails closed with `GlobalScopeNotRoutable`. Either way
+  // the contract is fail-loud: JSON-RPC `-32602` with
+  // `data.reason: "global_not_routable"`, never a fallback route.
   //
   // Critical adversarial detail: neither workspace's counter may
   // increment. A regression that "fails the call but routes to the
   // user's personal workspace anyway" would still tick the personal
   // counter — we assert it stays at zero.
-  it("tools/call with un-namespaced name rejects with -32602 invalid_tool_name and does NOT route anywhere (failure mode: silent fallback)", async () => {
+  it("tools/call with un-namespaced name rejects with -32602 and does NOT route anywhere (failure mode: silent fallback)", async () => {
     resetWorkspaceProbes();
     const client = await createExternalClient();
     try {
@@ -275,7 +279,8 @@ describe("external MCP cross-workspace (Stage 2 T011 smoke)", () => {
       let dataReason: string | undefined;
       try {
         await client.callTool({
-          // No `ws_<id>/` prefix — orchestrator MUST refuse.
+          // No `ws_<id>-` prefix — bare name parses to global scope, which
+          // the orchestrator refuses to route (no fallback to a workspace).
           name: `${fixture.shared.sourceName}__${fixture.shared.toolName}`,
           arguments: { echo: "noop" },
         });
@@ -286,7 +291,7 @@ describe("external MCP cross-workspace (Stage 2 T011 smoke)", () => {
       }
 
       expect(errorCode).toBe(-32602);
-      expect(dataReason).toBe("invalid_tool_name");
+      expect(dataReason).toBe("global_not_routable");
 
       // Adversarial: a silent fallback would tick the personal counter.
       // Neither side may move.


### PR DESCRIPTION
## Problem

`main` CI has been red since #272 merged. One smoke test fails on every push:

```
test/smoke/external-mcp-cross-workspace.test.ts:289
> tools/call with un-namespaced name rejects with -32602 ...
Expected: "invalid_tool_name"  Received: "global_not_routable"
```

## Root cause

#272 introduced a **`global` tool scope**. A bare `<source>__<tool>` name (no `ws_<id>-` prefix, e.g. `crm__search`) now parses to global scope, and the orchestrator fails closed pre-W3 with `GlobalScopeNotRoutable` → `-32602` / `reason: "global_not_routable"`.

The `namespace.ts` and `route.ts` **unit tests were updated** for this contract — but the **smoke test in the same PR was not**. It still asserted the old `reason: "invalid_tool_name"`, so it shipped red to `main`.

It went unnoticed because the `smoke` job is gated `if: github.ref == 'refs/heads/main'` — **it never runs on PRs**, so #272 went green and only broke `main` post-merge.

## Changes

- **Smoke test**: assert the global-scope contract (`global_not_routable`). The security invariant is unchanged — still `-32602`, neither workspace counter increments, never a silent fallback route. Updated comments + the `it(...)` title.
- **`mcp-server.ts`**: fix a stale comment with the same drift (bare → `global_not_routable`; five error classes, not four).
- **CI**: drop the `main`-only guard on the smoke job so this class of break is caught on PRs.

## Verification

Local (worktree off `origin/main`):
- `bun run smoke` → 24/24 ✓
- `test/unit/tools/namespace.test.ts` + `test/unit/orchestrator/route.test.ts` → 28/28 ✓
- `bun run verify:static` (lint, tsc, guard scripts) ✓