### PR TITLE
test(web): snapshot real api/client in preload (fix #297 residual flake)

### DIFF
--- a/web/src/__tests__/InstallConnectorDialog.test.tsx
+++ b/web/src/__tests__/InstallConnectorDialog.test.tsx
@@ -28,6 +28,7 @@
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "../../test/setup";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -39,14 +40,12 @@ const installConnector = mock(async (_entry: unknown, _wsId: string) => ({
   wsId: "ws_helix",
 }));
 
-// Spread the real module so this whole-module mock exposes every api/client
-// export. Bun's `mock.module` is process-global; a *partial* stub leaking into
-// another suite mid-run (under CI's parallelism) is what crashed bridge tests
-// with "Export named 'getActiveWorkspaceId' not found". A complete mock is inert
-// when it leaks — only `installConnector` is overridden here.
-const actualClient = await import("../api/client");
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only `installConnector`
+// is overridden. Keeps the process-global mock registry complete even when it
+// leaks into another suite mid-run.
 mock.module("../api/client", () => ({
-  ...actualClient,
+  ...realClient,
   installConnector,
 }));
 

--- a/web/src/__tests__/ResourceLinkView.test.tsx
+++ b/web/src/__tests__/ResourceLinkView.test.tsx
@@ -26,6 +26,7 @@
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "../../test/setup";
 
 // Tell React 19 we're inside an act-aware test environment. Without this
 // flag, every awaited setState inside an async useEffect logs a warning
@@ -36,15 +37,12 @@ const readResourceMock = mock(
   async (_server: string, _uri: string): Promise<{ contents: unknown[] }> => ({ contents: [] }),
 );
 
-// Spread the real module so this whole-module mock exposes every api/client
-// export. Bun's `mock.module` is process-global; a partial stub leaking into
-// another suite mid-run (under CI's parallelism) is what crashed bridge tests
-// with "Export named 'getActiveWorkspaceId' not found". The spread also gives us
-// the real `ApiClientError` constructor that ResourceLinkView's catch branch
-// (`err instanceof ApiClientError`) needs — only `readResource` is overridden.
-const actualClient = await import("../api/client");
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only `readResource` is
+// overridden. The snapshot also carries the real `ApiClientError` constructor
+// that ResourceLinkView's catch branch (`err instanceof ApiClientError`) needs.
 mock.module("../api/client", () => ({
-  ...actualClient,
+  ...realClient,
   readResource: readResourceMock,
 }));
 

--- a/web/src/__tests__/bridge/bridge-transport.test.ts
+++ b/web/src/__tests__/bridge/bridge-transport.test.ts
@@ -22,6 +22,7 @@
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "../../../test/setup";
 
 // ---------------------------------------------------------------------------
 // Mocks — each dependency is replaced with an observable stub so tests can
@@ -78,14 +79,12 @@ const getClientCalls = { count: 0 };
 // dispatching (Q3 auto-prefix). Mock `getActiveWorkspaceId` to return
 // a stable workspace id so the wire-name assertions below are
 // deterministic.
-// Spread the real module so this whole-module mock exposes every api/client
-// export. Bun's `mock.module` is process-global; a partial stub leaking into
-// another suite mid-run (under CI's parallelism) is what crashed these bridge
-// tests with "Export named 'getActiveWorkspaceId' not found". A complete mock
-// is inert when it leaks — only the two below are overridden.
-const actualClient = await import("../../api/client");
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only the two below are
+// overridden. Keeps the process-global mock registry complete even when it
+// leaks into another suite mid-run.
 mock.module("../../api/client", () => ({
-  ...actualClient,
+  ...realClient,
   getActiveWorkspaceId: () => "ws_test",
   // Keep upload benign for this transport test (no upload triggered here).
   uploadResource: async () => {

--- a/web/src/__tests__/connector-sections.test.tsx
+++ b/web/src/__tests__/connector-sections.test.tsx
@@ -27,13 +27,14 @@
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "../../test/setup";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 // ── api/client mocks ────────────────────────────────────────────────
 // Every section calls into one or two helpers from api/client. We
-// override those helpers but spread the real module (see the mock.module
-// call below) so the stub stays complete.
+// override those helpers but spread the real-module snapshot (see the
+// mock.module call below) so the stub stays complete.
 
 const disconnectConnector = mock(async () => ({
   ok: true,
@@ -60,14 +61,12 @@ const setupConnectorOperator = mock(async () => ({
   clientId: "cid-rotated",
 }));
 
-// Spread the real module so this whole-module mock exposes every api/client
-// export. Bun's `mock.module` is process-global; this 5-export stub previously
-// clobbered `../api/client` for other suites loading concurrently (the
-// `getActiveWorkspaceId`/`setActiveWorkspaceId` "export not found" flake). A
-// complete mock is inert when it leaks — only these five are overridden.
-const actualClient = await import("../api/client");
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only these five are
+// overridden. Keeps the process-global mock registry complete even when it
+// leaks into another suite loading concurrently.
 mock.module("../api/client", () => ({
-  ...actualClient,
+  ...realClient,
   disconnectConnector,
   initiateMcpOAuth,
   clearBundleUserConfig,

--- a/web/src/__tests__/workspace-section.test.tsx
+++ b/web/src/__tests__/workspace-section.test.tsx
@@ -16,6 +16,7 @@
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "../../test/setup";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -29,15 +30,13 @@ const setActiveSpy = mock((id: string | null) => {
 });
 const mockedGetActiveWorkspaceId = (): string | null => mockedActiveId;
 
-// Spread the real module so this whole-module mock exposes every api/client
-// export. Bun's `mock.module` is process-global; a partial stub leaking into
-// another suite mid-run (under CI's parallelism) is what crashed bridge tests
-// with "Export named 'getActiveWorkspaceId' not found" — and is why this file
-// used to need a `b-` filename to win the load order. A complete mock is inert
-// when it leaks; only the three below are overridden.
-const actualClient = await import("../api/client");
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only the three below are
+// overridden. Keeps the process-global mock registry complete even when it
+// leaks into another suite mid-run (this file used to need a `b-` filename to
+// win the load order; the snapshot makes that unnecessary).
 mock.module("../api/client", () => ({
-  ...actualClient,
+  ...realClient,
   setActiveWorkspaceId: setActiveSpy,
   getActiveWorkspaceId: mockedGetActiveWorkspaceId,
   callTool: mock(async () => ({ structuredContent: null, content: [] })),

--- a/web/test/WorkspaceOverviewPage.test.tsx
+++ b/web/test/WorkspaceOverviewPage.test.tsx
@@ -17,21 +17,24 @@
 // ---------------------------------------------------------------------------
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import * as actualClient from "../src/api/client";
 import type { WorkspaceInfo } from "../src/context/WorkspaceContext";
 import type { PlacementEntry } from "../src/types";
+import { realClient } from "./setup";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 // Stub only `callTool` so the briefing fetch hangs in its skeleton (its own
-// async timeline — not what this file tests). Spread the real module so every
-// other export stays intact: a bare `{ callTool }` mock leaks across files in
-// the same test process and strips functions the client/bridge suites depend
-// on (getAuthToken, getActiveWorkspaceId, …). WorkspaceContext skips its list
-// call when given bootstrap data, so the real setActiveWorkspaceId it calls is
-// harmless — sibling suites reset client state in their own beforeEach.
+// async timeline — not what this file tests). Spread the preload's real-module
+// snapshot (see web/test/setup.ts) so every other export stays intact: a bare
+// `{ callTool }` mock leaks across files in the same test process and strips
+// functions the client/bridge suites depend on (getAuthToken,
+// getActiveWorkspaceId, …). The snapshot predates every mock.module, so it
+// can't itself be an incomplete stub the way `import * as` from the registry
+// could. WorkspaceContext skips its list call when given bootstrap data, so the
+// real setActiveWorkspaceId it calls is harmless — sibling suites reset client
+// state in their own beforeEach.
 mock.module("../src/api/client", () => ({
-  ...actualClient,
+  ...realClient,
   callTool: () => new Promise(() => {}),
 }));
 

--- a/web/test/inlineError.test.tsx
+++ b/web/test/inlineError.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { realClient } from "./setup";
 import { renderHook, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
@@ -14,7 +15,13 @@ let capturedCallback: StreamCallback | null = null;
 let resolveStream: (() => void) | null = null;
 let rejectStream: ((err: Error) => void) | null = null;
 
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only the two below are
+// overridden. Bun's mock.module registry is process-global, so an incomplete
+// stub leaking into another suite's module graph is what crashed bridge tests
+// with "Export named 'getActiveWorkspaceId' not found".
 mock.module("../src/api/client", () => ({
+	...realClient,
 	streamChat: (_req: unknown, cb: StreamCallback) => {
 		capturedCallback = cb;
 		return new Promise<void>((resolve, reject) => {

--- a/web/test/setup.ts
+++ b/web/test/setup.ts
@@ -1,5 +1,25 @@
 import { Window } from "happy-dom";
 
+// Snapshot of the real `../src/api/client` module, captured here in the test
+// preload — guaranteed to run before any test file, so before any test can
+// register a `mock.module("../api/client", ...)` replacement. Several suites
+// whole-module-mock api/client but only stub the one or two functions they
+// call; spreading this snapshot into those mocks keeps every other export
+// present. Bun's `mock.module` registry is process-global, so an incomplete
+// replacement leaking into another file's module graph (a concurrency-order
+// race that only manifests on CI) is what produced the flaky
+// "Export named 'getActiveWorkspaceId' not found" link errors.
+//
+// Why a preload snapshot rather than `await import("../api/client")` inside
+// each test: that dynamic import reads the *same* global registry it's trying
+// to defend against, so under the wrong load order it can itself resolve to an
+// incomplete mock and propagate the gap. Capturing here, before any mock
+// exists, and copying into a plain object makes the snapshot immune to later
+// `mock.module` swaps.
+import * as realApiClient from "../src/api/client";
+
+export const realClient = { ...realApiClient };
+
 const window = new Window({ url: "http://localhost" });
 
 // Register DOM globals that React and testing-library need

--- a/web/test/streamingState.test.tsx
+++ b/web/test/streamingState.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { realClient } from "./setup";
 import { renderHook, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
@@ -14,7 +15,13 @@ type StreamCallback = (type: string, data: unknown) => void;
 let capturedCallback: StreamCallback | null = null;
 let resolveStream: (() => void) | null = null;
 
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only the two below are
+// overridden. Bun's mock.module registry is process-global, so an incomplete
+// stub leaking into another suite's module graph is what crashed bridge tests
+// with "Export named 'getActiveWorkspaceId' not found".
 mock.module("../src/api/client", () => ({
+	...realClient,
 	streamChat: (_req: unknown, cb: StreamCallback) => {
 		capturedCallback = cb;
 		return new Promise<void>((resolve) => {

--- a/web/test/useShell.test.tsx
+++ b/web/test/useShell.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useShell } from "../src/hooks/useShell";
+import { realClient } from "./setup";
 
 // ---------------------------------------------------------------------------
 // Mock getShell
@@ -10,7 +11,13 @@ const mockGetShell = mock(() =>
   Promise.resolve({ placements: [], chatEndpoint: "", eventsEndpoint: "" }),
 );
 
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only `getShell` is
+// overridden. Bun's mock.module registry is process-global, so an incomplete
+// stub leaking into another suite's module graph is what crashed bridge tests
+// with "Export named 'getActiveWorkspaceId' not found".
 mock.module("../src/api/client", () => ({
+  ...realClient,
   getShell: (...args: unknown[]) => mockGetShell(...args),
 }));
 

--- a/web/test/useWorkspaceBriefing.test.ts
+++ b/web/test/useWorkspaceBriefing.test.ts
@@ -5,6 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, renderHook } from "@testing-library/react";
+import { realClient } from "./setup";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -16,7 +17,13 @@ interface Deferred {
 
 let calls: Deferred[] = [];
 
+// Spread the preload's real-module snapshot (see web/test/setup.ts) so this
+// whole-module mock exposes every api/client export; only `callTool` is
+// overridden. Bun's mock.module registry is process-global, so an incomplete
+// stub leaking into another suite's module graph is what crashed bridge tests
+// with "Export named 'getActiveWorkspaceId' not found".
 mock.module("../src/api/client", () => ({
+  ...realClient,
   callTool: (_server: string, _tool: string, args?: Record<string, unknown>) =>
     new Promise((resolve, reject) => {
       calls.push({ resolve, reject, args });


### PR DESCRIPTION
## Problem

PR #297 tried to kill the intermittent `SyntaxError: Export named 'getActiveWorkspaceId' not found in module .../api/client.ts` CI flake by making every whole-module `api/client` mock *complete* — spreading `await import("../api/client")` and overriding only the functions each test stubs.

It didn't hold. The merge commit on `main` (c6e1e78) still failed CI with the same error (plus `ApiClientError`), dropping the web suite from 385 tests to 207. It passed on re-run, confirming the flake is **intermittent, not fixed**.

## Root cause of the residual flake

The defense reads the thing it's defending against:

```ts
const actualClient = await import("../api/client");        // reads the global mock registry
mock.module("../api/client", () => ({ ...actualClient, installConnector }));
```

Bun's `mock.module` registry is process-global. Under CI's file scheduling, `await import("../api/client")` can resolve to an **incomplete** mock that another file registered first, and the spread then propagates that gap. So a registered mock can still be missing exports, and any file that statically imports one (`bridge.ts` → `getActiveWorkspaceId`, `format-error` → `ApiClientError`) crashes at link time. The "a complete mock cannot drop an export" guarantee only holds if nothing ever registers an incomplete one — but the very mechanism meant to guarantee that is what captures the incomplete module.

It reproduces only on CI's runner scheduling (15×/10× clean locally on bun 1.3.14, both before and after), which is why #297's stress runs looked green.

## Fix

Capture the real module **once in the test preload** (`web/test/setup.ts`), before any test file can register a `mock.module` replacement, and freeze it as a plain object:

```ts
import * as realApiClient from "../src/api/client";
export const realClient = { ...realApiClient };
```

Each whole-module mock spreads `realClient` instead of a dynamic import. Because the snapshot is taken before any mock exists and a plain-object copy is immune to later `mock.module` swaps, **every registered mock is complete by construction** — there is no longer any code path that can register an incomplete `api/client`. No `await import` reads the registry.

## Verification

- Web suite: **385 pass / 0 fail**, **10× stable** on bun 1.3.14 (CI version)
- web `tsc`: clean · `biome format` (changed files): clean
- Race elimination is by construction, not by stress luck — the snapshot can't be incomplete because it predates every mock.

## Note / follow-up

The same enumerate-the-stub shape exists for `mcp-bridge-client` mocks (`bridge-tasks`, `bridge-target-origin`). They currently list all three exports so they're complete today, but they'd reintroduce the identical flake if a fourth export is added. Worth migrating to the same preload-snapshot pattern in a follow-up.