### PR TITLE
fix(web): make the route the single source of truth for the active workspace

### DIFF
--- a/web/src/__tests__/workspace-route-guard.test.tsx
+++ b/web/src/__tests__/workspace-route-guard.test.tsx
@@ -1,0 +1,191 @@
+// ---------------------------------------------------------------------------
+// WorkspaceRouteGuard — single-source-of-truth invariant.
+//
+// The URL slug is authoritative for the active workspace; the wire
+// workspace (`X-Workspace-Id`, from the ambient `activeWorkspaceId`) is a
+// projection of it. The load-bearing contract: a workspace-scoped child
+// must NOT mount until the ambient workspace equals the route — otherwise
+// a descendant's data fetch reads the stale ambient value (the bootstrap
+// personal default, or the previous route's workspace) and shows one
+// workspace's data under another workspace's URL.
+//
+// The probe child records `getActiveWorkspaceId()` on every render. The
+// regression we're pinning: the child must never observe the personal
+// default while sitting under `/w/<shared-slug>/...` — it should only ever
+// see the route's workspace. Same plumbing as workspace-section.test.tsx
+// (bun:test + react-dom/client + happy-dom via web/test/setup.ts).
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "../../test/setup";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Mirror the api/client setter's equality guard so the mocked ambient id
+// tracks exactly what production would send on the wire.
+let mockedActiveId: string | null = null;
+const setActiveSpy = mock((id: string | null) => {
+  if (mockedActiveId === id) return;
+  mockedActiveId = id;
+});
+const mockedGetActiveWorkspaceId = (): string | null => mockedActiveId;
+
+mock.module("../api/client", () => ({
+  ...realClient,
+  setActiveWorkspaceId: setActiveSpy,
+  getActiveWorkspaceId: mockedGetActiveWorkspaceId,
+  callTool: mock(async () => ({ structuredContent: null, content: [] })),
+}));
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { MemoryRouter, Route, Routes, useLocation } = await import("react-router-dom");
+const { WorkspaceProvider } = await import("../context/WorkspaceContext");
+const { WorkspaceRouteGuard } = await import("../components/WorkspaceRouteGuard");
+const { getActiveWorkspaceId } = await import("../api/client");
+
+import type { WorkspaceInfo } from "../context/WorkspaceContext";
+
+const PERSONAL = "ws_user_user_p";
+// Multi-underscore semantic id mirrors the real shared workspace that
+// surfaced the bug (`ws_nimblebrain_shared` → slug `nimblebrain_shared`).
+const SHARED = "ws_nimblebrain_shared";
+const SHARED_SLUG = "nimblebrain_shared";
+
+function ws(overrides: Partial<WorkspaceInfo> & { id: string; name: string }): WorkspaceInfo {
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    bundles: [],
+    memberCount: 1,
+    isPersonal: overrides.isPersonal ?? false,
+    userRole: overrides.userRole ?? "admin",
+    ...overrides,
+  };
+}
+
+// Records the ambient workspace id the child sees on every render, so we
+// can assert it never observed the stale (personal) default.
+let observedByChild: (string | null)[] = [];
+function ProbeChild() {
+  observedByChild.push(getActiveWorkspaceId());
+  return <div data-testid="probe">workspace child</div>;
+}
+
+let navTarget = "/";
+function NavigationProbe() {
+  navTarget = useLocation().pathname;
+  return null;
+}
+
+interface Mounted {
+  container: HTMLDivElement;
+  unmount(): void;
+}
+let mounted: Mounted | null = null;
+
+async function mount({
+  workspaces,
+  activeId,
+  initialPath,
+}: {
+  workspaces: WorkspaceInfo[];
+  activeId?: string;
+  initialPath: string;
+}): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(
+      <React.StrictMode>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <WorkspaceProvider initialWorkspaces={workspaces} initialActiveId={activeId}>
+            <NavigationProbe />
+            <Routes>
+              <Route path="/" element={<div data-testid="home" />} />
+              <Route path="/w/:slug" element={<WorkspaceRouteGuard />}>
+                <Route path="probe" element={<ProbeChild />} />
+              </Route>
+            </Routes>
+          </WorkspaceProvider>
+        </MemoryRouter>
+      </React.StrictMode>,
+    );
+  });
+  return {
+    container,
+    unmount() {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+beforeEach(() => {
+  mockedActiveId = null;
+  setActiveSpy.mockClear();
+  observedByChild = [];
+  navTarget = "/";
+});
+
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+});
+
+function hasTestId(container: HTMLElement, testid: string): boolean {
+  return Array.from(container.getElementsByTagName("*")).some(
+    (el) => el.getAttribute("data-testid") === testid,
+  );
+}
+
+describe("WorkspaceRouteGuard — workspace single-source-of-truth", () => {
+  test("child never observes the stale (personal) ambient workspace under a shared-workspace URL", async () => {
+    // Bootstrap defaults the ambient workspace to personal, but the URL
+    // names the shared workspace — the exact post-OAuth-redirect setup.
+    mounted = await mount({
+      workspaces: [
+        ws({ id: PERSONAL, name: "Personal", isPersonal: true }),
+        ws({ id: SHARED, name: "NimbleBrain Shared" }),
+      ],
+      activeId: PERSONAL,
+      initialPath: `/w/${SHARED_SLUG}/probe`,
+    });
+
+    // The child mounted (gate eventually opened)…
+    expect(hasTestId(mounted.container, "probe")).toBe(true);
+    // …and every value it ever observed was the route's workspace — it
+    // NEVER saw the personal default. Pre-fix, the child's first render
+    // observed PERSONAL (the bug: personal connectors under the shared URL).
+    expect(observedByChild.length).toBeGreaterThan(0);
+    expect(observedByChild.every((id) => id === SHARED)).toBe(true);
+    expect(observedByChild).not.toContain(PERSONAL);
+    // Ambient is reconciled to the route on the wire.
+    expect(getActiveWorkspaceId()).toBe(SHARED);
+  });
+
+  test("already-aligned ambient workspace renders the child immediately", async () => {
+    mounted = await mount({
+      workspaces: [
+        ws({ id: PERSONAL, name: "Personal", isPersonal: true }),
+        ws({ id: SHARED, name: "NimbleBrain Shared" }),
+      ],
+      activeId: SHARED,
+      initialPath: `/w/${SHARED_SLUG}/probe`,
+    });
+    expect(hasTestId(mounted.container, "probe")).toBe(true);
+    expect(observedByChild.every((id) => id === SHARED)).toBe(true);
+  });
+
+  test("unknown / non-member slug bounces home and never mounts the child", async () => {
+    mounted = await mount({
+      workspaces: [ws({ id: PERSONAL, name: "Personal", isPersonal: true })],
+      activeId: PERSONAL,
+      initialPath: "/w/ws_not_a_member/probe",
+    });
+    expect(hasTestId(mounted.container, "probe")).toBe(false);
+    expect(navTarget).toBe("/");
+  });
+});

