### PR TITLE
fix(api): detach interactive chat runs from the HTTP request lifecycle

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -73,12 +73,16 @@ export async function handleChat(
   const originSubscriberId = request.headers.get("x-origin-subscriber-id") ?? undefined;
 
   try {
-    // Thread the request's abort signal into the chat so a client
-    // disconnect or upstream timeout actually cancels the in-flight
-    // engine loop and tool calls — instead of orphaning the work until
-    // it eventually finishes writing to disk (the production bug behind
-    // the morning-brief executor lying about timeouts).
-    const result = await runtime.chat({ ...parsed, signal: request.signal });
+    // The run is owned by the runtime, not by this HTTP request — we do
+    // NOT pass `request.signal`. A client disconnect (mobile screen-lock,
+    // backgrounded tab, network blip) must not cancel the in-flight
+    // engine loop; the run completes server-side, persists, and is
+    // replayed to any reconnecting /v1/conversations/:id/events
+    // subscriber. See the detached `.chat(parsed, sink)` in
+    // handleChatStream for the full rationale (PR #251 regression). The
+    // automations executor's deadline cancellation is unaffected — that
+    // path supplies its own AbortController.
+    const result = await runtime.chat(parsed);
     // Cost is derived at the boundary, never stored. Same wire shape as
     // the streaming `done` event so clients see one consistent contract.
     const wireUsage = {
@@ -239,28 +243,41 @@ export async function handleChatStream(
   const convId = parsed.conversationId;
 
   const sink = new CallbackEventSink();
-  let markClosed: () => void;
+  // This HTTP stream is a detachable *observer* of the run, not its
+  // owner. `markTransportClosed` lets the stream's cancel() (client
+  // disconnect) stop writing to this response without touching the run.
+  let markTransportClosed: () => void = () => {};
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       const encoder = new TextEncoder();
-      let closed = false;
+      // Tracks whether THIS response is still writable. It does not track
+      // the run — the run's lifecycle is the sink subscription, torn down
+      // in `endRun()` when the run actually ends (see the .chat() call).
+      let transportOpen = true;
       // Keep the TCP connection alive during slow tool calls (Typst
       // compile, MCP task-augmented research) — ALB idle-timeout kills
-      // silent streams. Must be created before `markClosed` captures it.
+      // silent streams. Must be created before `markTransportClosed`
+      // captures it.
       const heartbeat = startSseHeartbeat(controller, HEARTBEAT_INTERVAL_MS);
-      markClosed = () => {
-        closed = true;
+      markTransportClosed = () => {
+        if (!transportOpen) return;
+        transportOpen = false;
         heartbeat.stop();
       };
+      // Write to this response. No-op once the client has detached — the
+      // run keeps producing events, which still reach other observers via
+      // the broadcast below and the persisted conversation.
       const send = (event: string, data: unknown) => {
-        if (closed) return;
+        if (!transportOpen) return;
         controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
       };
-      const finish = () => {
-        if (closed) return;
-        closed = true;
+      // Close this response's stream (run finished while the client was
+      // still connected — the happy path). If the client already left,
+      // this is a no-op; the controller is already torn down by cancel().
+      const closeTransport = () => {
+        if (!transportOpen) return;
+        transportOpen = false;
         heartbeat.stop();
-        unsubscribe();
         controller.close();
       };
 
@@ -324,12 +341,28 @@ export async function handleChatStream(
         }
       });
 
+      // Called exactly once when the run terminates (success or error),
+      // independent of transport state. Releasing the sink subscription
+      // here — not on client disconnect — is what lets a run finish in
+      // the background after the phone locks or the tab is backgrounded.
+      const endRun = () => {
+        unsubscribe();
+        closeTransport();
+      };
+
       runtime
-        // Thread the HTTP request's signal so client disconnect cancels
-        // the engine loop + in-flight tool calls (cooperative). The SSE
-        // stream's controller closes on cancellation via `closed` flag;
-        // this propagates the cancellation INTO the chat too.
-        .chat({ ...parsed, signal: request.signal }, sink)
+        // The run is deliberately NOT bound to this HTTP request: we do
+        // not pass `request.signal`. A client disconnect closes the
+        // stream (cancel() → markTransportClosed) but must not cancel the
+        // engine loop. The run completes server-side, persists to the
+        // conversation store, and replays to any reconnecting
+        // /v1/conversations/:id/events subscriber — the "leave and come
+        // back" contract. PR #251 bound the run to the connection and
+        // silently abandoned prompts the moment a mobile client dropped
+        // (run.error "The connection was closed"). The one caller that
+        // must cancel on a deadline — the automations executor — owns its
+        // own AbortController in bundles/automations/src/executor.ts.
+        .chat(parsed, sink)
         .then((result) => {
           // Cost is computed at the API boundary — never stored. The
           // wire-format `usage.costUsd` is what clients display; deriving
@@ -367,7 +400,7 @@ export async function handleChatStream(
               );
             }
           }
-          finish();
+          endRun();
         })
         .catch((err) => {
           if (err instanceof RunInProgressError) {
@@ -375,7 +408,7 @@ export async function handleChatStream(
               error: "run_in_progress",
               message: "This conversation already has an active response.",
             });
-            finish();
+            endRun();
             return;
           }
           if (err instanceof ConversationAccessDeniedError) {
@@ -383,7 +416,7 @@ export async function handleChatStream(
               error: "conversation_access_denied",
               message: "You do not have access to this conversation.",
             });
-            finish();
+            endRun();
             return;
           }
           if (err instanceof ConversationCorruptedError) {
@@ -391,7 +424,7 @@ export async function handleChatStream(
               error: "conversation_corrupted",
               message: err.message,
             });
-            finish();
+            endRun();
             return;
           }
           console.error("[routes] handleChatStream failed:", err);
@@ -401,11 +434,13 @@ export async function handleChatStream(
             error: friendly.code,
             message: friendly.message,
           });
