### PR TITLE
fix(oauth): resolve the MCP callback URL from one bouncer-aware source

### DIFF
--- a/src/api/routes/mcp-auth.ts
+++ b/src/api/routes/mcp-auth.ts
@@ -9,6 +9,7 @@ import {
   signEnvelope,
   verifyEnvelopeAsTenant,
 } from "../../oauth/envelope.ts";
+import { mcpAuthCallbackUrl } from "../../oauth/mcp-callback-url.ts";
 import { peekWorkspaceId, resolveWithCode } from "../../tools/oauth-flow-registry.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import { requireWorkspace } from "../middleware/workspace.ts";
@@ -71,28 +72,12 @@ const SUCCESS_PAGE_CSP = `default-src 'none'; style-src 'sha256-${SUCCESS_PAGE_S
  *   design — the user just came back from the AS and the platform's own
  *   session may not be present in this navigation context.
  */
-/**
- * The redirect URI the platform sends to remote authorization servers
- * for outbound OAuth flows. Operators must register this exact URL
- * with the vendor (Asana developer console, Google Cloud console,
- * etc.) — a mismatch yields the vendor-side `redirect_uri does not
- * match` error long after the user has left the platform.
- *
- * Exposed to the web shell via the `manage_connectors.get_redirect_uri`
- * tool action so OperatorSetupModal can show admins the value before
- * they leave to set up the OAuth app.
- */
-export function mcpAuthCallbackUrl(): string {
-  // In bouncer mode every vendor's OAuth Client is registered against
-  // the bouncer's single URL, not this tenant's host. The bouncer
-  // verifies the signed state envelope on the callback leg and 302s
-  // back to this tenant.
-  const bouncer = getBouncerMode();
-  if (bouncer) return bouncer.callbackUrl;
-
-  const apiBase = process.env.NB_API_URL ?? "http://localhost:27247";
-  return `${apiBase.replace(/\/+$/, "")}/v1/mcp-auth/callback`;
-}
+// The redirect URI the platform registers with remote authorization
+// servers is resolved by the single source of truth in
+// `src/oauth/mcp-callback-url.ts` (bouncer-aware). Re-exported here
+// because the web shell reaches it via the `manage_connectors` tool and
+// existing callers import it from this route module.
+export { mcpAuthCallbackUrl };
 
 export function mcpAuthRoutes(ctx: AppContext) {
   // Eagerly validate bouncer config (if any) so a misconfigured

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { log } from "../cli/log.ts";
 import { cleanupComposioBundle } from "../composio/sdk.ts";
 import type { EventSink } from "../engine/types.ts";
+import { mcpAuthCallbackUrl } from "../oauth/mcp-callback-url.ts";
 import type { PlacementRegistry } from "../runtime/placement-registry.ts";
 import { FileCredentialStore } from "../tools/credential-store.ts";
 import { McpSource } from "../tools/mcp-source.ts";
@@ -1284,7 +1285,15 @@ export class BundleLifecycleManager {
       serverName,
       workDir: opts.workDir,
       workspaceContext: new WorkspaceContext({ wsId, workDir: opts.workDir }),
-      callbackUrl: "http://_/", // unused for revocation path
+      // Resolve through the single source of truth (bouncer-aware), same as
+      // boot-start and `initiate`. Although revocation doesn't run an
+      // authorize round-trip, constructing the provider loads client.json
+      // and runs the DCR drift check against this `callbackUrl` — a
+      // placeholder (the old `http://_/`) never matches the registered
+      // redirect_uri, so it spuriously discards the client, mints a new
+      // client_id on the next flow, and orphans the refresh token. See
+      // src/oauth/mcp-callback-url.ts.
+      callbackUrl: mcpAuthCallbackUrl(),
       allowInsecureRemotes: opts.allowInsecureRemotes === true,
     });
     const result = await provider.revokeAndDeleteTokens({ bundleUrl: ref.url });

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -13,6 +13,7 @@ import {
   type HostResourcesRateLimit,
   type HostResourcesResolver,
 } from "../host-resources/index.ts";
+import { mcpAuthCallbackUrl } from "../oauth/mcp-callback-url.ts";
 import { FileCredentialStore } from "../tools/credential-store.ts";
 import { type BundleMcpContext, McpSource } from "../tools/mcp-source.ts";
 import type { ToolRegistry } from "../tools/registry.ts";
@@ -320,20 +321,25 @@ export async function startBundleSource(
       }
       const wsId = wsContext.workspaceId;
       const workDir = wsContext.workDir;
