### PR TITLE
Fix Files app: render thumbnails, center modal, enable download

### DIFF
--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -98,6 +98,7 @@ import {
 } from "../orchestrator/index.ts";
 import { type RequestContext, runWithRequestContext } from "../runtime/request-context.ts";
 import type { Runtime } from "../runtime/runtime.ts";
+import { IDENTITY_SOURCES } from "../tools/identity-sources.ts";
 import { McpSource } from "../tools/mcp-source.ts";
 import type { ToolRegistry } from "../tools/registry.ts";
 import {
@@ -982,6 +983,34 @@ function createServer(
     const uri = request.params.uri;
     if (!runtime || !identityId) {
       throw new McpError(RESOURCE_NOT_FOUND_CODE, `Resource not found: ${uri}`, { uri });
+    }
+
+    // Identity sources (files, conversations, automations) are owned by the
+    // user and live OUTSIDE every workspace registry, so the workspace sweep
+    // below can't see them — `files://<id>` would never resolve. Try them
+    // first, within the identity request context so the source reads the
+    // caller's own data (the files source resolves its store via
+    // `getCurrentIdentity()`, mirroring the identity-door tools/call path).
+    const identityReqCtx: RequestContext = {
+      identity: sessionCtx.identity ?? null,
+      scope: { kind: "identity" },
+    };
+    for (const sourceName of IDENTITY_SOURCES) {
+      const src = runtime.getIdentitySource(sourceName);
+      if (!(src instanceof McpSource)) continue;
+      const client = src.getClient();
+      if (!client) continue;
+      try {
+        const result = await runWithRequestContext(identityReqCtx, () =>
+          client.readResource({ uri }),
+        );
+        if (result.contents && result.contents.length > 0) {
+          return result;
+        }
+      } catch {
+        // Not this source, or not found here — fall through to the next
+        // identity source and ultimately the workspace sweep.
+      }
     }
 
     const wsStore = runtime.getWorkspaceStore();

--- a/src/bundles/files/ui/src/DetailOverlay.tsx
+++ b/src/bundles/files/ui/src/DetailOverlay.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from "react";
-import { formatSize, isImage } from "./format";
-import { FileTypeIcon } from "./icons";
+import { useEffect, useRef, useState } from "react";
+import { fileExtension, formatSize, isImage } from "./format";
+import { DownloadIcon, FileTypeIcon } from "./icons";
 import type { FileEntry } from "./types";
+import { useFileDownload, useFileObjectUrl } from "./useFileObjectUrl";
 
 interface Props {
   file: FileEntry;
@@ -23,6 +24,9 @@ interface Props {
  */
 export function DetailOverlay({ file, deleting, onClose, onDelete }: Props) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const download = useFileDownload();
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState(false);
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -32,6 +36,19 @@ export function DetailOverlay({ file, deleting, onClose, onDelete }: Props) {
       if (dialog.open) dialog.close();
     };
   }, []);
+
+  async function handleDownload() {
+    if (downloading) return;
+    setDownloading(true);
+    setDownloadError(false);
+    try {
+      await download(file);
+    } catch {
+      setDownloadError(true);
+    } finally {
+      setDownloading(false);
+    }
+  }
 
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: <dialog> handles Esc natively via onClose; the click handler is purely a backdrop-dismiss affordance.
@@ -54,11 +71,7 @@ export function DetailOverlay({ file, deleting, onClose, onDelete }: Props) {
         </div>
 
         <div className="detail-preview">
-          {isImage(file.mimeType) ? (
-            <img src={`/v1/files/${file.id}`} alt={file.filename} />
-          ) : (
-            <FileTypeIcon mimeType={file.mimeType} size={56} />
-          )}
+          <DetailPreview file={file} />
         </div>
 
         <div className="detail-fields">
@@ -85,13 +98,48 @@ export function DetailOverlay({ file, deleting, onClose, onDelete }: Props) {
           )}
         </div>
 
+        {downloadError && <div className="detail-error">Couldn’t download this file.</div>}
+
         <div className="detail-actions">
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={downloading}
+            onClick={handleDownload}
+          >
+            <DownloadIcon size={14} />
+            {downloading ? "Downloading…" : "Download"}
+          </button>
           <button type="button" className="btn-danger" disabled={deleting} onClick={onDelete}>
             {deleting ? "Deleting…" : "Delete File"}
           </button>
         </div>
       </div>
     </dialog>
+  );
+}
+
+/**
+ * Full-size preview. Images load through the bridge (same `files://`
+ * resource path as the grid thumbnails); non-images — and images that
+ * fail to load — show the type icon with the extension caption.
+ */
+function DetailPreview({ file }: { file: FileEntry }) {
+  const image = isImage(file.mimeType);
+  const { url, state } = useFileObjectUrl(file.id, file.mimeType, image);
+
+  if (image && url !== null && state === "loaded") {
+    return <img src={url} alt={file.filename} />;
+  }
+  if (image && state !== "error") {
+    return <div className="detail-shimmer" />;
+  }
+  const ext = fileExtension(file.filename);
+  return (
+    <>
+      <FileTypeIcon mimeType={file.mimeType} size={56} />
+      {ext && <span className="detail-preview-ext">{ext}</span>}
+    </>
   );
 }
 