-          finish();
+          endRun();
         });
     },
     cancel() {
-      markClosed();
+      // The client went away (disconnect / phone lock / tab close).
+      // Detach this observer ONLY — the run continues to completion.
+      markTransportClosed();
     },
   });
 

--- a/test/integration/chat-stream-disconnect.test.ts
+++ b/test/integration/chat-stream-disconnect.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression: a chat run must NOT be cancelled when the HTTP client that
+ * started it disconnects mid-stream.
+ *
+ * The run is owned by the runtime, not by the request transport. A mobile
+ * client that locks its screen / backgrounds the tab / hits a network blip
+ * tears down the SSE connection, but the engine loop must keep running,
+ * persist its result, and stay available to a reconnecting
+ * `/v1/conversations/:id/events` subscriber. This is the "leave and come
+ * back and it loaded" contract.
+ *
+ * PR #251 threaded `request.signal` into `runtime.chat`, so a disconnect
+ * aborted the run — it died with `run.error: "The connection was closed."`
+ * and never produced a reply. This test pins the corrected behavior: after
+ * the client disconnects, the conversation still ends in `run.done` with the
+ * assistant's response persisted, and no `run.error` is written.
+ *
+ * On the regressed code this fails (no `run.done`; a connection-closed
+ * `run.error` instead).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ServerHandle } from "../../src/api/server.ts";
+import { startServer } from "../../src/api/server.ts";
+import { EventSourcedConversationStore } from "../../src/conversation/event-sourced-store.ts";
+import { Runtime } from "../../src/runtime/runtime.ts";
+import { createMockModel } from "../helpers/mock-model.ts";
+import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
+
+const SENTINEL = "DETACH_SENTINEL";
+const BACKGROUND_REPLY = "completed in the background after disconnect";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+describe("POST /v1/chat/stream — run survives client disconnect", () => {
+  let handle: ServerHandle | null = null;
+  let runtime: Runtime | null = null;
+
+  afterEach(async () => {
+    handle?.stop(true);
+    await runtime?.shutdown();
+    handle = null;
+    runtime = null;
+  });
+
+  test("client disconnect mid-run does not cancel the run; it completes and persists", async () => {
+    // Gate only the streamed turn (identified by the sentinel in its
+    // prompt). The seed turn and its fire-and-forget auto-title pass
+    // through immediately, so the gate isolates the run under test.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // The gated turn mirrors a real provider: its in-flight call resolves
+    // when the gate opens, but rejects with an AbortError if the run's
+    // `abortSignal` fires first. That `abortSignal` is exactly what the
+    // engine forwards from `ChatRequest.signal` — so on the regressed code
+    // (which threads `request.signal`), a client disconnect aborts this
+    // call and the run errors. On the fixed code no signal is threaded,
+    // so `options.abortSignal` is undefined and the run completes.
+    const gatedModel = createMockModel((options) => {
+      const promptText = JSON.stringify(options.prompt ?? "");
+      if (!promptText.includes(SENTINEL)) {
+        return { content: [{ type: "text", text: "seeded" }] };
+      }
+      const signal = options.abortSignal;
+      return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+          return;
+        }
+        const onAbort = () =>
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        signal?.addEventListener("abort", onAbort, { once: true });
+        gate.then(() => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve({ content: [{ type: "text", text: BACKGROUND_REPLY }] });
+        });
+      });
+    });
+
+    const workDir = join(tmpdir(), `nb-detach-${Date.now()}`);
+    mkdirSync(workDir, { recursive: true });
+    runtime = await Runtime.start({
+      model: { provider: "custom", adapter: gatedModel },
+      noDefaultBundles: true,
+      logging: { disabled: true },
+      workDir,
+    });
+    await provisionTestWorkspace(runtime);
+    handle = startServer({ runtime, port: 0 });
+    const baseUrl = `http://localhost:${handle.port}`;
+
+    // Seed a conversation to get a stable convId to assert against.
+    const seed = await runtime.chat({ message: "seed", workspaceId: TEST_WORKSPACE_ID });
+    const convId = seed.conversationId;
+
+    // Start the streamed turn. The model gates, so the run is in-flight
+    // (and holds the conversation lock) while we yank the connection.
+    const ac = new AbortController();
+    const res = await fetch(`${baseUrl}/v1/chat/stream`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Workspace-Id": TEST_WORKSPACE_ID },
+      body: JSON.stringify({ message: `${SENTINEL} please answer`, conversationId: convId }),
+      signal: ac.signal,
+    });
+
+    // Read until the run has demonstrably started server-side.
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const startDeadline = Date.now() + 5_000;
+    while (!buffer.includes("event: chat.start") && Date.now() < startDeadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    expect(buffer).toContain("event: chat.start");
+    expect(runtime.isConversationActive(convId)).toBe(true);
+
+    // The mobile client drops: abort the request and tear down the reader.
+    // This fires the server stream's cancel(); on the regressed code it
+    // also aborted request.signal and killed the run.
+    await reader.cancel().catch(() => {});
+    ac.abort();
+
+    // Give the server a tick to observe the disconnect, then let the
+    // (now detached) run finish.
+    await new Promise((r) => setTimeout(r, 50));
+    release();
+
+    // The run must settle by completing — releasing the conversation lock.
+    await waitFor(() => runtime?.isConversationActive(convId) === false);
+    expect(runtime.isConversationActive(convId)).toBe(false);
+
+    // Inspect the persisted event log — the same surface that showed
+    // `run.error: "The connection was closed."` in the production repro.
+    const store = runtime.findConversationStore() as EventSourcedConversationStore;
+    const events = await store.readEvents(convId);
+
+    const runErrors = events.filter((e) => e.type === "run.error");
+    expect(runErrors).toEqual([]);
+    expect(events.some((e) => e.type === "run.done")).toBe(true);
+
+    // And the assistant's answer — produced entirely after the client
+    // left — was persisted.
+    const llmResponses = events.filter((e) => e.type === "llm.response");
+    expect(JSON.stringify(llmResponses)).toContain(BACKGROUND_REPLY);
+  });
+});


