### PR TITLE
fix(usage): filter reports by LLM event timestamp

### DIFF
--- a/src/conversation/usage-aggregator.ts
+++ b/src/conversation/usage-aggregator.ts
@@ -6,8 +6,8 @@
  *
  * The approach:
  * 1. Scan conversation directory for all .jsonl files
- * 2. Read line 1 (metadata) — check updatedAt against the date range
- * 3. For matching conversations, scan lines 2+ for llm.response events
+ * 2. Read line 1 (metadata) for conversation id / owner attribution
+ * 3. Scan lines 2+ for llm.response events whose own `ts` is in the date range
  * 4. Aggregate tokens, cost, model breakdown
  */
 
@@ -137,6 +137,7 @@ function normalizeModel(model: string): string {
 function isDateInRange(date: string, range: { from: string; to: string }): boolean {
   return date >= range.from && date <= range.to;
 }
+
 export function resolveDateRange(
   period: string,
   from?: string,

--- a/src/conversation/usage-aggregator.ts
+++ b/src/conversation/usage-aggregator.ts
@@ -134,6 +134,9 @@ function normalizeModel(model: string): string {
   return model.replace(/^(anthropic:|openai:|google:)/, "").replace(/-\d{8}$/, "");
 }
 
+function isDateInRange(date: string, range: { from: string; to: string }): boolean {
+  return date >= range.from && date <= range.to;
+}
 export function resolveDateRange(
   period: string,
   from?: string,
@@ -187,9 +190,9 @@ export interface AggregateUsageOptions {
  * Aggregate usage from conversation files in a directory.
  *
  * 1. List all .jsonl files in conversationsDir
- * 2. Read line 1 (metadata) — filter by updatedAt within date range
- *    (and by `ownerId` when `ownerFilter` is set)
- * 3. For matching files, scan for llm.response events
+ * 2. Read line 1 (metadata) for conversation id / owner attribution
+ *    (and filter by `ownerId` when `ownerFilter` is set)
+ * 3. Scan for llm.response events whose own `ts` date is in range
  * 4. Derive totals, per-model, and breakdown by groupBy key
  *    (`groupBy: "user"` buckets by the conversation owner)
  */
@@ -210,7 +213,7 @@ export async function aggregateUsage(
     filenames = [];
   }
 
-  // Collect LLM call records from conversations in the date range
+  // Collect LLM call records whose event timestamp is in the date range.
   const records: LlmCallRecord[] = [];
 
   for (const filename of filenames) {
@@ -226,19 +229,14 @@ export async function aggregateUsage(
     const firstLine = lines[0];
     if (!firstLine?.trim()) continue;
 
-    // Parse metadata (line 1) — filter by date range
+    // Parse metadata (line 1) for identity/owner attribution. Usage date
+    // range filtering is done per llm.response event below, not by updatedAt.
     let meta: Record<string, unknown>;
     try {
       meta = JSON.parse(firstLine);
     } catch {
       continue;
     }
-
-    const updatedAt = (meta.updatedAt as string) ?? "";
-    const updatedDate = updatedAt.slice(0, 10);
-
-    // Skip conversations outside the date range
-    if (updatedDate < range.from || updatedDate > range.to) continue;
 
     const sid = meta.id as string | undefined;
     const ownerId = meta.ownerId as string | undefined;
@@ -260,8 +258,11 @@ export async function aggregateUsage(
       }
 
       if (entry.type === "llm.response" && entry.usage) {
+        const ts = (entry.ts as string) ?? "";
+        if (!isDateInRange(ts.slice(0, 10), range)) continue;
+
         records.push({
-          ts: (entry.ts as string) ?? "",
+          ts,
           sid,
           ownerId,
           model: (entry.model as string) ?? "unknown",

--- a/test/unit/conversation/usage-aggregator.test.ts
+++ b/test/unit/conversation/usage-aggregator.test.ts
@@ -96,34 +96,47 @@ describe("usage-aggregator", () => {
     expect(report.totals.conversations).toBe(1);
   });
 
-  it("skips conversations outside date range", async () => {
+  it("filters usage by llm.response timestamp, not conversation updatedAt", async () => {
     const dir = makeTmpDir();
 
-    // Inside range
+    // Conversation updated inside range, but its only LLM usage happened before
+    // the report window. It should not make today's usage non-zero.
     writeFileSync(
-      join(dir, "in-range.jsonl"),
-      buildJsonl({ id: "in", updatedAt: "2026-04-10T10:00:00Z" }, [
-        llmEvent({ inputTokens: 100, outputTokens: 50 }),
+      join(dir, "updated-today.jsonl"),
+      buildJsonl({ id: "updated-today", updatedAt: "2026-04-12T10:00:00Z" }, [
+        llmEvent({ ts: "2026-04-11T23:00:00Z", inputTokens: 9999, outputTokens: 9999 }),
       ]),
     );
 
-    // Outside range (too old)
+    const report = await aggregateUsage(dir, "day", "day", {
+      from: "2026-04-12",
+      to: "2026-04-12",
+    });
+
+    expect(report.totals.tokens.input).toBe(0);
+    expect(report.totals.tokens.output).toBe(0);
+    expect(report.totals.llmCalls).toBe(0);
+    expect(report.totals.conversations).toBe(0);
+    expect(report.models).toHaveLength(0);
+    expect(report.breakdown).toHaveLength(1);
+    expect(report.breakdown[0].key).toBe("2026-04-12");
+    expect(report.breakdown[0].llmCalls).toBe(0);
+  });
+
+  it("counts in-range llm.response events even when conversation updatedAt is outside range", async () => {
+    const dir = makeTmpDir();
+
     writeFileSync(
-      join(dir, "too-old.jsonl"),
-      buildJsonl({ id: "old", updatedAt: "2026-03-01T10:00:00Z" }, [
-        llmEvent({ inputTokens: 9999, outputTokens: 9999 }),
+      join(dir, "updated-later.jsonl"),
+      buildJsonl({ id: "updated-later", updatedAt: "2026-05-01T10:00:00Z" }, [
+        llmEvent({ ts: "2026-04-10T12:00:00Z", inputTokens: 100, outputTokens: 50 }),
       ]),
     );
 
-    // Outside range (too new)
-    writeFileSync(
-      join(dir, "too-new.jsonl"),
-      buildJsonl({ id: "new", updatedAt: "2026-05-01T10:00:00Z" }, [
-        llmEvent({ inputTokens: 9999, outputTokens: 9999 }),
-      ]),
-    );
-
-    const report = await aggregateUsage(dir, "month", "day", { from: "2026-04-01", to: "2026-04-30" });
+    const report = await aggregateUsage(dir, "month", "day", {
+      from: "2026-04-01",
+      to: "2026-04-30",
+    });
 
     expect(report.totals.tokens.input).toBe(100);
     expect(report.totals.tokens.output).toBe(50);


### PR DESCRIPTION
## Summary
- Filter usage aggregation by each `llm.response.ts` event timestamp instead of conversation metadata `updatedAt`.
- Prevent updated conversations from attributing older LLM usage to the current report window.
- Add regression coverage for both false-positive and false-negative date-range cases.
## Details
Usage reports previously filtered conversation files by line-1 `updatedAt`, then included every `llm.response` event in matching files. That could make today's report include yesterday's usage if the conversation was updated today, or skip valid historical usage if the conversation was updated after the report window.

This change keeps metadata parsing for conversation id, owner attribution, and owner filtering, but applies the report date range to each individual `llm.response.ts`.

## Verification
- `bun test test/unit/conversation/usage-aggregator.test.ts test/unit/tools/platform/usage-source.test.ts`
- `bun run check`
- `bun run verify:static`
Fixes #301