### PR TITLE
fix(usage): aggregate org dashboard breakdowns in one scan

### DIFF
--- a/src/conversation/usage-aggregator.ts
+++ b/src/conversation/usage-aggregator.ts
@@ -14,6 +14,7 @@
 import { readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { USAGE_GROUP_BYS, type UsageGroupBy } from "../tools/platform/schemas/usage.ts";
 import { costBreakdown } from "../usage/cost.ts";
 import type { TokenUsage } from "../usage/types.ts";
 
@@ -30,8 +31,6 @@ interface LlmCallRecord {
   usage: TokenUsage;
   llmMs: number;
 }
-
-export type UsageGroupBy = "day" | "conversation" | "model" | "user";
 
 interface TokenBreakdown {
   input: number;
@@ -149,13 +148,14 @@ function isDateInRange(date: string, range: { from: string; to: string }): boole
 }
 
 function isUsageGroupBy(value: string): value is UsageGroupBy {
-  return value === "day" || value === "conversation" || value === "model" || value === "user";
+  return (USAGE_GROUP_BYS as readonly string[]).includes(value);
 }
 
 function normalizeGroupBys(groupBy: string | string[]): UsageGroupBy[] {
   const requested = Array.isArray(groupBy) ? groupBy : [groupBy];
   const valid = requested.filter(isUsageGroupBy);
-  return [...new Set(valid.length > 0 ? valid : ["day"])] as UsageGroupBy[];
+  const fallback: UsageGroupBy[] = ["day"];
+  return [...new Set(valid.length > 0 ? valid : fallback)];
 }
 
 function groupKeyFor(record: LlmCallRecord, groupBy: UsageGroupBy, modelKey: string): string {

--- a/src/conversation/usage-aggregator.ts
+++ b/src/conversation/usage-aggregator.ts
@@ -287,8 +287,8 @@ export interface AggregateUsageOptions {
  * 2. Read line 1 (metadata) for conversation id / owner attribution
  *    (and filter by `ownerId` when `ownerFilter` is set)
  * 3. Scan for llm.response events whose own `ts` date is in range
- * 4. Derive totals, per-model, and breakdown by groupBy key
- *    (`groupBy: "user"` buckets by the conversation owner)
+ * 4. Derive totals, per-model, and breakdowns for the requested groupBy
+ *    dimensions (`groupBy: "user"` buckets by the conversation owner)
  */
 export async function aggregateUsage(
   conversationsDir: string,

--- a/src/conversation/usage-aggregator.ts
+++ b/src/conversation/usage-aggregator.ts
@@ -31,6 +31,8 @@ interface LlmCallRecord {
   llmMs: number;
 }
 
+export type UsageGroupBy = "day" | "conversation" | "model" | "user";
+
 interface TokenBreakdown {
   input: number;
   output: number;
@@ -74,6 +76,14 @@ export interface UsageReport {
   totals: UsageTotals;
   models: ModelUsage[];
   breakdown: BreakdownEntry[];
+  breakdowns: Partial<Record<UsageGroupBy, BreakdownEntry[]>>;
+}
+
+interface BreakdownAccumulator {
+  tokens: TokenBreakdown;
+  cost: CostBreakdown;
+  llmCalls: number;
+  sids: Set<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +148,89 @@ function isDateInRange(date: string, range: { from: string; to: string }): boole
   return date >= range.from && date <= range.to;
 }
 
+function isUsageGroupBy(value: string): value is UsageGroupBy {
+  return value === "day" || value === "conversation" || value === "model" || value === "user";
+}
+
+function normalizeGroupBys(groupBy: string | string[]): UsageGroupBy[] {
+  const requested = Array.isArray(groupBy) ? groupBy : [groupBy];
+  const valid = requested.filter(isUsageGroupBy);
+  return [...new Set(valid.length > 0 ? valid : ["day"])] as UsageGroupBy[];
+}
+
+function groupKeyFor(record: LlmCallRecord, groupBy: UsageGroupBy, modelKey: string): string {
+  switch (groupBy) {
+    case "model":
+      return modelKey;
+    case "conversation":
+      return record.sid ?? "unknown";
+    case "user":
+      return record.ownerId ?? "unknown";
+    case "day":
+      return record.ts.slice(0, 10);
+  }
+}
+
+function getBreakdownAccumulator(
+  map: Map<string, BreakdownAccumulator>,
+  key: string,
+): BreakdownAccumulator {
+  let accumulator = map.get(key);
+  if (!accumulator) {
+    accumulator = {
+      tokens: createTokenBreakdown(),
+      cost: createCostBreakdown(),
+      llmCalls: 0,
+      sids: new Set(),
+    };
+    map.set(key, accumulator);
+  }
+  return accumulator;
+}
+
+function emptyBreakdownEntry(key: string): BreakdownEntry {
+  return {
+    key,
+    tokens: createTokenBreakdown(),
+    cost: createCostBreakdown(),
+    llmCalls: 0,
+    conversations: 0,
+  };
+}
+
+function finalizeBreakdown(
+  map: Map<string, BreakdownAccumulator>,
+  groupBy: UsageGroupBy,
+  period: string,
+  range: { from: string; to: string },
+): BreakdownEntry[] {
+  const breakdown: BreakdownEntry[] = [...map.entries()]
+    .map(([key, data]) => ({
+      key,
+      tokens: data.tokens,
+      cost: data.cost,
+      llmCalls: data.llmCalls,
+      conversations: data.sids.size,
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  // For day grouping over a bounded period, zero-fill missing days so the
+  // chart and table show the full window rather than only days with activity.
+  // Skipped for `all` — the range can span years and noise outweighs signal.
+  if (groupBy !== "day" || period === "all") return breakdown;
+
+  const byKey = new Map(breakdown.map((e) => [e.key, e]));
+  const filled: BreakdownEntry[] = [];
+  const cursor = new Date(`${range.from}T00:00:00Z`);
+  const end = new Date(`${range.to}T00:00:00Z`);
+  while (cursor <= end) {
+    const key = cursor.toISOString().slice(0, 10);
+    filled.push(byKey.get(key) ?? emptyBreakdownEntry(key));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return filled;
+}
+
 export function resolveDateRange(
   period: string,
   from?: string,
@@ -200,11 +293,12 @@ export interface AggregateUsageOptions {
 export async function aggregateUsage(
   conversationsDir: string,
   period: string,
-  groupBy: string,
+  groupBy: string | string[],
   options: AggregateUsageOptions = {},
 ): Promise<UsageReport> {
   const { from, to, ownerFilter } = options;
   const range = resolveDateRange(period, from, to);
+  const groupBys = normalizeGroupBys(groupBy);
 
   // List conversation files
   let filenames: string[];
@@ -284,10 +378,8 @@ export async function aggregateUsage(
   };
   const conversationIds = new Set<string>();
   const modelMap = new Map<string, ModelUsage>();
-  const breakdownMap = new Map<
-    string,
-    { tokens: TokenBreakdown; cost: CostBreakdown; llmCalls: number; sids: Set<string> }
-  >();
+  const breakdownMaps = new Map<UsageGroupBy, Map<string, BreakdownAccumulator>>();
+  for (const dimension of groupBys) breakdownMaps.set(dimension, new Map());
 
   for (const record of records) {
     const { tokens, cost } = decomposeUsage(record);
@@ -312,68 +404,25 @@ export async function aggregateUsage(
     addCost(m.cost, cost);
     m.llmCalls++;
 
-    // Breakdown
-    const key =
-      groupBy === "model"
-        ? modelKey
-        : groupBy === "conversation"
-          ? (record.sid ?? "unknown")
-          : groupBy === "user"
-            ? (record.ownerId ?? "unknown")
-            : record.ts.slice(0, 10);
-
-    if (!breakdownMap.has(key)) {
-      breakdownMap.set(key, {
-        tokens: createTokenBreakdown(),
-        cost: createCostBreakdown(),
-        llmCalls: 0,
-        sids: new Set(),
-      });
+    for (const dimension of groupBys) {
+      const map = breakdownMaps.get(dimension)!;
+      const key = groupKeyFor(record, dimension, modelKey);
+      const b = getBreakdownAccumulator(map, key);
+      addTokens(b.tokens, tokens);
+      addCost(b.cost, cost);
+      b.llmCalls++;
+      if (record.sid) b.sids.add(record.sid);
     }
-    const b = breakdownMap.get(key)!;
-    addTokens(b.tokens, tokens);
-    addCost(b.cost, cost);
-    b.llmCalls++;
-    if (record.sid) b.sids.add(record.sid);
   }
 
   totals.conversations = conversationIds.size;
 
   const models = [...modelMap.values()].sort((a, b) => b.cost.total - a.cost.total);
-
-  const breakdown: BreakdownEntry[] = [...breakdownMap.entries()]
-    .map(([key, data]) => ({
-      key,
-      tokens: data.tokens,
-      cost: data.cost,
-      llmCalls: data.llmCalls,
-      conversations: data.sids.size,
-    }))
-    .sort((a, b) => a.key.localeCompare(b.key));
-
-  // For day grouping over a bounded period, zero-fill missing days so the
-  // chart and table show the full window rather than only days with activity.
-  // Skipped for `all` — the range can span years and noise outweighs signal.
-  if (groupBy === "day" && period !== "all") {
-    const byKey = new Map(breakdown.map((e) => [e.key, e]));
-    const filled: BreakdownEntry[] = [];
-    const cursor = new Date(`${range.from}T00:00:00Z`);
-    const end = new Date(`${range.to}T00:00:00Z`);
-    while (cursor <= end) {
-      const key = cursor.toISOString().slice(0, 10);
-      filled.push(
-        byKey.get(key) ?? {
-          key,
-          tokens: createTokenBreakdown(),
-          cost: createCostBreakdown(),
-          llmCalls: 0,
-          conversations: 0,
-        },
-      );
-      cursor.setUTCDate(cursor.getUTCDate() + 1);
-    }
-    return { period: range, totals, models, breakdown: filled };
+  const breakdowns: Partial<Record<UsageGroupBy, BreakdownEntry[]>> = {};
+  for (const [dimension, map] of breakdownMaps) {
+    breakdowns[dimension] = finalizeBreakdown(map, dimension, period, range);
   }
+  const breakdown = breakdowns[groupBys[0]!] ?? [];
 
-  return { period: range, totals, models, breakdown };
+  return { period: range, totals, models, breakdown, breakdowns };
 }

--- a/src/tools/platform/schemas/usage.ts
+++ b/src/tools/platform/schemas/usage.ts
@@ -1,6 +1,10 @@
 import { type Static, Type } from "@sinclair/typebox";
 import { StringEnum } from "./_shared.ts";
 
+const UsageGroupBy = StringEnum(["day", "conversation", "model", "user"] as const, {
+  description: "Group breakdown. Default: day. `user` buckets by conversation owner (org scope).",
+});
+
 export const UsageReportInput = Type.Object({
   scope: Type.Optional(
     StringEnum(["user", "org"] as const, {
@@ -18,13 +22,19 @@ export const UsageReportInput = Type.Object({
   from: Type.Optional(Type.String({ description: "Start date (YYYY-MM-DD). Overrides period." })),
   to: Type.Optional(Type.String({ description: "End date (YYYY-MM-DD). Default: today." })),
   groupBy: Type.Optional(
-    StringEnum(["day", "conversation", "model", "user"] as const, {
-      description:
-        "Group breakdown. Default: day. `user` buckets by conversation owner (org scope).",
-    }),
+    Type.Union([
+      UsageGroupBy,
+      Type.Array(UsageGroupBy, {
+        minItems: 1,
+        description:
+          'Multiple breakdowns to compute in one aggregation scan, e.g. ["user", "day"].',
+      }),
+    ]),
   ),
 });
 export type UsageReportInput = Static<typeof UsageReportInput>;
+
+export type UsageGroupBy = "day" | "conversation" | "model" | "user";
 
 // ── Output types (§2.1) ────────────────────────────────────────────────
 //
@@ -78,4 +88,5 @@ export interface UsageReportOutput {
   };
   models: UsageModelEntry[];
   breakdown: UsageBreakdownEntry[];
+  breakdowns: Partial<Record<UsageGroupBy, UsageBreakdownEntry[]>>;
 }

--- a/src/tools/platform/schemas/usage.ts
+++ b/src/tools/platform/schemas/usage.ts
@@ -1,7 +1,15 @@
 import { type Static, Type } from "@sinclair/typebox";
 import { StringEnum } from "./_shared.ts";
 
-const UsageGroupBy = StringEnum(["day", "conversation", "model", "user"] as const, {
+/**
+ * Canonical list of usage breakdown dimensions. Single source of truth —
+ * the TypeBox enum, the `UsageGroupBy` type, and the aggregator's runtime
+ * guard (`src/conversation/usage-aggregator.ts`) all derive from this array
+ * so a new dimension is added in exactly one place.
+ */
+export const USAGE_GROUP_BYS = ["day", "conversation", "model", "user"] as const;
+
+const UsageGroupBy = StringEnum(USAGE_GROUP_BYS, {
   description: "Group breakdown. Default: day. `user` buckets by conversation owner (org scope).",
 });
 
@@ -34,7 +42,7 @@ export const UsageReportInput = Type.Object({
 });
 export type UsageReportInput = Static<typeof UsageReportInput>;
 
-export type UsageGroupBy = "day" | "conversation" | "model" | "user";
+export type UsageGroupBy = (typeof USAGE_GROUP_BYS)[number];
 
 // ── Output types (§2.1) ────────────────────────────────────────────────
 //

--- a/src/tools/platform/usage.ts
+++ b/src/tools/platform/usage.ts
@@ -28,12 +28,12 @@ import type { Runtime } from "../../runtime/runtime.ts";
 import { defineInProcessApp, type InProcessTool } from "../in-process-app.ts";
 import type { McpSource } from "../mcp-source.ts";
 import { loadUsageUi } from "../platform-resources/usage/dashboard.ts";
-import { UsageReportInput, type UsageReportOutput } from "./schemas/usage.ts";
+import { type UsageGroupBy, UsageReportInput, type UsageReportOutput } from "./schemas/usage.ts";
 
 interface UsageReportArgs {
   scope?: "user" | "org";
   period?: string;
-  groupBy?: string;
+  groupBy?: UsageGroupBy | UsageGroupBy[];
   from?: string;
   to?: string;
 }

--- a/test/unit/conversation/usage-aggregator.test.ts
+++ b/test/unit/conversation/usage-aggregator.test.ts
@@ -248,6 +248,41 @@ describe("usage-aggregator", () => {
     expect(report.breakdown[2].key).toBe("2026-04-12");
   });
 
+  it("returns multiple breakdown dimensions from one aggregation", async () => {
+    const dir = makeTmpDir();
+    writeFileSync(
+      join(dir, "alice.jsonl"),
+      buildJsonl({ id: "alice", updatedAt: "2026-04-12T10:00:00Z", ownerId: "usr_alice" }, [
+        llmEvent({ ts: "2026-04-10T08:00:00Z", inputTokens: 100, outputTokens: 50 }),
+        llmEvent({ ts: "2026-04-12T10:00:00Z", inputTokens: 200, outputTokens: 100 }),
+      ]),
+    );
+    writeFileSync(
+      join(dir, "bob.jsonl"),
+      buildJsonl({ id: "bob", updatedAt: "2026-04-11T10:00:00Z", ownerId: "usr_bob" }, [
+        llmEvent({ ts: "2026-04-11T10:00:00Z", inputTokens: 400, outputTokens: 200 }),
+      ]),
+    );
+
+    const report = await aggregateUsage(dir, "week", ["user", "day"], {
+      from: "2026-04-10",
+      to: "2026-04-12",
+    });
+
+    expect(report.breakdown).toEqual(report.breakdowns.user);
+    expect(report.breakdowns.user?.map((b) => b.key)).toEqual(["usr_alice", "usr_bob"]);
+    expect(report.breakdowns.day?.map((b) => b.key)).toEqual([
+      "2026-04-10",
+      "2026-04-11",
+      "2026-04-12",
+    ]);
+    expect(report.breakdowns.day?.[0].tokens.input).toBe(100);
+    expect(report.breakdowns.day?.[1].tokens.input).toBe(400);
+    expect(report.breakdowns.day?.[2].tokens.input).toBe(200);
+    expect(report.totals.tokens.input).toBe(700);
+    expect(report.totals.conversations).toBe(2);
+  });
+
   it("aggregator cost.total matches estimateCost for the same inputs (drift guard)", async () => {
     // Regression: pre-fix, decomposeUsage's cost math diverged from
     // estimateCost on models with cost.reasoning. Today no catalog model
@@ -299,7 +334,14 @@ describe("usage-aggregator", () => {
     const report = await aggregateUsage(dir, "all", "day");
 
     // Top-level
-    expect(Object.keys(report).sort()).toEqual(["breakdown", "models", "period", "totals"]);
+    expect(Object.keys(report).sort()).toEqual([
+      "breakdown",
+      "breakdowns",
+      "models",
+      "period",
+      "totals",
+    ]);
+    expect(report.breakdowns.day).toEqual(report.breakdown);
 
     // totals.tokens — exact bucket set; if a rename happens, this fails
     expect(Object.keys(report.totals.tokens).sort()).toEqual([

--- a/test/unit/tools/platform/usage-source.test.ts
+++ b/test/unit/tools/platform/usage-source.test.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { NoopEventSink } from "../../../../src/adapters/noop-events.ts";
 import type { McpSource } from "../../../../src/tools/mcp-source.ts";
+import type { UsageReportOutput } from "../../../../src/tools/platform/schemas/usage.ts";
 import { createUsageSource } from "../../../../src/tools/platform/usage.ts";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
@@ -85,16 +86,9 @@ async function buildSource(): Promise<McpSource> {
   return source;
 }
 
-interface UsageResult {
-  scope: "user" | "org";
-  totals: { tokens: { input: number; output: number }; conversations: number };
-  breakdown: Array<{ key: string }>;
-  breakdowns: Partial<Record<"day" | "conversation" | "model" | "user", Array<{ key: string }>>>;
-}
-
-function parse(result: { content?: Array<{ type: string; text?: string }> }): UsageResult {
+function parse(result: { content?: Array<{ type: string; text?: string }> }): UsageReportOutput {
   const text = result.content?.[0]?.text ?? "{}";
-  return JSON.parse(text) as UsageResult;
+  return JSON.parse(text) as UsageReportOutput;
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────

--- a/test/unit/tools/platform/usage-source.test.ts
+++ b/test/unit/tools/platform/usage-source.test.ts
@@ -89,6 +89,7 @@ interface UsageResult {
   scope: "user" | "org";
   totals: { tokens: { input: number; output: number }; conversations: number };
   breakdown: Array<{ key: string }>;
+  breakdowns: Partial<Record<"day" | "conversation" | "model" | "user", Array<{ key: string }>>>;
 }
 
 function parse(result: { content?: Array<{ type: string; text?: string }> }): UsageResult {
@@ -162,6 +163,27 @@ describe("usage source — scope: org", () => {
     expect(data.totals.tokens.input).toBe(500);
     expect(data.totals.conversations).toBe(2);
     expect(data.breakdown.map((b) => b.key).sort()).toEqual(["usr_alice", "usr_bob"]);
+  });
+
+  test("org admin can request user and day breakdowns in one report", async () => {
+    const src = await buildSource();
+    runtime.hasIdentityProvider = true;
+    runtime.identity = { id: "usr_admin", orgRole: "admin" };
+
+    const client = src.getClient()!;
+    const result = await client.callTool({
+      name: "report",
+      arguments: { scope: "org", period: "all", groupBy: ["user", "day"] },
+    });
+    expect(result.isError).toBeFalsy();
+
+    const data = parse(result as { content?: Array<{ type: string; text?: string }> });
+    expect(data.scope).toBe("org");
+    expect(data.breakdown.map((b) => b.key).sort()).toEqual(["usr_alice", "usr_bob"]);
+    expect(data.breakdowns.user?.map((b) => b.key).sort()).toEqual(["usr_alice", "usr_bob"]);
+    expect(data.breakdowns.day?.map((b) => b.key)).toEqual(["2026-04-10"]);
+    expect(data.totals.tokens.input).toBe(500);
+    expect(data.totals.conversations).toBe(2);
   });
 
   test("member is denied org scope", async () => {

--- a/web/src/_generated/platform-schemas/catalog.d.ts
+++ b/web/src/_generated/platform-schemas/catalog.d.ts
@@ -119,7 +119,7 @@ export declare const PlatformToolCatalog: {
                 period: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"day" | "week" | "month" | "all">>;
                 from: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
                 to: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
-                groupBy: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"model" | "user" | "day" | "conversation">>;
+                groupBy: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnion<[import("@sinclair/typebox").TUnsafe<"model" | "user" | "day" | "conversation">, import("@sinclair/typebox").TArray<import("@sinclair/typebox").TUnsafe<"model" | "user" | "day" | "conversation">>]>>;
             }>;
         };
     };

--- a/web/src/_generated/platform-schemas/usage.d.ts
+++ b/web/src/_generated/platform-schemas/usage.d.ts
@@ -3,6 +3,13 @@
  * Regenerate: bun run codegen. AI agents: edit the source, not this file.
  */
 import { type Static } from "@sinclair/typebox";
+/**
+ * Canonical list of usage breakdown dimensions. Single source of truth —
+ * the TypeBox enum, the `UsageGroupBy` type, and the aggregator's runtime
+ * guard (`src/conversation/usage-aggregator.ts`) all derive from this array
+ * so a new dimension is added in exactly one place.
+ */
+export declare const USAGE_GROUP_BYS: readonly ["day", "conversation", "model", "user"];
 export declare const UsageReportInput: import("@sinclair/typebox").TObject<{
     scope: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"user" | "org">>;
     period: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"day" | "week" | "month" | "all">>;
@@ -11,7 +18,7 @@ export declare const UsageReportInput: import("@sinclair/typebox").TObject<{
     groupBy: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnion<[import("@sinclair/typebox").TUnsafe<"model" | "user" | "day" | "conversation">, import("@sinclair/typebox").TArray<import("@sinclair/typebox").TUnsafe<"model" | "user" | "day" | "conversation">>]>>;
 }>;
 export type UsageReportInput = Static<typeof UsageReportInput>;
-export type UsageGroupBy = "day" | "conversation" | "model" | "user";
+export type UsageGroupBy = (typeof USAGE_GROUP_BYS)[number];
 export interface UsageTokenBreakdown {
     input: number;
     output: number;

--- a/web/src/_generated/platform-schemas/usage.d.ts
+++ b/web/src/_generated/platform-schemas/usage.d.ts
@@ -8,9 +8,10 @@ export declare const UsageReportInput: import("@sinclair/typebox").TObject<{
     period: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"day" | "week" | "month" | "all">>;
     from: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
     to: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
-    groupBy: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"model" | "user" | "day" | "conversation">>;
+    groupBy: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnion<[import("@sinclair/typebox").TUnsafe<"model" | "user" | "day" | "conversation">, import("@sinclair/typebox").TArray<import("@sinclair/typebox").TUnsafe<"model" | "user" | "day" | "conversation">>]>>;
 }>;
 export type UsageReportInput = Static<typeof UsageReportInput>;
+export type UsageGroupBy = "day" | "conversation" | "model" | "user";
 export interface UsageTokenBreakdown {
     input: number;
     output: number;
@@ -53,4 +54,5 @@ export interface UsageReportOutput {
     };
     models: UsageModelEntry[];
     breakdown: UsageBreakdownEntry[];
+    breakdowns: Partial<Record<UsageGroupBy, UsageBreakdownEntry[]>>;
 }

--- a/web/src/pages/settings/OrgUsageTab.tsx
+++ b/web/src/pages/settings/OrgUsageTab.tsx
@@ -30,10 +30,8 @@ import {
 // personal workspace, not a focused one. So usage moved off workspace
 // settings to the org/audit surface, aggregated BY USER.
 //
-// Two reads per period: one `groupBy: "user"` for the per-user table and
-// totals, one `groupBy: "day"` for the cost-over-time chart. `groupBy` is a
-// single dimension per aggregation call, so the chart and table take
-// separate calls rather than one over-loaded response.
+// One usage read per period asks the backend to bucket the same scan by user
+// and by day. The roster resolves ownerId → name/email for the table.
 
 interface UserRow {
   id: string;
@@ -54,8 +52,7 @@ function resolveUser(
 
 export function OrgUsageTab() {
   const [period, setPeriod] = useState<Period>("month");
-  const [byUser, setByUser] = useState<UsageReport | null>(null);
-  const [byDay, setByDay] = useState<UsageReport | null>(null);
+  const [report, setReport] = useState<UsageReport | null>(null);
   const [users, setUsers] = useState<Map<string, UserRow>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -64,17 +61,12 @@ export function OrgUsageTab() {
     setLoading(true);
     setError(null);
     try {
-      // Run the two usage reads + the user roster in parallel. The roster
-      // resolves ownerId → name/email for the table (best-effort; unknown
-      // owners fall back to the raw id).
-      const [userRes, dayRes, usersRes] = await Promise.all([
-        callTool("usage", "report", { scope: "org", period: p, groupBy: "user" }),
-        callTool("usage", "report", { scope: "org", period: p, groupBy: "day" }),
+      const [usageRes, usersRes] = await Promise.all([
+        callTool("usage", "report", { scope: "org", period: p, groupBy: ["user", "day"] }),
         callTool("nb", "manage_users", { action: "list" }).catch(() => null),
       ]);
 
-      setByUser(parseToolResult<UsageReport>(userRes));
-      setByDay(parseToolResult<UsageReport>(dayRes));
+      setReport(parseToolResult<UsageReport>(usageRes));
 
       if (usersRes) {
         const data = parseToolResult<{ users: UserRow[] }>(usersRes);
@@ -85,8 +77,7 @@ export function OrgUsageTab() {
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to load usage data.";
       setError(msg);
-      setByUser(null);
-      setByDay(null);
+      setReport(null);
     } finally {
       setLoading(false);
     }
@@ -121,33 +112,27 @@ export function OrgUsageTab() {
       loadingMessage="Loading usage data..."
       loadError={error}
     >
-      {byUser && byDay ? <OrgUsageBody byUser={byUser} byDay={byDay} users={users} /> : null}
+      {report ? <OrgUsageBody report={report} users={users} /> : null}
     </SettingsDashboardPage>
   );
 }
 
-function OrgUsageBody({
-  byUser,
-  byDay,
-  users,
-}: {
-  byUser: UsageReport;
-  byDay: UsageReport;
-  users: Map<string, UserRow>;
-}) {
-  const hasActivity = byUser.totals.llmCalls > 0;
+function OrgUsageBody({ report, users }: { report: UsageReport; users: Map<string, UserRow> }) {
+  const hasActivity = report.totals.llmCalls > 0;
+  const userBreakdown = report.breakdowns.user ?? [];
+  const dayBreakdown = report.breakdowns.day ?? [];
 
   // Per-user rows sorted by cost descending — the audit question is
   // "who is spending the most."
-  const userRows = [...byUser.breakdown].sort((a, b) => b.cost.total - a.cost.total);
+  const userRows = [...userBreakdown].sort((a, b) => b.cost.total - a.cost.total);
 
   return (
     <div className="space-y-6">
-      <UsageTotalsCards totals={byUser.totals} />
+      <UsageTotalsCards totals={report.totals} />
 
       {hasActivity ? (
         <Section title="Daily Cost" flush>
-          <CostChart data={byDay.breakdown} />
+          <CostChart data={dayBreakdown} />
         </Section>
       ) : null}
 
@@ -188,7 +173,7 @@ function OrgUsageBody({
         )}
       </Section>
 
-      {byUser.models && byUser.models.length > 0 ? (
+      {report.models && report.models.length > 0 ? (
         <Section title="By Model">
           <Table>
             <TableHeader>
@@ -200,7 +185,7 @@ function OrgUsageBody({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {byUser.models.map((m) => (
+              {report.models.map((m) => (
                 <TableRow key={m.model}>
                   <TableCell className="font-mono text-xs">{shortModel(m.model)}</TableCell>
                   <TableCell className="text-right">


### PR DESCRIPTION
## Summary

- Addresses issue #286
- Extend `aggregateUsage()` so one usage report can compute multiple breakdown dimensions, including `user` and `day`, from a single conversation scan.
- Add `breakdowns` to the usage report contract while preserving the existing `breakdown` field for single-dimension/backward-compatible callers.
- Update Organization > Usage to make one `usage__report` call for both the user table and daily cost chart.
## Verification
- `bun test test/unit/conversation/usage-aggregator.test.ts`
- `bun test test/unit/tools/platform/usage-source.test.ts`
- `bun run check`
- `bun run format:check`
- `bun run lint`
- `bun run verify`