### PR TITLE
test(web): fix flaky CI from api/client mock.module pollution

### DIFF
--- a/web/src/__tests__/InstallConnectorDialog.test.tsx
+++ b/web/src/__tests__/InstallConnectorDialog.test.tsx
@@ -39,7 +39,14 @@ const installConnector = mock(async (_entry: unknown, _wsId: string) => ({
   wsId: "ws_helix",
 }));
 
+// Spread the real module so this whole-module mock exposes every api/client
+// export. Bun's `mock.module` is process-global; a *partial* stub leaking into
+// another suite mid-run (under CI's parallelism) is what crashed bridge tests
+// with "Export named 'getActiveWorkspaceId' not found". A complete mock is inert
+// when it leaks — only `installConnector` is overridden here.
+const actualClient = await import("../api/client");
 mock.module("../api/client", () => ({
+  ...actualClient,
   installConnector,
 }));
 

--- a/web/src/__tests__/ResourceLinkView.test.tsx
+++ b/web/src/__tests__/ResourceLinkView.test.tsx
@@ -36,22 +36,16 @@ const readResourceMock = mock(
   async (_server: string, _uri: string): Promise<{ contents: unknown[] }> => ({ contents: [] }),
 );
 
+// Spread the real module so this whole-module mock exposes every api/client
+// export. Bun's `mock.module` is process-global; a partial stub leaking into
+// another suite mid-run (under CI's parallelism) is what crashed bridge tests
+// with "Export named 'getActiveWorkspaceId' not found". The spread also gives us
+// the real `ApiClientError` constructor that ResourceLinkView's catch branch
+// (`err instanceof ApiClientError`) needs — only `readResource` is overridden.
+const actualClient = await import("../api/client");
 mock.module("../api/client", () => ({
+  ...actualClient,
   readResource: readResourceMock,
-  // ApiClientError is referenced as a value in ResourceLinkView's catch
-  // branch (`err instanceof ApiClientError`), so the mock must export a
-  // real constructor — not just a type — or the import fails at evaluation.
-  ApiClientError: class ApiClientError extends Error {
-    code: string;
-    status: number;
-    details?: unknown;
-    constructor(code: string, message: string, status: number, details?: unknown) {
-      super(message);
-      this.code = code;
-      this.status = status;
-      this.details = details;
-    }
-  },
 }));
 
 const React = await import("react");

--- a/web/src/__tests__/bridge/bridge-transport.test.ts
+++ b/web/src/__tests__/bridge/bridge-transport.test.ts
@@ -78,10 +78,16 @@ const getClientCalls = { count: 0 };
 // dispatching (Q3 auto-prefix). Mock `getActiveWorkspaceId` to return
 // a stable workspace id so the wire-name assertions below are
 // deterministic.
