### PR TITLE
fix(oauth): surface (don't swallow) interactive-auth start failures

### DIFF
--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1178,13 +1178,24 @@ export class BundleLifecycleManager {
       })
       .catch((err) => {
         const msg = err instanceof Error ? err.message : String(err);
-        // For UnauthorizedError, the callback path already recorded
-        // pending_auth — we don't want to overwrite that with `dead`.
-        // Other errors (network, SSRF block, server crash) → record dead.
+        // Always surface the failure. The interactive path (capturedAuthUrl
+        // set) used to be swallowed here: if the background start() failed
+        // AFTER the auth URL was returned — the token exchange or reconnect
+        // threw once the user came back, or the pending flow timed out — the
+        // connection was left stuck in `pending_auth` ("Connecting…") forever
+        // with no log and no tokens. Log it and move the connection to `dead`
+        // (+ lastError) so the UI offers a recoverable Reconnect instead of
+        // an indefinite spinner.
+        log.warn(
+          `[lifecycle] startAuth: ${serverName} start failed for ${principalId} in ${wsId}: ${msg}`,
+        );
+        this.recordConnectionStateChange(serverName, wsId, principalId, "dead", {
+          lastError: msg,
+        });
+        // `authUrlPromise` already resolved on the interactive path, so a
+        // reject there is a no-op; only the headless / pre-auth failure path
+        // (no captured URL) still needs the caller's promise rejected.
         if (!capturedAuthUrl) {
-          this.recordConnectionStateChange(serverName, wsId, principalId, "dead", {
-            lastError: msg,
-          });
           rejectAuthUrl(err instanceof Error ? err : new Error(msg));
         }
       });
