### PR TITLE
fix(supervisor): input-aware fingerprint for success results

### DIFF
--- a/src/engine/supervisor.ts
+++ b/src/engine/supervisor.ts
@@ -5,27 +5,47 @@ import type { ToolCall, ToolResult } from "./types.ts";
 /**
  * Per-run loop supervisor.
  *
- * Watches the (toolName, isError, content) fingerprint of every tool result
- * inside an engine run. If a single tool returns the same fingerprint N
- * times in a row, the supervisor declares that tool stuck and replaces its
- * next result with a synthetic directive instructing the model to stop
- * calling the tool and produce a final response.
+ * Watches the per-call fingerprint of every tool result inside an engine
+ * run. If a single tool returns the same fingerprint N times in a row,
+ * the supervisor declares that tool stuck and replaces its next result
+ * with a synthetic directive instructing the model to stop calling the
+ * tool and produce a final response.
  *
  * Two failure modes this catches:
- *  - Upstream returns identical 4xx errors on every call (e.g. a tool whose
- *    schema-derived args trigger a deterministic server-side rejection).
- *  - Upstream returns identical "empty success" payloads (pagination dead-ends).
+ *  - Upstream returns identical 4xx errors on every call (e.g. a tool
+ *    whose schema-derived args trigger a deterministic server-side
+ *    rejection). The model often retries with cosmetic argument tweaks
+ *    and gets the same rejection each time.
+ *  - Upstream returns identical "empty success" payloads to the same
+ *    call (pagination dead-ends; idempotent lookups against an
+ *    unchanged state).
  *
- * Per-tool isolation: a stuck tool doesn't trip the supervisor on unrelated
- * tools. Reset-on-different-fingerprint preserves legitimate adaptive retry
- * behaviour (a tool that fails once with error A, then once with error B,
- * then succeeds, never trips).
+ * Fingerprint composition (success vs. error are different shapes of
+ * "stuck"):
  *
- * The supervisor itself never aborts the run; the engine reads the verdict
- * and decides what to surface. On a trip the engine also filters the
- * tripped tool out of the model's toolset for the rest of the run, so the
- * model can't call the broken tool again regardless of how it reads the
- * synth directive.
+ *  - SUCCESS: (toolName, S, content, canonical(input)).
+ *    A successful call advances state; "stuck" means the model invoked
+ *    the same call (same name + same input) and got the same answer
+ *    back, repeatedly. Distinct inputs producing structurally-uniform
+ *    success output (e.g. `patch_source(edits=...)` returning
+ *    `applied:true, compiled:true` for each of several edits in a row)
+ *    is progress, not a loop, and must not trip.
+ *
+ *  - ERROR: (toolName, E, content). Input is deliberately omitted so
+ *    the "model retries-with-tweaks against a deterministic rejection"
+ *    failure mode still trips at N repeats — the canonical case the
+ *    supervisor was originally written to catch.
+ *
+ * Per-tool isolation: a stuck tool doesn't trip the supervisor on
+ * unrelated tools. Reset-on-different-fingerprint preserves legitimate
+ * adaptive retry behaviour (a tool that fails once with error A, then
+ * once with error B, then succeeds, never trips).
+ *
+ * The supervisor itself never aborts the run; the engine reads the
+ * verdict and decides what to surface. On a trip the engine also
+ * filters the tripped tool out of the model's toolset for the rest of
+ * the run, so the model can't call the broken tool again regardless of
+ * how it reads the synth directive.
  */
 
 export interface SupervisorConfig {
@@ -77,6 +97,27 @@ interface ToolState {
 const DEFAULT_MAX_REPEATS = 3;
 const DEFAULT_FINGERPRINT_CAP = 512;
 
+/**
+ * Canonical (stable) JSON encoding for the supervisor's input-aware
+ * success fingerprint. Object keys are sorted so that two semantically
+ * identical inputs that arrived with different key orderings hash to
+ * the same value; arrays preserve order (positional). Bypasses
+ * `JSON.stringify`'s implementation-defined key order.
+ *
+ * Not a public utility — the supervisor only needs this for repeat
+ * detection. Inputs are bounded upstream by the model's output limit,
+ * so we don't cap here; if that ever changes, cap to `textCap` to
+ * match the result-text policy.
+ */
+function canonicalJson(value: unknown): string {
+  if (value === undefined) return "null";
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`).join(",")}}`;
+}
+
 export function createRunSupervisor(config: SupervisorConfig = {}): RunSupervisor {
   const maxRepeats = config.maxConsecutiveRepeats ?? DEFAULT_MAX_REPEATS;
   const textCap = config.fingerprintTextCap ?? DEFAULT_FINGERPRINT_CAP;
@@ -100,8 +141,12 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
     // supervisor early. Addressable later by hashing head+tail or
     // structuredContent when present; out of scope here.
     const text = extractTextForModel(result.content).trim().slice(0, textCap);
+    // Input is part of the fingerprint for SUCCESS results only — see the
+    // file header for the rationale. Errors stay input-agnostic so the
+    // "deterministic-4xx with retry-with-tweaks" loop still trips.
+    const inputKey = result.isError ? "" : canonicalJson(call.input);
     return createHash("sha1")
-      .update(`${call.name}\0${result.isError ? "E" : "S"}\0${text}`)
+      .update(`${call.name}\0${result.isError ? "E" : "S"}\0${text}\0${inputKey}`)
       .digest("hex");
   }
 

--- a/test/unit/engine/supervisor.test.ts
+++ b/test/unit/engine/supervisor.test.ts
@@ -196,3 +196,79 @@ describe("supervisor — snapshot", () => {
     expect(snap.callCounts.bar).toBe(1);
   });
 });
