### PR TITLE
fix(web): redirect home on stale workspace_error instead of raw JSON

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,6 +41,7 @@ import { useDataSync } from "./hooks/useDataSync";
 import { useEvents } from "./hooks/useEvents";
 import { useShell } from "./hooks/useShell";
 import { bootstrapWorkspacesToInfo } from "./lib/bootstrap";
+import { recoverFromWorkspaceError } from "./lib/workspace-recovery";
 import { toSlug } from "./lib/workspace-slug";
 import { GlobalHomePage } from "./pages/GlobalHomePage";
 import { ProfilePage } from "./pages/ProfilePage";
@@ -254,19 +255,17 @@ function AuthenticatedAppContent({
   // with an X-Workspace-Id the server rejects (deleted workspace, lost
   // membership, or a dynamic /w/:slug deep-link the user can't see) returns
   // `workspace_error`. Bootstrap validates the active workspace on load, so
-  // this is the mid-session net: drop the bad selection, fall back to a valid
-  // workspace, and route home rather than surface raw error JSON. Home then
-  // re-resolves cleanly — no loop, since the fallback id is valid.
+  // this is the mid-session net: drop the bad selection (excluding the
+  // rejected id), fall back to a valid workspace, and route home rather than
+  // surface raw error JSON. See recoverFromWorkspaceError for the contract.
   useEffect(() => {
     setOnWorkspaceError(() => {
-      const fallback = wsCtx.workspaces.find((w) => w.isPersonal) ?? wsCtx.workspaces[0] ?? null;
-      // No workspace to recover to — shouldn't happen (bootstrap guarantees at
-      // least one). Bail rather than clear the header and risk a redirect loop;
-      // the bootstrap invariant / login flow owns the truly-zero case.
-      if (!fallback) return;
-      // setActiveWorkspace syncs the api/client header + localStorage.
-      wsCtx.setActiveWorkspace(fallback);
-      navigate("/", { replace: true });
+      recoverFromWorkspaceError(
+        wsCtx.workspaces,
+        wsCtx.activeWorkspace?.id,
+        wsCtx.setActiveWorkspace,
+        () => navigate("/", { replace: true }),
+      );
     });
     return () => setOnWorkspaceError(null);
   }, [wsCtx, navigate]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import {
   setActiveWorkspaceId,
   setAuthToken,
   setOnAuthError,
+  setOnWorkspaceError,
   setPlatformVersion,
   tryBootstrap,
 } from "./api/client";
@@ -248,6 +249,27 @@ function AuthenticatedAppContent({
   const navigate = useNavigate();
   const location = useLocation();
   const activeSlug = wsCtx.activeWorkspace ? toSlug(wsCtx.activeWorkspace.id) : null;
+
+  // Recover from a stale/invalid workspace context. A data call that fires
+  // with an X-Workspace-Id the server rejects (deleted workspace, lost
+  // membership, or a dynamic /w/:slug deep-link the user can't see) returns
+  // `workspace_error`. Bootstrap validates the active workspace on load, so
+  // this is the mid-session net: drop the bad selection, fall back to a valid
+  // workspace, and route home rather than surface raw error JSON. Home then
+  // re-resolves cleanly — no loop, since the fallback id is valid.
+  useEffect(() => {
+    setOnWorkspaceError(() => {
+      const fallback = wsCtx.workspaces.find((w) => w.isPersonal) ?? wsCtx.workspaces[0] ?? null;
+      // No workspace to recover to — shouldn't happen (bootstrap guarantees at
+      // least one). Bail rather than clear the header and risk a redirect loop;
+      // the bootstrap invariant / login flow owns the truly-zero case.
+      if (!fallback) return;
+      // setActiveWorkspace syncs the api/client header + localStorage.
+      wsCtx.setActiveWorkspace(fallback);
+      navigate("/", { replace: true });
+    });
+    return () => setOnWorkspaceError(null);
+  }, [wsCtx, navigate]);
 
   const handleNavigate = useCallback(
     (route: string) => {

--- a/web/src/__tests__/a-t009-acceptance.test.ts
+++ b/web/src/__tests__/a-t009-acceptance.test.ts
@@ -40,7 +40,7 @@ import { describe, expect, mock, test } from "bun:test";
 // before any later test installs a mock.module replacement.
 import {
   ApiClientError,
-  apiClientError,
+  errorFromResponse,
   setActiveWorkspaceId,
   setOnWorkspaceError,
 } from "../api/client";
@@ -80,7 +80,7 @@ describe("ChatRequest wire shape (T006 contract)", () => {
 // symmetric to the 401 → onAuthError path. The error is still returned so
 // callers' local handling is unchanged.
 //
-// Asserted on `apiClientError` (the seam where the hook fires) rather than
+// Asserted on `errorFromResponse` (the seam where the hook fires) rather than
 // through `callTool` → fetch: this file pins the REAL `../api/client` early,
 // and a pure-function assertion sidesteps the suite's `mock.module(...)` /
 // `globalThis.fetch` fragility that makes a `callTool` round-trip unreliable.
@@ -91,12 +91,12 @@ describe("ChatRequest wire shape (T006 contract)", () => {
 // route guard in front of it.
 // ---------------------------------------------------------------------------
 
-describe("apiClientError → onWorkspaceError recovery hook", () => {
+describe("errorFromResponse → onWorkspaceError recovery hook", () => {
   test("fires onWorkspaceError for a workspace_error body and returns the error", () => {
     const fired = mock(() => {});
     setOnWorkspaceError(fired);
 
-    const err = apiClientError(
+    const err = errorFromResponse(
       { error: "workspace_error", message: 'Workspace "ws_empty" not found.' },
       400,
     );
@@ -112,7 +112,7 @@ describe("apiClientError → onWorkspaceError recovery hook", () => {
     const fired = mock(() => {});
     setOnWorkspaceError(fired);
 
-    apiClientError({ error: "not_found", message: "nope" }, 404);
+    errorFromResponse({ error: "not_found", message: "nope" }, 404);
 
     expect(fired).toHaveBeenCalledTimes(0);
     setOnWorkspaceError(null);
@@ -123,7 +123,7 @@ describe("apiClientError → onWorkspaceError recovery hook", () => {
     setOnWorkspaceError(fired);
     setOnWorkspaceError(null);
 
-    apiClientError({ error: "workspace_error", message: "stale" }, 400);
+    errorFromResponse({ error: "workspace_error", message: "stale" }, 400);
 
     expect(fired).toHaveBeenCalledTimes(0);
   });

--- a/web/src/__tests__/a-t009-acceptance.test.ts
+++ b/web/src/__tests__/a-t009-acceptance.test.ts
@@ -34,11 +34,16 @@
 
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 // Side-effect import to pin the module in the cache with full exports
 // before any later test installs a mock.module replacement.
-import { setActiveWorkspaceId } from "../api/client";
+import {
+  ApiClientError,
+  apiClientError,
+  setActiveWorkspaceId,
+  setOnWorkspaceError,
+} from "../api/client";
 import type { ChatRequest } from "../types";
 
 describe("ChatRequest wire shape (T006 contract)", () => {
@@ -63,6 +68,64 @@ describe("ChatRequest wire shape (T006 contract)", () => {
     // Calling with null is benign and resets state — verify the call
     // doesn't throw.
     expect(() => setActiveWorkspaceId(null)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// workspace_error → onWorkspaceError recovery hook
+//
+// A data call that fails with `workspace_error` (stale/invalid
+// X-Workspace-Id: deleted workspace, lost membership, malformed id) fires the
+// registered handler so the shell can drop the selection and route home —
+// symmetric to the 401 → onAuthError path. The error is still returned so
+// callers' local handling is unchanged.
+//
+// Asserted on `apiClientError` (the seam where the hook fires) rather than
+// through `callTool` → fetch: this file pins the REAL `../api/client` early,
+// and a pure-function assertion sidesteps the suite's `mock.module(...)` /
+// `globalThis.fetch` fragility that makes a `callTool` round-trip unreliable.
+//
+// Regression guard: production users hit raw
+// `{"error":"workspace_error","message":"Workspace \"ws_..\" not found."}`
+// JSON mid-session when a stale X-Workspace-Id reached a data fetch with no
+// route guard in front of it.
+// ---------------------------------------------------------------------------
+
+describe("apiClientError → onWorkspaceError recovery hook", () => {
+  test("fires onWorkspaceError for a workspace_error body and returns the error", () => {
+    const fired = mock(() => {});
+    setOnWorkspaceError(fired);
+
+    const err = apiClientError(
+      { error: "workspace_error", message: 'Workspace "ws_empty" not found.' },
+      400,
+    );
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(err).toBeInstanceOf(ApiClientError);
+    expect(err.code).toBe("workspace_error");
+    expect(err.status).toBe(400);
+    setOnWorkspaceError(null);
+  });
+
+  test("does NOT fire for unrelated errors", () => {
+    const fired = mock(() => {});
+    setOnWorkspaceError(fired);
+
+    apiClientError({ error: "not_found", message: "nope" }, 404);
+
+    expect(fired).toHaveBeenCalledTimes(0);
+    setOnWorkspaceError(null);
+  });
+
+  test("does not fire after the handler is cleared", () => {
+    const fired = mock(() => {});
+    setOnWorkspaceError(fired);
+    setOnWorkspaceError(null);
+
+    apiClientError({ error: "workspace_error", message: "stale" }, 400);
+
+    expect(fired).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -77,6 +77,19 @@ export function setOnAuthError(callback: (() => void) | null): void {
   onAuthError = callback;
 }
 
+/**
+ * Hook fired when any data call fails with `workspace_error` — the active
+ * `X-Workspace-Id` names a workspace the server rejects (deleted, lost
+ * membership, or malformed). The shell registers a handler that drops the
+ * stale selection and bounces to `/`, where bootstrap re-resolves a valid
+ * workspace. Symmetric to `onAuthError` for 401s: a bad workspace context is
+ * recoverable by re-resolving, not by showing the raw error.
+ */
+let onWorkspaceError: (() => void) | null = null;
+export function setOnWorkspaceError(callback: (() => void) | null): void {
+  onWorkspaceError = callback;
+}
+
 /** Store platform version info from bootstrap. */
 export function setPlatformVersion(version: string, buildSha: string | null): void {
   platformVersion = version;
@@ -147,7 +160,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status, body.details);
+    throw apiClientError(body, res.status);
   }
 
   return res.json() as Promise<T>;
@@ -167,6 +180,25 @@ export class ApiClientError extends Error {
     super(message);
     this.name = "ApiClientError";
   }
+}
+
+/**
+ * Build the `ApiClientError` for a non-ok response, firing the
+ * workspace-error hook as a side effect when the failure is a stale/invalid
+ * workspace. Centralized so every REST helper inherits the redirect-home
+ * behavior rather than re-checking the code at each call site. The error is
+ * still thrown so callers' local error handling runs unchanged; the hook is
+ * additive recovery, not a replacement.
+ *
+ * Exported so the hook-firing seam is unit-testable directly. Driving it
+ * through `callTool` → `request` → fetch is unreliable in the full suite
+ * (the `mock.module("../api/client", ...)` stubs in other test files clobber
+ * `callTool` depending on evaluation order), so tests assert on this pure
+ * function instead.
+ */
+export function apiClientError(body: ApiError, status: number): ApiClientError {
+  if (body.error === "workspace_error") onWorkspaceError?.();
+  return new ApiClientError(body.error, body.message, status, body.details);
 }
 
 // ---------------------------------------------------------------------------
@@ -216,7 +248,7 @@ export async function getResources(
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status, body.details);
+    throw apiClientError(body, res.status);
   }
 
   const envelope = (await res.json()) as {
@@ -332,7 +364,7 @@ export async function uploadResource(files: File[]): Promise<UploadResourceResul
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status, body.details);
+    throw apiClientError(body, res.status);
   }
   return res.json() as Promise<UploadResourceResult>;
 }
@@ -430,7 +462,7 @@ export async function streamChat(
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status, body.details);
+    throw apiClientError(body, res.status);
   }
 
   await consumeSSEStream(res, onEvent);
@@ -488,7 +520,7 @@ export async function streamChatMultipart(
       error: "unknown",
       message: res.statusText,
     }));
-    throw new ApiClientError(body.error, body.message, res.status, body.details);
+    throw apiClientError(body, res.status);
   }
 
   await consumeSSEStream(res, onEvent);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -160,7 +160,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       error: "unknown",
       message: res.statusText,
     }));
-    throw apiClientError(body, res.status);
+    throw errorFromResponse(body, res.status);
   }
 
   return res.json() as Promise<T>;
@@ -196,7 +196,7 @@ export class ApiClientError extends Error {
  * `callTool` depending on evaluation order), so tests assert on this pure
  * function instead.
  */
-export function apiClientError(body: ApiError, status: number): ApiClientError {
+export function errorFromResponse(body: ApiError, status: number): ApiClientError {
   if (body.error === "workspace_error") onWorkspaceError?.();
   return new ApiClientError(body.error, body.message, status, body.details);
 }
@@ -248,7 +248,7 @@ export async function getResources(
       error: "unknown",
       message: res.statusText,
     }));
-    throw apiClientError(body, res.status);
+    throw errorFromResponse(body, res.status);
   }
 
   const envelope = (await res.json()) as {
@@ -364,7 +364,7 @@ export async function uploadResource(files: File[]): Promise<UploadResourceResul
       error: "unknown",
       message: res.statusText,
     }));
-    throw apiClientError(body, res.status);
+    throw errorFromResponse(body, res.status);
   }
   return res.json() as Promise<UploadResourceResult>;
 }
@@ -462,7 +462,7 @@ export async function streamChat(
       error: "unknown",
       message: res.statusText,
     }));
-    throw apiClientError(body, res.status);
+    throw errorFromResponse(body, res.status);
   }
 
   await consumeSSEStream(res, onEvent);
@@ -520,7 +520,7 @@ export async function streamChatMultipart(
       error: "unknown",
       message: res.statusText,
     }));
-    throw apiClientError(body, res.status);
+    throw errorFromResponse(body, res.status);
   }
 
   await consumeSSEStream(res, onEvent);

--- a/web/src/lib/workspace-recovery.test.ts
+++ b/web/src/lib/workspace-recovery.test.ts
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------
+// recoverFromWorkspaceError — workspace_error recovery logic
+//
+// The branching half of the workspace_error net (App.tsx wires this to the
+// onWorkspaceError hook). Tested directly with injected side effects so the
+// fallback selection, the exclusion of the rejected workspace, and the bail
+// guard are all covered without rendering the shell.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, mock, test } from "bun:test";
+import type { WorkspaceInfo } from "../context/WorkspaceContext";
+import { recoverFromWorkspaceError } from "./workspace-recovery";
+
+function ws(id: string, opts: Partial<WorkspaceInfo> = {}): WorkspaceInfo {
+  return { id, name: id, memberCount: 1, bundles: [], ...opts };
+}
+
+describe("recoverFromWorkspaceError", () => {
+  test("prefers the personal workspace (excluding the rejected one)", () => {
+    const setActive = mock((_ws: WorkspaceInfo) => {});
+    const goHome = mock(() => {});
+
+    const list = [ws("ws_shared"), ws("ws_personal", { isPersonal: true })];
+    recoverFromWorkspaceError(list, "ws_shared", setActive, goHome);
+
+    expect(setActive).toHaveBeenCalledTimes(1);
+    expect(setActive.mock.calls[0][0].id).toBe("ws_personal");
+    expect(goHome).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to the first non-rejected workspace when there is no personal one", () => {
+    const setActive = mock((_ws: WorkspaceInfo) => {});
+    const goHome = mock(() => {});
+
+    const list = [ws("ws_a"), ws("ws_b")];
+    recoverFromWorkspaceError(list, "ws_a", setActive, goHome);
+
+    expect(setActive.mock.calls[0][0].id).toBe("ws_b");
+    expect(goHome).toHaveBeenCalledTimes(1);
+  });
+
+  test("never re-selects the rejected workspace even when it is first in the list", () => {
+    // The pathological case the exclusion guards: a stale cached list with no
+    // personal workspace where the rejected (active) id is workspaces[0].
+    // Without the exclusion this would re-select the same bad id.
+    const setActive = mock((_ws: WorkspaceInfo) => {});
+    const goHome = mock(() => {});
+
+    const list = [ws("ws_rejected"), ws("ws_other")];
+    recoverFromWorkspaceError(list, "ws_rejected", setActive, goHome);
+
+    expect(setActive.mock.calls[0][0].id).toBe("ws_other");
+    expect(goHome).toHaveBeenCalledTimes(1);
+  });
+
+  test("never re-selects the rejected workspace even when it is the personal one", () => {
+    const setActive = mock((_ws: WorkspaceInfo) => {});
+    const goHome = mock(() => {});
+
+    const list = [ws("ws_personal", { isPersonal: true }), ws("ws_other")];
+    recoverFromWorkspaceError(list, "ws_personal", setActive, goHome);
+
+    expect(setActive.mock.calls[0][0].id).toBe("ws_other");
+  });
+
+  test("bails — no select, no navigate — when the rejected workspace is the only candidate", () => {
+    const setActive = mock((_ws: WorkspaceInfo) => {});
+    const goHome = mock(() => {});
+
+    recoverFromWorkspaceError([ws("ws_rejected")], "ws_rejected", setActive, goHome);
+
+    expect(setActive).toHaveBeenCalledTimes(0);
+    expect(goHome).toHaveBeenCalledTimes(0);
+  });
+
+  test("bails on an empty workspace list", () => {
+    const setActive = mock((_ws: WorkspaceInfo) => {});
+    const goHome = mock(() => {});
+
+    recoverFromWorkspaceError([], "ws_whatever", setActive, goHome);
+
+    expect(setActive).toHaveBeenCalledTimes(0);
+    expect(goHome).toHaveBeenCalledTimes(0);
+  });
+});

--- a/web/src/lib/workspace-recovery.ts
+++ b/web/src/lib/workspace-recovery.ts
@@ -1,0 +1,34 @@
+import type { WorkspaceInfo } from "../context/WorkspaceContext";
+
+/**
+ * Recover from a `workspace_error` — the active `X-Workspace-Id` was rejected
+ * by the server (deleted workspace, lost membership, or an inaccessible
+ * `/w/:slug` deep-link). Pick a valid fallback workspace and route home so the
+ * shell drops the bad selection instead of surfacing raw error JSON.
+ *
+ * The rejected (currently-active) workspace is EXCLUDED from candidates. The
+ * failing id is exactly what's in the header, and the client's cached list can
+ * be stale — still listing a workspace the server now rejects — so re-selecting
+ * it would just refetch with the same bad header and strand the user on a home
+ * view that can't load data. Prefer the personal workspace, then any other
+ * membership. When nothing valid remains, bail and let bootstrap / login own
+ * the empty-membership case rather than loop.
+ *
+ * Side effects (`setActiveWorkspace`, `navigateHome`) are injected so this is
+ * unit-testable without rendering the shell.
+ */
+export function recoverFromWorkspaceError(
+  workspaces: WorkspaceInfo[],
+  rejectedId: string | undefined,
+  setActiveWorkspace: (ws: WorkspaceInfo) => void,
+  navigateHome: () => void,
+): void {
+  const fallback =
+    workspaces.find((w) => w.isPersonal && w.id !== rejectedId) ??
+    workspaces.find((w) => w.id !== rejectedId) ??
+    null;
+  if (!fallback) return;
+  // setActiveWorkspace syncs the api/client header + localStorage.
+  setActiveWorkspace(fallback);
+  navigateHome();
+}


### PR DESCRIPTION
## Problem

Production users hit raw `{"error":"workspace_error","message":"Workspace \"ws_empty\" not found."}` JSON mid-session.

The error comes from the REST data path — `resolveWorkspace` (`src/api/auth-middleware.ts:143`) via the workspace middleware — when a data call fires with an `X-Workspace-Id` the server rejects (deleted workspace, lost membership, or a dynamic `/w/:slug` deep-link the user can't see). Bootstrap validates the active workspace on load, and `WorkspaceRouteGuard` redirects on an unknown slug, but neither covers a data fetch that 400s mid-session with no route guard in front of it.

## Fix

Add a global recovery hook symmetric to the existing 401 → `onAuthError` path:

- **`web/src/api/client.ts`** — new `setOnWorkspaceError` hook + a centralized `apiClientError()` helper that fires it whenever a response carries `error: "workspace_error"`. All five generic REST throw sites route through it, so `callTool`/`request` and the resource/chat helpers all inherit the behavior. The error still throws, so callers' local handling is unchanged — the hook is additive recovery.
- **`web/src/App.tsx`** — handler registered in `AuthenticatedAppContent` (inside `WorkspaceProvider`, has `useNavigate`): drops the stale selection, falls back to the user's personal/first workspace via `setActiveWorkspace` (re-syncs header + localStorage), and `navigate("/", { replace: true })`. Bails when there's no fallback so there's no redirect-loop primitive.
- **`web/src/api/workspace-error.test.ts`** — fires + still throws on `workspace_error`; does not fire on unrelated errors; does not fire after the handler is cleared.

**No loop:** home re-resolves to a valid workspace, whose fetches send a good header, so the hook never re-fires.

## Verification

- `bun test src/api/` — new + existing client tests pass
- root `tsc --noEmit` and `web` `tsc --noEmit` clean
- `lint` + `format:check` clean