-      const apiBase = process.env.NB_API_URL;
-      // Startup warning when a URL-ref bundle is being wired but NB_API_URL
-      // isn't set. Default is only safe for local dev — in prod (NB behind a
-      // proxy), the OAuth provider would hand the authorization server a
-      // redirect_uri pointing at the pod's localhost, which the user's
-      // browser can't reach. One-time log per process is enough.
-      if (!apiBase) {
+      // Resolve the OAuth callback through the single source of truth
+      // (bouncer-aware). Boot-start MUST register the same redirect_uri the
+      // interactive `initiate` flow uses — otherwise the provider's DCR
+      // drift check discards client.json, re-registration mints a new
+      // client_id, and the stored refresh token is orphaned (silent refresh
+      // then fails and the bundle falls into a headless interactive flow
+      // that times out at boot). See src/oauth/mcp-callback-url.ts.
+      const callbackUrl = mcpAuthCallbackUrl();
+      // Startup warning when a URL-ref bundle is being wired with no
+      // externally reachable origin and no bouncer. The localhost default is
+      // only safe for local dev — in prod the authorization server would get
+      // a redirect_uri pointing at the pod's localhost. One log per process.
+      if (!process.env.NB_API_URL && callbackUrl.startsWith("http://localhost")) {
         log.warn(
           `[bundles] NB_API_URL not set; OAuth callback defaults to http://localhost:27247. ` +
             "In production (NB behind a proxy / on a different host from the user's browser), " +
             "set NB_API_URL to the platform's externally reachable URL.",
         );
       }
-      const callbackUrl = `${(apiBase ?? "http://localhost:27247").replace(/\/+$/, "")}/v1/mcp-auth/callback`;
 
       // Track A: resolve pre-registered client config when present. The
       // oauthClient.clientSecret is a reference into the workspace

--- a/src/oauth/mcp-callback-url.ts
+++ b/src/oauth/mcp-callback-url.ts
@@ -1,0 +1,32 @@
+import { getBouncerMode } from "./bouncer-config.ts";
+
+/**
+ * The single source of truth for the MCP OAuth callback URL — the
+ * `redirect_uri` registered with each vendor's authorization server via DCR.
+ *
+ * In bouncer mode every vendor's OAuth client is registered against the
+ * bouncer's single URL (`NB_OAUTH_BOUNCER_CALLBACK_URL`); the bouncer
+ * verifies the signed state envelope on the callback leg and 302s back to
+ * this tenant. Outside bouncer mode it's this tenant's own
+ * `${NB_API_URL}/v1/mcp-auth/callback`.
+ *
+ * **Every code path that constructs a `WorkspaceOAuthProvider` MUST resolve
+ * the callback through here** — the interactive `initiate` flow, boot-time
+ * auto-start, AND token revocation. The provider's DCR drift check discards
+ * `client.json` whenever the registered `redirect_uri` ≠ the provider's
+ * `callbackUrl`, so a path that computes the callback differently
+ * (raw `NB_API_URL`, a `http://_/` placeholder, …) makes the drift check
+ * fire on our *own* inconsistency: the client gets re-registered, mints a
+ * new `client_id`, and orphans the stored refresh token — after which
+ * silent refresh fails and the bundle falls into an interactive flow that
+ * times out headlessly at boot. Resolving every path here keeps the
+ * registered redirect_uri identical across paths, so the drift check only
+ * fires on a genuine operator change (its intended purpose).
+ */
+export function mcpAuthCallbackUrl(): string {
+  const bouncer = getBouncerMode();
+  if (bouncer) return bouncer.callbackUrl;
+
+  const apiBase = process.env.NB_API_URL ?? "http://localhost:27247";
+  return `${apiBase.replace(/\/+$/, "")}/v1/mcp-auth/callback`;
+}

--- a/test/unit/oauth/mcp-callback-url.test.ts
+++ b/test/unit/oauth/mcp-callback-url.test.ts
@@ -1,0 +1,62 @@
+import { randomBytes } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { _resetBouncerModeForTest } from "../../../src/oauth/bouncer-config.ts";
+import { mcpAuthCallbackUrl } from "../../../src/oauth/mcp-callback-url.ts";
+
+// The single source of truth for the OAuth redirect_uri. Every provider
+// path (initiate, boot-start, revocation) resolves through this, so the
+// DCR drift check never fires on our own inconsistency. These cases pin
+// that contract: bouncer mode wins; otherwise NB_API_URL; otherwise the
+// localhost dev default.
+const ENV_KEYS = [
+  "NB_OAUTH_BOUNCER_CALLBACK_URL",
+  "NB_OAUTH_BOUNCER_TENANT_KEY",
+  "NB_TENANT_ID",
+  "NB_API_URL",
+] as const;
+
+describe("mcpAuthCallbackUrl — single callback-URL authority", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    for (const k of ENV_KEYS) delete process.env[k];
+    _resetBouncerModeForTest();
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      const v = saved[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    _resetBouncerModeForTest();
+  });
+
+  it("returns the bouncer callback when bouncer mode is enabled (its presence is the mode signal)", () => {
+    const bouncerCallback = "https://connect.nimblebrain.ai/v1/mcp-auth/callback";
+    process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = bouncerCallback;
+    process.env.NB_OAUTH_BOUNCER_TENANT_KEY = randomBytes(32).toString("base64");
+    process.env.NB_TENANT_ID = "tenant-a";
+    // Even with a tenant-direct NB_API_URL set, bouncer wins — this is the
+    // exact prod config where boot-start used to diverge onto NB_API_URL.
+    process.env.NB_API_URL = "https://hq.platform.nimblebrain.ai";
+    _resetBouncerModeForTest();
+
+    expect(mcpAuthCallbackUrl()).toBe(bouncerCallback);
+  });
+
+  it("falls back to NB_API_URL when not in bouncer mode", () => {
+    process.env.NB_API_URL = "https://hq.platform.nimblebrain.ai";
+    expect(mcpAuthCallbackUrl()).toBe("https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback");
+  });
+
+  it("trims a trailing slash on NB_API_URL so the path isn't doubled", () => {
+    process.env.NB_API_URL = "https://hq.platform.nimblebrain.ai/";
+    expect(mcpAuthCallbackUrl()).toBe("https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback");
+  });
+
+  it("defaults to the localhost dev callback when neither bouncer nor NB_API_URL is set", () => {
+    expect(mcpAuthCallbackUrl()).toBe("http://localhost:27247/v1/mcp-auth/callback");
+  });
+});


