### PR TITLE
diag(oauth): env-gated logging of OAuth token-exchange request + response

### DIFF
--- a/src/oauth/oauth-fetch-debug.ts
+++ b/src/oauth/oauth-fetch-debug.ts
@@ -1,0 +1,89 @@
+import { log } from "../cli/log.ts";
+
+/**
+ * TEMPORARY diagnostic: log outbound OAuth **token-endpoint** requests and
+ * raw responses, gated behind `NB_DEBUG_OAUTH_EXCHANGE`.
+ *
+ * Why this exists: a remote-OAuth connector's token exchange fails in the
+ * agent with the vendor returning `invalid_code`, even though the identical
+ * exchange (same code, PKCE, redirect, client) succeeds from a clean `fetch`
+ * on the same host. The MCP SDK collapses the vendor's error into an opaque
+ * `ServerError` and discards the request/response detail, so we can't see
+ * what the agent sends differently — or whether the code is POSTed more than
+ * once. This wrapper captures exactly that, for token endpoints only, then is
+ * removed once the cause is identified.
+ *
+ * Off by default. Set `NB_DEBUG_OAUTH_EXCHANGE=1` to enable. Logs are
+ * sequence-numbered so a double-exchange of the same code is obvious.
+ */
+let installed = false;
+
+function isTokenEndpoint(rawUrl: string): boolean {
+  try {
+    const { pathname } = new URL(rawUrl);
+    // `/token`, `/oauth2/token`, `/oauth/token`, … — the OAuth token endpoint.
+    return /\/token\/?$/.test(pathname);
+  } catch {
+    return false;
+  }
+}
+
+function requestUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return (input as Request).url;
+}
+
+/** Wrap a fetch implementation to log token-endpoint traffic. Pure — returns a new fn. */
+export function wrapFetchForOAuthDebug(orig: typeof fetch): typeof fetch {
+  let seq = 0;
+  const wrapped = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => {
+    const url = requestUrl(input);
+    if (!isTokenEndpoint(url)) return orig(input, init);
+
+    const n = ++seq;
+    const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+    let body = "";
+    try {
+      body = init?.body != null ? String(init.body) : "";
+    } catch {
+      body = "<unstringifiable body>";
+    }
+    let headers = "";
+    try {
+      headers = JSON.stringify(Object.fromEntries(new Headers(init?.headers)));
+    } catch {
+      /* ignore */
+    }
+    log.warn(`[oauth-debug] #${n} TOKEN ${method} ${url}`);
+    log.warn(`[oauth-debug] #${n} req-headers ${headers}`);
+    log.warn(`[oauth-debug] #${n} req-body ${body}`);
+
+    const res = await orig(input, init);
+    let respText = "";
+    try {
+      respText = await res.clone().text();
+    } catch {
+      respText = "<unreadable response body>";
+    }
+    log.warn(`[oauth-debug] #${n} resp ${res.status} ${respText.slice(0, 800)}`);
+    return res;
+  };
+  return wrapped as typeof fetch;
+}
+
+/**
+ * Install the token-exchange logger on `globalThis.fetch` when
+ * `NB_DEBUG_OAUTH_EXCHANGE` is set. Idempotent. No-op otherwise.
+ */
+export function installOAuthFetchDebug(env: NodeJS.ProcessEnv = process.env): void {
+  if (installed || !env.NB_DEBUG_OAUTH_EXCHANGE) return;
+  installed = true;
+  globalThis.fetch = wrapFetchForOAuthDebug(globalThis.fetch);
+  log.warn(
+    "[oauth-debug] token-exchange fetch logging ENABLED (NB_DEBUG_OAUTH_EXCHANGE) — temporary diagnostic",
+  );
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -62,6 +62,7 @@ import { UserStore } from "../identity/user.ts";
 import { InstructionsStore } from "../instructions/index.ts";
 import { getProviderFromModel } from "../model/catalog.ts";
 import { buildModelResolver, resolveModelString } from "../model/registry.ts";
+import { installOAuthFetchDebug } from "../oauth/oauth-fetch-debug.ts";
 import {
   createToolListAggregator,
   routeToolCall,
@@ -350,6 +351,11 @@ export class Runtime {
 
   /** Create and start a runtime from config. */
   static async start(config: RuntimeConfig): Promise<Runtime> {
+    // Temporary OAuth token-exchange diagnostic (no-op unless
+    // NB_DEBUG_OAUTH_EXCHANGE is set). Installed before any bundle OAuth so
+    // it captures the agent's /token request + the vendor's raw response.
+    installOAuthFetchDebug();
+
     // Derive the override-file path when the caller supplied a configPath
     // but not an explicit override path. The CLI's loadConfig already
     // populates both; this fallback covers embedded callers (tests,

--- a/test/unit/oauth/oauth-fetch-debug.test.ts
+++ b/test/unit/oauth/oauth-fetch-debug.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, mock } from "bun:test";
+import { wrapFetchForOAuthDebug } from "../../../src/oauth/oauth-fetch-debug.ts";
+
+// The wrapper must be transparent: it logs token-endpoint traffic and passes
+// every request through to the underlying fetch unchanged, returning the same
+// response. Non-token requests must not be touched.
+
+describe("wrapFetchForOAuthDebug", () => {
+  it("passes a token-endpoint request through and returns the original response", async () => {
+    const orig = mock(async () => new Response('{"error":"invalid_code"}', { status: 400 }));
+    const wrapped = wrapFetchForOAuthDebug(orig as unknown as typeof fetch);
+
+    const res = await wrapped("https://mcp-auth.granola.ai/oauth2/token", {
+      method: "POST",
+      body: new URLSearchParams({ grant_type: "authorization_code", code: "abc" }),
+    });
+
+    expect(orig).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(400);
+    // Body still readable by the caller (the wrapper only cloned it to log).
+    expect(await res.text()).toBe('{"error":"invalid_code"}');
+  });
+
+  it("passes non-token requests through untouched", async () => {
+    const orig = mock(async () => new Response("ok", { status: 200 }));
+    const wrapped = wrapFetchForOAuthDebug(orig as unknown as typeof fetch);
+
+    const res = await wrapped("https://mcp.granola.ai/mcp", { method: "POST" });
+
+    expect(orig).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+
+  it("matches token endpoints by path (/token, /oauth2/token) and ignores others", async () => {
+    const orig = mock(async () => new Response("{}", { status: 200 }));
+    const wrapped = wrapFetchForOAuthDebug(orig as unknown as typeof fetch);
+    // All of these must still pass through (the wrapper never blocks); this
+    // just exercises the matcher without throwing on odd inputs.
+    for (const u of [
+      "https://as.example.com/token",
+      "https://as.example.com/oauth2/token",
+      "https://as.example.com/authorize",
+      "not-a-url",
+    ]) {
+      const res = await wrapped(u, { method: "POST" });
+      expect(res.status).toBe(200);
+    }
+    expect(orig).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## What & why (temporary diagnostic)

A remote-OAuth connector (granola on prod/hq) fails its token exchange with the vendor returning **`invalid_code`** — but we've proven it's **not** the environment:

| Exchange | Result |
|---|---|
| SDK `exchangeAuthorization`, from a laptop | ✅ 200 + tokens |
| Raw `fetch`, **from the agent pod** (same code, pod IP) | ✅ 200 + tokens |
| **The agent's own `finishAuth` flow (prod)** | ❌ `invalid_code` |

So Granola, the pod's IP, the SDK's exchange function, and the PKCE/redirect/resource/client values are all fine — a clean exchange from the very same pod works. The failure is **specific to what the agent's `finishAuth` → `auth()` → `exchangeAuthorization` actually sends** (or a double-exchange). The SDK collapses the vendor error into an opaque `ServerError` and discards the request + response, so we can't see the difference statically.

## What this does

Wraps `globalThis.fetch` to log **token-endpoint** traffic only — method, URL, headers, form body, and the raw response — **sequence-numbered** so a double-POST of the same code is obvious. Gated behind `NB_DEBUG_OAUTH_EXCHANGE` (off by default; no-op otherwise). Installed at the top of `Runtime.start()` so it's active before any bundle OAuth.

The SDK uses global `fetch` (no custom `fetchFn` in `createRemoteTransport`), so wrapping global fetch captures the exact exchange.

## How to use

1. Deploy to `tenant-hq`.
2. `kubectl set env deploy/tenant-hq-platform NB_OAUTH_BOUNCER... ` → set **`NB_DEBUG_OAUTH_EXCHANGE=1`** and roll.
3. Do one clean granola connect.
4. Read the `[oauth-debug]` lines (request bytes + raw response, with a `#N` sequence). That shows exactly what the agent sends that a clean exchange doesn't — and whether the code is POSTed more than once.
5. **Revert this PR** once the cause is identified.

## Safety / scope

- Off unless `NB_DEBUG_OAUTH_EXCHANGE` is set; matches only token endpoints (`/token`, `/oauth2/token`), passes everything through unchanged.
- Logs single-use auth codes / verifiers (acceptable for a temporary debug build; they're spent immediately and the flag is off by default).
- Unit test covers transparent passthrough (token + non-token) and the matcher. `verify:static` exit 0, `test:unit` 3145/0.

This is a throwaway diagnostic to capture one request, not a feature.