### PR TITLE
fix(web): show the resizable chat sidebar on every route

### DIFF
--- a/web/src/components/AppWithChat.tsx
+++ b/web/src/components/AppWithChat.tsx
@@ -23,7 +23,6 @@ import type { UiChatContext } from "../bridge/types";
 import { useChatContext } from "../context/ChatContext";
 import { useChatPanelContext } from "../context/ChatPanelContext";
 import type { AppContext, PlacementEntry } from "../types";
-import { ResizeHandle } from "./ResizeHandle";
 import { SlotRenderer } from "./SlotRenderer";
 
 function useIsMobile(): boolean {
@@ -46,13 +45,11 @@ interface AppWithChatProps {
   forceRefresh?: boolean;
 }
 
-const DEFAULT_WIDTH = 380;
 const TRANSITION_STANDARD = "300ms cubic-bezier(0.33, 1, 0.68, 1)";
 const TRANSITION_FULLSCREEN = "350ms cubic-bezier(0.4, 0, 0.2, 1)";
 
 export function AppWithChat({ placement, onNavigate, forceRefresh }: AppWithChatProps) {
-  const { panelState, panelWidth, setPanelWidth, openPanel } = useChatPanelContext();
-  const [isDragging, setIsDragging] = useState(false);
+  const { panelState, openPanel } = useChatPanelContext();
 
   const chat = useChatContext();
   const isMobile = useIsMobile();
@@ -92,10 +89,6 @@ export function AppWithChat({ placement, onNavigate, forceRefresh }: AppWithChat
     [panelState, openPanel],
   );
 
-  const handleResizeDoubleClick = useCallback(() => {
-    setPanelWidth(DEFAULT_WIDTH);
-  }, [setPanelWidth]);
-
   const isSidebar = panelState === "sidebar";
   const isFullscreen = panelState === "fullscreen";
   const hideMobileApp = isMobile && isSidebar;
@@ -112,9 +105,7 @@ export function AppWithChat({ placement, onNavigate, forceRefresh }: AppWithChat
           className={
             isFullscreen
               ? "flex-1 h-full min-w-0 opacity-30 scale-[0.98] blur-sm pointer-events-none transition-all duration-350 ease-out"
-              : isDragging
-                ? "flex-1 h-full min-w-0 pointer-events-none"
-                : "flex-1 h-full min-w-0"
+              : "flex-1 h-full min-w-0"
           }
           style={{
             transition: isFullscreen
@@ -129,23 +120,6 @@ export function AppWithChat({ placement, onNavigate, forceRefresh }: AppWithChat
             onNavigate={onNavigate}
             onPromptAction={handlePromptAction}
             forceRefresh={forceRefresh}
-          />
-        </div>
-      )}
-
-      {/* Resize handle — anchored to the chat panel's left edge.
-          Coordinates with the iframe's marginRight via the shared
-          panelWidth in ChatPanelContext. The panel itself is rendered
-          by ChatChrome (mounted at the shell level). */}
-      {isSidebar && !isMobile && (
-        <div className="fixed top-0 h-full z-20 hidden sm:block" style={{ right: panelWidth }}>
-          <ResizeHandle
-            initialWidth={panelWidth}
-            onWidthChange={setPanelWidth}
-            onDragStart={() => setIsDragging(true)}
-            onDragEnd={() => setIsDragging(false)}
-            onDoubleClick={handleResizeDoubleClick}
-            className="h-full"
           />
         </div>
       )}

--- a/web/src/components/AppWithChat.tsx
+++ b/web/src/components/AppWithChat.tsx
@@ -1,21 +1,18 @@
 // ---------------------------------------------------------------------------
-// AppWithChat — iframe renderer for an app placement, with chat-panel
-// coordination via shared ChatPanelContext.
+// AppWithChat — iframe renderer for a single app placement.
 //
-// The chat panel itself (toggle button, sliding sidebar/fullscreen,
-// keyboard shortcuts, unread tracking, deep-link) lives in
-// `ChatChrome` mounted at the shell level, so chat is always one
-// click away regardless of route. This component keeps only what's
-// iframe-specific:
-//   - `SlotRenderer` for the app placement
-//   - `marginRight: panelWidth` on the iframe area so the app doesn't
-//     get covered when the chat panel is open as a sidebar
-//   - `ResizeHandle` anchored to the chat panel's left edge for
-//     drag-to-resize (the handle coordinates with the iframe's
-//     marginRight via shared ChatPanelContext state)
+// Scope is deliberately narrow. The chat panel — toggle, sliding
+// sidebar/fullscreen, resize handle — and the `marginRight` push-over
+// that makes room for it are all shell-level (`ChatChrome` and
+// `ShellLayout`), so they behave identically on every route. Don't pull
+// any of that back in here; this component renders one app and nothing
+// about the panel's own layout.
+//
+// What stays here, because it needs the focused app:
+//   - `SlotRenderer` — renders the placement's iframe
 //   - `handleChat` / `handlePromptAction` — iframe→shell channels for
-//     "send this message in chat from inside the app"; these stamp
-//     the app's AppContext on outgoing messages
+//     "send this from inside the app". These are the one place a focused
+//     app is known, so they stamp its `AppContext` on outgoing messages.
 // ---------------------------------------------------------------------------
 
 import { useCallback, useEffect, useMemo, useState } from "react";

--- a/web/src/components/ChatChrome.tsx
+++ b/web/src/components/ChatChrome.tsx
@@ -27,6 +27,7 @@ import { useSidebar } from "../context/SidebarContext";
 import type { AppContext } from "../types";
 import type { ChatPanelRef } from "./ChatPanel";
 import { ChatPanel } from "./ChatPanel";
+import { ResizeHandle } from "./ResizeHandle";
 
 const DEFAULT_WIDTH = 380;
 const TRANSITION_STANDARD = "300ms cubic-bezier(0.33, 1, 0.68, 1)";
@@ -51,7 +52,8 @@ interface ChatChromeProps {
 }
 
 export function ChatChrome({ appContext }: ChatChromeProps) {
-  const { panelState, panelWidth, openPanel, closePanel, toggleFullscreen } = useChatPanelContext();
+  const { panelState, panelWidth, setPanelWidth, openPanel, closePanel, toggleFullscreen } =
+    useChatPanelContext();
   const panelRef = useRef<ChatPanelRef>(null);
   const chat = useChatContext();
   const sidebar = useSidebar();
@@ -232,6 +234,21 @@ export function ChatChrome({ appContext }: ChatChromeProps) {
           onRetry={chat.retryLastMessage}
         />
       </div>
+
+      {/* Resize handle — anchored to the panel's left edge. Rendered here at
+          the single panel mount point so EVERY route gets a resizable,
+          collapsible chat sidebar, not just app views. App iframes read
+          `isResizing` from ChatPanelContext to drop pointer-events mid-drag. */}
+      {isSidebar && !isMobile && (
+        <div className="fixed top-0 h-full z-20 hidden sm:block" style={{ right: panelWidth }}>
+          <ResizeHandle
+            initialWidth={panelWidth}
+            onWidthChange={setPanelWidth}
+            onDoubleClick={() => setPanelWidth(DEFAULT_WIDTH)}
+            className="h-full"
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/web/src/components/ChatChrome.tsx
+++ b/web/src/components/ChatChrome.tsx
@@ -1,21 +1,17 @@
 // ---------------------------------------------------------------------------
-// ChatChrome — the floating chat toggle + sliding chat panel + resize
-// handle, lifted out of AppWithChat so it can be mounted globally from
-// ShellLayout (chat is always available, not just on app routes).
+// ChatChrome — the chat panel chrome: floating toggle, sliding
+// sidebar/fullscreen panel, resize handle, keyboard shortcuts, unread
+// tracking, and deep-link open.
 //
-// Two usage modes:
-//   1. With `appContext`: AppWithChat passes the active app's context
-//      so chats sent from inside an app carry "[App Context: …]"
-//      metadata in the message.
-//   2. Without `appContext` (global mode): ShellLayout mounts this
-//      with no app context; chats sent from non-app routes (Home,
-//      workspace overview, settings, …) are workspace-agnostic.
+// INVARIANT: mounted exactly once, globally, by ShellLayout. A second
+// mount renders a second panel. Nothing else may render it — every route
+// gets chat through this single instance via ChatPanelContext, which is
+// why the panel is identical on home, workspace overview, and app views.
 //
-// Mounted twice would render two panels — ShellLayout's instance is
-// active on every route, so AppWithChat MUST NOT render this directly.
-// AppWithChat's `chat-on-app-route` behavior comes from the same shell
-// instance through ChatPanelContext, plus app-specific iframe
-// coordination (marginRight + resize handle) which stays in AppWithChat.
+// App-context stamping ("[App Context: …]" on a message) is deliberately
+// NOT done here: a global mount has no focused app to attach. That
+// stamping lives where the focus is known — AppWithChat's iframe→chat
+// channel. Messages typed into this panel are workspace-agnostic.
 // ---------------------------------------------------------------------------
 
 import { MessageSquare } from "lucide-react";
@@ -24,7 +20,6 @@ import { useLocation } from "react-router-dom";
 import { useChatContext } from "../context/ChatContext";
 import { useChatPanelContext } from "../context/ChatPanelContext";
 import { useSidebar } from "../context/SidebarContext";
-import type { AppContext } from "../types";
 import type { ChatPanelRef } from "./ChatPanel";
 import { ChatPanel } from "./ChatPanel";
 import { ResizeHandle } from "./ResizeHandle";
@@ -46,12 +41,7 @@ function useIsMobile(): boolean {
   return isMobile;
 }
 
-interface ChatChromeProps {
-  /** App context to stamp on messages, if any. Omit for global mode. */
-  appContext?: AppContext;
-}
-
-export function ChatChrome({ appContext }: ChatChromeProps) {
+export function ChatChrome() {
   const { panelState, panelWidth, setPanelWidth, openPanel, closePanel, toggleFullscreen } =
     useChatPanelContext();
   const panelRef = useRef<ChatPanelRef>(null);
@@ -162,13 +152,10 @@ export function ChatChrome({ appContext }: ChatChromeProps) {
   const handleFullscreen = useCallback(() => toggleFullscreen(), [toggleFullscreen]);
 
   const handleSendMessage = useCallback(
-    (text: string, files?: File[]) => {
-      // App context stamps the message metadata when a chat is sent
-      // from inside an app's iframe (AppWithChat). In global mode no
-      // app context is attached.
-      return chat.sendMessage(text, appContext, files);
-    },
-    [chat, appContext],
+    // No app context: this global mount has no focused app (see file
+    // header). Stamping happens in AppWithChat's iframe→chat channel.
+    (text: string, files?: File[]) => chat.sendMessage(text, undefined, files),
+    [chat],
   );
 
   const isSidebar = panelState === "sidebar";
@@ -236,9 +223,10 @@ export function ChatChrome({ appContext }: ChatChromeProps) {
       </div>
 
       {/* Resize handle — anchored to the panel's left edge. Rendered here at
-          the single panel mount point so EVERY route gets a resizable,
-          collapsible chat sidebar, not just app views. App iframes read
-          `isResizing` from ChatPanelContext to drop pointer-events mid-drag. */}
+          the single panel mount point so EVERY route gets a resizable
+          sidebar, not just app views. ResizeHandle is self-contained: while
+          dragging it renders a full-viewport overlay that captures the mouse
+          over app iframes, so no shared drag flag crosses components. */}
       {isSidebar && !isMobile && (
         <div className="fixed top-0 h-full z-20 hidden sm:block" style={{ right: panelWidth }}>
           <ResizeHandle

--- a/web/src/components/ResizeHandle.tsx
+++ b/web/src/components/ResizeHandle.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface ResizeHandleProps {
   initialWidth: number;
   onWidthChange: (width: number) => void;
-  onDragStart?: () => void;
-  onDragEnd?: () => void;
   onDoubleClick?: () => void;
   min?: number;
   max?: number;
@@ -14,8 +12,6 @@ interface ResizeHandleProps {
 export function ResizeHandle({
   initialWidth,
   onWidthChange,
-  onDragStart,
-  onDragEnd,
   onDoubleClick,
   min = 280,
   max = 520,
@@ -24,10 +20,12 @@ export function ResizeHandle({
   const ref = useRef<HTMLDivElement>(null);
   const cbRef = useRef(onWidthChange);
   cbRef.current = onWidthChange;
-  const onDragStartRef = useRef(onDragStart);
-  onDragStartRef.current = onDragStart;
-  const onDragEndRef = useRef(onDragEnd);
-  onDragEndRef.current = onDragEnd;
+
+  // While dragging, render a full-viewport overlay (below). It captures the
+  // mouse over everything — including app iframes, which would otherwise eat
+  // the mousemove and stall the drag — so resize is fully self-contained: no
+  // parent needs to know a drag is happening (no shared "isResizing" flag).
+  const [dragging, setDragging] = useState(false);
 
   const liveWidthRef = useRef(initialWidth);
   useEffect(() => {
@@ -53,7 +51,7 @@ export function ResizeHandle({
       document.removeEventListener("mouseup", onMouseUp);
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
-      onDragEndRef.current?.();
+      setDragging(false);
     }
 
     function onMouseDown(e: MouseEvent) {
@@ -62,7 +60,7 @@ export function ResizeHandle({
       dragStartWidth = liveWidthRef.current;
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
-      onDragStartRef.current?.();
+      setDragging(true);
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     }
@@ -77,12 +75,15 @@ export function ResizeHandle({
     };
   }, [min, max]);
 
-  // biome-ignore lint/a11y/noStaticElementInteractions: drag handle uses pointer events for resize
   return (
-    <div
-      ref={ref}
-      onDoubleClick={onDoubleClick}
-      className={`hidden sm:block w-1 shrink-0 cursor-col-resize bg-border hover:bg-ring active:bg-primary transition-colors ${className ?? ""}`}
-    />
+    <>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: drag handle uses pointer events for resize */}
+      <div
+        ref={ref}
+        onDoubleClick={onDoubleClick}
+        className={`hidden sm:block w-1 shrink-0 cursor-col-resize bg-border hover:bg-ring active:bg-primary transition-colors ${className ?? ""}`}
+      />
+      {dragging && <div className="fixed inset-0 z-[60] cursor-col-resize" />}
+    </>
   );
 }

--- a/web/src/components/ShellLayout.tsx
+++ b/web/src/components/ShellLayout.tsx
@@ -179,11 +179,11 @@ export const ShellLayout = memo(function ShellLayout({
         <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
       </main>
 
-      {/* Chat chrome (floating toggle + sliding panel) — mounted at
-          the shell level so chat is always one click away from any
-          route. AppWithChat keeps iframe-specific coordination
-          (marginRight, resize handle) but does NOT render its own
-          chat panel — this is the single mount point. */}
+      {/* Chat chrome (toggle + sliding panel + resize handle) — the
+          single, global mount point, so chat is one click away from any
+          route. The push-over that makes room for the panel is the
+          `marginRight` on <main> above; the panel and handle live inside
+          ChatChrome itself. */}
       <ChatChrome />
 
       {/* Mobile drawer — single-column layout mirroring desktop. */}


### PR DESCRIPTION
## Problem
The chat panel mounts globally (`ChatChrome`), but its `ResizeHandle` lived in `AppWithChat` — so the grab/resize bar only appeared on **app views**, not on `/` (home) or `/w/<slug>/` (workspace dashboard). The panel was there everywhere; the handle wasn't. The original lift of the panel into `ChatChrome` left the handle behind (its own comment even claimed the handle was lifted — it wasn't).

## Fix — simplify, don't patch
Rather than thread a shared "is dragging" flag between the handle and the iframe, the resize logic now lives **entirely inside `ResizeHandle`**:

- **`ResizeHandle` is self-contained** — while dragging it renders its own transparent full-viewport overlay, which captures the mouse over iframes too (the thing that used to stall the drag). No parent needs to know a drag is happening.
- **`ChatChrome`** (the single panel mount point) renders the handle → the **resizable + collapsible sidebar is uniform on every route**.
- **`AppWithChat` drops all resize coordination**: the handle, the `isDragging` state, the `panelWidth`/`setPanelWidth`/`DEFAULT_WIDTH` plumbing, the double-click reset, and the iframe pointer-events toggle. It's back to just rendering the app iframe + chat handlers.
- `ResizeHandle` loses its now-unused `onDragStart`/`onDragEnd` props.

**Net deletion** (−46/+38) — no shared `isResizing` flag, no cross-component drag state.

## Verification
- `web tsc` + biome clean · `test:web` **354/0**.
- Verified live (dev instance): the resize handle now renders on `/` and `/w/<slug>/`, not just app views; chat panel open/close/resize work on the dashboard.