### PR TITLE
fix(tools): resolve anyOf/oneOf unions in coerce-input

### DIFF
--- a/src/tools/coerce-input.ts
+++ b/src/tools/coerce-input.ts
@@ -26,6 +26,28 @@
  * Why not AJV's `coerceTypes`: AJV only coerces between scalar types
  * (string ↔ number, etc.). It does not parse string-as-JSON into objects
  * or arrays. This helper fills exactly that gap.
+ *
+ * ## Union schemas (`anyOf` / `oneOf`)
+ *
+ * Pydantic v2 encodes `Optional[T]` / `T | None` as
+ * `{ anyOf: [{ type: <T-shape> }, { type: "null" }] }` — the canonical
+ * shape for any optional structural parameter on a FastMCP bundle. We
+ * resolve such unions before coercing: `null` branches carry no
+ * structural shape, so we drop them; what remains is the effective
+ * sub-schema. For the dominant `T | null` case this collapses to a single
+ * concrete branch and the rest of the coercer operates as if the property
+ * had been declared with a plain `type` from the start.
+ *
+ * Unions with multiple structural branches (rare; e.g. `list | dict`) are
+ * disambiguated by the runtime value's shape — an array (or a string
+ * starting with `[`) selects the array branch, an object (or `{`) the
+ * object branch. The first-character heuristic mirrors `tryJsonParse`;
+ * both lean on the model's intent being legible from the leading byte.
+ *
+ * `allOf` and `$ref` are out of scope. A property declared with either
+ * passes through unchanged at that level — the validator still gets to
+ * speak. The bug class this helper solves (`Optional[list[...]]` /
+ * `Optional[dict[...]]` on FastMCP bundles) does not require them.
  */
 
 type Schema = Record<string, unknown> | undefined;
