### PR TITLE
feat(web): inline app quick-list under the focused workspace

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import { ChatProvider, useChatConfigContext, useChatContext } from "./context/Ch
 import { ChatPanelProvider, useChatPanelContext } from "./context/ChatPanelContext";
 import { SessionProvider } from "./context/SessionContext";
 import { ShellProvider } from "./context/ShellContext";
+import { WorkspaceAppIconsProvider } from "./context/WorkspaceAppIconsProvider";
 import { SidebarProvider } from "./context/SidebarContext";
 import { ThemeProvider, useTheme } from "./context/ThemeContext.tsx";
 import {
@@ -182,18 +183,20 @@ function BootstrappedShell({
 
   return (
     <SidebarProvider>
-      <ChatProvider initialConfig={initialConfig} currentUserId={currentUserId}>
-        <ChatPanelProvider>
-          <AuthenticatedAppContent
-            token={token}
-            forSlot={forSlot}
-            mainRoutes={mainRoutes}
-            shellWorkspaceId={shellWorkspaceId}
-            refreshShell={refreshShell}
-            onLogout={onLogout}
-          />
-        </ChatPanelProvider>
-      </ChatProvider>
+      <WorkspaceAppIconsProvider token={token} workspaceId={activeWorkspace?.id}>
+        <ChatProvider initialConfig={initialConfig} currentUserId={currentUserId}>
+          <ChatPanelProvider>
+            <AuthenticatedAppContent
+              token={token}
+              forSlot={forSlot}
+              mainRoutes={mainRoutes}
+              shellWorkspaceId={shellWorkspaceId}
+              refreshShell={refreshShell}
+              onLogout={onLogout}
+            />
+          </ChatPanelProvider>
+        </ChatProvider>
+      </WorkspaceAppIconsProvider>
     </SidebarProvider>
   );
 }

--- a/web/src/__tests__/b-workspace-section.test.tsx
+++ b/web/src/__tests__/b-workspace-section.test.tsx
@@ -47,8 +47,10 @@ const { act } = await import("react");
 const { MemoryRouter, Route, Routes, useLocation } = await import("react-router-dom");
 const { WorkspaceProvider } = await import("../context/WorkspaceContext");
 const { WorkspaceSection } = await import("../components/shell/WorkspaceSection");
+const { ShellProvider } = await import("../context/ShellContext");
 
 import type { WorkspaceInfo } from "../context/WorkspaceContext";
+import type { PlacementEntry } from "../types";
 
 interface Mounted {
   container: HTMLDivElement;
@@ -65,17 +67,35 @@ function NavigationProbe() {
   return null;
 }
 
+// Mirror useShell's forSlot: prefix-match `slot` + `slot.`, priority asc.
+function makeForSlot(placements: PlacementEntry[]) {
+  return (slot: string): PlacementEntry[] =>
+    placements
+      .filter((p) => p.slot === slot || p.slot.startsWith(`${slot}.`))
+      .sort((a, b) => a.priority - b.priority);
+}
+
 async function mount({
   workspaces,
   activeId,
   initialPath = "/",
+  placements,
 }: {
   workspaces: WorkspaceInfo[];
   activeId?: string;
   initialPath?: string;
+  /** When provided, wrap in a ShellProvider so the inline app quick-list
+   *  has placements to render. Omit to exercise the null-shell path. */
+  placements?: PlacementEntry[];
 }): Promise<Mounted> {
   const container = document.createElement("div");
   document.body.appendChild(container);
+
+  const routes = (
+    <Routes>
+      <Route path="*" element={<WorkspaceSection />} />
+    </Routes>
+  );
 
   const root = ReactDOMClient.createRoot(container);
   await act(async () => {
@@ -84,9 +104,21 @@ async function mount({
         <MemoryRouter initialEntries={[initialPath]}>
           <WorkspaceProvider initialWorkspaces={workspaces} initialActiveId={activeId}>
             <NavigationProbe />
-            <Routes>
-              <Route path="*" element={<WorkspaceSection />} />
-            </Routes>
+            {placements ? (
+              <ShellProvider
+                value={{
+                  forSlot: makeForSlot(placements),
+                  mainRoutes: () => [],
+                  // The shell reflects the focused (active) workspace; the
+                  // inline app list gates on shellWorkspaceId === workspaceId.
+                  shellWorkspaceId: activeId,
+                }}
+              >
+                {routes}
+              </ShellProvider>
+            ) : (
+              routes
+            )}
           </WorkspaceProvider>
         </MemoryRouter>
       </React.StrictMode>,
@@ -280,5 +312,127 @@ describe("WorkspaceSection — navigation", () => {
     });
     // toSlug strips the `ws_` prefix: "ws_helix" → "helix".
     expect(mounted.navigationTarget()).toBe("/w/helix/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (5) Inline app quick-list
+// ---------------------------------------------------------------------------
+
+function appPlacement(serverName: string, over: Partial<PlacementEntry> = {}): PlacementEntry {
+  return {
+    serverName,
+    slot: "sidebar.apps",
+    resourceUri: `ui://${serverName}/main`,
+    priority: 100,
+    label: serverName,
+    route: serverName,
+    ...over,
+  };
+}
+
+function appRows(container: HTMLElement): HTMLAnchorElement[] {
+  return findAllByTestId(container, "sidebar-workspace-app") as unknown as HTMLAnchorElement[];
+}
+
+describe("WorkspaceSection — inline app quick-list", () => {
+  test("renders the focused workspace's apps, capped at MAX_INLINE_APPS, with a View-all overflow link", async () => {
+    const helix = ws({ id: "ws_helix", name: "Helix" });
+    mounted = await mount({
+      workspaces: [ws({ id: "ws_user_u1", name: "Personal", isPersonal: true }), helix],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      placements: [
+        appPlacement("collateral", { priority: 10 }),
+        appPlacement("salesforce", { priority: 20 }),
+        appPlacement("apollo", { priority: 30 }),
+        appPlacement("gong", { priority: 40 }),
+        appPlacement("knowledge", { priority: 50 }),
+      ],
+    });
+
+    // 5 apps installed, capped at 4 shown.
+    expect(appRows(mounted.container)).toHaveLength(4);
+    // Container reports the true (uncapped) count for the overflow copy.
+    const group = findAllByTestId(mounted.container, "sidebar-workspace-apps");
+    expect(group).toHaveLength(1);
+    expect(group[0]?.getAttribute("data-app-count")).toBe("5");
+
+    const viewAll = findAllByTestId(mounted.container, "sidebar-workspace-view-all");
+    expect(viewAll).toHaveLength(1);
+    expect(viewAll[0]?.textContent).toContain("View all 5 apps");
+    expect(viewAll[0]?.getAttribute("href")).toBe("/w/helix/");
+  });
+
+  test("no overflow link when apps fit within the cap", async () => {
+    const helix = ws({ id: "ws_helix", name: "Helix" });
+    mounted = await mount({
+      workspaces: [helix],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      placements: [appPlacement("collateral"), appPlacement("salesforce")],
+    });
+
+    expect(appRows(mounted.container)).toHaveLength(2);
+    expect(findAllByTestId(mounted.container, "sidebar-workspace-view-all")).toHaveLength(0);
+  });
+
+  test("inline apps render only under the focused workspace", async () => {
+    const helix = ws({ id: "ws_helix", name: "Helix" });
+    const personal = ws({ id: "ws_user_u1", name: "Personal", isPersonal: true });
+    mounted = await mount({
+      workspaces: [personal, helix],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      placements: [appPlacement("collateral")],
+    });
+
+    // Exactly one app group, and it sits under the focused (active) row.
+    expect(findAllByTestId(mounted.container, "sidebar-workspace-apps")).toHaveLength(1);
+  });
+
+  test("each app links into /w/<slug>/app/<route>", async () => {
+    const helix = ws({ id: "ws_helix", name: "Helix" });
+    mounted = await mount({
+      workspaces: [helix],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      placements: [appPlacement("collateral", { route: "@nb/collateral", label: "Collateral" })],
+    });
+
+    const [row] = appRows(mounted.container);
+    expect(row?.getAttribute("data-app-route")).toBe("@nb/collateral");
+    expect(row?.getAttribute("href")?.startsWith("/w/helix/app/")).toBe(true);
+  });
+
+  test("the app matching the current route is marked active", async () => {
+    const helix = ws({ id: "ws_helix", name: "Helix" });
+    mounted = await mount({
+      workspaces: [helix],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/app/salesforce",
+      placements: [
+        appPlacement("collateral", { priority: 10 }),
+        appPlacement("salesforce", { priority: 20 }),
+      ],
+    });
+
+    const active = appRows(mounted.container).filter(
+      (r) => r.getAttribute("data-is-active") === "true",
+    );
+    expect(active).toHaveLength(1);
+    expect(active[0]?.getAttribute("data-app-route")).toBe("salesforce");
+  });
+
+  test("renders nothing when the shell has no placements (null-shell path)", async () => {
+    const helix = ws({ id: "ws_helix", name: "Helix" });
+    mounted = await mount({
+      workspaces: [helix],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      // no `placements` → no ShellProvider → useShellContext() is null
+    });
+
+    expect(findAllByTestId(mounted.container, "sidebar-workspace-apps")).toHaveLength(0);
   });
 });

--- a/web/src/__tests__/b-workspace-section.test.tsx
+++ b/web/src/__tests__/b-workspace-section.test.tsx
@@ -424,6 +424,28 @@ describe("WorkspaceSection — inline app quick-list", () => {
     expect(active[0]?.getAttribute("data-app-route")).toBe("salesforce");
   });
 
+  test("active highlight is exact — a route that is a string prefix of the current one stays inactive", async () => {
+    // Regression pin: `crm` is a string prefix of `crm-archive`. A
+    // startsWith match would light BOTH rows when viewing crm-archive.
+    // App routes are leaf paths, so the match must be exact.
+    const helix = ws({ id: "ws_helix", name: "Helix" });
+    mounted = await mount({
+      workspaces: [helix],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/app/crm-archive",
+      placements: [
+        appPlacement("crm", { priority: 10 }),
+        appPlacement("crm-archive", { priority: 20 }),
+      ],
+    });
+
+    const active = appRows(mounted.container).filter(
+      (r) => r.getAttribute("data-is-active") === "true",
+    );
+    expect(active).toHaveLength(1);
+    expect(active[0]?.getAttribute("data-app-route")).toBe("crm-archive");
+  });
+
   test("renders nothing when the shell has no placements (null-shell path)", async () => {
     const helix = ws({ id: "ws_helix", name: "Helix" });
     mounted = await mount({

--- a/web/src/__tests__/workspace-apps.test.ts
+++ b/web/src/__tests__/workspace-apps.test.ts
@@ -10,7 +10,7 @@
 // ---------------------------------------------------------------------------
 
 import { describe, expect, test } from "bun:test";
-import { MAX_INLINE_APPS, workspaceApps } from "../lib/workspace-apps";
+import { iconMapFromInstalled, MAX_INLINE_APPS, workspaceApps } from "../lib/workspace-apps";
 import type { PlacementEntry } from "../types";
 
 function p(over: Partial<PlacementEntry> & { serverName: string; slot: string }): PlacementEntry {
@@ -65,5 +65,23 @@ describe("workspaceApps", () => {
   test("MAX_INLINE_APPS is a small positive cap", () => {
     expect(MAX_INLINE_APPS).toBeGreaterThan(0);
     expect(MAX_INLINE_APPS).toBeLessThanOrEqual(6);
+  });
+});
+
+describe("iconMapFromInstalled", () => {
+  test("maps serverName -> iconUrl, omitting connectors without an icon", () => {
+    const map = iconMapFromInstalled([
+      { serverName: "crm", iconUrl: "https://cdn/crm.png" },
+      { serverName: "todo" }, // no icon → omitted; caller falls back to a letter avatar
+      { serverName: "sf", iconUrl: "https://cdn/sf.svg" },
+    ]);
+    expect(map.get("crm")).toBe("https://cdn/crm.png");
+    expect(map.get("sf")).toBe("https://cdn/sf.svg");
+    expect(map.has("todo")).toBe(false);
+    expect(map.size).toBe(2);
+  });
+
+  test("empty list -> empty map", () => {
+    expect(iconMapFromInstalled([]).size).toBe(0);
   });
 });

--- a/web/src/__tests__/workspace-apps.test.ts
+++ b/web/src/__tests__/workspace-apps.test.ts
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------
+// workspaceApps — the shared app-set projection used by both the sidebar
+// quick-list and the workspace overview grid. Pins three contracts:
+//   1. Only grouped sidebar slots (`sidebar.<group>`) count as apps —
+//      bare `sidebar` (core nav), `sidebar.bottom` (utility tray), and
+//      `main` are excluded.
+//   2. One entry per app (`serverName`), keeping the highest-priority
+//      (lowest-number) placement when an app declares several.
+//   3. Sorted by priority ascending, so "top N" is meaningful.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test } from "bun:test";
+import { MAX_INLINE_APPS, workspaceApps } from "../lib/workspace-apps";
+import type { PlacementEntry } from "../types";
+
+function p(over: Partial<PlacementEntry> & { serverName: string; slot: string }): PlacementEntry {
+  return {
+    resourceUri: `ui://${over.serverName}/main`,
+    priority: 100,
+    route: over.serverName,
+    label: over.serverName,
+    ...over,
+  };
+}
+
+describe("workspaceApps", () => {
+  test("keeps only grouped sidebar slots", () => {
+    const out = workspaceApps([
+      p({ serverName: "home", slot: "sidebar" }), // core nav — excluded
+      p({ serverName: "tray", slot: "sidebar.bottom" }), // utility tray — excluded
+      p({ serverName: "main-app", slot: "main" }), // not a sidebar slot — excluded
+      p({ serverName: "crm", slot: "sidebar.apps" }), // app — kept
+      p({ serverName: "research", slot: "sidebar.research" }), // app — kept
+    ]);
+    expect(out.map((e) => e.serverName).sort()).toEqual(["crm", "research"]);
+  });
+
+  test("keeps every matching placement (no dedup) — a route is a destination", () => {
+    // An app may declare multiple sidebar placements (distinct routes /
+    // views). Each is its own navigable card, so we keep them all; callers
+    // key by resourceUri, not serverName.
+    const out = workspaceApps([
+      p({ serverName: "crm", slot: "sidebar.apps", priority: 50, route: "crm/list" }),
+      p({ serverName: "crm", slot: "sidebar.apps", priority: 10, route: "crm/board" }),
+    ]);
+    expect(out).toHaveLength(2);
+    // Sorted by priority — the board view (10) comes before the list (50).
+    expect(out.map((e) => e.route)).toEqual(["crm/board", "crm/list"]);
+  });
+
+  test("sorts by priority ascending", () => {
+    const out = workspaceApps([
+      p({ serverName: "c", slot: "sidebar.apps", priority: 30 }),
+      p({ serverName: "a", slot: "sidebar.apps", priority: 10 }),
+      p({ serverName: "b", slot: "sidebar.apps", priority: 20 }),
+    ]);
+    expect(out.map((e) => e.serverName)).toEqual(["a", "b", "c"]);
+  });
+
+  test("returns [] when there are no app placements", () => {
+    expect(workspaceApps([p({ serverName: "home", slot: "sidebar" })])).toEqual([]);
+    expect(workspaceApps([])).toEqual([]);
+  });
+
+  test("MAX_INLINE_APPS is a small positive cap", () => {
+    expect(MAX_INLINE_APPS).toBeGreaterThan(0);
+    expect(MAX_INLINE_APPS).toBeLessThanOrEqual(6);
+  });
+});

--- a/web/src/components/shell/WorkspaceSection.tsx
+++ b/web/src/components/shell/WorkspaceSection.tsx
@@ -192,7 +192,12 @@ function WorkspaceInlineApps({ workspaceId }: { workspaceId: string }) {
       {shown.map((p) => {
         const label = p.label ?? p.route ?? "App";
         const target = `/w/${slug}/app/${p.route}`;
-        const isActive = !!p.route && location.pathname.startsWith(target);
+        // Exact match, not startsWith: app routes are leaf paths (App.tsx
+        // registers `app/<route>` with no splat), so the current URL maps to
+        // exactly one placement. startsWith would mis-light a `crm` row when
+        // viewing a sibling `crm-archive` (string prefix) or a `crm/board`
+        // sub-view.
+        const isActive = !!p.route && location.pathname === target;
         return (
           <Link
             key={p.resourceUri}

--- a/web/src/components/shell/WorkspaceSection.tsx
+++ b/web/src/components/shell/WorkspaceSection.tsx
@@ -10,23 +10,36 @@
 // without inline apps — borrowed the Discord/Slack pattern where the
 // rail IS a parent column; that mismatch broke the metaphor here.
 //
-// Each row: avatar (deterministic letter+color), workspace name, role
-// badge. One click target. Click = setActiveWorkspace + navigate to
-// `/w/<slug>/`. No expand toggle, no inline apps. App discovery lives
-// on the workspace overview page.
+// Each workspace row: avatar (deterministic letter+color), workspace
+// name, role badge. One click target. Click = setActiveWorkspace +
+// navigate to `/w/<slug>/`.
+//
+// Under the FOCUSED workspace (the one matching `activeWorkspace`, whose
+// placements the shell context holds) we render a quick-access list of
+// its top apps — see `WorkspaceInlineApps`. This is the Notion/Linear
+// "teamspace → pages" tree, still not the Discord rail (the section is a
+// sibling of the global nav, not a parent column). Capped at
+// `MAX_INLINE_APPS`; an overflow "View all N apps" link routes to the
+// workspace overview page (the full grid). No pinning / recency yet —
+// it's a priority-ordered top-N. Other rows stay collapsed (their
+// placements aren't loaded).
 //
 // The `+` affordance on the section heading routes to the existing
 // org-workspaces page (no new UX invented).
 // ---------------------------------------------------------------------------
 
-import { Plus } from "lucide-react";
-import { useCallback, useMemo } from "react";
-import { matchPath, useLocation, useNavigate } from "react-router-dom";
+import { ArrowRight, Plus } from "lucide-react";
+import { Fragment, useCallback, useMemo } from "react";
+import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
+import { useShellContext } from "../../context/ShellContext";
+import { useWorkspaceAppIcons } from "../../context/WorkspaceAppIconsContext";
 import { useWorkspaceContext, type WorkspaceInfo } from "../../context/WorkspaceContext";
 import { cn } from "../../lib/utils";
+import { MAX_INLINE_APPS, workspaceApps } from "../../lib/workspace-apps";
 import { getWorkspaceAvatar } from "../../lib/workspace-avatar";
 import { orderWorkspacesForSidebar } from "../../lib/workspace-order";
 import { toSlug } from "../../lib/workspace-slug";
+import { ConnectorIcon } from "../connectors/ConnectorIcon";
 
 interface WorkspaceSectionProps {
   /**
@@ -122,14 +135,98 @@ export function WorkspaceSection({ collapsed = false }: WorkspaceSectionProps) {
             </div>
           )
         : ordered.map((ws) => (
-            <WorkspaceItem
-              key={ws.id}
-              workspace={ws}
-              isActive={activeRouteSlug === toSlug(ws.id)}
-              onSelect={() => handleSelect(ws)}
-              collapsed={collapsed}
-            />
+            <Fragment key={ws.id}>
+              <WorkspaceItem
+                workspace={ws}
+                isActive={activeRouteSlug === toSlug(ws.id)}
+                onSelect={() => handleSelect(ws)}
+                collapsed={collapsed}
+              />
+              {/* Inline app quick-list under the focused workspace only.
+                  `activeWorkspace` is whose placements the shell context
+                  holds; rendering it under any other row would show the
+                  wrong workspace's apps. Hidden in collapsed (icon-only)
+                  mode — there's no room for labels. */}
+              {!collapsed && ws.id === wsCtx.activeWorkspace?.id && (
+                <WorkspaceInlineApps workspaceId={ws.id} />
+              )}
+            </Fragment>
           ))}
+    </div>
+  );
+}
+
+// Quick-access list of the focused workspace's top apps, rendered under
+// its row. App set + ordering come from the shell placement registry
+// (same source as the overview grid, via `workspaceApps`); brand icons
+// come from `useWorkspaceAppIcons` with a letter-avatar fallback. The
+// workspace is already active here, so each app is a plain `<Link>` into
+// `/w/<slug>/app/<route>` (no setActiveWorkspace dance needed).
+function WorkspaceInlineApps({ workspaceId }: { workspaceId: string }) {
+  const shell = useShellContext();
+  const { iconFor } = useWorkspaceAppIcons();
+  const location = useLocation();
+  const slug = toSlug(workspaceId);
+
+  // Only show apps once the shell's placements reflect THIS workspace.
+  // The shell holds one workspace's placements at a time and lags a
+  // switch (see ShellContext.shellWorkspaceId), so without this gate a
+  // switch would briefly paint the previous workspace's apps under the
+  // newly-focused row. Mirrors the overview grid's readiness check.
+  const ready = shell != null && shell.shellWorkspaceId === workspaceId;
+  const apps = useMemo(
+    () => (ready && shell ? workspaceApps(shell.forSlot("sidebar")) : []),
+    [ready, shell],
+  );
+
+  if (apps.length === 0) return null;
+  const shown = apps.slice(0, MAX_INLINE_APPS);
+  const hasOverflow = apps.length > shown.length;
+
+  return (
+    <div
+      className="ml-4 mr-2 mb-1 mt-px flex flex-col border-l border-sidebar-foreground/10 pl-1"
+      data-testid="sidebar-workspace-apps"
+      data-app-count={apps.length}
+    >
+      {shown.map((p) => {
+        const label = p.label ?? p.route ?? "App";
+        const target = `/w/${slug}/app/${p.route}`;
+        const isActive = !!p.route && location.pathname.startsWith(target);
+        return (
+          <Link
+            key={p.resourceUri}
+            to={target}
+            title={label}
+            data-testid="sidebar-workspace-app"
+            data-app-route={p.route ?? ""}
+            data-is-active={isActive ? "true" : "false"}
+            className={cn(
+              "flex items-center gap-2 text-[13px] transition-colors rounded-md px-2 py-1",
+              isActive
+                ? "bg-sidebar-foreground/10 text-sidebar-foreground"
+                : "text-sidebar-foreground/80 hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground",
+            )}
+          >
+            <ConnectorIcon
+              name={label}
+              iconUrl={iconFor(p.serverName)}
+              className="h-[18px] w-[18px] rounded-[5px] text-[9px]"
+            />
+            <span className="flex-1 truncate">{label}</span>
+          </Link>
+        );
+      })}
+      {hasOverflow && (
+        <Link
+          to={`/w/${slug}/`}
+          data-testid="sidebar-workspace-view-all"
+          className="flex items-center gap-1.5 px-2 py-1 text-[12px] text-sidebar-foreground/55 hover:text-sidebar-foreground transition-colors"
+        >
+          <ArrowRight style={{ width: 12, height: 12 }} className="shrink-0" />
+          <span className="truncate">View all {apps.length} apps</span>
+        </Link>
+      )}
     </div>
   );
 }

--- a/web/src/context/WorkspaceAppIconsContext.tsx
+++ b/web/src/context/WorkspaceAppIconsContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react";
+
+export interface WorkspaceAppIconsValue {
+  /**
+   * Brand icon URL for an installed app by `serverName`, or `undefined`
+   * when the app has no registry icon. Callers pass the result straight
+   * to `ConnectorIcon`, which falls back to a deterministic letter
+   * avatar on `undefined` / load failure.
+   */
+  iconFor: (serverName: string) => string | undefined;
+}
+
+// Default is a no-op resolver so consumers rendered outside the provider
+// (or before its first fetch) degrade to letter avatars rather than
+// crash. Kept in its own module — separate from the provider — so
+// consumers can import the hook without pulling in the provider's
+// data-fetch / SSE dependency chain (api/client, useEvents). Mirrors the
+// ShellContext split.
+export const WorkspaceAppIconsContext = createContext<WorkspaceAppIconsValue>({
+  iconFor: () => undefined,
+});
+
+export function useWorkspaceAppIcons(): WorkspaceAppIconsValue {
+  return useContext(WorkspaceAppIconsContext);
+}

--- a/web/src/context/WorkspaceAppIconsProvider.tsx
+++ b/web/src/context/WorkspaceAppIconsProvider.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { getInstalledConnectors } from "../api/client";
 import { useEvents } from "../hooks/useEvents";
+import { iconMapFromInstalled } from "../lib/workspace-apps";
 import { WorkspaceAppIconsContext, type WorkspaceAppIconsValue } from "./WorkspaceAppIconsContext";
 
 /**
@@ -32,11 +33,7 @@ export function WorkspaceAppIconsProvider({
   const refresh = useCallback(async () => {
     try {
       const { installed } = await getInstalledConnectors({ scope: "workspace" });
-      const next = new Map<string, string>();
-      for (const c of installed) {
-        if (c.iconUrl) next.set(c.serverName, c.iconUrl);
-      }
-      setIcons(next);
+      setIcons(iconMapFromInstalled(installed));
     } catch {
       // Icons are decorative. On a failed fetch keep whatever we have and
       // let the letter-avatar fallback cover the gaps — never block the

--- a/web/src/context/WorkspaceAppIconsProvider.tsx
+++ b/web/src/context/WorkspaceAppIconsProvider.tsx
@@ -1,0 +1,75 @@
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { getInstalledConnectors } from "../api/client";
+import { useEvents } from "../hooks/useEvents";
+import { WorkspaceAppIconsContext, type WorkspaceAppIconsValue } from "./WorkspaceAppIconsContext";
+
+/**
+ * Shares the focused workspace's app brand icons across the sidebar
+ * quick-list and the workspace overview grid from a single fetch.
+ *
+ * The brand-icon resolution itself is server-side and centralized in
+ * `manage_connectors` (`catalog.iconUrl ?? mpak ServerDetail.icons[0].src`,
+ * matched by package name) — see `src/tools/connector-tools.ts`. This
+ * provider only caches the `serverName → iconUrl` projection so the UI
+ * never re-implements that resolution or fans out duplicate fetches.
+ *
+ * Scoped to the active workspace (the connectors list reads the
+ * `X-Workspace-Id` header); refetched on workspace switch and on the
+ * same bundle-lifecycle / connection-state SSE signals that refresh the
+ * shell placements, so icons stay in lockstep with the app set.
+ */
+export function WorkspaceAppIconsProvider({
+  token,
+  workspaceId,
+  children,
+}: {
+  token: string;
+  workspaceId?: string;
+  children: ReactNode;
+}) {
+  const [icons, setIcons] = useState<Map<string, string>>(() => new Map());
+
+  const refresh = useCallback(async () => {
+    try {
+      const { installed } = await getInstalledConnectors({ scope: "workspace" });
+      const next = new Map<string, string>();
+      for (const c of installed) {
+        if (c.iconUrl) next.set(c.serverName, c.iconUrl);
+      }
+      setIcons(next);
+    } catch {
+      // Icons are decorative. On a failed fetch keep whatever we have and
+      // let the letter-avatar fallback cover the gaps — never block the
+      // sidebar or grid on icon resolution.
+    }
+  }, []);
+
+  // Refetch when the focused workspace changes. The connectors list is
+  // workspace-scoped, so a stale map would paint the previous
+  // workspace's icons onto this one's apps.
+  useEffect(() => {
+    if (!workspaceId) return;
+    void refresh();
+  }, [workspaceId, refresh]);
+
+  // Brand icons appear / disappear when a bundle is installed or
+  // uninstalled, or when a connection settles — mirror the shell's
+  // refetch triggers.
+  useEvents(token, workspaceId, {
+    onBundleLifecycleChanged: () => {
+      void refresh();
+    },
+    onConnectionStateChanged: () => {
+      void refresh();
+    },
+  });
+
+  const value = useMemo<WorkspaceAppIconsValue>(
+    () => ({ iconFor: (serverName: string) => icons.get(serverName) }),
+    [icons],
+  );
+
+  return (
+    <WorkspaceAppIconsContext.Provider value={value}>{children}</WorkspaceAppIconsContext.Provider>
+  );
+}

--- a/web/src/lib/workspace-apps.ts
+++ b/web/src/lib/workspace-apps.ts
@@ -1,0 +1,32 @@
+import type { PlacementEntry } from "../types";
+
+/**
+ * Max apps shown inline under the focused workspace in the sidebar
+ * before the "View all N apps" overflow link takes over. Pinning /
+ * recency are future work; for now this is a simple priority-ordered
+ * top-N.
+ */
+export const MAX_INLINE_APPS = 4;
+
+/**
+ * The app placements for the focused workspace, derived from the shell
+ * placement registry. "Apps" are the grouped sidebar placements
+ * (`sidebar.<group>`, e.g. `sidebar.apps`); bare `sidebar` items are
+ * core nav (Home, Conversations, …) and `sidebar.bottom` is the utility
+ * tray — neither is an app. This is the filter the workspace overview
+ * page already used, lifted into one shared, tested helper so the
+ * sidebar quick-list and the overview grid show the same set and the
+ * "View all N apps" count matches the grid by construction.
+ *
+ * One entry per placement (not per app) — a route is a navigable
+ * destination, so callers key by `resourceUri`. Sorted by priority
+ * (lower = higher) so a "top N" slice is meaningful regardless of the
+ * caller's input order.
+ *
+ * Pass the result of `forSlot("sidebar")`.
+ */
+export function workspaceApps(sidebarPlacements: PlacementEntry[]): PlacementEntry[] {
+  return sidebarPlacements
+    .filter((p) => p.slot.startsWith("sidebar.") && !p.slot.startsWith("sidebar.bottom"))
+    .sort((a, b) => a.priority - b.priority);
+}

--- a/web/src/lib/workspace-apps.ts
+++ b/web/src/lib/workspace-apps.ts
@@ -30,3 +30,20 @@ export function workspaceApps(sidebarPlacements: PlacementEntry[]): PlacementEnt
     .filter((p) => p.slot.startsWith("sidebar.") && !p.slot.startsWith("sidebar.bottom"))
     .sort((a, b) => a.priority - b.priority);
 }
+
+/**
+ * Project the installed-connector list into the `serverName → brand icon URL`
+ * map the sidebar quick-list and overview grid consume. Connectors without an
+ * `iconUrl` are omitted — callers fall back to a letter avatar. Pure (no React,
+ * no fetch) so the map-building contract is testable without the provider's
+ * fetch / SSE wiring; `WorkspaceAppIconsProvider` is the only caller.
+ */
+export function iconMapFromInstalled(
+  installed: ReadonlyArray<{ serverName: string; iconUrl?: string }>,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const c of installed) {
+    if (c.iconUrl) map.set(c.serverName, c.iconUrl);
+  }
+  return map;
+}

--- a/web/src/pages/WorkspaceOverviewPage.tsx
+++ b/web/src/pages/WorkspaceOverviewPage.tsx
@@ -2,20 +2,21 @@
 // WorkspaceOverviewPage — workspace landing at `/w/<slug>/`
 //
 // Stage 2 follow-up: the workspace's apps used to surface in a bottom
-// `APPS` group in the sidebar. That section is gone; this page is where
-// app discovery lives now. The sidebar still shows the active workspace's
-// app names inline (quick-access), but the full grid + workspace metadata
-// lives here.
+// `APPS` group in the sidebar. That section is gone; this page is the
+// full app grid + workspace metadata. The sidebar now shows a top-N
+// quick-list under the focused workspace and links here via "View all N
+// apps" (see WorkspaceSection) — both surfaces read the same app set
+// through `workspaceApps()` so the grid and the count agree.
 //
-// v1 scope (per Mat 2026-05-23): header + all-apps grid. Filter chips
-// (All / Pinned / With UI / Tools only), pin/recent state, and "View all
-// N apps" truncation land in follow-ups when the underlying per-user-
-// per-workspace state exists.
+// App data source: `forSlot("sidebar")` → `workspaceApps()`, which keeps
+// the grouped sub-slots (`sidebar.<group>`), one card per placement. The
+// placement registry is already workspace-scoped server-side, so this is
+// the right surface — the same data that fed the old `APPS` group. Icons
+// are the apps' brand icons (registry `icons[].src`) via
+// `useWorkspaceAppIcons`, with a letter-avatar fallback.
 //
-// App data source: `forSlot("sidebar")` filtered to grouped sub-slots
-// (everything under `sidebar.<group>`). The placement registry is
-// already workspace-scoped server-side, so this is the right surface —
-// the same data that used to feed the bottom `APPS` group.
+// Future: filter chips (All / With UI / Tools only) + pin/recency once
+// per-user-per-workspace state exists.
 // ---------------------------------------------------------------------------
 
 import { Settings } from "lucide-react";
@@ -23,11 +24,13 @@ import { useCallback } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import type { BriefingAction } from "../_generated/platform-schemas/home";
 import { BriefingView } from "../components/briefing/BriefingView";
+import { ConnectorIcon } from "../components/connectors/ConnectorIcon";
 import { useShellContext } from "../context/ShellContext";
+import { useWorkspaceAppIcons } from "../context/WorkspaceAppIconsContext";
 import { useWorkspaceContext, type WorkspaceInfo } from "../context/WorkspaceContext";
 import { useWorkspaceBriefing } from "../hooks/useWorkspaceBriefing";
-import { resolveIcon } from "../lib/icons";
 import { cn } from "../lib/utils";
+import { workspaceApps } from "../lib/workspace-apps";
 import { toSlug } from "../lib/workspace-slug";
 import type { PlacementEntry } from "../types";
 
@@ -35,6 +38,7 @@ export function WorkspaceOverviewPage() {
   const { slug } = useParams<{ slug: string }>();
   const wsCtx = useWorkspaceContext();
   const shell = useShellContext();
+  const { iconFor } = useWorkspaceAppIcons();
   const navigate = useNavigate();
 
   const workspace = slug ? wsCtx.workspaces.find((w) => toSlug(w.id) === slug) : undefined;
@@ -75,9 +79,10 @@ export function WorkspaceOverviewPage() {
     );
   }
 
-  // Apps come from the placement registry's grouped sub-slots (anything under
-  // `sidebar.<group>`). Bare `sidebar` items (Home, Conversations, …) are core
-  // nav, not apps.
+  // Apps come from the placement registry's grouped sub-slots via the shared
+  // `workspaceApps()` helper (one card per placement) — so this grid and the
+  // sidebar quick-list agree by construction. Bare `sidebar` items (Home,
+  // Conversations, …) are core nav, not apps.
   //
   // Readiness — not just "is there a shell?". The shell holds ONE workspace's
   // placements at a time and lags a switch (old data stays visible while the
@@ -90,12 +95,7 @@ export function WorkspaceOverviewPage() {
   // registered eagerly server-side, so a matching shell resolves near-instantly
   // — apps don't wait on the (slower, async) briefing.
   const appsReady = shell != null && shell.shellWorkspaceId === workspace.id;
-  const apps =
-    appsReady && shell
-      ? shell
-          .forSlot("sidebar")
-          .filter((p) => p.slot.startsWith("sidebar.") && !p.slot.startsWith("sidebar.bottom"))
-      : [];
+  const apps = appsReady && shell ? workspaceApps(shell.forSlot("sidebar")) : [];
 
   return (
     <div className="h-full overflow-y-auto" data-testid="workspace-overview-page">
@@ -159,6 +159,7 @@ export function WorkspaceOverviewPage() {
               <AppCard
                 key={p.resourceUri}
                 placement={p}
+                iconUrl={iconFor(p.serverName)}
                 onOpen={() => {
                   if (!p.route) return;
                   navigate(`/w/${toSlug(workspace.id)}/app/${p.route}`);
@@ -206,8 +207,16 @@ function AppGridSkeleton() {
   );
 }
 
-function AppCard({ placement, onOpen }: { placement: PlacementEntry; onOpen: () => void }) {
-  const Icon = placement.icon ? resolveIcon(placement.icon) : null;
+function AppCard({
+  placement,
+  iconUrl,
+  onOpen,
+}: {
+  placement: PlacementEntry;
+  iconUrl?: string;
+  onOpen: () => void;
+}) {
+  const label = placement.label ?? placement.route ?? "App";
   return (
     <button
       type="button"
@@ -220,10 +229,8 @@ function AppCard({ placement, onOpen }: { placement: PlacementEntry; onOpen: () 
       )}
     >
       <div className="flex items-center gap-2">
-        {Icon && <Icon className="w-4 h-4 text-muted-foreground shrink-0" />}
-        <div className="truncate text-sm font-medium text-foreground">
-          {placement.label ?? placement.route ?? "App"}
-        </div>
+        <ConnectorIcon name={label} iconUrl={iconUrl} className="h-5 w-5 rounded text-[10px]" />
+        <div className="truncate text-sm font-medium text-foreground">{label}</div>
       </div>
       <div className="text-[10px] font-medium tracking-[0.04em] uppercase text-muted-foreground">
         {describePlacementType(placement)}


### PR DESCRIPTION
## What

Adds a quick-access app list in the left sidebar, nested under the **focused** workspace: the top apps (capped at `MAX_INLINE_APPS = 4`), then a "View all N apps" overflow link to the workspace overview. Reintroduces inline apps in the sidebar — a deliberate follow-up flagged in `WorkspaceOverviewPage`'s header comment ("'View all N apps' truncation land in follow-ups") — as a designed MVP. No pinning / recency yet; it's a priority-ordered top-N.

Also upgrades app icons to the apps' **brand icons** (registry `server.json` `icons[].src`) in both the sidebar and the overview grid, with a letter-avatar fallback. Previously the overview rendered a generic lucide line icon from `_meta["ai.nimblebrain/host"].icon` (which is a lucide name, not a brand image).

## How

- **`web/src/lib/workspace-apps.ts`** — `workspaceApps()` shared projection over `forSlot("sidebar")` (grouped `sidebar.<group>` slots, priority-sorted, one card per placement). One source of truth so the sidebar list and the overview grid stay consistent. `MAX_INLINE_APPS` const.
- **`WorkspaceAppIconsContext` + `WorkspaceAppIconsProvider`** — caches a `serverName → iconUrl` map from one `manage_connectors` (list) fetch per focused workspace, refetched on workspace switch and bundle/connection SSE events. Reuses the centralized brand-icon resolver (`catalog.iconUrl ?? mpak ServerDetail.icons[0].src`) rather than re-implementing it. Split into a light context/hook module + provider module so consumers don't pull in the fetch/SSE chain (mirrors `ShellContext`).
- **`WorkspaceSection.tsx`** — `WorkspaceInlineApps` under the focused row; `<Link>`s to `/w/<slug>/app/<route>` with active-route highlight, `ConnectorIcon`. Gated on `shellWorkspaceId` readiness so a switch never flashes the previous workspace's apps.
- **`WorkspaceOverviewPage.tsx`** — grid now sources from `workspaceApps()` and renders `ConnectorIcon` (brand icons) instead of the lucide placeholder. Keeps #282's three-state (skeleton / empty / populated) surface intact.
- **`App.tsx`** — mounts the provider.

## Notes for review

- **Which workspace shows apps:** the *focused* workspace (`activeWorkspace.id`, whose placements the shell holds), not every row. Easy one-line flip to gate on the active *route* instead if preferred.
- Synapse apps that only declare a lucide host-icon (e.g. CRM) render as letter avatars — brand logos appear for registry connectors that ship `icons[].src`. Expected, not a bug.
- Rebased onto current `main` (integrates with #282's overview-grid rewrite + `shellWorkspaceId` readiness).

## Tests

- `web/src/__tests__/workspace-apps.test.ts` — filter / sort / no-dedup / empty (pure).
- `web/src/__tests__/b-workspace-section.test.tsx` — +6 cases: cap + overflow link, focused-only, link target, active highlight, null-shell.
- Full suite: **382 web tests pass**; `bun run verify:static` green (format, lint, both typechecks, cycles, codegen).