--- a/web/src/components/WorkspaceRouteGuard.tsx
+++ b/web/src/components/WorkspaceRouteGuard.tsx
@@ -3,44 +3,65 @@ import { Navigate, Outlet, useParams } from "react-router-dom";
 import { useWorkspaceContext } from "../context/WorkspaceContext";
 import { toWsId } from "../lib/workspace-slug";
 
+const loadingWorkspace = (
+  <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+    Loading workspace...
+  </div>
+);
+
 /**
- * Route guard for /w/:slug/* routes.
- * Reads the workspace slug from URL, syncs it to WorkspaceContext,
- * and renders child routes via Outlet.
+ * Route guard for `/w/:slug/*`.
+ *
+ * The URL slug is the single source of truth for the active workspace.
+ * The wire workspace (`X-Workspace-Id`, sent from the ambient
+ * `activeWorkspaceId`) is a *projection* of that slug — never an
+ * independent value. This guard enforces the projection with one
+ * invariant: **a workspace-scoped subtree does not mount until the
+ * ambient workspace equals the route.**
+ *
+ * Why the invariant and not just the sync effect below: React effects
+ * run child → parent, so a descendant's data fetch (e.g. the connectors
+ * list) would read the *previous* ambient workspace — the bootstrap
+ * personal default, or the last route's workspace — before this guard's
+ * effect could correct it. That surfaced one workspace's connectors
+ * under another workspace's URL (and let `install` / `connect` target
+ * the wrong workspace). Gating the `Outlet` makes that state
+ * unrepresentable: descendants only exist once ambient === URL, so they
+ * fetch and act against the right workspace by construction.
  */
 export function WorkspaceRouteGuard() {
   const { slug } = useParams<{ slug: string }>();
   const { workspaces, activeWorkspace, setActiveWorkspace, loading } = useWorkspaceContext();
 
-  // Sync URL slug → workspace context
+  const routeWsId = slug ? toWsId(slug) : null;
+
+  // Reconcile the ambient workspace to the URL. This stays an effect
+  // (React state can't be set during another component's render), but
+  // the gate below means no descendant observes the pre-reconciliation
+  // value — the effect only has to win against itself, not against child
+  // effects.
   useEffect(() => {
-    if (loading || !slug || workspaces.length === 0) return;
+    if (loading || !routeWsId || workspaces.length === 0) return;
+    if (activeWorkspace?.id === routeWsId) return;
+    const target = workspaces.find((ws) => ws.id === routeWsId);
+    if (target) setActiveWorkspace(target);
+  }, [routeWsId, workspaces, activeWorkspace?.id, setActiveWorkspace, loading]);
 
-    const wsId = toWsId(slug);
-    // Only update if the URL workspace differs from the active one
-    if (activeWorkspace?.id !== wsId) {
-      const target = workspaces.find((ws) => ws.id === wsId);
-      if (target) {
-        setActiveWorkspace(target);
-      }
-    }
-  }, [slug, workspaces, activeWorkspace?.id, setActiveWorkspace, loading]);
+  if (loading) return loadingWorkspace;
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-        Loading workspace...
-      </div>
-    );
+  // Unknown / non-member slug → bounce to the default landing (only
+  // decidable once the workspace list has loaded).
+  if (routeWsId && workspaces.length > 0 && !workspaces.some((ws) => ws.id === routeWsId)) {
+    return <Navigate to="/" replace />;
   }
 
