### PR TITLE
fix(api): invert rate limiting onto the remote /mcp surface (relax first-party, bypass dev)

### DIFF
--- a/src/api/middleware/rate-limit.ts
+++ b/src/api/middleware/rate-limit.ts
@@ -6,9 +6,19 @@ import { apiError } from "../types.ts";
 /**
  * Per-user rate limiting middleware for authenticated endpoints.
  * Keys on identity.id from the auth middleware. Records every request.
+ *
+ * `bypass` short-circuits the limiter entirely — used in dev mode (no real
+ * identity provider configured), where rate limiting is a multi-tenant abuse
+ * control with no purpose: there's a single local user, and every request
+ * collapses to one shared identity (`usr_default`), so a per-identity budget
+ * is meaningless and only creates friction.
  */
-export function requestRateLimit(limiter: RequestRateLimiter) {
+export function requestRateLimit(limiter: RequestRateLimiter, opts?: { bypass?: boolean }) {
   return createMiddleware<AppEnv>(async (c, next) => {
+    if (opts?.bypass) {
+      await next();
+      return;
+    }
     const key = c.var.identity?.id ?? "anon";
     if (!limiter.consume(key)) {
       return apiError(429, "rate_limited", "Rate limit exceeded", undefined, {

--- a/src/api/routes/chat.ts
+++ b/src/api/routes/chat.ts
@@ -8,7 +8,7 @@ import { optionalWorkspace } from "../middleware/workspace.ts";
 import type { AppContext, AppEnv } from "../types.ts";
 
 export function chatRoutes(ctx: AppContext) {
-  const rl = requestRateLimit(ctx.chatLimiter);
+  const rl = requestRateLimit(ctx.chatLimiter, { bypass: ctx.isDevMode });
   // maxTotalSize is snapshot at route construction. Today filesConfig is
   // built once from startup config + defaults and never mutated; if that
   // invariant changes, make this limit lazy.

--- a/src/api/routes/mcp.ts
+++ b/src/api/routes/mcp.ts
@@ -8,6 +8,7 @@ import {
 } from "../auth-middleware.ts";
 import type { McpSessionContext } from "../mcp-server.ts";
 import { bodyLimit } from "../middleware/body-limit.ts";
+import { requestRateLimit } from "../middleware/rate-limit.ts";
 import { type AppContext, type AuthEnv, apiError } from "../types.ts";
 
 /**
@@ -73,28 +74,37 @@ export function mcpRoutes(ctx: AppContext) {
   const app = new Hono<AuthEnv>();
   app.use("*", requireMcpAuth(ctx.authOptions, ctx));
 
-  app.all("/mcp", bodyLimit(1_048_576), async (c) => {
-    const features = ctx.runtime.getFeatures();
+  // Rate limit the remote surface: external MCP clients + sandboxed bundle
+  // iframes (the bridge speaks `/mcp`). Chained on the route, NOT `.use("*")`,
+  // so it can't leak onto sibling routes — and it runs after `requireMcpAuth`
+  // above, so the per-identity key is populated. Bypassed in dev.
+  app.all(
+    "/mcp",
+    requestRateLimit(ctx.mcpLimiter, { bypass: ctx.isDevMode }),
+    bodyLimit(1_048_576),
+    async (c) => {
+      const features = ctx.runtime.getFeatures();
 
-    // Stage 2: `/mcp` sessions are identity-bound only. The `X-Workspace-Id`
-    // header is no longer consulted here — the host logs once at debug
-    // (`NB_DEBUG=mcp`) if a client still sends one. Tool calls derive their
-    // target workspace from the namespaced tool name on every call (parsed
-    // and routed by the orchestrator).
-    const identity = c.var.identity;
-    if (!identity || !ctx.workspaceStore) {
-      return apiError(
-        401,
-        "unauthorized",
-        "Authentication required for MCP",
-        undefined,
-        hasAuthkitOAuth(ctx) ? { "WWW-Authenticate": mcpWwwAuthenticate(c.req.raw) } : undefined,
-      );
-    }
+      // Stage 2: `/mcp` sessions are identity-bound only. The `X-Workspace-Id`
+      // header is no longer consulted here — the host logs once at debug
+      // (`NB_DEBUG=mcp`) if a client still sends one. Tool calls derive their
+      // target workspace from the namespaced tool name on every call (parsed
+      // and routed by the orchestrator).
+      const identity = c.var.identity;
+      if (!identity || !ctx.workspaceStore) {
+        return apiError(
+          401,
+          "unauthorized",
+          "Authentication required for MCP",
+          undefined,
+          hasAuthkitOAuth(ctx) ? { "WWW-Authenticate": mcpWwwAuthenticate(c.req.raw) } : undefined,
+        );
+      }
 
-    const sessionCtx: McpSessionContext = { identity };
-    return ctx.mcpHost.handle(c.req.raw, features, sessionCtx);
-  });
+      const sessionCtx: McpSessionContext = { identity };
+      return ctx.mcpHost.handle(c.req.raw, features, sessionCtx);
+    },
+  );
 
   return app;
 }

--- a/src/api/routes/tools.ts
+++ b/src/api/routes/tools.ts
@@ -20,7 +20,7 @@ export function toolRoutes(ctx: AppContext) {
       "/v1/tools/call",
       optionalWorkspace(ctx.workspaceStore),
       bodyLimit(1_048_576),
-      requestRateLimit(ctx.toolCallLimiter),
+      requestRateLimit(ctx.toolCallLimiter, { bypass: ctx.isDevMode }),
       (c) =>
         handleToolCall(c.req.raw, ctx.runtime, ctx.features, {
           sseManager: ctx.sseManager,

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -77,13 +77,26 @@ export function startServer(options: ServerOptions): ServerHandle {
   const rateLimiter = new LoginRateLimiter();
   rateLimiter.start();
 
-  // Per-user request rate limiters for expensive endpoints
+  // Per-identity request rate limiters. The limit lives on the caller's
+  // trust class, not "is it expensive":
+  //   - `/mcp` (mcpLimiter) is the remote/untrusted surface — external MCP
+  //     clients and sandboxed bundle iframes. This is the real abuse vector,
+  //     so it carries a present-but-generous cap.
+  //   - `/v1/tools/call` (toolCallLimiter) is the trusted first-party shell.
+  //     Its only failure mode is a runaway client loop, so the ceiling is
+  //     high — far above human navigation, low enough to stop a hot loop.
+  //   - `/v1/chat` (chatLimiter) is first-party + LLM-expensive, so it stays
+  //     modest.
+  // All are bypassed in dev mode (see `isDevMode` below).
   const chatRateLimit = Number(process.env.NB_CHAT_RATE_LIMIT) || 20;
-  const toolRateLimit = Number(process.env.NB_TOOL_RATE_LIMIT) || 60;
+  const toolRateLimit = Number(process.env.NB_TOOL_RATE_LIMIT) || 600;
+  const mcpRateLimit = Number(process.env.NB_MCP_RATE_LIMIT) || 300;
   const chatLimiter = new RequestRateLimiter(chatRateLimit, 60_000);
   chatLimiter.start();
   const toolCallLimiter = new RequestRateLimiter(toolRateLimit, 60_000);
   toolCallLimiter.start();
+  const mcpLimiter = new RequestRateLimiter(mcpRateLimit, 60_000);
+  mcpLimiter.start();
 
   // Wire runtime events to the SSE manager by subscribing to the event sink.
   const runtimeSink = runtime.getEventSink();
@@ -151,8 +164,15 @@ export function startServer(options: ServerOptions): ServerHandle {
     }
   };
 
-  // Resolve identity provider
+  // Resolve identity provider. `isDevMode` is captured BEFORE the dev
+  // substitution: when no real provider is configured we still install a
+  // DevIdentityProvider (so the local app authenticates as a single
+  // `usr_default`), which makes `authMode` look like a real adapter. The
+  // honest "is this local dev" signal is therefore "was a real provider
+  // configured", not the post-substitution auth mode. Request rate limiting
+  // keys off this to bypass in dev.
   let effectiveProvider: IdentityProvider | null = optProvider ?? runtime.getIdentityProvider();
+  const isDevMode = effectiveProvider === null;
   if (!effectiveProvider) {
     const workDir = runtime.getWorkDir();
     effectiveProvider = new DevIdentityProvider(
@@ -194,6 +214,8 @@ export function startServer(options: ServerOptions): ServerHandle {
     rateLimiter,
     chatLimiter,
     toolCallLimiter,
+    mcpLimiter,
+    isDevMode,
     eventSink: runtime.getEventSink(),
     isLocalhost: true, // Updated after Bun.serve starts
     appOrigin: allowedOrigins ? [...allowedOrigins][0] : undefined,
@@ -225,6 +247,7 @@ export function startServer(options: ServerOptions): ServerHandle {
       rateLimiter.stop();
       chatLimiter.stop();
       toolCallLimiter.stop();
+      mcpLimiter.stop();
       sseManager.stop();
       conversationEventManager.stop();
       healthMonitor.stop();

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -73,6 +73,14 @@ export interface AppContext {
   rateLimiter: LoginRateLimiter;
   chatLimiter: RequestRateLimiter;
   toolCallLimiter: RequestRateLimiter;
+  /** Per-identity limiter for the remote `/mcp` surface (external clients + bundle iframes). */
+  mcpLimiter: RequestRateLimiter;
+  /**
+   * True when no real identity provider is configured (local dev — a
+   * `DevIdentityProvider` is substituted). Request rate limiting is bypassed
+   * in this mode; see `requestRateLimit`.
+   */
+  isDevMode: boolean;
   eventSink: EventSink;
   isLocalhost: boolean;
   appOrigin: string | undefined;

--- a/test/integration/api/request-rate-limit.test.ts
+++ b/test/integration/api/request-rate-limit.test.ts
@@ -1,20 +1,72 @@
-import { describe, expect, it, afterAll, beforeAll } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEV_IDENTITY } from "../../../src/identity/providers/dev.ts";
+import type {
+  CreateUserInput,
+  CreateUserResult,
+  IdentityProvider,
+  ProviderCapabilities,
+  UserIdentity,
+} from "../../../src/identity/provider.ts";
+import type { User } from "../../../src/identity/user.ts";
 import { Runtime } from "../../../src/runtime/runtime.ts";
-import { createEchoModel } from "../../helpers/echo-model.ts";
 import { startServer } from "../../../src/api/server.ts";
 import type { ServerHandle } from "../../../src/api/server.ts";
+import { createEchoModel } from "../../helpers/echo-model.ts";
 import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../../helpers/test-workspace.ts";
 
 /**
- * Integration tests for per-user request rate limiting on chat and tool-call endpoints.
- * Uses a dedicated server with low limits (3 chat, 3 tools) to verify:
- * - 429 when limit is exceeded
- * - Rate limiting doesn't bleed to unrelated endpoints
- * - Correct error shape and Retry-After header
+ * Integration tests for per-identity request rate limiting on the chat,
+ * tool-call, and `/mcp` surfaces. Uses a dedicated server with low limits
+ * (3 each) to verify:
+ * - 429 when a surface's limit is exceeded
+ * - rate limiting doesn't bleed to unrelated endpoints
+ * - correct error shape and Retry-After header
+ *
+ * Rate limiting is an authenticated-mode control — it's bypassed entirely in
+ * dev mode (no real identity provider). So this server is started WITH a
+ * provider. The adapter authenticates as `usr_default` (the same id
+ * `provisionTestWorkspace` adds as a member of the test workspace) so the
+ * workspace-scoped calls pass membership and actually reach the limiter.
  */
+
+const TOKEN = "rate-limit-test-token-abcdef";
+const IDENTITY: UserIdentity = {
+  id: DEV_IDENTITY.id,
+  email: "ratelimit@example.test",
+  displayName: "Rate Limit Tester",
+  orgRole: "member",
+};
+
+class TokenAuthAdapter implements IdentityProvider {
+  readonly capabilities: ProviderCapabilities = {
+    authCodeFlow: false,
+    tokenRefresh: false,
+    managedUsers: false,
+  };
+  async verifyRequest(req: Request): Promise<UserIdentity | null> {
+    const auth = req.headers.get("authorization");
+    if (!auth?.startsWith("Bearer ")) return null;
+    return auth.slice(7) === TOKEN ? IDENTITY : null;
+  }
+  async listUsers(): Promise<User[]> {
+    return [];
+  }
+  async createUser(_data: CreateUserInput): Promise<CreateUserResult> {
+    throw new Error("not supported");
+  }
+  async deleteUser(): Promise<boolean> {
+    return false;
+  }
+}
+
+const authHeaders = (extra: Record<string, string> = {}) => ({
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${TOKEN}`,
+  ...extra,
+});
 
 let runtime: Runtime;
 let handle: ServerHandle;
@@ -24,98 +76,130 @@ const testDir = join(tmpdir(), `nimblebrain-rate-limit-${Date.now()}`);
 // Set low limits so tests can exhaust them quickly
 const originalChatLimit = process.env.NB_CHAT_RATE_LIMIT;
 const originalToolLimit = process.env.NB_TOOL_RATE_LIMIT;
+const originalMcpLimit = process.env.NB_MCP_RATE_LIMIT;
 
 beforeAll(async () => {
-	process.env.NB_CHAT_RATE_LIMIT = "3";
-	process.env.NB_TOOL_RATE_LIMIT = "3";
+  process.env.NB_CHAT_RATE_LIMIT = "3";
+  process.env.NB_TOOL_RATE_LIMIT = "3";
+  process.env.NB_MCP_RATE_LIMIT = "3";
 
-	mkdirSync(testDir, { recursive: true });
-	runtime = await Runtime.start({
-		model: { provider: "custom", adapter: createEchoModel() },
-		noDefaultBundles: true,
-		logging: { disabled: true },
-		workDir: testDir,
-	});
+  mkdirSync(testDir, { recursive: true });
+  runtime = await Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    logging: { disabled: true },
+    workDir: testDir,
+  });
 
-	await provisionTestWorkspace(runtime);
+  await provisionTestWorkspace(runtime);
 
-	handle = startServer({ runtime, port: 0 });
-	baseUrl = `http://localhost:${handle.port}`;
+  // WITH a provider → not dev mode → rate limiting is active.
+  handle = startServer({ runtime, port: 0, provider: new TokenAuthAdapter() });
+  baseUrl = `http://localhost:${handle.port}`;
 });
 
 afterAll(async () => {
-	handle.stop(true);
-	await runtime.shutdown();
-	rmSync(testDir, { recursive: true, force: true });
+  handle.stop(true);
+  await runtime.shutdown();
+  rmSync(testDir, { recursive: true, force: true });
 
-	// Restore env
-	if (originalChatLimit === undefined) delete process.env.NB_CHAT_RATE_LIMIT;
-	else process.env.NB_CHAT_RATE_LIMIT = originalChatLimit;
-	if (originalToolLimit === undefined) delete process.env.NB_TOOL_RATE_LIMIT;
-	else process.env.NB_TOOL_RATE_LIMIT = originalToolLimit;
+  // Restore env
+  for (const [key, original] of [
+    ["NB_CHAT_RATE_LIMIT", originalChatLimit],
+    ["NB_TOOL_RATE_LIMIT", originalToolLimit],
+    ["NB_MCP_RATE_LIMIT", originalMcpLimit],
+  ] as const) {
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
 });
 
 describe("chat rate limiting", () => {
-	it("returns 429 after exceeding chat limit", async () => {
-		// Exhaust the limit
-		for (let i = 0; i < 3; i++) {
-			const res = await fetch(`${baseUrl}/v1/chat`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json", "X-Workspace-Id": TEST_WORKSPACE_ID },
-				body: JSON.stringify({ message: `msg ${i}`, workspaceId: TEST_WORKSPACE_ID }),
-			});
-			expect(res.status).toBe(200);
-		}
+  it("returns 429 after exceeding chat limit", async () => {
+    // Exhaust the limit
+    for (let i = 0; i < 3; i++) {
+      const res = await fetch(`${baseUrl}/v1/chat`, {
+        method: "POST",
+        headers: authHeaders({ "X-Workspace-Id": TEST_WORKSPACE_ID }),
+        body: JSON.stringify({ message: `msg ${i}`, workspaceId: TEST_WORKSPACE_ID }),
+      });
+      expect(res.status).toBe(200);
+    }
 
-		// Next request should be rate-limited
-		const res = await fetch(`${baseUrl}/v1/chat`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json", "X-Workspace-Id": TEST_WORKSPACE_ID },
-			body: JSON.stringify({ message: "over limit", workspaceId: TEST_WORKSPACE_ID }),
-		});
+    // Next request should be rate-limited
+    const res = await fetch(`${baseUrl}/v1/chat`, {
+      method: "POST",
+      headers: authHeaders({ "X-Workspace-Id": TEST_WORKSPACE_ID }),
+      body: JSON.stringify({ message: "over limit", workspaceId: TEST_WORKSPACE_ID }),
+    });
 
-		expect(res.status).toBe(429);
-		const body = await res.json();
-		expect(body.error).toBe("rate_limited");
-		expect(body.message).toBe("Rate limit exceeded");
-		expect(res.headers.get("Retry-After")).toBe("60");
-	});
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("rate_limited");
+    expect(body.message).toBe("Rate limit exceeded");
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
 
-	it("does not rate-limit unrelated endpoints when chat is exhausted", async () => {
-		// Chat is already exhausted from the previous test.
-		// Health endpoint should still work.
-		const healthRes = await fetch(`${baseUrl}/v1/health`);
-		expect(healthRes.status).toBe(200);
-	});
+  it("does not rate-limit unrelated endpoints when chat is exhausted", async () => {
+    // Chat is already exhausted from the previous test.
+    // Health endpoint should still work.
+    const healthRes = await fetch(`${baseUrl}/v1/health`);
+    expect(healthRes.status).toBe(200);
+  });
 });
 
 describe("tool-call rate limiting", () => {
-	it("returns 429 after exceeding tool-call limit", async () => {
-		// Exhaust the limit — these return 400/404 but still count
-		for (let i = 0; i < 3; i++) {
-			await fetch(`${baseUrl}/v1/tools/call`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json", "X-Workspace-Id": TEST_WORKSPACE_ID },
-				body: JSON.stringify({ server: "x", tool: "y", arguments: {} }),
-			});
-		}
+  it("returns 429 after exceeding tool-call limit", async () => {
+    // Exhaust the limit — these return 400/404 but still count
+    for (let i = 0; i < 3; i++) {
+      await fetch(`${baseUrl}/v1/tools/call`, {
+        method: "POST",
+        headers: authHeaders({ "X-Workspace-Id": TEST_WORKSPACE_ID }),
+        body: JSON.stringify({ server: "x", tool: "y", arguments: {} }),
+      });
+    }
 
-		const res = await fetch(`${baseUrl}/v1/tools/call`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json", "X-Workspace-Id": TEST_WORKSPACE_ID },
-			body: JSON.stringify({ server: "x", tool: "y", arguments: {} }),
-		});
+    const res = await fetch(`${baseUrl}/v1/tools/call`, {
+      method: "POST",
+      headers: authHeaders({ "X-Workspace-Id": TEST_WORKSPACE_ID }),
+      body: JSON.stringify({ server: "x", tool: "y", arguments: {} }),
+    });
 
-		expect(res.status).toBe(429);
-		const body = await res.json();
-		expect(body.error).toBe("rate_limited");
-	});
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("rate_limited");
+  });
 
-	it("does not rate-limit shell or file endpoints when tools/call is exhausted", async () => {
-		// tools/call is exhausted, but /v1/shell should still work
-		const shellRes = await fetch(`${baseUrl}/v1/shell`, {
-			headers: { "X-Workspace-Id": TEST_WORKSPACE_ID },
-		});
-		expect(shellRes.status).toBe(200);
-	});
+  it("does not rate-limit shell or file endpoints when tools/call is exhausted", async () => {
+    // tools/call is exhausted, but /v1/shell should still work
+    const shellRes = await fetch(`${baseUrl}/v1/shell`, {
+      headers: authHeaders({ "X-Workspace-Id": TEST_WORKSPACE_ID }),
+    });
+    expect(shellRes.status).toBe(200);
+  });
+});
+
+describe("mcp rate limiting", () => {
+  it("returns 429 after exceeding the /mcp limit", async () => {
+    // Authenticated POSTs to /mcp. The body isn't a valid initialize, so the
+    // handler errors — but the limiter runs before the handler, so each call
+    // still counts (same as the tool-call test counts 400s).
+    for (let i = 0; i < 3; i++) {
+      await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: authHeaders({ Accept: "application/json, text/event-stream" }),
+        body: JSON.stringify({ jsonrpc: "2.0", id: i, method: "tools/list" }),
+      });
+    }
+
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: authHeaders({ Accept: "application/json, text/event-stream" }),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 99, method: "tools/list" }),
+    });
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("rate_limited");
+  });
 });