@@ -34,13 +56,74 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** True iff the schema declares a single concrete type matching `target`. */
+/** True iff the (effective) schema declares a concrete type matching `target`. */
 function declaresType(schema: Schema, target: "object" | "array"): boolean {
   if (!schema) return false;
   const t = schema.type;
   if (t === target) return true;
   if (Array.isArray(t) && t.includes(target)) return true;
   return false;
+}
+
+/**
+ * Surface the structural sub-schemas reachable from `schema` through
+ * `anyOf` / `oneOf`. `null` branches are dropped — a non-null value
+ * can't coerce into a null, so they contribute nothing to a coercion
+ * decision. A schema with a direct `type` is itself the structural
+ * branch: composition and direct typing don't combine in the schemas
+ * we accept (and AJV would already validate against both, so this
+ * matches its precedence).
+ *
+ * Returns `[]` if no structural branch is reachable from this node
+ * (e.g. a leaf with only `$ref`, or an `allOf` we don't unfold).
+ */
+function structuralBranches(schema: Schema): Array<Record<string, unknown>> {
+  if (!schema) return [];
+  if (schema.type !== undefined) return [schema];
+  const composed: unknown[] = [];
+  if (Array.isArray(schema.anyOf)) composed.push(...schema.anyOf);
+  if (Array.isArray(schema.oneOf)) composed.push(...schema.oneOf);
+  if (composed.length === 0) return [];
+  const out: Array<Record<string, unknown>> = [];
+  for (const branch of composed) {
+    if (!isPlainObject(branch)) continue;
+    for (const sub of structuralBranches(branch)) {
+      if (sub.type === "null") continue;
+      out.push(sub);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a possibly-union schema to the concrete sub-schema we'll
+ * coerce against, picked by the runtime value's shape. For `T | null`
+ * (Pydantic's canonical `Optional[T]` shape) this collapses to T. For a
+ * schema that's already concrete, returns it unchanged.
+ *
+ * Returns the original schema (not a structural branch) when no
+ * structural branch is reachable; the caller's existing logic then
+ * passes the value through.
+ */
+function effectiveSchemaFor(value: unknown, schema: Schema): Schema {
+  if (!schema || schema.type !== undefined) return schema;
+  const branches = structuralBranches(schema);
+  if (branches.length === 0) return schema;
+  if (branches.length === 1) return branches[0];
+
+  // Multiple structural branches — disambiguate by runtime shape.
+  if (Array.isArray(value)) {
+    return branches.find((b) => declaresType(b, "array")) ?? branches[0];
+  }
+  if (isPlainObject(value)) {
+    return branches.find((b) => declaresType(b, "object")) ?? branches[0];
+  }
+  if (typeof value === "string") {
+    const first = value.trim()[0];
+    if (first === "[") return branches.find((b) => declaresType(b, "array")) ?? branches[0];
+    if (first === "{") return branches.find((b) => declaresType(b, "object")) ?? branches[0];
+  }
+  return branches[0];
 }
 
 /** Try to parse a string as JSON; return undefined on failure. */
@@ -60,30 +143,35 @@ function tryJsonParse(s: string): unknown {
 }
 
 /**
- * Coerce one value against one sub-schema. Recurses through nested objects
- * (via `properties`) and array items (via `items`); union types declared
- * as `type: ["object", "null"]` etc. are honored. `oneOf` / `anyOf` are
- * NOT walked — first-party tools follow the strict-schema convention in
- * `src/tools/platform/CLAUDE.md` § 1.2 and don't use them; if a bundle
- * ever needs it, the fix is additive (treat each alternative as a
- * candidate sub-schema and pick the one that produces a non-string value).
+ * Coerce one value against one sub-schema. Recurses through nested
+ * objects (via `properties`) and array items (via `items`); union-typed
+ * sub-schemas are resolved to their effective structural branch up
+ * front, so the property/items walk below sees a concrete `type` the
+ * same as a plainly-declared schema would.
  *
  * Returns the (possibly new) value — callers should rebind, not mutate.
  */
 function coerceValue(value: unknown, schema: Schema): unknown {
   if (!schema) return value;
 
+  // Collapse union schemas down to the structural branch matched against
+  // this value. For Pydantic `Optional[T]` this resolves the canonical
+  // `anyOf: [{type: T}, {type: null}]` to the T branch before the rest
+  // of the function runs.
+  const effective = effectiveSchemaFor(value, schema);
+  if (!effective) return value;
+
   // String → object/array recovery via schema-declared expected type.
   if (typeof value === "string") {
-    const wantObject = declaresType(schema, "object");
-    const wantArray = declaresType(schema, "array");
+    const wantObject = declaresType(effective, "object");
+    const wantArray = declaresType(effective, "array");
     if (wantObject || wantArray) {
       const parsed = tryJsonParse(value);
       if (parsed !== undefined) {
         // Recurse so a nested misencoding inside the just-parsed value
         // also unwinds. The `parsed` shape may itself need further
         // coercion (object whose property is also string-encoded).
-        return coerceValue(parsed, schema);
+        return coerceValue(parsed, effective);
       }
       // Parse failed — leave as string. Validator will surface the
       // content-aware error ("must be object", "must be array").
@@ -93,8 +181,8 @@ function coerceValue(value: unknown, schema: Schema): unknown {
   }
 
   // Walk into objects: coerce each declared property by its sub-schema.
-  if (isPlainObject(value) && declaresType(schema, "object")) {
-    const properties = schema.properties as Record<string, Schema> | undefined;
+  if (isPlainObject(value) && declaresType(effective, "object")) {
+    const properties = effective.properties as Record<string, Schema> | undefined;
     if (!properties) return value;
     let mutated: Record<string, unknown> | undefined;
     for (const key of Object.keys(value)) {
@@ -110,8 +198,8 @@ function coerceValue(value: unknown, schema: Schema): unknown {
   }
 
   // Walk into arrays: coerce each element by `items`.
-  if (Array.isArray(value) && declaresType(schema, "array")) {
-    const items = schema.items as Schema;
+  if (Array.isArray(value) && declaresType(effective, "array")) {
+    const items = effective.items as Schema;
     if (!items) return value;
     let mutated: unknown[] | undefined;
     for (let i = 0; i < value.length; i++) {

--- a/src/tools/coerce-input.ts
+++ b/src/tools/coerce-input.ts
@@ -38,11 +38,14 @@
  * concrete branch and the rest of the coercer operates as if the property
  * had been declared with a plain `type` from the start.
  *
- * Unions with multiple structural branches (rare; e.g. `list | dict`) are
- * disambiguated by the runtime value's shape — an array (or a string
- * starting with `[`) selects the array branch, an object (or `{`) the
- * object branch. The first-character heuristic mirrors `tryJsonParse`;
- * both lean on the model's intent being legible from the leading byte.
+ * Unions with two or more structural branches (rare; e.g. `list | dict`, or
+ * any union that also includes a `string` branch) pass through unchanged —
+ * we deliberately do not guess. Coercion's premise is that a stringified
+ * value is a misencoding, which only holds when the schema can't accept a
+ * string; a union that accepts a string accepts the value as-is, so coercing
+ * it would silently change a legitimate value's type. The validator
+ * adjudicates. Disambiguation can be added additively if a real bundle ever
+ * ships such a param.
  *
  * `allOf` and `$ref` are out of scope. A property declared with either
  * passes through unchanged at that level — the validator still gets to

--- a/src/tools/coerce-input.ts
+++ b/src/tools/coerce-input.ts
@@ -96,34 +96,24 @@ function structuralBranches(schema: Schema): Array<Record<string, unknown>> {
 }
 
 /**
- * Resolve a possibly-union schema to the concrete sub-schema we'll
- * coerce against, picked by the runtime value's shape. For `T | null`
- * (Pydantic's canonical `Optional[T]` shape) this collapses to T. For a
- * schema that's already concrete, returns it unchanged.
+ * Resolve a possibly-union schema to the concrete sub-schema we'll coerce
+ * against. For `T | null` (Pydantic's canonical `Optional[T]` shape) this
+ * drops the `null` branch and collapses to T. A schema that's already
+ * concrete is returned unchanged.
  *
- * Returns the original schema (not a structural branch) when no
- * structural branch is reachable; the caller's existing logic then
- * passes the value through.
+ * When two or more structural branches remain (e.g. `str | list`, `list |
+ * dict`) we deliberately do NOT pick one. Coercion's premise is that a
+ * stringified value is a misencoding — which only holds when the schema
+ * can't accept a string. A union that includes a `string` branch accepts
+ * the string as-is, so coercing it would silently change a legitimate
+ * value's type. Return the original union and let the validator adjudicate;
+ * the caller's pass-through then leaves the value untouched. Disambiguation
+ * can be added additively if a real bundle ever ships such a param.
  */
-function effectiveSchemaFor(value: unknown, schema: Schema): Schema {
+function effectiveSchemaFor(schema: Schema): Schema {
   if (!schema || schema.type !== undefined) return schema;
   const branches = structuralBranches(schema);
-  if (branches.length === 0) return schema;
-  if (branches.length === 1) return branches[0];
-
-  // Multiple structural branches — disambiguate by runtime shape.
-  if (Array.isArray(value)) {
-    return branches.find((b) => declaresType(b, "array")) ?? branches[0];
-  }
-  if (isPlainObject(value)) {
-    return branches.find((b) => declaresType(b, "object")) ?? branches[0];
-  }
-  if (typeof value === "string") {
-    const first = value.trim()[0];
-    if (first === "[") return branches.find((b) => declaresType(b, "array")) ?? branches[0];
-    if (first === "{") return branches.find((b) => declaresType(b, "object")) ?? branches[0];
-  }
-  return branches[0];
+  return branches.length === 1 ? branches[0] : schema;
 }
 
 /** Try to parse a string as JSON; return undefined on failure. */
@@ -154,11 +144,11 @@ function tryJsonParse(s: string): unknown {
 function coerceValue(value: unknown, schema: Schema): unknown {
   if (!schema) return value;
 
-  // Collapse union schemas down to the structural branch matched against
-  // this value. For Pydantic `Optional[T]` this resolves the canonical
-  // `anyOf: [{type: T}, {type: null}]` to the T branch before the rest
-  // of the function runs.
-  const effective = effectiveSchemaFor(value, schema);
+  // Collapse a single-structural-branch union to that branch (dropping
+  // `null`). For Pydantic `Optional[T]` this resolves the canonical
+  // `anyOf: [{type: T}, {type: null}]` to the T branch before the rest of
+  // the function runs; multi-branch unions pass through unchanged.
+  const effective = effectiveSchemaFor(schema);
   if (!effective) return value;
 
   // String → object/array recovery via schema-declared expected type.

--- a/test/unit/tools/coerce-input.test.ts
+++ b/test/unit/tools/coerce-input.test.ts
@@ -307,7 +307,28 @@ describe("coerceInputForSchema — anyOf / oneOf union resolution", () => {
     ]);
   });
 
-  it("anyOf with multiple structural branches: picks the array branch for `[...]` input", () => {
+  it("does not coerce a JSON-looking string when a `string` branch is present (str | list)", () => {
+    // A union that accepts a string accepts the value as-is, so coercion's
+    // "stringified misencoding" premise doesn't hold. Leave it untouched and
+    // let the validator adjudicate — coercing would silently change a
+    // legitimate string into a list.
+    const schema = {
+      type: "object" as const,
+      properties: {
+        value: {
+          anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+        },
+      },
+    };
+    const input = { value: "[draft]" };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.value).toBe("[draft]");
+  });
+
+  it("leaves a multi-structural union (array | object, no null) untouched", () => {
+    // We deliberately do not disambiguate 2+ structural branches; the value
+    // passes through for the validator. Re-add disambiguation additively if a
+    // real bundle ever ships such a param.
     const schema = {
       type: "object" as const,
       properties: {
@@ -315,32 +336,13 @@ describe("coerceInputForSchema — anyOf / oneOf union resolution", () => {
           anyOf: [
             { type: "array", items: { type: "string" } },
             { type: "object", properties: { kind: { type: "string" } } },
-            { type: "null" },
           ],
         },
       },
     };
     const input = { payload: '["a","b","c"]' };
     const out = coerceInputForSchema(input, schema);
-    expect(out.payload).toEqual(["a", "b", "c"]);
-  });
-
-  it("anyOf with multiple structural branches: picks the object branch for `{...}` input", () => {
-    const schema = {
-      type: "object" as const,
-      properties: {
-        payload: {
-          anyOf: [
-            { type: "array", items: { type: "string" } },
-            { type: "object", properties: { kind: { type: "string" } } },
-            { type: "null" },
-          ],
-        },
-      },
-    };
-    const input = { payload: '{"kind":"x"}' };
-    const out = coerceInputForSchema(input, schema);
-    expect(out.payload).toEqual({ kind: "x" });
+    expect(out.payload).toBe('["a","b","c"]');
   });
 
   it("anyOf wrapping the root: nested coercion still finds the property branch", () => {

--- a/test/unit/tools/coerce-input.test.ts
+++ b/test/unit/tools/coerce-input.test.ts
@@ -163,3 +163,226 @@ describe("coerceInputForSchema — depth and edge cases", () => {
     expect(out.edits).toEqual([{ find: "a" }]);
   });
 });
+
+describe("coerceInputForSchema — anyOf / oneOf union resolution", () => {
+  // Pydantic v2 encodes `Optional[T]` (= `T | None`) as
+  // `{anyOf: [{type: T-shape}, {type: "null"}]}` — the canonical shape
+  // for any optional structural parameter on a FastMCP bundle. These
+  // tests pin the behavior that recovers stringified values arriving at
+  // such properties (the live `patch_source(edits=...)` bug).
+
+  it("anyOf [array, null]: parses a stringified array (Pydantic Optional[list[...]])", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        edits: {
+          anyOf: [
+            {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  find: { type: "string" },
+                  replace: { type: "string" },
+                },
+              },
+            },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const input = {
+      edits: '[{"find":"a","replace":"b"},{"find":"c","replace":"d"}]',
+    };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.edits).toEqual([
+      { find: "a", replace: "b" },
+      { find: "c", replace: "d" },
+    ]);
+  });
+
+  it("anyOf [object, null]: parses a stringified object (Pydantic Optional[dict])", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        manifest: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                description: { type: "string" },
+              },
+            },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const input = { manifest: '{"name":"foo","description":"bar"}' };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.manifest).toEqual({ name: "foo", description: "bar" });
+  });
+
+  it("oneOf [array, null]: parses a stringified array", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        edits: {
+          oneOf: [{ type: "array", items: { type: "object" } }, { type: "null" }],
+        },
+      },
+    };
+    const input = { edits: '[{"find":"a"}]' };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.edits).toEqual([{ find: "a" }]);
+  });
+
+  it("anyOf [array, null]: leaves an already-correct array unchanged (idempotent)", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        edits: {
+          anyOf: [
+            { type: "array", items: { type: "object" } },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const input = { edits: [{ find: "a" }] };
+    const out = coerceInputForSchema(input, schema);
+    expect(out).toEqual(input);
+  });
+
+  it("anyOf [array, null]: leaves null unchanged (still a valid value for the union)", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        edits: {
+          anyOf: [
+            { type: "array", items: { type: "object" } },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const input = { edits: null };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.edits).toBeNull();
+  });
+
+  it("anyOf [array, null]: recurses through array items after collapsing the union", () => {
+    // The recovered array's elements are themselves stringified objects —
+    // we should keep walking after resolving the union, not stop at the
+    // outer-shape recovery.
+    const schema = {
+      type: "object" as const,
+      properties: {
+        edits: {
+          anyOf: [
+            {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  find: { type: "string" },
+                  replace: { type: "string" },
+                },
+              },
+            },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const input = {
+      edits: ['{"find":"a","replace":"b"}', '{"find":"c","replace":"d"}'],
+    };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.edits).toEqual([
+      { find: "a", replace: "b" },
+      { find: "c", replace: "d" },
+    ]);
+  });
+
+  it("anyOf with multiple structural branches: picks the array branch for `[...]` input", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        payload: {
+          anyOf: [
+            { type: "array", items: { type: "string" } },
+            { type: "object", properties: { kind: { type: "string" } } },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const input = { payload: '["a","b","c"]' };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.payload).toEqual(["a", "b", "c"]);
+  });
+
+  it("anyOf with multiple structural branches: picks the object branch for `{...}` input", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        payload: {
+          anyOf: [
+            { type: "array", items: { type: "string" } },
+            { type: "object", properties: { kind: { type: "string" } } },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const input = { payload: '{"kind":"x"}' };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.payload).toEqual({ kind: "x" });
+  });
+
+  it("anyOf wrapping the root: nested coercion still finds the property branch", () => {
+    // Realistic shape if a future Upjack/FastMCP tool emits an outer
+    // `anyOf` at root (e.g. result-union from `# type: <X> | <Y>`). The
+    // resolver must walk through to find the structural object branch
+    // before walking its properties.
+    const schema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            edits: {
+              anyOf: [
+                { type: "array", items: { type: "object" } },
+                { type: "null" },
+              ],
+            },
+          },
+        },
+        { type: "null" },
+      ],
+    };
+    const input = { edits: '[{"find":"a"}]' };
+    const out = coerceInputForSchema(input, schema as Record<string, unknown>);
+    expect(out.edits).toEqual([{ find: "a" }]);
+  });
+
+  it("non-JSON string at an anyOf property passes through unchanged for the validator", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        edits: {
+          anyOf: [
+            { type: "array", items: { type: "object" } },
+            { type: "null" },
+          ],
+        },
+      },
+    };
+    const input = { edits: "not json" };
+    const out = coerceInputForSchema(input, schema);
+    expect(out.edits).toBe("not json");
+  });
+});