+
+describe("supervisor — input-aware success fingerprinting", () => {
+  // Success and error are different shapes of "stuck":
+  //  - Success: distinct inputs producing the same payload is progress.
+  //    The classic motivating case is `patch_source(edits=[...])`
+  //    returning a structurally-uniform `{applied:true, compiled:true}`
+  //    across distinct edits — must NOT trip.
+  //  - Error: deterministic-rejection loops should trip whether or not
+  //    the model rotates arg values between retries (documented failure
+  //    mode), so error fingerprints stay input-agnostic.
+
+  it("3 distinct successful inputs with identical output do NOT trip", () => {
+    const sup = createRunSupervisor();
+    const sameOutput = textResult('{"applied":true,"compiled":true,"reason":null}', false);
+    // Three distinct patch_source-style calls, each returns the same
+    // structurally-uniform success payload. Progress, not a loop.
+    expect(sup.observe(call("patch_source", { find: "a", replace: "b" }), sameOutput).type).toBe(
+      "pass",
+    );
+    expect(sup.observe(call("patch_source", { find: "c", replace: "d" }), sameOutput).type).toBe(
+      "pass",
+    );
+    expect(sup.observe(call("patch_source", { find: "e", replace: "f" }), sameOutput).type).toBe(
+      "pass",
+    );
+    expect(sup.snapshot().trippedTools).toEqual([]);
+  });
+
+  it("3 identical successful calls with identical output still trip", () => {
+    // The genuinely-stuck case: same call (name + input) → same output,
+    // repeated. Still a loop; still trips.
+    const sup = createRunSupervisor();
+    const sameInput = { find: "a", replace: "b" };
+    const sameOutput = textResult('{"applied":true,"compiled":true}', false);
+    expect(sup.observe(call("patch_source", sameInput), sameOutput).type).toBe("pass");
+    expect(sup.observe(call("patch_source", sameInput), sameOutput).type).toBe("pass");
+    const v3 = sup.observe(call("patch_source", sameInput), sameOutput);
+    expect(v3.type).toBe("synth");
+  });
+
+  it("3 distinct erroring inputs with identical output STILL trip", () => {
+    // The documented "deterministic-4xx with retry-with-tweaks" loop —
+    // each call has different input but the same rejection text.
+    // Errors are input-agnostic; this still trips.
+    const sup = createRunSupervisor();
+    const sameError = textResult("AxiosError 400: bad request", true);
+    expect(sup.observe(call("foo", { attempt: 1, payload: "a" }), sameError).type).toBe("pass");
+    expect(sup.observe(call("foo", { attempt: 2, payload: "b" }), sameError).type).toBe("pass");
+    const v3 = sup.observe(call("foo", { attempt: 3, payload: "c" }), sameError);
+    expect(v3.type).toBe("synth");
+  });
+
+  it("canonical input form: reordered object keys hash to the same success fingerprint", () => {
+    // Object key insertion order varies across model providers and SDK
+    // serializers; the supervisor must treat semantically identical
+    // inputs as the same call.
+    const sup = createRunSupervisor();
+    const sameOutput = textResult('{"ok":true}', false);
+    expect(sup.observe(call("foo", { a: 1, b: 2 }), sameOutput).type).toBe("pass");
+    // Same semantic input with different key order.
+    expect(sup.observe(call("foo", { b: 2, a: 1 }), sameOutput).type).toBe("pass");
+    const v3 = sup.observe(call("foo", { a: 1, b: 2 }), sameOutput);
+    expect(v3.type).toBe("synth");
+  });
+
+  it("varied successful inputs and outputs do not trip (baseline)", () => {
+    const sup = createRunSupervisor();
+    for (let i = 0; i < 5; i++) {
+      const v = sup.observe(
+        call("foo", { i }),
+        textResult(`{"index":${i},"applied":true}`, false),
+      );
+      expect(v.type).toBe("pass");
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The loop supervisor fingerprints each tool result as `(name, isError, content)` and trips after N identical fingerprints in a row. Input is deliberately omitted — appropriate for the documented error failure mode (deterministic 4xx where the model retries with cosmetic arg tweaks and gets the same rejection), but wrong for success: distinct successful calls producing a structurally-uniform payload also collapse to one fingerprint and false-trip on the third call.

**Live impact:** `synapse-collateral`'s `patch_source(edits=[...])` returns the same `{applied:true, compiled:true, reason:null, workspace:{...}}` shape on every successful edit — the changed source isn't echoed back, and the `WorkspaceState` (document_id, name, template_id, theme) doesn't vary per edit. Two successful patches then a third on the same turn trips the supervisor and disables the tool for the rest of the run, blocking the multi-touch revision work the bundle is built for. Reported workaround was switching to `set_source` against the bundle's own guidance.

## Fix

Split fingerprint composition by result kind. Success and error are different shapes of "stuck":

- **Success**: `(name, S, content, canonical(input))`. A successful call advances state; "stuck" means the model invoked the same call (same name + same input) and got the same answer back, repeatedly. Distinct inputs producing structurally-uniform success output is progress, not a loop.
- **Error**: `(name, E, content)`. Input is deliberately omitted so the "model retries-with-tweaks against a deterministic rejection" failure mode still trips at N repeats — the canonical case the supervisor was originally written to catch.

`canonicalJson` produces a stable encoding (object keys sorted, arrays positional) so semantically-identical inputs that arrived with different key orderings hash the same.

## Tests

Added a new `describe` block covering:
- 3 distinct successful inputs with identical output do NOT trip (the patch_source case)
- 3 identical successful calls (same input + same output) still trip
- 3 distinct erroring inputs with identical output STILL trip (preserves the documented safety net)
- Canonical form: reordered object keys hash to the same success fingerprint
- Baseline varied success passes through

Existing tests still pass — notably the pagination dead-end test uses an identical empty input (`{}`) across calls, so its fingerprint is unchanged.

## Tradeoff (explicit)

A model retrying a deterministic SUCCESS payload by rotating inputs would no longer trip at 3 — it'd fall back to the iteration cap (default 25). I think this is right: distinct successful inputs returning a uniform-shaped success is the model exploring with a tool whose response surface is intentionally compact (the `patch_source` case), not a stuck loop. If we ever see a real loop the iteration cap can't catch, we can reintroduce more aggressive success-side detection (e.g. include a hash of `structuredContent` when present, or hash head+tail of content to defeat stable-preamble false-negatives).