--- a/test/unit/api/rate-limit-middleware.test.ts
+++ b/test/unit/api/rate-limit-middleware.test.ts
@@ -172,4 +172,29 @@ describe("requestRateLimit middleware", () => {
 		const res2 = await app.request("/v1/chat", { method: "POST" });
 		expect(res2.status).toBe(429);
 	});
+
+	it("bypasses the limit entirely when opts.bypass is true (dev mode)", async () => {
+		// Limit of 1, but bypass set — so even a burst well past the limit is
+		// never throttled. This is the dev-mode behavior: no real identity
+		// provider, single local user, rate limiting is pure friction.
+		const limiter = new RequestRateLimiter(1, 60_000);
+		const app = new Hono();
+		app.use("*", requestRateLimit(limiter, { bypass: true }));
+		app.post("/v1/chat", (c) => c.json({ ok: true }));
+
+		for (let i = 0; i < 5; i++) {
+			const res = await app.request("/v1/chat", { method: "POST" });
+			expect(res.status).toBe(200);
+		}
+	});
+
+	it("still enforces the limit when opts.bypass is false", async () => {
+		const limiter = new RequestRateLimiter(1, 60_000);
+		const app = new Hono();
+		app.use("*", requestRateLimit(limiter, { bypass: false }));
+		app.post("/v1/chat", (c) => c.json({ ok: true }));
+
+		expect((await app.request("/v1/chat", { method: "POST" })).status).toBe(200);
+		expect((await app.request("/v1/chat", { method: "POST" })).status).toBe(429);
+	});
 });