-  // If the slug doesn't match any workspace, redirect to default
-  if (slug && workspaces.length > 0) {
-    const wsId = toWsId(slug);
-    const exists = workspaces.some((ws) => ws.id === wsId);
-    if (!exists) {
-      return <Navigate to="/" replace />;
-    }
+  // The invariant (see the doc comment). Reaching here with a known
+  // `routeWsId` means the effect above will reconcile to it; hold the
+  // subtree until it has. The `workspaces.length > 0` guard lets the
+  // no-memberships case fall through to the child's own empty-state
+  // instead of spinning here forever.
+  if (routeWsId && workspaces.length > 0 && activeWorkspace?.id !== routeWsId) {
+    return loadingWorkspace;
   }
 
   return <Outlet />;


### PR DESCRIPTION
## Problem

A workspace-scoped page could render against a **different workspace than its `/w/:slug` URL named.** Reported on prod: landing on `https://hq.platform.nimblebrain.ai/w/nimblebrain_shared/settings/connectors` (the post-OAuth redirect target) showed the user's **personal** connectors (e.g. Outlook), not the shared workspace's. The same desync let `install` / `connect` fired in that window target the wrong workspace — the through-line behind the "connector in the wrong workspace" class of bugs (incl. the symptom #303 patched).

## Root cause (first principles)

A single fact — *which workspace am I in* — had two representations that could disagree:

- **The URL `/w/:slug`** — the declared source of truth.
- **The ambient `activeWorkspaceId`** (module global → `X-Workspace-Id` header), reconciled to the URL by a `useEffect` in `WorkspaceRouteGuard`.

REST data calls (`/v1/tools/call`, used by the connectors list) read the ambient value. React effects run **child → parent**, so on a fresh load a descendant's fetch (`getInstalledConnectors`) read the *previous* ambient workspace — the bootstrap **personal default**, or the last route's workspace — **before** the guard's effect could correct it. And the guard rendered `<Outlet/>` immediately, so children mounted and fetched against the stale value. `RequireActiveWorkspace` didn't catch it: it checks that *an* active workspace exists, not that it matches the slug.

This isn't a timing bug to tune — it's a **second source of truth** racing the URL.

## Fix

Enforce one invariant: **a workspace-scoped subtree does not mount until the ambient workspace equals the route.** `WorkspaceRouteGuard` holds the `Outlet` (showing the existing "Loading workspace…" affordance) until `activeWorkspace.id === toWsId(slug)`.

Consequences:
- The wire workspace becomes a **projection** of the URL — descendants only exist once ambient === URL, so they fetch/act against the right workspace **by construction**.
- No per-component refetch hacks (e.g. adding `activeWorkspace?.id` to every fetch's deps); `ConnectorList` and friends need no change.
- `install` / `connect` can no longer land in the wrong workspace via a stale header.

This makes the URL authoritative rather than narrowing a race window. (The fuller elimination of the ambient header — explicit per-call workspace — is tracked in #305; this lands the route-derived invariant now.)

## Tests

- New `web/src/__tests__/workspace-route-guard.test.tsx` pins the invariant: a probe child records `getActiveWorkspaceId()` on every render and must **never** observe the personal default under a shared-workspace URL. Also covers already-aligned (renders immediately) and unknown-slug (bounces home, child never mounts).
- **Verified the test fails without the gate** (neutralized the gate → the desync test fails; restored → passes) — it's a real regression test, not a tautology.
- `bun run verify:static` → exit 0 (format, lint, `tsc` root + web, all guard checks). `bun run test:web` → 372 pass / 0 fail. (Change is web-only; CI runs full `verify`.)

## Scope / follow-ups

- Web-only; no server or API change.
- The OAuth callback-URL / bouncer "stuck connector" root cause (boot-start using `NB_API_URL` instead of the bouncer callback, `client.json` drift-discard) is a **separate** root cause in a different subsystem — filed/fixed independently.