### PR TITLE
fix(oauth): gate redirect-probe behind headlessAuthProbe (default off) — the root cause

### DIFF
--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1121,6 +1121,7 @@ export class BundleLifecycleManager {
       workspaceContext: new WorkspaceContext({ wsId, workDir: opts.workDir }),
       callbackUrl: opts.callbackUrl,
       allowInsecureRemotes: opts.allowInsecureRemotes === true,
+      headlessAuthProbe: ref.headlessAuthProbe === true,
       onInteractiveAuthRequired: (url) => {
         capturedAuthUrl = url;
         this.recordConnectionStateChange(serverName, wsId, principalId, "pending_auth", {

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -382,6 +382,7 @@ export async function startBundleSource(
         workspaceContext: wsContext,
         callbackUrl,
         allowInsecureRemotes: opts?.allowInsecureRemotes === true,
+        headlessAuthProbe: ref.headlessAuthProbe === true,
         onInteractiveAuthRequired: wrappedCallback,
         ...(staticClient ? { staticClient } : {}),
         ...(ref.scopes ? { scopes: ref.scopes } : {}),

--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -123,6 +123,17 @@ export type BundleRef =
        */
       oauthScope?: "workspace";
       /**
+       * Opt in to the headless authorize-redirect probe. Default false.
+       * Set only for bundles whose OAuth provider 302s straight to our
+       * callback with a code (Reboot's `Anonymous` dev provider). MUST stay
+       * false for normal interactive providers — a server-side `/authorize`
+       * probe spins up a vendor auth session bound to our PKCE challenge
+       * before the user acts and makes the vendor reject the user's real
+       * code (`invalid_code`). See `headlessAuthProbe` in
+       * `WorkspaceOAuthProvider`.
+       */
+      headlessAuthProbe?: boolean;
+      /**
        * Pre-registered OAuth client config. Required for vendors that don't
        * support Dynamic Client Registration (RFC 7591) — Gmail, Outlook,
        * HubSpot, Asana, Zoom Marketplace user-OAuth apps. Operator pre-

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -166,6 +166,24 @@ export interface WorkspaceOAuthProviderOptions {
    * default behavior (no cancellation).
    */
   abortSignal?: AbortSignal;
+  /**
+   * Opt in to the server-side authorize-redirect probe — a HEADLESS-only
+   * optimization. When true, `redirectToAuthorization` fetches the
+   * authorize URL server-side and follows the redirect chain to extract a
+   * code without a browser (Reboot's `Anonymous` dev provider 302s
+   * straight to our callback with `?code=…`).
+   *
+   * Default false, and it MUST stay false for normal interactive
+   * providers. Probing a real OAuth server (Granola, Claude.ai, etc.)
+   * issues a genuine server-side `/authorize` request that spins up a live
+   * authorization session bound to our PKCE `code_challenge` BEFORE the
+   * user acts — which the vendor then treats as a competing/abandoned
+   * attempt and rejects the user's real code at exchange (`invalid_code`)
+   * or strands the flow. A standard client never touches `/authorize`
+   * server-side; it just hands the URL to the browser. So: probe only when
+   * the bundle is known-headless.
+   */
+  headlessAuthProbe?: boolean;
 }
 
 /**
@@ -435,6 +453,7 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
   private readonly scopes?: string[];
   private readonly additionalAuthorizationParams?: Record<string, string>;
   private readonly abortSignal?: AbortSignal;
+  private readonly headlessAuthProbe: boolean;
   /** Cached DCR result + tokens to avoid redundant disk reads within a flow. */
   private cachedClientInfo: OAuthClientInformationFull | null = null;
   private cachedTokens: OAuthTokens | null = null;
@@ -471,6 +490,7 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
     validateAdditionalAuthorizationParams(opts.additionalAuthorizationParams);
     this.additionalAuthorizationParams = opts.additionalAuthorizationParams;
     this.abortSignal = opts.abortSignal;
+    this.headlessAuthProbe = opts.headlessAuthProbe === true;
 
     // Resolve the per-owner storage root. Two construction modes:
     //
@@ -747,75 +767,83 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
     // Real interactive providers (Granola, Claude.ai hosted) redirect to a
     // login page on a different origin — the loop never lands on our
     // callback and we fall through to the interactive branch.
-    const MAX_HOPS = 10;
-    let current = url;
-    try {
-      for (let hop = 0; hop < MAX_HOPS; hop++) {
-        // SSRF defense: validate EVERY hop (including the initial URL the
-        // server handed us), not just the configured bundle URL. The
-        // authorize URL and every Location header are attacker-controlled —
-        // a compromised remote MCP server could otherwise use our fetch()
-        // as an internal-network probe tool (AWS IMDS, RFC1918 admin
-        // panels, loopback services). Wrap with our marker prefix so the
-        // outer catch rethrows instead of silently falling through to the
-        // interactive branch.
-        try {
-          validateBundleUrl(current, { allowInsecure: this.allowInsecureRemotes });
-        } catch (err) {
-          throw new Error(
-            `[workspace-oauth-provider] SSRF block on ${current.toString()}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          );
-        }
+    // Headless-only (see `headlessAuthProbe`). A standard interactive
+    // provider must NOT be probed server-side: fetching `/authorize`
+    // ourselves spins up a vendor authorization session bound to our PKCE
+    // challenge before the user acts, which makes the vendor reject the
+    // user's real code at exchange (`invalid_code`) or strand the flow.
+    // Default-off; only Reboot-style headless bundles opt in.
+    if (this.headlessAuthProbe) {
+      const MAX_HOPS = 10;
+      let current = url;
+      try {
+        for (let hop = 0; hop < MAX_HOPS; hop++) {
+          // SSRF defense: validate EVERY hop (including the initial URL the
+          // server handed us), not just the configured bundle URL. The
+          // authorize URL and every Location header are attacker-controlled —
+          // a compromised remote MCP server could otherwise use our fetch()
+          // as an internal-network probe tool (AWS IMDS, RFC1918 admin
+          // panels, loopback services). Wrap with our marker prefix so the
+          // outer catch rethrows instead of silently falling through to the
+          // interactive branch.
+          try {
+            validateBundleUrl(current, { allowInsecure: this.allowInsecureRemotes });
+          } catch (err) {
+            throw new Error(
+              `[workspace-oauth-provider] SSRF block on ${current.toString()}: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+          }
 
-        // Honor lifecycle's timeout: when the controller aborts, the
-        // in-flight TCP read terminates with an AbortError instead of
-        // running its full network timeout in the background.
-        const res = await fetch(current.toString(), {
-          redirect: "manual",
-          ...(this.abortSignal ? { signal: this.abortSignal } : {}),
-        });
-        if (res.status < 300 || res.status >= 400) {
-          // Non-redirect response — provider sent us a login page (200) or
-          // an error (4xx/5xx). Not headless.
-          break;
-        }
-        const location = res.headers.get("location");
-        if (!location) break;
-        const next = new URL(location, current);
-        if (canonicalEndpoint(next) === this.canonicalCallback) {
-          const code = next.searchParams.get("code");
-          const errParam = next.searchParams.get("error");
-          if (code) {
-            log.debug(
-              "mcp",
-              `[oauth] headless flow: ${this.serverName} got code=${code.slice(0, 8)}… after ${hop + 1} hop(s)`,
-            );
-            d?.resolve(code);
-            return;
+          // Honor lifecycle's timeout: when the controller aborts, the
+          // in-flight TCP read terminates with an AbortError instead of
+          // running its full network timeout in the background.
+          const res = await fetch(current.toString(), {
+            redirect: "manual",
+            ...(this.abortSignal ? { signal: this.abortSignal } : {}),
+          });
+          if (res.status < 300 || res.status >= 400) {
+            // Non-redirect response — provider sent us a login page (200) or
+            // an error (4xx/5xx). Not headless.
+            break;
           }
-          if (errParam) {
-            const err = new Error(
-              `[workspace-oauth-provider] authorization server returned error: ${errParam}`,
-            );
-            d?.reject(err);
-            throw err;
+          const location = res.headers.get("location");
+          if (!location) break;
+          const next = new URL(location, current);
+          if (canonicalEndpoint(next) === this.canonicalCallback) {
+            const code = next.searchParams.get("code");
+            const errParam = next.searchParams.get("error");
+            if (code) {
+              log.debug(
+                "mcp",
+                `[oauth] headless flow: ${this.serverName} got code=${code.slice(0, 8)}… after ${hop + 1} hop(s)`,
+              );
+              d?.resolve(code);
+              return;
+            }
+            if (errParam) {
+              const err = new Error(
+                `[workspace-oauth-provider] authorization server returned error: ${errParam}`,
+              );
+              d?.reject(err);
+              throw err;
+            }
+            break;
           }
-          break;
+          current = next;
         }
-        current = next;
+      } catch (probeErr) {
+        // Rethrow our own explicit errors (authz server error, SSRF block)
+        // so callers see the real cause instead of the generic
+        // interactive-branch surface. Swallow network failures and fall
+        // through to the interactive branch below.
+        if (probeErr instanceof Error && probeErr.message.includes("[workspace-oauth-provider]")) {
+          d?.reject(probeErr);
+          throw probeErr;
+        }
+        log.debug("mcp", `[oauth] ${this.serverName} redirect probe failed: ${String(probeErr)}`);
       }
-    } catch (probeErr) {
-      // Rethrow our own explicit errors (authz server error, SSRF block)
-      // so callers see the real cause instead of the generic
-      // interactive-branch surface. Swallow network failures and fall
-      // through to the interactive branch below.
-      if (probeErr instanceof Error && probeErr.message.includes("[workspace-oauth-provider]")) {
-        d?.reject(probeErr);
-        throw probeErr;
-      }
-      log.debug("mcp", `[oauth] ${this.serverName} redirect probe failed: ${String(probeErr)}`);
     }
 
     // Interactive branch: real browser redirect required. Register the

--- a/test/integration/mcp-source-oauth-retry.test.ts
+++ b/test/integration/mcp-source-oauth-retry.test.ts
@@ -198,6 +198,9 @@ describe("McpSource — OAuth retry path", () => {
       callbackUrl: CALLBACK,
       // Mock runs on localhost; SSRF validator would otherwise reject.
       allowInsecureRemotes: true,
+      // This test exercises the headless 302→code path, which only runs
+      // when the redirect probe is enabled (off by default now).
+      headlessAuthProbe: true,
     });
 
     const source = new McpSource(

--- a/test/integration/workspace-oauth-provider-abort.test.ts
+++ b/test/integration/workspace-oauth-provider-abort.test.ts
@@ -48,6 +48,9 @@ describe("WorkspaceOAuthProvider — abortSignal threading", () => {
         workDir,
         callbackUrl: CALLBACK,
         allowInsecureRemotes: true,
+        // The abort threads into the redirect-probe fetch, which only runs
+        // when the probe is enabled (off by default now).
+        headlessAuthProbe: true,
         abortSignal: controller.signal,
       });
 
@@ -89,6 +92,7 @@ describe("WorkspaceOAuthProvider — abortSignal threading", () => {
         workDir,
         callbackUrl: CALLBACK,
         allowInsecureRemotes: true,
+        headlessAuthProbe: true,
         // no abortSignal
       });
       const authUrl = new URL(`http://localhost:${mockServer.port}/authorize`);

--- a/test/integration/workspace-oauth-provider.test.ts
+++ b/test/integration/workspace-oauth-provider.test.ts
@@ -30,6 +30,10 @@ function makeProvider(
     // blocks by default. Each test opts in explicitly; the "SSRF block" test
     // flips this off to assert the blocker works.
     allowInsecureRemotes: overrides.allowInsecureRemotes ?? true,
+    // This whole suite exercises the headless authorize-redirect probe, so
+    // it must opt in — the probe is off by default now (interactive
+    // providers never fetch /authorize server-side; see `headlessAuthProbe`).
+    headlessAuthProbe: true,
   });
 }
 
@@ -170,6 +174,7 @@ describe("WorkspaceOAuthProvider — authorize redirect probe (interactive)", ()
         workDir,
         callbackUrl: CALLBACK,
         allowInsecureRemotes: true,
+        headlessAuthProbe: true,
         onInteractiveAuthRequired: (url) => callbackUrls.push(url),
       });
       const state = p.state();
@@ -213,6 +218,7 @@ describe("WorkspaceOAuthProvider — authorize redirect probe (interactive)", ()
         workDir,
         callbackUrl: CALLBACK,
         allowInsecureRemotes: true,
+        headlessAuthProbe: true,
         onInteractiveAuthRequired: (url) => {
           captured = url;
         },

--- a/test/unit/workspace-oauth-provider-headless-probe.test.ts
+++ b/test/unit/workspace-oauth-provider-headless-probe.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { _clearAll } from "../../src/tools/oauth-flow-registry.ts";
+import { WorkspaceOAuthProvider } from "../../src/tools/workspace-oauth-provider.ts";
+
+// The redirect-probe is a headless-only optimization. For a normal
+// interactive provider (Granola, Claude.ai, …) it MUST NOT run: fetching
+// `/authorize` server-side spins up a vendor authorization session bound to
+// our PKCE challenge before the user acts, and the vendor then rejects the
+// user's real code at exchange (`invalid_code`). This pins the gate: probe
+// iff `headlessAuthProbe`.
+
+const AUTH_URL =
+  "https://mcp-auth.granola.example/oauth2/authorize?response_type=code&client_id=c1&code_challenge=ch&code_challenge_method=S256&state=st_abc&redirect_uri=https%3A%2F%2Fhq.example%2Fv1%2Fmcp-auth%2Fcallback";
+
+function makeProvider(
+  workDir: string,
+  headlessAuthProbe: boolean,
+  onInteractiveAuthRequired: (url: string) => void,
+): WorkspaceOAuthProvider {
+  return new WorkspaceOAuthProvider({
+    owner: { type: "workspace", wsId: "ws_test" },
+    serverName: "granola-test",
+    workDir,
+    callbackUrl: "https://hq.example/v1/mcp-auth/callback",
+    allowInsecureRemotes: true,
+    headlessAuthProbe,
+    onInteractiveAuthRequired,
+  });
+}
+
+describe("WorkspaceOAuthProvider — redirect-probe is gated on headlessAuthProbe", () => {
+  let workDir: string;
+  let origFetch: typeof fetch;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "nb-probe-gate-"));
+    origFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    _clearAll();
+  });
+
+  it("interactive (default, headlessAuthProbe=false): does NOT fetch /authorize; goes straight to the interactive branch", async () => {
+    const fetchSpy = mock(async () => new Response("login page", { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    let capturedUrl = "";
+    const p = makeProvider(workDir, false, (u) => {
+      capturedUrl = u;
+    });
+    p.state(); // initializes pendingFlow (the SDK calls this before redirect)
+
+    // Interactive branch registers the flow + fires the callback + throws.
+    await expect(p.redirectToAuthorization(new URL(AUTH_URL))).rejects.toBeInstanceOf(
+      UnauthorizedError,
+    );
+    // The crux: no server-side authorize probe happened.
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+    expect(capturedUrl).toContain("/oauth2/authorize");
+  });
+
+  it("headless (headlessAuthProbe=true): DOES probe /authorize server-side", async () => {
+    const fetchSpy = mock(async () => new Response("login page", { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const p = makeProvider(workDir, true, () => {});
+    p.state();
+
+    // 200 from the probe → not headless → falls through to interactive (throws),
+    // but the probe fetch DID fire.
+    await expect(p.redirectToAuthorization(new URL(AUTH_URL))).rejects.toBeInstanceOf(
+      UnauthorizedError,
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/workspace-oauth-provider.test.ts
+++ b/test/unit/workspace-oauth-provider.test.ts
@@ -446,6 +446,8 @@ describe("WorkspaceOAuthProvider — Track A: pre-registered client + scopes + e
         workDir,
         callbackUrl: CALLBACK,
         allowInsecureRemotes: true,
+        // This test inspects the URL the probe's fetch sees, so enable the probe.
+        headlessAuthProbe: true,
         additionalAuthorizationParams: {
           access_type: "offline",
           prompt: "consent",


### PR DESCRIPTION
## The root cause

`WorkspaceOAuthProvider.redirectToAuthorization` runs a **"redirect-probe"** — a *server-side* `fetch` of the vendor's `/authorize` endpoint, following the redirect chain to try to extract a code. It was added for **headless** providers (Reboot `Anonymous` dev, which 302s straight to our callback with a code). For a normal **interactive** provider, this is **destructive**:

> Fetching `/authorize` server-side spins up a real vendor authorization session bound to our PKCE `code_challenge` *before the user acts*. The vendor then rejects the user's subsequent code at exchange (`invalid_code`), or strands the flow.

A standard OAuth client never touches `/authorize` server-side; it just hands the URL to the browser. We did, and it broke every interactive OAuth bundle.

## How it was proven

End-to-end, by direct test:

| Exchange | Result |
|---|---|
| SDK `exchangeAuthorization` from a laptop | ✅ 200 + tokens |
| Raw `fetch` from the **agent pod** (same code, pod IP) | ✅ 200 + tokens |
| The agent's `finishAuth` path (with the probe in front of it) | ❌ `invalid_code` / orphan |

And the probe's behavior, replicated against Granola:
```
GET /oauth2/authorize → 302
Location: https://mcp-auth.granola.ai/?authorization_session_id=01KSP4SY…
```
Real authorization state, server-side, before the user — exactly the corruption above.

(The bouncer is innocent — confirmed by reading `infra/oauth-bouncer/src/handler.ts`: pure 302 router that forwards `code`+`state` unchanged.)

## The fix

Add `headlessAuthProbe?: boolean` to `WorkspaceOAuthProviderOptions` (default **false**) and gate the redirect-probe loop behind it. Threaded through the URL `BundleRef` to both provider construction sites (`startup.ts` boot-start, `lifecycle.ts` `startAuth`).

- **Interactive providers (Granola, Dropbox, every real OAuth bundle): probe off by default → normal OAuth client behavior → exchange works.**
- **Headless bundles (Reboot): set `headlessAuthProbe: true` on the bundle ref** to opt in to the probe.

The existing probe/SSRF/headless tests are explicitly about the probe; they opt in with `headlessAuthProbe: true`. New unit test pins the gate (no `/authorize` fetch when the flag is off).

## Diff

```
src/tools/workspace-oauth-provider.ts          156 ++++++++++++---------
src/bundles/types.ts                            11 ++   (BundleRef opt)
src/bundles/startup.ts                           1 +    (thread)
src/bundles/lifecycle.ts                         1 +    (thread)
test/unit/workspace-oauth-provider-headless-probe.test.ts  +81  (new test)
test/{unit,integration}/…                       +15  (opt existing suites into the probe)
```

`verify:static` exit 0, `test:unit` **3144 / 0**, full provider/probe suite **47 / 0**.

## Operational note

Once deployed, the existing `NB_DEBUG_OAUTH_EXCHANGE` diagnostic (PR #313) is no longer needed; that PR can be reverted after we confirm the connect goes green on prod/hq.