### PR DESCRIPTION
## Problem

In **bouncer mode** (multi-tenant prod), remote-OAuth connectors (granola, dropbox, …) get stuck **"Connecting…" / `McpSource "…" not started`** after any pod restart — including a deploy. The connector was working; it breaks on the next restart and won't recover on its own.

## Root cause (re-verified on prod, tenant-hq)

The OAuth `redirect_uri` (the DCR-registered callback) was computed **three different ways**:

| Path | Callback used |
|---|---|
| `initiate` (`/v1/mcp-auth/initiate`) | `mcpAuthCallbackUrl()` → **bouncer** (`https://connect.nimblebrain.ai/...`) |
| boot-start (`startup.ts`) | `NB_API_URL` → tenant-direct (`https://hq.platform.nimblebrain.ai/...`) |
| revocation (`lifecycle.ts`) | `"http://_/"` placeholder |

The provider's DCR **drift check discards `client.json`** whenever the registered `redirect_uri` ≠ the current path's `callbackUrl`. Because the paths disagreed, the client was repeatedly discarded and **re-registered with a new `client_id`**, which **orphaned the stored refresh token**. Silent refresh then failed, so boot-start fell into an **interactive** authorization flow that can't complete headlessly and **timed out after 15 min** (`flow … timed out after 900000ms`) — leaving the source registered-but-not-started.

Prod evidence:
- `[oauth] ai-granola-mcp cached DCR client redirect_uri drift detected (registered=https://connect.nimblebrain.ai/..., current=http://_/) — discarding cached client.json`
- `ai-granola-mcp start failed: [oauth-flow-registry] flow RM38v5Kl… timed out after 900000ms` (15 min after the restart)
- on disk: the stored access token's `aud` (`client_01JZ…`) ≠ current `client.json` `client_id` (`client_01KSMCQK…`), and `tokens.json` hasn't been refreshed since the original connect.

**Note:** this is unrelated to #303/#304/#309 (workspace scoping). It's an OAuth-callback consistency bug, gated by bouncer mode + the DCR drift-discard added in #193.

## Fix — single source of truth for the callback

- Move `mcpAuthCallbackUrl()` to `src/oauth/mcp-callback-url.ts` (bouncer-aware; `src/oauth` is a leaf, no cycle), re-exported from `mcp-auth.ts` for existing importers.
- Resolve **every** provider path through it: `initiate` (unchanged), **boot-start** (was `NB_API_URL`), **revocation** (was `"http://_/"`).

With one `redirect_uri` across paths, the drift check only fires on a **genuine operator change** (its intended purpose). `client_id` stays stable → refresh succeeds at boot → the source comes up `running` and survives restarts.

## Tests

- New `test/unit/oauth/mcp-callback-url.test.ts` pins the authority: bouncer mode wins (even with `NB_API_URL` set — the exact prod config), else `NB_API_URL`, else localhost; trailing slash trimmed.
- Existing provider drift tests (`workspace-oauth-provider.test.ts`) already cover discard-on-mismatch / keep-on-match — the behavior this fix relies on.
- `bun run verify:static` exit 0 (format, lint+organizeImports, `tsc` ×2, cycles, all guard checks). `test:unit` 3141 pass / 0 fail. Relevant integration suites (startup-credentials, remote-lifecycle, workspace-oauth-provider, mcp-source-oauth-retry) pass.

## Remediation for already-orphaned connectors

The code fix prevents new orphaning but doesn't re-mint already-orphaned tokens. After deploy, reconnect once (uninstall+reinstall, or Connect) so tokens are issued under a stable `client_id`; it then survives restarts.