### PR DESCRIPTION
## Problem

The per-request rate limiter was on the **wrong surface**. `/v1/tools/call` and `/v1/chat` — the trusted, same-origin first-party shell — were capped at 60/20 per minute, while **`/mcp`** (external MCP clients **and** sandboxed bundle iframes via the bridge — the actual abuse surface) had **no limit at all**. So the UI tripped "Rate limit exceeded" on normal navigation (the admin/settings views fan out to several tool calls each), while remote callers were unthrottled. The threat model was inverted.

## Fix — scope the limit to the caller's trust class

- **`/mcp`**: add a per-identity limiter (`NB_MCP_RATE_LIMIT`, default **300/min**). Chained on the route (not via `.use("*")`) **after** `requireMcpAuth`, so the per-identity key is populated and the middleware can't leak onto sibling routes.
- **`/v1/tools/call`**: raise default **60 → 600/min** (`NB_TOOL_RATE_LIMIT`) — a runaway-loop guard for the trusted shell, far above human navigation.
- **`/v1/chat`**: unchanged at 20/min (LLM-expensive, human pace).
- **Dev bypass**: when no *real* identity provider is configured (local dev substitutes a `DevIdentityProvider`, collapsing every request to one `usr_default` bucket), skip request rate limiting entirely. It's a multi-tenant abuse control with no purpose for a single local user — and was the direct cause of the dev friction.

All three limits are env-tunable for ops to dial in.

## Tests

- `requestRateLimit` unit coverage for the new `bypass` option (bypassed → never 429; not bypassed → still enforces).
- The rate-limit **integration test now runs authenticated** (the only mode where limiting is active post-change; previously it implicitly tested the dev path) and adds **`/mcp` 429 coverage**.
- `bun run verify` green locally. Note: the repo's web/smoke suite is intermittently flaky under CI ordering (tracked in #288); a red CI run may just need a re-run — the new test is deterministic (verified 3×).

## Context

This is the immediate, per-surface instance of the broader **audience-aware dispatch** direction in #89 — the typed caller-audience model (rate limit + tool visibility + CSRF + observability keyed off audience rather than transport) remains the longer-term generalization.