### PR DESCRIPTION
## Problem

The schema-driven coercion pass at `coerceInputForSchema` recovers nested string-encoded objects/arrays the model occasionally emits, using the declared `type` as a parsing oracle. It quietly stops at composed schemas: `declaresType` only matched a direct `type`, ignoring `anyOf` / `oneOf`.

Pydantic v2 emits every `Optional[T]` / `T | None` as `anyOf: [{type: T}, {type: "null"}]` — the canonical shape for any optional structural parameter on a FastMCP bundle. So the safety net had a hole exactly where Python optionals land.

**Live impact:** `synapse-collateral`'s `patch_source(edits=[...])` declares `edits: list[dict[str, str]] | None`. The model emits the array as a JSON string (a known over-generalization the coercer is specifically designed to recover), but the recovery no-ops on the `anyOf` schema, the string passes through to the bundle, and Pydantic rejects it:

```
Input should be a valid list [type=list_type, input_value='[{"find":"...","replace":"..."}]', input_type=str]
```

This is not bundle-specific — every FastMCP tool with an optional structural param hits the same gap.

## Fix

Collapse union schemas to their effective structural branch before coercing.

- `structuralBranches(schema)` — walks `anyOf` / `oneOf`, drops `null` branches (a non-null value can't coerce to null), surfaces concretely-typed sub-schemas.
- `effectiveSchemaFor(value, schema)` — picks the branch matching the runtime value's shape. For the dominant `T | null` case there is exactly one structural branch, so it collapses to T and the rest of `coerceValue` operates on a concrete schema as before.
- Unions with 2+ structural branches (rare; e.g. `list | dict`, or any union that also includes a `string` branch) pass through unchanged — we deliberately do not guess. Coercion's premise is that the string is a misencoding, which only holds when the schema can't accept a string; the validator adjudicates the rest. Disambiguation can be added additively if a real bundle ships such a param.

`allOf` and `$ref` remain out of scope — the validator still gets to speak. The bug class this solves does not require them; we can revisit additively if a future bundle does.

## Tests

Added a new `describe` block covering:
- Pydantic-shape recovery for `anyOf: [{type: array}, {type: null}]` (the patch_source case)
- Same for `anyOf: [{type: object}, {type: null}]`
- `oneOf` parity
- `null` value passes through unchanged (still valid for the union)
- Recursion through `items` after the union collapse
- A multi-structural union (`array | object`, no null) is left untouched for the validator
- A union that includes a `string` branch leaves a JSON-looking string untouched (`str | list`)
- `anyOf` wrapping the root (nested resolution finds the right property)
- Idempotence on already-correct values
- Non-JSON-shaped strings still pass through for the validator

All 22 tests in `coerce-input.test.ts` pass; full `bun run verify` is green.

## Out of scope

- The `synapse-collateral` bundle can also avoid the union shape on its end by switching `edits: list[dict[str, str]] | None = None` to `edits: list[dict[str, str]] = Field(default_factory=list)`. Worth doing as a defense-in-depth follow-up, but this runtime fix is the right place for the primary change — it covers every other bundle that will hit the same shape.