@@ -1202,15 +1213,22 @@ export class BundleLifecycleManager {
     });
     try {
       const authorizationUrl = await Promise.race([authUrlPromise, timeout]);
-      return { authorizationUrl };
-    } finally {
       if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
-      // Either branch resolved — cancel any provider fetches still in
-      // flight. Success path: redirect-probe was about to be torn down
-      // anyway. Timeout path: cuts an unresponsive server's TCP read
-      // instead of letting it run its full network timeout in the
-      // background.
+      // SUCCESS: the interactive flow (or a headless completion) continues
+      // in the background `source.start()` — it still has to run the token
+      // exchange + reconnect when the user returns from the authorization
+      // server. Do NOT abort the provider here; that would cancel a
+      // still-pending flow's in-flight fetches mid-dance. The abort below
+      // is only for the give-up paths.
+      return { authorizationUrl };
+    } catch (err) {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+      // Timed out, or the background start() rejected before any auth URL
+      // (headless / pre-auth failure). Cancel the provider's in-flight
+      // fetches so an unresponsive auth server's TCP read doesn't linger
+      // for its full network deadline.
       providerAbort.abort();
+      throw err;
     }
   }
 

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1177,7 +1177,11 @@ export class BundleLifecycleManager {
         }
       })
       .catch((err) => {
-        const msg = err instanceof Error ? err.message : String(err);
+        // The SDK's OAuth error classes (InvalidGrantError, InvalidClientError,
+        // …) carry their detail in `.name` with an EMPTY `.message`, so fall
+        // back to the name — otherwise the surfaced diagnostic is blank, which
+        // is nearly as useless as swallowing it.
+        const msg = err instanceof Error ? err.message || err.name : String(err);
         // Always surface the failure. The interactive path (capturedAuthUrl
         // set) used to be swallowed here: if the background start() failed
         // AFTER the auth URL was returned — the token exchange or reconnect

--- a/test/integration/lifecycle-startauth-interactive-failure.test.ts
+++ b/test/integration/lifecycle-startauth-interactive-failure.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { WORKSPACE_PRINCIPAL_ID } from "../../src/bundles/connection.ts";
+import { BundleLifecycleManager } from "../../src/bundles/lifecycle.ts";
+import type { BundleInstance, BundleRef } from "../../src/bundles/types.ts";
+import type { EngineEvent, EventSink } from "../../src/engine/types.ts";
+import { _clearAll, resolveWithCode } from "../../src/tools/oauth-flow-registry.ts";
+
+/**
+ * Regression for the silent interactive-OAuth hang fixed in
+ * `lifecycle.startAuth`: when an interactive flow's background
+ * `source.start()` fails AFTER the auth URL was returned (the token
+ * exchange / reconnect throws once the user resumes), the failure must be
+ * logged and the Connection moved to `dead` (+ lastError) — not swallowed,
+ * leaving it stuck in `pending_auth` ("Connecting…") forever.
+ *
+ * Drive the real `startAuth` against a mock authorization server that:
+ *   - 401s `/mcp` (triggers OAuth),
+ *   - serves DCR + discovery,
+ *   - returns a NON-redirect `/authorize` (200 login page) so the
+ *     provider's redirect-probe falls through to the interactive branch,
+ *   - then FAILS `/token` (400 invalid_grant) on resume.
+ *
+ * Integration tier: real `Bun.serve`, real SDK OAuth handshake.
+ */
+
+interface MockAS {
+  base: string;
+  stop: () => void;
+}
+
+function startMockAuthServer(): MockAS {
+  const httpServer = Bun.serve({
+    port: 0,
+    async fetch(req: Request) {
+      const url = new URL(req.url);
+      const base = `http://localhost:${httpServer.port}`;
+
+      if (url.pathname === "/.well-known/oauth-protected-resource") {
+        return Response.json({ resource: base, authorization_servers: [base] });
+      }
+      if (url.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: base,
+          authorization_endpoint: `${base}/authorize`,
+          token_endpoint: `${base}/token`,
+          registration_endpoint: `${base}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          code_challenge_methods_supported: ["S256"],
+          token_endpoint_auth_methods_supported: ["none"],
+        });
+      }
+      if (url.pathname === "/register" && req.method === "POST") {
+        const body = (await req.json()) as Record<string, unknown>;
+        return Response.json(
+          {
+            client_id: `mock-client-${Math.random().toString(36).slice(2, 10)}`,
+            client_id_issued_at: Math.floor(Date.now() / 1000),
+            redirect_uris: body.redirect_uris ?? [],
+            grant_types: ["authorization_code", "refresh_token"],
+            response_types: ["code"],
+            token_endpoint_auth_method: "none",
+          },
+          { status: 201 },
+        );
+      }
+      // Interactive: a real login page, NOT a redirect-with-code — so the
+      // provider's redirect-probe breaks and falls through to interactive.
+      if (url.pathname === "/authorize") {
+        return new Response("<html><body>log in</body></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      // The exchange fails — this is the failure we want surfaced.
+      if (url.pathname === "/token" && req.method === "POST") {
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      // Never issues a usable token → always unauthorized.
+      if (url.pathname === "/mcp") {
+        return Response.json(
+          { error: "invalid_token" },
+          {
+            status: 401,
+            headers: {
+              "WWW-Authenticate": `Bearer realm="${base}", resource_metadata="${base}/.well-known/oauth-protected-resource"`,
+            },
+          },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return { base: `http://localhost:${httpServer.port}`, stop: () => httpServer.stop(true) };
+}
+
+class CapturingSink implements EventSink {
+  events: EngineEvent[] = [];
+  emit(event: EngineEvent): void {
+    this.events.push(event);
+  }
+}
+
+const WS = "ws_test";
+const SERVER = "interactive-fail-test";
+
+describe("lifecycle.startAuth — interactive-flow failure is surfaced, not swallowed", () => {
+  let workDir: string;
+  let mock: MockAS;
+  let lifecycle: BundleLifecycleManager;
+  let sink: CapturingSink;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "nb-startauth-interactive-"));
+    mock = startMockAuthServer();
+    sink = new CapturingSink();
+    lifecycle = new BundleLifecycleManager(sink, undefined);
+    const ref: BundleRef = { url: `${mock.base}/mcp`, serverName: SERVER, oauthScope: "workspace" };
+    const instance: BundleInstance = {
+      serverName: SERVER,
+      bundleName: ref.url,
+      version: "remote",
+      state: "starting",
+      trustScore: null,
+      ui: null,
+      briefing: null,
+      httpProxy: null,
+      protected: false,
+      type: "plain",
+      wsId: WS,
+      oauthScope: "workspace",
+      ref,
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: reach into the private instance map the same way the sibling unit harness does.
+    (lifecycle as any).instances.set(`${SERVER}|${WS}`, instance);
+  });
+
+  afterEach(() => {
+    _clearAll();
+    mock.stop();
+  });
+
+  it("a failed token exchange after the auth URL is returned → Connection 'dead' with lastError (not stuck pending_auth)", async () => {
+    const { authorizationUrl } = await lifecycle.startAuth(SERVER, WS, WORKSPACE_PRINCIPAL_ID, {
+      workDir,
+      callbackUrl: `${mock.base}/callback`,
+      allowInsecureRemotes: true,
+    });
+
+    // Interactive flow opened: the connector is parked in pending_auth.
+    const conn = () => lifecycle.getInstance(SERVER, WS)?.connections?.get(WORKSPACE_PRINCIPAL_ID);
+    expect(conn()?.state).toBe("pending_auth");
+
+    // Simulate the user completing the authorization: resolve the pending
+    // flow with a code. The background start() resumes, tries the token
+    // exchange, and the mock /token returns 400 → start() rejects.
+    const state = new URL(authorizationUrl).searchParams.get("state");
+    expect(state).toBeTruthy();
+    expect(resolveWithCode(state as string, "mock-auth-code")).toBe(true);
+
+    // Poll until the background start() settles into the surfaced failure.
+    const deadline = Date.now() + 8000;
+    while (conn()?.state !== "dead" && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // The fix: surfaced, not swallowed — and with a meaningful diagnostic.
+    // The mock /token returns 400 invalid_grant, so the SDK throws
+    // `InvalidGrantError` (whose `.message` is empty, hence the `.name`
+    // fallback in startAuth's catch).
+    expect(conn()?.state).toBe("dead");
+    expect(conn()?.lastError).toBe("InvalidGrantError");
+  }, 20_000);
+});


### PR DESCRIPTION
## Problem

A remote-OAuth connector (granola on prod/hq) hangs in **"Connecting…"** forever — no `tokens.json`, **no error log**, the connector page shows `McpSource not started`. We confirmed everything upstream is correct after the prior fixes: deploy is live (`0f44a4b`), workspace is right (#309), DCR client is clean with the bouncer redirect (#310), and the bouncer delivers a valid authorization code (the user even sees the **"You're in"** success page). Yet tokens never land.

## Root cause of the silence

In `lifecycle.startAuth`, the interactive path works like this:

1. `source.start()` runs in the background, hits `UnauthorizedError`, fires `onInteractiveAuthRequired` (captures the auth URL, records `pending_auth`, resolves the URL back to the caller), then parks in `awaitPendingFlow()`.
2. When the user returns, the code wakes it → `finishAuth(code)` (token exchange) + reconnect.

If step 2 throws (exchange rejected, reconnect failed, or the pending flow hit its 15-min TTL), the failure lands in `startAuth`'s `.catch` — which **only did anything `if (!capturedAuthUrl)`**. On the interactive path `capturedAuthUrl` is set, so the branch was the silently-dropped `else`: **no state change, no log, stuck in `pending_auth`.** That's why this has been invisible — the real exchange/reconnect error is computed and discarded.

## Fix

- **Surface it.** The `.catch` now **always logs** the failure and transitions the connection to `dead` (+ `lastError`), so the UI offers a recoverable **Reconnect** instead of an indefinite spinner — and the underlying error finally appears in the logs.
- **Scope `providerAbort.abort()` to the give-up path.** It previously fired in a `finally` on the success path too, aborting a provider whose interactive flow is still pending in the background. The token exchange uses the SDK's own fetch (not this signal), so this wasn't the cause of the hang, but aborting a still-pending provider is wrong on its face.

## Why no regression test in this PR

The interactive-failure path can't be unit-tested with the current harness — `lifecycle.startAuth` builds the `McpSource` + provider internally, and the existing lifecycle tests deliberately avoid driving a live source (the OAuth-retry integration harness drives `McpSource` directly via the headless 302 path, not `startAuth`'s interactive branch). Driving `startAuth` through an interactive-then-failing exchange needs a new mock-AS harness at the lifecycle layer. Tracked as a fast-follow alongside the actual exchange-failure fix.

## How this gets us to the real fix

This is a diagnostic-enabling + silent-hang UX fix. After deploy, one reproduce will print the real error — `[lifecycle] startAuth: ai-granola-mcp start failed for _workspace in ws_nimblebrain_shared: <CAUSE>` — and the connector will show a Reconnect instead of hanging. Then we fix the underlying exchange/reconnect cause directly.

## Verification

`bun run verify:static` exit 0 (format, lint, `tsc` ×2, cycles, all guard checks). `bun run test:unit` 3141 pass / 0 fail. Related integration suites (lifecycle-startauth-disconnect, workspace-oauth-provider, workspace-oauth-provider-abort, mcp-source-oauth-retry) pass.