### PR TITLE
fix(connectors): redirect post-OAuth to the workspace-scoped connectors page

### DIFF
--- a/src/api/routes/composio-auth.ts
+++ b/src/api/routes/composio-auth.ts
@@ -10,7 +10,6 @@ import { log } from "../../cli/log.ts";
 import {
   COMPOSIO_CALLBACK_PATH,
   composioCallbackUrl,
-  composioSuccessRedirectUrl,
   composioUserId,
   findActiveComposioConnection,
   initiateComposioConnection,
@@ -19,6 +18,7 @@ import {
 import { requireAuth } from "../middleware/auth.ts";
 import { requireWorkspace } from "../middleware/workspace.ts";
 import { type AppContext, type AppEnv, apiError } from "../types.ts";
+import { workspaceConnectorsUrl } from "./connectors-redirect.ts";
 
 /**
  * OAuth integration routes for connectors backed by Composio as a
@@ -235,7 +235,7 @@ export function composioAuthRoutes(ctx: AppContext) {
             "running",
           );
           return c.json({
-            authorizationUrl: composioSuccessRedirectUrl(c.req.url),
+            authorizationUrl: workspaceConnectorsUrl(wsId, c.req.url),
             alreadyConnected: true,
           });
         }
@@ -404,23 +404,7 @@ export function composioAuthRoutes(ctx: AppContext) {
     if (!ctx.isLocalhost) expireParts.push("Secure");
     c.header("Set-Cookie", expireParts.join("; "));
 
-    const fallbackOrigin = (() => {
-      try {
-        return new URL(c.req.url).origin;
-      } catch {
-        return "";
-      }
-    })();
-    const webBase = process.env.NB_WEB_URL ?? process.env.NB_API_URL ?? fallbackOrigin;
-    let returnUrl = `${webBase.replace(/\/+$/, "")}/settings/workspace/connectors`;
-    try {
-      const parsed = new URL(returnUrl);
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-        returnUrl = "/settings/workspace/connectors";
-      }
-    } catch {
-      returnUrl = "/settings/workspace/connectors";
-    }
+    const returnUrl = workspaceConnectorsUrl(wsId, c.req.url);
     const safeReturnUrl = escapeHtml(returnUrl);
     c.header("Content-Security-Policy", SUCCESS_PAGE_CSP);
     return c.html(

--- a/src/api/routes/connectors-redirect.ts
+++ b/src/api/routes/connectors-redirect.ts
@@ -1,0 +1,51 @@
+/**
+ * Post-OAuth return URL for the connectors UI.
+ *
+ * Connectors are workspace-scoped: the page lives at
+ * `/w/<slug>/settings/connectors`, where the slug is the workspace id with
+ * its `ws_` prefix stripped (see `web/src/lib/workspace-slug.ts` — the slug
+ * is an opaque, name-independent token, not a name derivation). Every OAuth
+ * callback that brings the user back to NimbleBrain — mcp-auth, composio-auth,
+ * and the composio "reuse existing connection" short-circuit — routes through
+ * here so the three paths can't drift back onto a stale, unscoped URL.
+ *
+ * Resolution order for the absolute base:
+ *   1. NB_WEB_URL  (operator config — the platform's user-facing origin)
+ *   2. NB_API_URL  (single-origin deployments share the API + SPA host)
+ *   3. the request origin (last resort: the callback hit us here)
+ */
+export function workspaceConnectorsUrl(wsId: string, requestUrl: string): string {
+  // Slug is the workspace id minus the `ws_` prefix — mirrors the SPA's
+  // `toSlug`. Workspace ids are opaque, so this is a pure prefix strip, not
+  // a name derivation.
+  const slug = wsId.replace(/^ws_/, "");
+  const path = `/w/${slug}/settings/connectors`;
+
+  const fallbackOrigin = (() => {
+    try {
+      return new URL(requestUrl).origin;
+    } catch {
+      return "";
+    }
+  })();
+  const webBase = (process.env.NB_WEB_URL ?? process.env.NB_API_URL ?? fallbackOrigin).replace(
+    /\/+$/,
+    "",
+  );
+  const absolute = `${webBase}${path}`;
+
+  // Defense-in-depth: NB_WEB_URL / NB_API_URL are operator-controlled, but a
+  // malformed value with a `javascript:` / `data:` scheme would survive
+  // escapeHtml (which only escapes &<>"') and execute when the meta-refresh
+  // fires. Validate the protocol; fall back to a same-origin relative path
+  // (which also covers the no-base case, where `absolute` is already relative).
+  try {
+    const parsed = new URL(absolute);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return path;
+    }
+  } catch {
+    return path;
+  }
+  return absolute;
+}

--- a/src/api/routes/mcp-auth.ts
+++ b/src/api/routes/mcp-auth.ts
@@ -9,10 +9,11 @@ import {
   signEnvelope,
   verifyEnvelopeAsTenant,
 } from "../../oauth/envelope.ts";
-import { resolveWithCode } from "../../tools/oauth-flow-registry.ts";
+import { peekWorkspaceId, resolveWithCode } from "../../tools/oauth-flow-registry.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import { requireWorkspace } from "../middleware/workspace.ts";
 import { type AppContext, type AppEnv, apiError } from "../types.ts";
+import { workspaceConnectorsUrl } from "./connectors-redirect.ts";
 
 /**
  * Inline CSS for the OAuth success page. Held in a module constant so the
@@ -321,6 +322,11 @@ export function mcpAuthRoutes(ctx: AppContext) {
       );
     }
 
+    // Recover the workspace the flow was initiated in *before* resolving
+    // (which deletes the registry entry), so we can land the user back on
+    // the right `/w/<slug>/settings/connectors` page. Synchronous + single-
+    // process, so the peek can't race the resolve below.
+    const flowWsId = peekWorkspaceId(state);
     if (!resolveWithCode(state, code)) {
       return c.html(
         "<html><body><h3>Unknown or expired OAuth flow.</h3>" +
@@ -345,41 +351,14 @@ export function mcpAuthRoutes(ctx: AppContext) {
     if (!ctx.isLocalhost) expireParts.push("Secure");
     c.header("Set-Cookie", expireParts.join("; "));
 
-    // Auto-redirect back to the Connectors page (Personal or Workspace
-    // depending on the bundle's scope). The user came from NimbleBrain
-    // and was navigated away to the OAuth provider in their existing
-    // tab — telling them to "close this tab" is wrong because they'd
-    // lose NimbleBrain entirely. We bring them home.
-    //
-    // Resolution order for the return URL:
-    //   1. NB_WEB_URL env (operator config — production should set this
-    //      to the platform's user-facing origin)
-    //   2. NB_API_URL env (in single-origin deployments the API and
-    //      SPA share a host)
-    //   3. The request origin (last-resort: callback hit us at ${origin},
-    //      so the SPA is *probably* on the same origin)
-    const fallbackOrigin = (() => {
-      try {
-        return new URL(c.req.url).origin;
-      } catch {
-        return "";
-      }
-    })();
-    const webBase = process.env.NB_WEB_URL ?? process.env.NB_API_URL ?? fallbackOrigin;
-    let returnUrl = `${webBase.replace(/\/+$/, "")}/settings/workspace/connectors`;
-    // Defense-in-depth: NB_WEB_URL / NB_API_URL are operator-controlled,
-    // but a malformed value with a `javascript:` / `data:` scheme would
-    // survive escapeHtml (which only escapes `&<>"'`) and execute when
-    // the meta-refresh fires. Validate the protocol; fall back to a
-    // same-origin relative path if anything looks off.
-    try {
-      const parsed = new URL(returnUrl);
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-        returnUrl = "/settings/workspace/connectors";
-      }
-    } catch {
-      returnUrl = "/settings/workspace/connectors";
-    }
+    // Auto-redirect back to the workspace Connectors page. The user came
+    // from NimbleBrain and was navigated away to the OAuth provider in
+    // their existing tab — telling them to "close this tab" is wrong
+    // because they'd lose NimbleBrain entirely. We bring them home, to the
+    // same `/w/<slug>` workspace the flow was initiated in. `flowWsId` is
+    // non-null here (resolveWithCode succeeded just above ⟹ the flow
+    // existed when we peeked it).
+    const returnUrl = workspaceConnectorsUrl(flowWsId ?? "", c.req.url);
     const safeReturnUrl = escapeHtml(returnUrl);
     // Override the platform-default CSP (`default-src 'none'`) for this
     // response only. Without this the inline <style> below is blocked and

--- a/src/composio/sdk.ts
+++ b/src/composio/sdk.ts
@@ -175,34 +175,6 @@ export function composioCallbackUrl(): string {
   return `${apiBase.replace(/\/+$/, "")}/v1/composio-auth/callback`;
 }
 
-/**
- * Build the post-success redirect URL the SPA navigates to after a
- * "reuse existing connection" short-circuit. Same target the
- * `/v1/composio-auth/callback` page meta-refreshes to; centralized so
- * the two paths can't drift. Resolution order: `NB_WEB_URL` →
- * `NB_API_URL` → request origin → same-origin relative path.
- */
-export function composioSuccessRedirectUrl(requestUrl: string): string {
-  const fallbackOrigin = (() => {
-    try {
-      return new URL(requestUrl).origin;
-    } catch {
-      return "";
-    }
-  })();
-  const webBase = process.env.NB_WEB_URL ?? process.env.NB_API_URL ?? fallbackOrigin;
-  const url = `${webBase.replace(/\/+$/, "")}/settings/workspace/connectors`;
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return "/settings/workspace/connectors";
-    }
-  } catch {
-    return "/settings/workspace/connectors";
-  }
-  return url;
-}
-
 // ── SDK call wrappers ───────────────────────────────────────────────
 
 /**

--- a/src/tools/oauth-flow-registry.ts
+++ b/src/tools/oauth-flow-registry.ts
@@ -72,6 +72,18 @@ export function register(
   return promise;
 }
 
+/**
+ * Read the workspace id a pending flow was registered under, without
+ * resolving or removing it. The `/v1/mcp-auth/callback` route peeks this to
+ * build the workspace-scoped return URL (`/w/<slug>/settings/connectors`)
+ * before calling `resolveWithCode` (which deletes the flow). Single-process
+ * and synchronous, so peek-then-resolve has no TOCTOU. Returns null when no
+ * flow is registered for `state`.
+ */
+export function peekWorkspaceId(state: string): string | null {
+  return flows.get(state)?.wsId ?? null;
+}
+
 /** Resolve a pending flow by state. Returns true if found. */
 export function resolveWithCode(state: string, code: string): boolean {
   const flow = flows.get(state);

--- a/test/unit/api/connectors-redirect.test.ts
+++ b/test/unit/api/connectors-redirect.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { workspaceConnectorsUrl } from "../../../src/api/routes/connectors-redirect.ts";
+
+describe("workspaceConnectorsUrl", () => {
+  const savedWeb = process.env.NB_WEB_URL;
+  const savedApi = process.env.NB_API_URL;
+
+  beforeEach(() => {
+    delete process.env.NB_WEB_URL;
+    delete process.env.NB_API_URL;
+  });
+
+  afterEach(() => {
+    if (savedWeb === undefined) delete process.env.NB_WEB_URL;
+    else process.env.NB_WEB_URL = savedWeb;
+    if (savedApi === undefined) delete process.env.NB_API_URL;
+    else process.env.NB_API_URL = savedApi;
+  });
+
+  it("builds the workspace-scoped connectors path, stripping the ws_ prefix", () => {
+    // The whole point of this fix: connectors live at
+    // `/w/<slug>/settings/connectors`, NOT the pre-scoping
+    // `/settings/workspace/connectors`. Slug = wsId minus `ws_`.
+    process.env.NB_WEB_URL = "https://app.example.com";
+    expect(workspaceConnectorsUrl("ws_acme", "http://ignored/")).toBe(
+      "https://app.example.com/w/acme/settings/connectors",
+    );
+  });
+
+  it("prefers NB_WEB_URL over NB_API_URL over the request origin", () => {
+    process.env.NB_API_URL = "https://api.example.com";
+    // No NB_WEB_URL → falls through to NB_API_URL.
+    expect(workspaceConnectorsUrl("ws_x", "http://origin.test/cb")).toBe(
+      "https://api.example.com/w/x/settings/connectors",
+    );
+    process.env.NB_WEB_URL = "https://web.example.com";
+    expect(workspaceConnectorsUrl("ws_x", "http://origin.test/cb")).toBe(
+      "https://web.example.com/w/x/settings/connectors",
+    );
+  });
+
+  it("falls back to the request origin when no env base is set", () => {
+    expect(workspaceConnectorsUrl("ws_x", "http://localhost:27247/v1/mcp-auth/callback")).toBe(
+      "http://localhost:27247/w/x/settings/connectors",
+    );
+  });
+
+  it("trims a trailing slash on the base so the path isn't doubled", () => {
+    process.env.NB_WEB_URL = "https://app.example.com/";
+    expect(workspaceConnectorsUrl("ws_x", "http://ignored/")).toBe(
+      "https://app.example.com/w/x/settings/connectors",
+    );
+  });
+
+  it("returns a same-origin relative path when the base has a non-http(s) scheme", () => {
+    // Defense-in-depth: a tampered NB_WEB_URL with a javascript:/data: scheme
+    // must never survive into the meta-refresh. Degrade to a relative path.
+    process.env.NB_WEB_URL = "javascript:alert(1)";
+    expect(workspaceConnectorsUrl("ws_acme", "http://ignored/")).toBe(
+      "/w/acme/settings/connectors",
+    );
+  });
+
+  it("returns a relative path when there is no resolvable base at all", () => {
+    // No env, unparseable request URL → no origin. The absolute string is
+    // already relative, so URL parsing throws and we return the path.
+    expect(workspaceConnectorsUrl("ws_acme", "not a url")).toBe("/w/acme/settings/connectors");
+  });
+});

--- a/test/unit/api/mcp-auth-routes.test.ts
+++ b/test/unit/api/mcp-auth-routes.test.ts
@@ -217,6 +217,13 @@ describe("GET /v1/mcp-auth/callback", () => {
     const html = await res.text();
     expect(html).toContain("Authorization complete");
 
+    // Redirect back to the workspace-scoped connectors page for the
+    // workspace the flow was initiated in (WS_ID = "ws_test" → slug
+    // "test"). The pre-scoping `/settings/workspace/connectors` path is
+    // gone — landing there 404s now that connectors live under `/w/<slug>`.
+    expect(html).toContain("/w/test/settings/connectors");
+    expect(html).not.toContain("/settings/workspace/connectors");
+
     // Cookie cleared: Max-Age=0
     const setCookie = res.headers.get("Set-Cookie");
     expect(setCookie).not.toBeNull();

--- a/test/unit/composio-auth.test.ts
+++ b/test/unit/composio-auth.test.ts
@@ -286,6 +286,13 @@ describe("GET /v1/composio-auth/callback", () => {
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type") ?? "").toContain("text/html");
 
+      // Redirect back to the workspace-scoped connectors page for the
+      // workspace the connection landed in (ws_test → slug "test"), not the
+      // pre-scoping `/settings/workspace/connectors` (which 404s now).
+      const html = await res.text();
+      expect(html).toContain("/w/test/settings/connectors");
+      expect(html).not.toContain("/settings/workspace/connectors");
+
       const stored = await readComposioConnection(dir, wsId, cid);
       expect(stored).not.toBeNull();
       expect(stored?.connectedAccountId).toBe("ca_xyz");

--- a/test/unit/oauth-flow-registry.test.ts
+++ b/test/unit/oauth-flow-registry.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import {
   _clearAll,
+  peekWorkspaceId,
   register,
   rejectFlow,
   resolveWithCode,
@@ -19,6 +20,23 @@ describe("oauth-flow-registry", () => {
 
   it("returns false for unknown state on resolve", () => {
     expect(resolveWithCode("unknown-state", "code")).toBe(false);
+  });
+
+  it("peekWorkspaceId reads the flow's wsId without resolving it", async () => {
+    // The callback peeks the workspace to build the `/w/<slug>` return URL
+    // before it resolves (which deletes the flow). Peek must be read-only:
+    // the subsequent resolve still finds the flow.
+    const p = register("state-peek", "ws_acme", "srv");
+    expect(peekWorkspaceId("state-peek")).toBe("ws_acme");
+    // Still resolvable — peek didn't consume the flow.
+    expect(resolveWithCode("state-peek", "code")).toBe(true);
+    await expect(p).resolves.toBe("code");
+    // Gone after resolve.
+    expect(peekWorkspaceId("state-peek")).toBeNull();
+  });
+
+  it("peekWorkspaceId returns null for an unknown state", () => {
+    expect(peekWorkspaceId("never-registered")).toBeNull();
   });
 
   it("rejects a registered flow with the provided error", async () => {


### PR DESCRIPTION
## Problem

After authorizing an MCP connector (and Composio connectors), the OAuth success page redirects to `http://<host>/settings/workspace/connectors` — the **pre-workspace-scoping** path. Now that connectors live under `/w/<slug>/settings/connectors` (per #303), that landing 404s. Reported in production: "after we auth with an mcp connector, we get redirected to `/settings/workspace/connectors`, which is incorrect now that we are workspace scoped."

## Root cause

Three backend return-URL sites hardcoded the stale path:

- `src/api/routes/mcp-auth.ts` — the `/v1/mcp-auth/callback` success page
- `src/api/routes/composio-auth.ts` — the `/v1/composio-auth/callback` success page **and** the "reuse existing connection" short-circuit
- `src/composio/sdk.ts` — `composioSuccessRedirectUrl`

The URL-building logic (NB_WEB_URL → NB_API_URL → request origin, plus `javascript:`/`data:` protocol guard) was **triplicated** — despite a comment in `sdk.ts` claiming it was "centralized so the two paths can't drift." And the redirect path had **zero test coverage**.

## Fix

- New `workspaceConnectorsUrl(wsId, requestUrl)` helper builds `/w/<slug>/settings/connectors`, where `slug = wsId` minus the `ws_` prefix (mirrors the SPA's `toSlug` — an opaque token, not a name derivation). Keeps the same base-resolution order and protocol-guard/relative-fallback as before.
- All three sites call it. The composio sites already had `wsId` in scope. The mcp-auth callback recovers it via a new read-only `peekWorkspaceId(state)` on the flow registry, peeked **before** `resolveWithCode` deletes the entry (single-process + synchronous → no TOCTOU). `resolveWithCode`'s boolean contract is unchanged (it's asserted in three test files).
- Deletes the now-dead `composioSuccessRedirectUrl` and both duplicated URL blocks.

Net: src-side removes ~50 lines of duplicated logic for one 51-line helper + a 12-line accessor.

## Tests

- New `test/unit/api/connectors-redirect.test.ts`: workspace-scoped path + `ws_` strip, base precedence, trailing-slash trim, non-http(s) scheme → relative fallback, no-base → relative.
- `oauth-flow-registry.test.ts`: `peekWorkspaceId` is read-only (flow still resolvable after peek) and returns null for unknown state.
- Extended the mcp-auth **and** composio callback success tests to assert the HTML redirects to `/w/test/settings/connectors` and **not** `/settings/workspace/connectors`.
- `bun test test/unit/` → 0 fail; related integration tests pass; `tsc --noEmit` and `biome check src/` clean.

## Out of scope (noted, not fixed)

`mcp-auth.ts` and `composio-auth.ts` still each carry their own copy of `escapeHtml`, `SUCCESS_PAGE_STYLE`, and the success-page HTML. Consolidating those is a separate cleanup.