+// Spread the real module so this whole-module mock exposes every api/client
+// export. Bun's `mock.module` is process-global; a partial stub leaking into
+// another suite mid-run (under CI's parallelism) is what crashed these bridge
+// tests with "Export named 'getActiveWorkspaceId' not found". A complete mock
+// is inert when it leaks — only the two below are overridden.
+const actualClient = await import("../../api/client");
 mock.module("../../api/client", () => ({
+  ...actualClient,
   getActiveWorkspaceId: () => "ws_test",
-  // Other api/client exports the bridge file imports — keep them
-  // benign for this transport test (no upload triggered here).
+  // Keep upload benign for this transport test (no upload triggered here).
   uploadResource: async () => {
     throw new Error("uploadResource not stubbed in this test");
   },

--- a/web/src/__tests__/connector-sections.test.tsx
+++ b/web/src/__tests__/connector-sections.test.tsx
@@ -32,7 +32,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── api/client mocks ────────────────────────────────────────────────
 // Every section calls into one or two helpers from api/client. We
-// mock the module wholesale so the components don't try to fetch.
+// override those helpers but spread the real module (see the mock.module
+// call below) so the stub stays complete.
 
 const disconnectConnector = mock(async () => ({
   ok: true,
@@ -59,7 +60,14 @@ const setupConnectorOperator = mock(async () => ({
   clientId: "cid-rotated",
 }));
 
+// Spread the real module so this whole-module mock exposes every api/client
+// export. Bun's `mock.module` is process-global; this 5-export stub previously
+// clobbered `../api/client` for other suites loading concurrently (the
+// `getActiveWorkspaceId`/`setActiveWorkspaceId` "export not found" flake). A
+// complete mock is inert when it leaks — only these five are overridden.
+const actualClient = await import("../api/client");
 mock.module("../api/client", () => ({
+  ...actualClient,
   disconnectConnector,
   initiateMcpOAuth,
   clearBundleUserConfig,

--- a/web/src/__tests__/t009-acceptance.test.ts
+++ b/web/src/__tests__/t009-acceptance.test.ts
@@ -25,19 +25,18 @@
 //   - `setAuthToken` fires lifecycle handler, `setActiveWorkspaceId`
 //     does not: `api-client-lifecycle.test.ts`.
 //
-// File is prefixed `a-` to load early — `mock.module(...)` from
-// `connector-sections.test.tsx` later in the suite installs a 5-export
-// stub for `../api/client`, and any file importing `setAuthToken` /
-// `streamChat` after that fails to resolve. Existing
-// `api-client-lifecycle.test.ts` uses the same alphabetical-load trick.
+// This file reads the REAL `../api/client` (it installs no mock.module of its
+// own). The whole-module client mocks in other suites now spread the real
+// module, so they never drop an export even when Bun's process-global mock
+// registry leaks one across concurrently-loading files — no filename-ordering
+// trick required.
 // ---------------------------------------------------------------------------
 
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 
-// Side-effect import to pin the module in the cache with full exports
-// before any later test installs a mock.module replacement.
+// Real exports under test — asserted as values/types below.
 import {
   ApiClientError,
   errorFromResponse,

--- a/web/src/__tests__/workspace-section.test.tsx
+++ b/web/src/__tests__/workspace-section.test.tsx
@@ -13,12 +13,6 @@
 //      lost the guard would silently invalidate the REST cache on
 //      every click.
 //   4. Click navigates to `/w/<slug>/`.
-//
-// Prefixed `b-` (after `a-t009-acceptance.test.ts`) so it loads before
-// the suite's `mock.module("../api/client", ...)` stubs in
-// `connector-sections.test.tsx`. The acceptance file installs partial
-// mocks of the api client surface that would break this test's
-// `setActiveWorkspaceId` import otherwise.
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -35,7 +29,15 @@ const setActiveSpy = mock((id: string | null) => {
 });
 const mockedGetActiveWorkspaceId = (): string | null => mockedActiveId;
 
+// Spread the real module so this whole-module mock exposes every api/client
+// export. Bun's `mock.module` is process-global; a partial stub leaking into
+// another suite mid-run (under CI's parallelism) is what crashed bridge tests
+// with "Export named 'getActiveWorkspaceId' not found" — and is why this file
+// used to need a `b-` filename to win the load order. A complete mock is inert
+// when it leaks; only the three below are overridden.
+const actualClient = await import("../api/client");
 mock.module("../api/client", () => ({
+  ...actualClient,
   setActiveWorkspaceId: setActiveSpy,
   getActiveWorkspaceId: mockedGetActiveWorkspaceId,
   callTool: mock(async () => ({ structuredContent: null, content: [] })),


### PR DESCRIPTION
## Problem

Web unit tests fail **intermittently on CI** (never reproducibly local) with:

```
SyntaxError: Export named 'getActiveWorkspaceId' not found in module .../web/src/api/client.ts
```

Surfaced on #291 CI, but it is **pre-existing** and unrelated to that PR — the failing commit there was an empty commit, byte-identical to a commit that had passed CI three minutes earlier.

## Root cause

Not a circular import, and not a bun-version regression (CI's `bun-version: latest` = 1.3.14 runs the suite 30/30 green locally).

Several web test files replace the **entire** `../api/client` module with a *partial* `mock.module` stub containing only the exports that file needs:

- `InstallConnectorDialog` → `{ installConnector }`
- `connector-sections` → 5 functions
- `ResourceLinkView` → `{ readResource, ApiClientError }`
- `workspace-section` → `{ setActiveWorkspaceId, getActiveWorkspaceId, callTool }`

Bun's `mock.module` registry is **process-global**. Under CI's parallel execution, one partial stub can be the active version of `../api/client` at the moment a bridge test's module graph first evaluates `bridge.ts` / `mcp-bridge-client.ts`, which statically import `getActiveWorkspaceId` — an export those partial stubs omit → the crash. Timing/concurrency dependent, hence CI-only and non-deterministic. The codebase already half-knew this (the `a-`/`b-` filename prefixes and the comment in `client.ts`).

## Fix

Make every whole-module `../api/client` mock **complete**: spread the real module, then override only the functions the test stubs.

```ts
const actualClient = await import("../api/client");
mock.module("../api/client", () => ({ ...actualClient, installConnector }));
```

A complete mock is **inert when it leaks** — no export can go missing regardless of load order. The overrides the components actually call still win; the existing passing tests prove the components never invoke the spread-in real functions.

Because completeness removes the load-order dependency, the `a-`/`b-` filename-ordering hacks are no longer needed (and were ineffective under concurrent execution anyway). Renamed:

- `a-t009-acceptance.test.ts` → `t009-acceptance.test.ts`
- `b-workspace-section.test.tsx` → `workspace-section.test.tsx`

## Verification

- `format:check`, `lint`, web `tsc`: clean
- Web suite: **385 pass / 0 fail**
- Stress-run **20×** on bun 1.3.14 (CI) and 1.3.12 (local): 0 failures each

Note: the original flake does not reproduce locally even pre-fix (the race needs CI's concurrency), so the guarantee here is logical — a complete mock cannot drop an export — not a failing-test-now-passing demonstration.