### PR DESCRIPTION
Interactive chat runs were cancelled when the HTTP client that started them disconnected. On mobile, locking the screen / backgrounding the tab / a network blip tears down the SSE connection; via the request `AbortSignal` threaded in #251, that aborted the in-flight engine loop. Prompts died with `run.error "The connection was closed."` and never produced a reply — the "leave and come back and it loaded" behavior was lost.

## Root cause

`handleChat` and `handleChatStream` passed `request.signal` into `runtime.chat`, coupling the run's lifetime to the client connection. `request.signal` is the *connection's* abort signal — a client disconnect fired it, the engine treated it as cancellation (between-iteration check, in-flight tool `tasks/cancel`, LLM-stream abort), and the run was abandoned without persisting.

## Fix

Stop sourcing the run's signal from `request.signal`. The run is owned by the runtime: it completes server-side, persists to the conversation store, and replays to any reconnecting `/v1/conversations/:id/events` subscriber.

In the streaming handler, split the two lifecycles #251 had fused:
- **Transport** (`transportOpen` / `markTransportClosed` / `closeTransport`): controller writes + heartbeat; stops on client disconnect.
- **Run** (`endRun` → `unsubscribe()`): the sink subscription, now always released when the *run* ends regardless of transport state. This also fixes a latent unsubscribe leak (the old `finish()` bailed early on a closed transport).

`broadcastToConversation` stays ungated, so events keep flowing to reconnecting subscribers after a disconnect.

The automations executor's `maxRunDurationMs` deadline cancellation is **unaffected** — that path owns its own `AbortController` (`src/bundles/automations/src/executor.ts`), which is what #251 actually needed.

## Test

Adds `test/integration/chat-stream-disconnect.test.ts`: disconnects mid-run, then asserts the run still completes (`run.done`, assistant reply persisted, no connection-closed `run.error`). Verified it fails on the regressed code with the exact `DOMException` abort signature and passes on the fix.

## Validation

- `verify:static`: green
- `test:unit`: 3126 pass / 0 fail
- `test:web`: 385 pass / 0 fail
- `test:integration`: 616 pass / 0 fail

## Follow-up

Closing the connection no longer cancels a run (by design), and there is no Stop control in the composer — so explicit, intent-driven cancellation is now a gap. Tracked in #294 (deliberately out of scope here).