### PR TITLE
fix(web): dashboard app grid is a three-state surface (loading/empty/populated)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -151,6 +151,7 @@ function BootstrappedShell({
   const {
     loading,
     error,
+    shellWorkspaceId,
     forSlot,
     mainRoutes,
     refresh: refreshShell,
@@ -187,6 +188,7 @@ function BootstrappedShell({
             token={token}
             forSlot={forSlot}
             mainRoutes={mainRoutes}
+            shellWorkspaceId={shellWorkspaceId}
             refreshShell={refreshShell}
             onLogout={onLogout}
           />
@@ -208,12 +210,14 @@ function AuthenticatedAppContent({
   token,
   forSlot,
   mainRoutes,
+  shellWorkspaceId,
   refreshShell,
   onLogout,
 }: {
   token: string;
   forSlot: (slot: string) => PlacementEntry[];
   mainRoutes: () => PlacementEntry[];
+  shellWorkspaceId: string | undefined;
   refreshShell: () => Promise<void>;
   onLogout: () => void;
 }) {
@@ -324,7 +328,7 @@ function AuthenticatedAppContent({
   const identityAppPlacements = allRoutable.filter((p) => isIdentityApp(p.serverName));
 
   return (
-    <ShellProvider value={{ forSlot, mainRoutes }}>
+    <ShellProvider value={{ forSlot, mainRoutes, shellWorkspaceId }}>
       {/* ActionBridge handles iframe action events. It consumes ChatContext
           (streaming) but renders nothing, so its re-renders are free. */}
       <ActionBridge handleNavigate={handleNavigate} resolveAppRoute={resolveAppRoute} />

--- a/web/src/components/briefing/BriefingView.tsx
+++ b/web/src/components/briefing/BriefingView.tsx
@@ -86,9 +86,9 @@ function Eyebrow() {
 function Skeleton() {
   return (
     <div className="mt-3 space-y-2.5" aria-hidden>
-      <div className="h-3 w-2/3 rounded bg-muted animate-pulse" />
-      <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
-      <div className="h-3 w-3/5 rounded bg-muted animate-pulse" />
+      <div className="h-3 w-2/3 rounded bg-muted-foreground/20 animate-pulse" />
+      <div className="h-3 w-1/2 rounded bg-muted-foreground/20 animate-pulse" />
+      <div className="h-3 w-3/5 rounded bg-muted-foreground/20 animate-pulse" />
     </div>
   );
 }

--- a/web/src/context/ShellContext.tsx
+++ b/web/src/context/ShellContext.tsx
@@ -4,6 +4,21 @@ import type { PlacementEntry } from "../types";
 export interface ShellContextValue {
   forSlot: (slot: string) => PlacementEntry[];
   mainRoutes: () => PlacementEntry[];
+  /**
+   * The workspace id the current placements reflect, or `undefined` before the
+   * first shell load. A per-workspace consumer (e.g. the overview page's app
+   * grid) must compare this to its own workspace id: when they differ the
+   * shell hasn't caught up to a switch yet, so the consumer should render a
+   * loading state, NOT an empty state. `forSlot` returns the *previous*
+   * workspace's placements during that window.
+   *
+   * This is the only readiness signal consumers need. The shell's `loading` /
+   * `error` are handled one level up (`BootstrappedShell` gates the whole app
+   * on them), so by the time any context consumer renders, loading is false
+   * and there's no error — a workspace *switch* keeps loading false and swaps
+   * `shellWorkspaceId` instead, which is exactly the window this exposes.
+   */
+  shellWorkspaceId: string | undefined;
 }
 
 const ShellContext = createContext<ShellContextValue | null>(null);

--- a/web/src/hooks/useShell.ts
+++ b/web/src/hooks/useShell.ts
@@ -7,8 +7,25 @@ export function useShell(_token: string, workspaceId?: string, initialShell?: Sh
   const [shell, setShell] = useState<ShellData | null>(initialShell ?? null);
   const [loading, setLoading] = useState(!initialShell);
   const [error, setError] = useState<string | null>(null);
+  // Which workspace the current `shell` placements reflect. Seeded from the
+  // mount-time workspace, because the bootstrap shell is built server-side for
+  // `bootstrap.activeWorkspace` — the same id passed here on first render.
+  //
+  // Why a separate signal and not just `loading`: on a workspace switch we
+  // deliberately keep the old shell visible and leave `loading === false` (no
+  // sidebar flash). During that window `shell` still holds the *previous*
+  // workspace's placements, so a per-workspace consumer (the overview page's
+  // app grid) needs to know the shell hasn't caught up yet — `loading` can't
+  // tell it. Comparing `shellWorkspaceId` to the target id closes that gap.
+  const [shellWorkspaceId, setShellWorkspaceId] = useState<string | undefined>(
+    initialShell ? workspaceId : undefined,
+  );
   // When bootstrap data is provided, skip the first effect invocation
   const skipNext = useRef(!!initialShell);
+  // Latest workspaceId, readable from the stable `refresh` callback without
+  // making it churn (and re-subscribe its SSE consumer) on every switch.
+  const workspaceIdRef = useRef(workspaceId);
+  workspaceIdRef.current = workspaceId;
 
   /**
    * Refetch the shell payload. Used by bundle lifecycle SSE events so
@@ -20,6 +37,7 @@ export function useShell(_token: string, workspaceId?: string, initialShell?: Sh
     try {
       const data = await getShell();
       setShell(data);
+      setShellWorkspaceId(workspaceIdRef.current);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load shell");
@@ -43,6 +61,7 @@ export function useShell(_token: string, workspaceId?: string, initialShell?: Sh
       .then((data) => {
         if (!cancelled) {
           setShell(data);
+          setShellWorkspaceId(workspaceId);
           setLoading(false);
         }
       })
@@ -80,5 +99,5 @@ export function useShell(_token: string, workspaceId?: string, initialShell?: Sh
     );
   }, [shell]);
 
-  return { shell, loading, error, forSlot, mainRoutes, refresh };
+  return { shell, loading, error, shellWorkspaceId, forSlot, mainRoutes, refresh };
 }

--- a/web/src/pages/WorkspaceOverviewPage.tsx
+++ b/web/src/pages/WorkspaceOverviewPage.tsx
@@ -196,10 +196,10 @@ function AppGridSkeleton() {
       {[0, 1, 2].map((i) => (
         <div key={i} className="flex flex-col gap-2 p-4 rounded-lg border border-border bg-card">
           <div className="flex items-center gap-2">
-            <div className="h-4 w-4 shrink-0 rounded bg-muted animate-pulse" />
-            <div className="h-3.5 w-2/3 rounded bg-muted animate-pulse" />
+            <div className="h-4 w-4 shrink-0 rounded bg-muted-foreground/20 animate-pulse" />
+            <div className="h-3.5 w-2/3 rounded bg-muted-foreground/20 animate-pulse" />
           </div>
-          <div className="h-2.5 w-1/3 rounded bg-muted animate-pulse" />
+          <div className="h-2.5 w-1/3 rounded bg-muted-foreground/20 animate-pulse" />
         </div>
       ))}
     </div>

--- a/web/src/pages/WorkspaceOverviewPage.tsx
+++ b/web/src/pages/WorkspaceOverviewPage.tsx
@@ -75,17 +75,27 @@ export function WorkspaceOverviewPage() {
     );
   }
 
-  // Apps in this workspace come from the placement registry's grouped
-  // sub-slots (anything under `sidebar.<group>`). Bare `sidebar` items
-  // (Home, Conversations, …) are core nav, not apps. The shell context
-  // is always mounted by the time this page renders (the route lives
-  // under the same provider in `App.tsx`), so a null shell would mean
-  // a real wiring bug — render empty rather than crash.
-  const apps = shell
-    ? shell
-        .forSlot("sidebar")
-        .filter((p) => p.slot.startsWith("sidebar.") && !p.slot.startsWith("sidebar.bottom"))
-    : [];
+  // Apps come from the placement registry's grouped sub-slots (anything under
+  // `sidebar.<group>`). Bare `sidebar` items (Home, Conversations, …) are core
+  // nav, not apps.
+  //
+  // Readiness — not just "is there a shell?". The shell holds ONE workspace's
+  // placements at a time and lags a switch (old data stays visible while the
+  // refetch is in flight, with no `loading` flag — see ShellContext). Compare
+  // the shell's workspace to THIS page's workspace (`workspace.id`, derived
+  // from the route slug — the stable truth; the active workspace converges to
+  // it after the route guard's sync effect). Until they match, the shell is
+  // still showing the previous workspace's apps, so the grid is "not ready"
+  // and must render a skeleton, never the empty state. Placements are
+  // registered eagerly server-side, so a matching shell resolves near-instantly
+  // — apps don't wait on the (slower, async) briefing.
+  const appsReady = shell != null && shell.shellWorkspaceId === workspace.id;
+  const apps =
+    appsReady && shell
+      ? shell
+          .forSlot("sidebar")
+          .filter((p) => p.slot.startsWith("sidebar.") && !p.slot.startsWith("sidebar.bottom"))
+      : [];
 
   return (
     <div className="h-full overflow-y-auto" data-testid="workspace-overview-page">
@@ -102,7 +112,7 @@ export function WorkspaceOverviewPage() {
               {workspace.name}
             </h1>
             <p className="mt-2 text-sm text-muted-foreground italic">
-              {describeWorkspace(workspace, apps.length)}
+              {describeWorkspace(workspace, appsReady ? apps.length : null)}
             </p>
           </div>
           <Link
@@ -131,7 +141,9 @@ export function WorkspaceOverviewPage() {
         <div className="text-[11px] font-bold tracking-[0.08em] uppercase text-muted-foreground mb-3">
           Available apps
         </div>
-        {apps.length === 0 ? (
+        {!appsReady ? (
+          <AppGridSkeleton />
+        ) : apps.length === 0 ? (
           <div
             className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground"
             data-testid="workspace-overview-empty"
@@ -160,10 +172,38 @@ export function WorkspaceOverviewPage() {
   );
 }
 
-function describeWorkspace(workspace: WorkspaceInfo, appCount: number): string {
-  const apps = `${appCount} ${appCount === 1 ? "app installed" : "apps installed"}`;
+// `appCount === null` means the app list hasn't resolved for this workspace
+// yet — show only the member count (known immediately from the workspace
+// list) rather than flashing a wrong "0 apps installed".
+function describeWorkspace(workspace: WorkspaceInfo, appCount: number | null): string {
   const members = `${workspace.memberCount} ${workspace.memberCount === 1 ? "member" : "members"}`;
+  if (appCount === null) return `${members}.`;
+  const apps = `${appCount} ${appCount === 1 ? "app installed" : "apps installed"}`;
   return `${apps}, ${members}.`;
+}
+
+// Loading placeholder for the app grid: shown while the shell hasn't caught up
+// to this workspace (switch / deep-link window). Mirrors AppCard's shape so the
+// grid doesn't jump when real cards replace it. A fixed three-card placeholder
+// — the real count is unknown until the shell resolves.
+function AppGridSkeleton() {
+  return (
+    <div
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3"
+      data-testid="workspace-overview-apps-skeleton"
+      aria-hidden
+    >
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex flex-col gap-2 p-4 rounded-lg border border-border bg-card">
+          <div className="flex items-center gap-2">
+            <div className="h-4 w-4 shrink-0 rounded bg-muted animate-pulse" />
+            <div className="h-3.5 w-2/3 rounded bg-muted animate-pulse" />
+          </div>
+          <div className="h-2.5 w-1/3 rounded bg-muted animate-pulse" />
+        </div>
+      ))}
+    </div>
+  );
 }
 
 function AppCard({ placement, onOpen }: { placement: PlacementEntry; onOpen: () => void }) {

--- a/web/test/ComposerFooter.test.tsx
+++ b/web/test/ComposerFooter.test.tsx
@@ -116,6 +116,9 @@ const SHELL_VALUE = {
     },
   ],
   mainRoutes: (): PlacementEntry[] => [],
+  // Unused by ComposerFooter (it reads forSlot directly); present to satisfy
+  // the ShellContextValue contract.
+  shellWorkspaceId: undefined,
 };
 
 function harness({

--- a/web/test/WorkspaceOverviewPage.test.tsx
+++ b/web/test/WorkspaceOverviewPage.test.tsx
@@ -1,0 +1,170 @@
+// ---------------------------------------------------------------------------
+// WorkspaceOverviewPage — app grid is a three-state surface
+//
+// The bug this pins: the grid used to render "No apps installed" whenever
+// `forSlot` returned [] — which also happens while the shell hasn't caught up
+// to this workspace (deep-link / switch window). Loading was conflated with
+// empty, so a workspace that DOES have apps flashed a false-empty dashboard.
+//
+// Readiness is `shell.shellWorkspaceId === <this page's workspace id>`. The
+// three states:
+//   not-ready  → skeleton           (never the empty card)
+//   ready+empty → "No apps installed"
+//   ready+populated → the app grid
+//
+// Briefing is independent (its own async timeline) — callTool is stubbed to a
+// never-resolving promise so it sits in its skeleton and doesn't interfere.
+// ---------------------------------------------------------------------------
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as actualClient from "../src/api/client";
+import type { WorkspaceInfo } from "../src/context/WorkspaceContext";
+import type { PlacementEntry } from "../src/types";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Stub only `callTool` so the briefing fetch hangs in its skeleton (its own
+// async timeline — not what this file tests). Spread the real module so every
+// other export stays intact: a bare `{ callTool }` mock leaks across files in
+// the same test process and strips functions the client/bridge suites depend
+// on (getAuthToken, getActiveWorkspaceId, …). WorkspaceContext skips its list
+// call when given bootstrap data, so the real setActiveWorkspaceId it calls is
+// harmless — sibling suites reset client state in their own beforeEach.
+mock.module("../src/api/client", () => ({
+  ...actualClient,
+  callTool: () => new Promise(() => {}),
+}));
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { MemoryRouter, Route, Routes } = await import("react-router-dom");
+const { WorkspaceOverviewPage } = await import("../src/pages/WorkspaceOverviewPage");
+const { WorkspaceProvider } = await import("../src/context/WorkspaceContext");
+const { ShellProvider } = await import("../src/context/ShellContext");
+const { toSlug } = await import("../src/lib/workspace-slug");
+
+interface Mounted {
+  container: HTMLDivElement;
+  unmount(): void;
+}
+
+let mounted: Mounted | null = null;
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+});
+
+async function mount(element: React.ReactElement): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return {
+    container,
+    unmount() {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+function findByTestId(container: HTMLElement, testid: string): HTMLElement | null {
+  for (const el of Array.from(container.getElementsByTagName("*"))) {
+    if (el.getAttribute("data-testid") === testid) return el as HTMLElement;
+  }
+  return null;
+}
+
+function findAllByTestId(container: HTMLElement, testid: string): HTMLElement[] {
+  return Array.from(container.getElementsByTagName("*")).filter(
+    (el) => el.getAttribute("data-testid") === testid,
+  ) as HTMLElement[];
+}
+
+const WS: WorkspaceInfo = {
+  id: "ws_acme",
+  name: "Acme",
+  memberCount: 2,
+  bundles: [],
+  userRole: "admin",
+};
+
+function appPlacement(over: Partial<PlacementEntry>): PlacementEntry {
+  return {
+    serverName: "crm",
+    slot: "sidebar.apps",
+    resourceUri: "ui://crm/main",
+    priority: 10,
+    label: "CRM",
+    route: "crm",
+    ...over,
+  };
+}
+
+// `shellWorkspaceId` is the lever: equal to WS.id → ready; anything else → not.
+function harness(shellWorkspaceId: string | undefined, placements: PlacementEntry[]) {
+  const shellValue = {
+    forSlot: (slot: string): PlacementEntry[] =>
+      placements.filter((p) => p.slot === slot || p.slot.startsWith(`${slot}.`)),
+    mainRoutes: (): PlacementEntry[] => [],
+    shellWorkspaceId,
+  };
+  return (
+    <MemoryRouter initialEntries={[`/w/${toSlug(WS.id)}`]}>
+      <ShellProvider value={shellValue}>
+        <WorkspaceProvider initialWorkspaces={[WS]} initialActiveId={WS.id}>
+          <Routes>
+            <Route path="/w/:slug" element={<WorkspaceOverviewPage />} />
+          </Routes>
+        </WorkspaceProvider>
+      </ShellProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("WorkspaceOverviewPage — app grid three states", () => {
+  test("not ready (shell lags this workspace) → skeleton, never the empty card", async () => {
+    // Shell still reflects a different workspace (the switch/deep-link window).
+    mounted = await mount(harness("ws_other", [appPlacement({})]));
+
+    expect(findByTestId(mounted.container, "workspace-overview-apps-skeleton")).not.toBeNull();
+    // The false-empty regression: must NOT show "No apps installed" while loading.
+    expect(findByTestId(mounted.container, "workspace-overview-empty")).toBeNull();
+    expect(findByTestId(mounted.container, "workspace-overview-app-grid")).toBeNull();
+    // Header omits the (unknown) app count, but still shows members.
+    const breadcrumb = findByTestId(mounted.container, "workspace-overview-page");
+    expect(breadcrumb?.textContent).toContain("2 members");
+    expect(breadcrumb?.textContent).not.toContain("apps installed");
+  });
+
+  test("ready + empty → the empty card, no skeleton", async () => {
+    mounted = await mount(harness(WS.id, []));
+
+    expect(findByTestId(mounted.container, "workspace-overview-empty")).not.toBeNull();
+    expect(findByTestId(mounted.container, "workspace-overview-apps-skeleton")).toBeNull();
+    expect(findByTestId(mounted.container, "workspace-overview-app-grid")).toBeNull();
+  });
+
+  test("ready + populated → the grid with cards, header shows the count", async () => {
+    mounted = await mount(
+      harness(WS.id, [
+        appPlacement({ route: "crm", label: "CRM", resourceUri: "ui://crm/main" }),
+        appPlacement({ route: "todo", label: "Todo", resourceUri: "ui://todo/main" }),
+      ]),
+    );
+
+    expect(findByTestId(mounted.container, "workspace-overview-app-grid")).not.toBeNull();
+    expect(findAllByTestId(mounted.container, "workspace-overview-app-card")).toHaveLength(2);
+    expect(findByTestId(mounted.container, "workspace-overview-apps-skeleton")).toBeNull();
+    expect(findByTestId(mounted.container, "workspace-overview-empty")).toBeNull();
+
+    const page = findByTestId(mounted.container, "workspace-overview-page");
+    expect(page?.textContent).toContain("2 apps installed, 2 members");
+  });
+});

--- a/web/test/useShell.test.tsx
+++ b/web/test/useShell.test.tsx
@@ -39,6 +39,8 @@ describe("useShell", () => {
     expect(result.current.shell).toBe(bootstrap);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
+    // Bootstrap shell is built for the mount-time workspace.
+    expect(result.current.shellWorkspaceId).toBe("ws-1");
     expect(mockGetShell).not.toHaveBeenCalled();
   });
 
@@ -61,11 +63,17 @@ describe("useShell", () => {
 
     expect(result.current.loading).toBe(false);
     expect(result.current.shell).toBe(bootstrap); // still showing old data
+    // ...and shellWorkspaceId still points at the OLD workspace: this is the
+    // window the overview page reads to render a skeleton instead of the old
+    // workspace's apps (loading stays false, so it can't rely on that).
+    expect(result.current.shellWorkspaceId).toBe("ws-1");
 
     await waitFor(() => {
       expect(result.current.shell).toBe(newShell);
     });
 
+    // Once the fetch lands, the shell reflects the new workspace.
+    expect(result.current.shellWorkspaceId).toBe("ws-2");
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(mockGetShell).toHaveBeenCalled();
@@ -158,10 +166,13 @@ describe("useShell", () => {
     const { result } = renderHook(() => useShell("tok", "ws-1"));
 
     expect(result.current.loading).toBe(true);
+    // No bootstrap → nothing resolved yet, so no workspace is reflected.
+    expect(result.current.shellWorkspaceId).toBeUndefined();
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.shell).toBe(fetched);
+    expect(result.current.shellWorkspaceId).toBe("ws-1");
     expect(mockGetShell).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Symptom

The workspace dashboard sometimes shows an empty state — no apps, header reading like an empty workspace — before it populates. A workspace that *does* have apps flashes a false-empty dashboard.

## Root cause

The app grid conflated **loading** with **empty**. `WorkspaceOverviewPage` rendered "No apps installed" whenever `forSlot("sidebar")` returned `[]` — but `[]` is also what you get while the shell hasn't caught up to the current workspace:

- `useShell` holds **one** workspace's placements at a time and, on a workspace switch, deliberately keeps the *old* set visible with `loading === false` (to avoid a sidebar flash). So during a switch / deep-link the page reads the previous workspace's placements (or none) with no loading signal.
- `ShellContext` exposed only `forSlot`/`mainRoutes` — no readiness signal at all — so the page literally couldn't tell "still fetching" from "genuinely empty."

Apps are *not* slow server-side: placements are registered **eagerly at boot** from bundle manifests (no subprocess spawn), and `GET /v1/shell` is a synchronous in-memory read. The briefing is the only genuinely-async surface, and it already has its own skeleton + stale-while-revalidate. The two had been coupled in the render.

## Fix — three states against one resolved identity

- `useShell` tracks **`shellWorkspaceId`** (the workspace the current placements reflect), seeded from the bootstrap active workspace.
- `ShellContext` exposes `shellWorkspaceId`; `App` threads it through the provider.
- `WorkspaceOverviewPage` derives readiness as `shellWorkspaceId === workspace.id` — comparing against the **slug-resolved** id (the page's stable truth; the active workspace converges to it after the route guard's sync effect), which also covers the pre-sync window. Three states:
  - **not ready** → app-grid skeleton (never the empty card)
  - **ready + empty** → "No apps installed"
  - **ready + populated** → the grid
- Header omits the app count until resolved (shows members only) instead of flashing "0 apps installed".

Net: apps paint as soon as the (fast) per-workspace shell resolves; the briefing stays on its own slower timeline with its own skeleton; the false-empty is gone.

## Scope notes

- `WorkspaceAppsTab` / `SettingsAppPanel` render apps from the same shell and share the latent false-empty; `shellWorkspaceId` is now available to fix them the same way in a follow-up. Left out to keep this focused.
- The deferred SSE `/v1/events` identity re-scope would *shorten* the not-ready window (shell refresh partly rides on SSE); this fix makes that window render correctly (skeleton, not false-empty) regardless. Separate change.

## Tests

- `useShell`: `shellWorkspaceId` lags during a switch, then catches up on resolve; `undefined` with no bootstrap.
- New `WorkspaceOverviewPage` render test pinning all three states (the regression: not-ready must render a skeleton, never "No apps installed").

Verified: `verify:static` (incl. `check:web`), full web suite (371), web build, `test:unit` (3083) all green locally.