--- a/src/bundles/files/ui/src/FileGrid.tsx
+++ b/src/bundles/files/ui/src/FileGrid.tsx
@@ -1,5 +1,6 @@
-import { formatSize, isImage, relativeTime } from "./format";
-import { FileTypeIcon, FolderIcon } from "./icons";
+import { FileThumb } from "./FileThumb";
+import { formatSize, relativeTime } from "./format";
+import { FolderIcon } from "./icons";
 import type { FileEntry } from "./types";
 
 const SKELETON_KEYS = ["s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"] as const;
@@ -53,13 +54,7 @@ export function FileGrid({ loading, files, searchQuery, hasFilter, onSelect }: P
     <div className="file-grid">
       {files.map((f) => (
         <button type="button" key={f.id} className="file-card" onClick={() => onSelect(f)}>
-          <div className="file-thumb">
-            {isImage(f.mimeType) ? (
-              <img src={`/v1/files/${f.id}`} alt={f.filename} loading="lazy" />
-            ) : (
-              <FileTypeIcon mimeType={f.mimeType} />
-            )}
-          </div>
+          <FileThumb file={f} />
           <div className="file-info">
             <div className="file-name" title={f.filename}>
               {f.filename}

--- a/src/bundles/files/ui/src/FileThumb.tsx
+++ b/src/bundles/files/ui/src/FileThumb.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+import { fileExtension, isImage } from "./format";
+import { FileTypeIcon } from "./icons";
+import type { FileEntry } from "./types";
+import { useFileObjectUrl } from "./useFileObjectUrl";
+
+/**
+ * Grid thumbnail. Images are fetched through the bridge and shown
+ * cover-cropped; everything else shows a type icon plus the uppercase
+ * file extension so a PDF, an XML, and a spreadsheet are distinguishable
+ * at a glance. Image bytes load lazily once the card scrolls within 200px
+ * of the viewport, so a large grid doesn't fan out N reads on mount.
+ */
+export function FileThumb({ file }: { file: FileEntry }) {
+  const image = isImage(file.mimeType);
+  const ref = useRef<HTMLDivElement>(null);
+  const [near, setNear] = useState(false);
+
+  useEffect(() => {
+    if (!image || near) return;
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setNear(true);
+          io.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [image, near]);
+
+  const { url, state } = useFileObjectUrl(file.id, file.mimeType, image && near);
+
+  const showImage = image && url !== null && state === "loaded";
+  // Fall back to the icon for non-images and for images whose read failed.
+  const showIcon = !image || state === "error";
+  const ext = fileExtension(file.filename);
+
+  return (
+    <div className="file-thumb" ref={ref}>
+      {showImage ? (
+        <img src={url} alt={file.filename} />
+      ) : showIcon ? (
+        <>
+          <FileTypeIcon mimeType={file.mimeType} />
+          {ext && <span className="file-thumb-ext">{ext}</span>}
+        </>
+      ) : (
+        // Image bytes are in flight (or queued behind the viewport gate).
+        <div className="file-thumb-shimmer" />
+      )}
+    </div>
+  );
+}

--- a/src/bundles/files/ui/src/format.ts
+++ b/src/bundles/files/ui/src/format.ts
@@ -29,6 +29,18 @@ export function isImage(mimeType: string | undefined): boolean {
   return Boolean(mimeType?.startsWith("image/"));
 }
 
+// Uppercase file extension for the thumbnail caption (e.g. "PDF", "XML").
+// Returns "" when there's no usable extension. Capped at 4 chars so a
+// stray dotted filename can't blow out the label.
+export function fileExtension(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  if (dot <= 0 || dot >= filename.length - 1) return "";
+  return filename
+    .slice(dot + 1)
+    .toUpperCase()
+    .slice(0, 4);
+}
+
 // Compose-once filter matchers. Used by the type-pill filter and the
 // pill-count tally on each pill.
 export const TYPE_FILTERS: Array<{

--- a/src/bundles/files/ui/src/icons.tsx
+++ b/src/bundles/files/ui/src/icons.tsx
@@ -51,7 +51,7 @@ export function ImageIcon({ size = 40 }: IconProps) {
   );
 }
 
-export function ChartIcon({ size = 40 }: IconProps) {
+export function FileTextIcon({ size = 40 }: IconProps) {
   return (
     <svg
       aria-hidden="true"
@@ -61,8 +61,45 @@ export function ChartIcon({ size = 40 }: IconProps) {
       viewBox="0 0 24 24"
       {...STROKE_PROPS}
     >
-      <path d="M3 3v16a2 2 0 002 2h16" />
-      <path d="M7 16l4-8 4 4 4-10" />
+      <path d="M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7Z" />
+      <path d="M14 2v4a2 2 0 002 2h4" />
+      <line x1="8" x2="16" y1="13" y2="13" />
+      <line x1="8" x2="14" y1="17" y2="17" />
+    </svg>
+  );
+}
+
+export function SheetIcon({ size = 40 }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      {...STROKE_PROPS}
+    >
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+      <line x1="3" x2="21" y1="9" y2="9" />
+      <line x1="3" x2="21" y1="15" y2="15" />
+      <line x1="9" x2="9" y1="3" y2="21" />
+      <line x1="15" x2="15" y1="3" y2="21" />
+    </svg>
+  );
+}
+
+export function CodeIcon({ size = 40 }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      {...STROKE_PROPS}
+    >
+      <polyline points="16 18 22 12 16 6" />
+      <polyline points="8 6 2 12 8 18" />
     </svg>
   );
 }
@@ -120,8 +157,31 @@ export function UploadIcon({ size = 14 }: IconProps) {
   );
 }
 
-// Pick the right icon for a given mime type. Mirrors the original
-// browser.ts dispatch table.
+export function DownloadIcon({ size = 14 }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" x2="12" y1="15" y2="3" />
+    </svg>
+  );
+}
+
+// Pick the right icon for a given mime type. The buckets mirror the
+// type-filter pills (Images / Documents / Data) plus spreadsheets and
+// fonts; the thumbnail pairs the icon with an extension caption, so the
+// icon only needs to convey the broad family.
 export function FileTypeIcon({
   mimeType,
   size = 40,
@@ -132,8 +192,30 @@ export function FileTypeIcon({
   if (!mimeType) return <FileIcon size={size} />;
   if (mimeType.startsWith("image/")) return <ImageIcon size={size} />;
   if (mimeType.startsWith("font/")) return <TypeIcon size={size} />;
-  if (mimeType === "text/csv" || mimeType === "application/json") return <ChartIcon size={size} />;
-  if (mimeType.includes("spreadsheet") || mimeType.includes("xlsx"))
-    return <ChartIcon size={size} />;
+  if (
+    mimeType === "text/csv" ||
+    mimeType.includes("spreadsheet") ||
+    mimeType.includes("xlsx") ||
+    mimeType.includes("excel")
+  ) {
+    return <SheetIcon size={size} />;
+  }
+  if (
+    mimeType === "application/json" ||
+    mimeType.includes("xml") ||
+    mimeType.includes("javascript") ||
+    mimeType.startsWith("text/x-")
+  ) {
+    return <CodeIcon size={size} />;
+  }
+  if (
+    mimeType === "application/pdf" ||
+    mimeType.includes("word") ||
+    mimeType.includes("document") ||
+    mimeType === "text/plain" ||
+    mimeType === "text/markdown"
+  ) {
+    return <FileTextIcon size={size} />;
+  }
   return <FileIcon size={size} />;
 }

--- a/src/bundles/files/ui/src/index.css
+++ b/src/bundles/files/ui/src/index.css
@@ -32,7 +32,7 @@ body {
 .header {
   position: sticky; top: 0; z-index: 10;
   background: var(--color-background-primary, #faf9f7);
-  padding: 20px 20px 0;
+  padding: 24px 20px 0;
   flex-shrink: 0;
 }
 .header-top {
@@ -169,7 +169,9 @@ body {
 /* ===== Content area ===== */
 .content {
   flex: 1; overflow-y: auto;
-  padding: 0 20px 20px;
+  /* Top padding keeps the first row off the sticky controls so a card's
+     hover lift + shadow doesn't bleed into the filter pills above. */
+  padding: 8px 20px 24px;
 }
 
 /* ===== File Grid ===== */
@@ -202,7 +204,8 @@ body {
 }
 .file-thumb {
   width: 100%; height: 120px;
-  display: flex; align-items: center; justify-content: center;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 8px;
   background: var(--color-background-primary, #faf9f7);
   overflow: hidden;
   flex-shrink: 0;
@@ -211,6 +214,16 @@ body {
 .file-thumb img {
   width: 100%; height: 100%;
   object-fit: cover;
+}
+.file-thumb-ext {
+  font-size: 10px; font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary, #737373);
+}
+.file-thumb-shimmer {
+  width: 100%; height: 100%;
+  background: var(--color-border-primary, #e5e5e5);
+  animation: breathe 3s ease-in-out infinite;
 }
 .file-info {
   padding: 10px 12px;
@@ -248,8 +261,14 @@ body {
   border: none;
   padding: 0;
   background: transparent;
-  max-width: none;
-  max-height: none;
+  /* Center in the (iframe) viewport regardless of content height. Explicit
+     `margin:auto` + `inset:0` mirrors the UA modal centering; the fixed
+     width and capped height keep a tall panel from pushing off the top
+     edge — the panel scrolls internally instead. */
+  margin: auto;
+  inset: 0;
+  width: min(480px, calc(100% - 32px));
+  max-height: calc(100% - 32px);
   animation: fadeIn 0.15s ease;
 }
 .detail-overlay::backdrop {
@@ -259,8 +278,8 @@ body {
 .detail-panel {
   background: var(--color-background-secondary, #ffffff);
   border-radius: var(--border-radius-sm, 0.5rem);
-  width: 90%; max-width: 480px;
-  max-height: 80vh;
+  width: 100%;
+  max-height: calc(100vh - 32px);
   overflow-y: auto;
   box-shadow: 0 8px 32px rgba(0,0,0,0.15);
   animation: fadeIn 0.2s ease;
@@ -288,7 +307,8 @@ body {
   border-radius: var(--border-radius-sm, 0.5rem);
   overflow: hidden;
   background: var(--color-background-primary, #faf9f7);
-  display: flex; align-items: center; justify-content: center;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 10px;
   min-height: 120px;
   font-size: 56px;
   color: var(--color-text-secondary, #737373);
@@ -296,6 +316,16 @@ body {
 .detail-preview img {
   max-width: 100%; max-height: 300px;
   object-fit: contain;
+}
+.detail-preview-ext {
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary, #737373);
+}
+.detail-shimmer {
+  width: 100%; height: 220px;
+  background: var(--color-border-primary, #e5e5e5);
+  animation: breathe 3s ease-in-out infinite;
 }
 .detail-fields {
   padding: 0 20px 16px;
@@ -325,10 +355,33 @@ body {
   background: color-mix(in srgb, var(--color-text-accent, #0055FF) 8%, transparent);
   color: var(--color-text-accent, #0055FF);
 }
+.detail-error {
+  margin: 0 20px 12px;
+  font-size: 12px;
+  color: var(--nb-color-danger, #dc2626);
+}
 .detail-actions {
   padding: 0 20px 20px;
   display: flex; gap: 8px;
 }
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 16px;
+  border: 1px solid var(--color-text-accent, #0055FF);
+  border-radius: 20px;
+  background: transparent;
+  color: var(--color-text-accent, #0055FF);
+  font-size: 12px; font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-text-accent, #0055FF);
+  color: #fff;
+}
+.btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn-primary svg { width: 14px; height: 14px; }
 .btn-danger {
   padding: 6px 16px;
   border: 1px solid color-mix(in srgb, var(--nb-color-danger, #dc2626) 40%, transparent);

--- a/src/bundles/files/ui/src/useFileObjectUrl.ts
+++ b/src/bundles/files/ui/src/useFileObjectUrl.ts
@@ -1,0 +1,123 @@
+import type { Synapse } from "@nimblebrain/synapse";
+import { useSynapse } from "@nimblebrain/synapse/react";
+import { useCallback, useEffect, useState } from "react";
+
+export type FileUrlState = "idle" | "loading" | "loaded" | "error";
+
+/**
+ * Read a stored file's bytes through the Synapse bridge (`resources/read`
+ * on `files://<id>`) and return them as a Blob.
+ *
+ * The bridge is the right path — not `/v1/files/:id` directly. The app
+ * runs in a sandboxed `srcdoc` iframe: a bare `<img>`/fetch GET carries no
+ * auth token (so it 401s under bearer auth), and the iframe CSP only
+ * permits `data:`/`blob:`/`https:` sources, never the `http:` host origin
+ * in dev. The bridge already holds the authenticated MCP session.
+ */
+export async function fetchFileBlob(
+  synapse: Synapse,
+  fileId: string,
+  mimeType: string | undefined,
+): Promise<Blob> {
+  const result = await synapse.readResource(`files://${fileId}`);
+  const part = result.contents?.[0];
+  // Binary resources arrive as base64 in `blob`; text resources as `text`.
+  if (part && "blob" in part && typeof part.blob === "string") {
+    return new Blob([base64ToBytes(part.blob)], {
+      type: mimeType || "application/octet-stream",
+    });
+  }
+  if (part && "text" in part && typeof part.text === "string") {
+    return new Blob([part.text], { type: mimeType || "text/plain" });
+  }
+  throw new Error("file resource has no readable contents");
+}
+
+/**
+ * Resolve a stored file into a `blob:` object URL usable as an `<img>`
+ * src. A `blob:` URL is CSP-clean inside the sandboxed iframe.
+ *
+ * Pass `enabled=false` to defer the fetch (e.g. off-screen thumbnails).
+ * The object URL is revoked on unmount and whenever the file id changes.
+ */
+export function useFileObjectUrl(
+  fileId: string,
+  mimeType: string | undefined,
+  enabled: boolean,
+): { url: string | null; state: FileUrlState } {
+  const synapse = useSynapse();
+  const [url, setUrl] = useState<string | null>(null);
+  const [state, setState] = useState<FileUrlState>("idle");
+
+  useEffect(() => {
+    if (!enabled) {
+      setState("idle");
+      return;
+    }
+
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    setState("loading");
+
+    (async () => {
+      try {
+        const blob = await fetchFileBlob(synapse, fileId, mimeType);
+        objectUrl = URL.createObjectURL(blob);
+        if (cancelled) {
+          URL.revokeObjectURL(objectUrl);
+          return;
+        }
+        setUrl(objectUrl);
+        setState("loaded");
+      } catch {
+        if (!cancelled) setState("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      setUrl(null);
+    };
+  }, [synapse, fileId, mimeType, enabled]);
+
+  return { url, state };
+}
+
+/**
+ * Returns a callback that downloads a file to the user's machine. Fetches
+ * the bytes through the bridge, then triggers a same-document anchor
+ * download from a `blob:` URL. Requires the host iframe sandbox to carry
+ * `allow-downloads` (see `web/src/bridge/iframe.ts`).
+ */
+export function useFileDownload(): (file: {
+  id: string;
+  filename: string;
+  mimeType?: string;
+}) => Promise<void> {
+  const synapse = useSynapse();
+  return useCallback(
+    async (file) => {
+      const blob = await fetchFileBlob(synapse, file.id, file.mimeType);
+      const objectUrl = URL.createObjectURL(blob);
+      try {
+        const anchor = document.createElement("a");
+        anchor.href = objectUrl;
+        anchor.download = file.filename;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+      } finally {
+        URL.revokeObjectURL(objectUrl);
+      }
+    },
+    [synapse],
+  );
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}

--- a/test/integration/files-mcp-resources.test.ts
+++ b/test/integration/files-mcp-resources.test.ts
@@ -7,6 +7,9 @@
  * Coverage:
  * - text MIME → returned as `text` (utf-8 decoded)
  * - binary MIME → returned as `blob` (base64-encoded)
+ * - `/mcp` JSON-RPC `resources/read` (the iframe-bridge path) resolves
+ *   identity-owned `files://` URIs even though `files` lives outside every
+ *   workspace registry
  * - non-existent URI → 404 / not-found
  */
 
@@ -14,6 +17,8 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { type ServerHandle, startServer } from "../../src/api/server.ts";
 import { DEV_IDENTITY } from "../../src/identity/providers/dev.ts";
 import { Runtime } from "../../src/runtime/runtime.ts";
@@ -133,6 +138,31 @@ describe("workspace files exposed as MCP resources", () => {
     expect(first.text).toBeUndefined();
     expect(first.blob).toBeDefined();
     expect(Buffer.from(first.blob!, "base64").equals(PNG_BYTES)).toBe(true);
+  });
+
+  it("resolves identity files over the /mcp JSON-RPC surface (iframe-bridge path)", async () => {
+    // Regression: the iframe bridge reads `files://<id>` through `/mcp`
+    // `resources/read` (bare URI, no `server` param) — NOT the REST endpoint
+    // the other cases above exercise. The `/mcp` handler used to search only
+    // workspace registries, but `files` is a kernel identity source that
+    // lives outside them, so the read never resolved and the request hung.
+    // This drives the real MCP SDK client end-to-end to lock in the fix.
+    const id = await uploadChatFile(PNG_BYTES, "bridge.png", "image/png");
+
+    const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`));
+    const client = new Client({ name: "files-mcp-bridge-test", version: "1.0.0" });
+    await client.connect(transport);
+    try {
+      const result = await client.readResource({ uri: `files://${id}` });
+      expect(result.contents).toHaveLength(1);
+      const first = result.contents[0]!;
+      expect(first.uri).toBe(`files://${id}`);
+      expect(first.mimeType).toBe("image/png");
+      expect(typeof first.blob).toBe("string");
+      expect(Buffer.from(first.blob as string, "base64").equals(PNG_BYTES)).toBe(true);
+    } finally {
+      await client.close();
+    }
   });
 
   it("missing files:// URI surfaces as not-found", async () => {

--- a/web/src/bridge/iframe.ts
+++ b/web/src/bridge/iframe.ts
@@ -207,6 +207,10 @@ export function injectCSP(html: string, policy: string): string {
  * - allow-same-origin: Needed for postMessage origin checks
  * - allow-popups: External link opening
  * - allow-popups-to-escape-sandbox: Opened popups are not sandboxed
+ * - allow-downloads: Lets an app save bytes it already holds (e.g. the
+ *   Files app's "Download" action, which fetches via the bridge and saves
+ *   from a blob: URL). Gesture-gated by the browser; without it Chromium
+ *   silently blocks the download.
  *
  * Explicitly NOT allowed: allow-forms, allow-top-navigation, allow-modals.
  */
@@ -223,6 +227,7 @@ export function createAppIframe(
     "allow-same-origin",
     "allow-popups",
     "allow-popups-to-escape-sandbox",
+    "allow-downloads",
   );
 
   // Permissions Policy: clipboard-write always on (gesture-gated by browser).


### PR DESCRIPTION
## Problem

The Files app was broken in three ways visible in the UI:

1. **Images never rendered** — thumbnails and the modal preview showed a broken-image glyph (the filename `alt` text rendered at 56px, which also bloated the detail panel and threw off its centering).
2. **Detail modal** wasn't reliably centered and had **no way to download** a file.
3. File types were indistinguishable — every non-image showed the same generic document icon.

## Root cause

The app runs in a sandboxed `srcdoc` iframe. Pointing `<img>` at `/v1/files/:id` directly can't work there: a bare GET carries no auth token (401s under bearer auth), and the iframe CSP forbids the host origin (and the `http:` dev origin). Files must be read through the Synapse bridge.

But the bridge read was *also* broken server-side: the `/mcp` `resources/read` handler searched **only workspace registries**, while `files` is a kernel identity source that lives **outside** them — so `files://<id>` never resolved and the request hung with no response. (The REST path worked because it passes `server: "files"` explicitly, which is why existing tests stayed green.)

## Changes

- **`src/api/mcp-server.ts`** — `resources/read` now searches identity sources (`files`/`conversations`/`automations`) first, within the identity request context (so the source resolves the caller's own store via `getCurrentIdentity()`), then falls back to the workspace sweep. This is the core fix.
- **Files bundle UI** — read image bytes through the bridge (`resources/read` on `files://<id>`) and render a `blob:` URL (CSP-clean). Grid thumbnails load lazily (IntersectionObserver) with a shimmer placeholder and a type-icon fallback. Same path powers the modal preview.
- **Detail modal** — explicit centering so a tall panel scrolls internally instead of pushing off-screen; a **Download** action that fetches via the bridge and saves from a `blob:` URL.
- **`web/src/bridge/iframe.ts`** — add `allow-downloads` to the app iframe sandbox (gesture-gated; without it Chromium silently blocks the save). Benefits every app.
- **File-type icons** — distinct document / spreadsheet / code icons matching the filter buckets, plus a muted uppercase extension caption (`PDF`, `XML`, `DOCX`) so files are scannable at a glance.
- **Spacing** — top padding on the content area so a card's hover lift no longer bleeds into the filter pills.

## Tests

- New regression test in `test/integration/files-mcp-resources.test.ts` drives the **real MCP SDK client over `/mcp`** to read `files://<id>` — the exact iframe-bridge path that was broken. Fails without the fix, passes with it.
- `verify:static` clean · 3137/3137 unit tests · web + MCP integration suites pass.