### PR TITLE
feat(events): one identity-scoped SSE stream per tab

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -185,14 +185,19 @@ export class SseEventManager implements EventSink {
    * Create an SSE stream for a legacy workspace-scoped or unfiltered
    * client.
    *
-   *   - `addClient()` — no filter; receives every event (used by activity
-   *     dashboards and tests that need the unfiltered firehose).
+   *   - `addClient()` — no filter; receives every event.
    *   - `addClient(wsId)` — single-workspace filter; receives events
    *     where `event.wsId === wsId` plus all global events.
    *
-   * Kept for back-compat. New code should use `addIdentityClient`, which
-   * the `/v1/events` route uses — it carries an identity-bound cache that
-   * survives workspace switches and refreshes on membership changes.
+   * **No production caller today.** Both forms are kept solely as the
+   * surface that the V5 workspace-isolation security regression tests
+   * (`test/integration/security/workspace-isolation.test.ts`) and the
+   * `SseEventManager` routing-table unit tests
+   * (`test/unit/sse-event-manager.test.ts`) were written against. Those
+   * suites lock in the workspace-isolation contract under the legacy
+   * frozen-workspace model; migrating them to `addIdentityClient` would
+   * subtly change what they assert. Production code uses
+   * `addIdentityClient` via the `/v1/events` route.
    */
   addClient(workspaceId?: string): ReadableStream<Uint8Array> {
     return this.attachClient({

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -1,11 +1,38 @@
 import type { EngineEvent, EngineEventType, EventSink } from "../engine/types.ts";
+import type { WorkspaceStore } from "../workspace/workspace-store.ts";
 
-/** SSE client connection tracked by the event manager. */
+/**
+ * SSE client connection tracked by the event manager.
+ *
+ * Workspace-scoped fan-out is filtered through `workspaceMemberships`:
+ *
+ *   - `undefined` — receive every event regardless of `wsId`. This is the
+ *     legacy `addClient()` no-arg semantic, kept for internal consumers
+ *     (activity dashboards, tests) that need the unfiltered firehose.
+ *   - `Set<string>` — receive only events whose `wsId` is in the set.
+ *
+ * Identity-scoped clients (the `/v1/events` route) carry both an
+ * `identityId` and a memberships set computed from the workspaces the
+ * identity belongs to. The set is refreshed when the injected
+ * `WorkspaceStore` fires a `membershipChanged` for that identity, so a
+ * mid-stream `addMember` / `removeMember` is reflected without a
+ * reconnect.
+ *
+ * Legacy single-workspace clients (`addClient(wsId)`) store a one-element
+ * set. The unified filter delivers identical behavior to the prior
+ * `client.workspaceId === wsId` check, so all existing tests pass.
+ */
 interface SseClient {
   id: string;
   controller: ReadableStreamDefaultController<Uint8Array>;
   closed: boolean;
-  workspaceId?: string;
+  /** Identity the connection is bound to. Only set for `addIdentityClient`. */
+  identityId?: string;
+  /**
+   * Workspaces this client should receive events for. `undefined` = no
+   * filter (legacy firehose); a `Set` is the explicit allowlist.
+   */
+  workspaceMemberships?: Set<string>;
 }
 
 /** A buffered event retained in the in-memory event buffer. */
@@ -23,9 +50,10 @@ const encoder = new TextEncoder();
  *
  *   - `scope: "global"`   — broadcast to every connected client (e.g. shared
  *                            config, skills library, workspace-agnostic events)
- *   - `scope: "workspace"` — broadcast only to clients whose `workspaceId`
- *                             matches `data[wsIdField]`. The named field MUST
- *                             be present on the event's payload; if it's
+ *   - `scope: "workspace"` — broadcast only to clients whose
+ *                             `workspaceMemberships` includes the event's
+ *                             `data[wsIdField]`. The named field MUST be
+ *                             present on the event's payload; if it's
  *                             missing we drop the event rather than fan it
  *                             out to every workspace (the alternative leaks
  *                             one workspace's signals to its neighbors).
@@ -73,13 +101,21 @@ const SSE_ROUTES: Partial<Record<EngineEventType, SseRoute>> = {
 };
 
 /**
- * SSE Event Manager for the workspace-level event stream (PRODUCT_SPEC ss9.3).
+ * SSE Event Manager for the workspace-level event stream.
  *
- * Tracks connected SSE clients, broadcasts events to all clients, and sends
- * heartbeats at a configurable interval (default 30s).
+ * Tracks connected SSE clients, broadcasts events per the `SSE_ROUTES`
+ * table, and sends heartbeats at a configurable interval (default 30s).
  *
  * Maintains a bounded in-memory event buffer so that consumers (e.g.
  * ActivityCollector) can query recent events without being SSE clients.
+ *
+ * **Identity-scoped clients.** The `/v1/events` route uses
+ * `addIdentityClient`, which binds a connection to an identity and caches
+ * the set of workspaces the identity is a member of. The cache is
+ * refreshed in-process when the injected `WorkspaceStore` fires a
+ * membership change, so workspace switches don't churn the SSE.
+ * Authorization happens at emit time against the cached set — same
+ * `WorkspaceStore` that gates every other authorization path.
  */
 export class SseEventManager implements EventSink {
   private clients = new Map<string, SseClient>();
@@ -88,12 +124,22 @@ export class SseEventManager implements EventSink {
   private eventBuffer: BufferedEvent[] = [];
   private readonly MAX_BUFFER_SIZE = 500;
   private localListeners = new Set<(event: string, data: Record<string, unknown>) => void>();
+  private workspaceStore?: WorkspaceStore;
+  private unsubscribeMembership: (() => void) | null = null;
 
-  constructor(heartbeatIntervalMs = 30_000) {
+  /**
+   * @param heartbeatIntervalMs - heartbeat cadence in ms. Default 30s.
+   * @param workspaceStore - optional. When supplied, `addIdentityClient`
+   *   queries it for memberships and the manager refreshes a client's
+   *   cached set on membership-change events. Tests and internal
+   *   consumers that only use `addClient()` may omit it.
+   */
+  constructor(heartbeatIntervalMs = 30_000, workspaceStore?: WorkspaceStore) {
     this.heartbeatIntervalMs = heartbeatIntervalMs;
+    this.workspaceStore = workspaceStore;
   }
 
-  /** Start the heartbeat timer. */
+  /** Start the heartbeat timer and (if a workspace store is wired) the membership-change subscription. */
   start(): void {
     if (this.heartbeatTimer) return;
     this.heartbeatTimer = setInterval(() => {
@@ -101,13 +147,28 @@ export class SseEventManager implements EventSink {
         timestamp: new Date().toISOString(),
       });
     }, this.heartbeatIntervalMs);
+
+    if (this.workspaceStore && !this.unsubscribeMembership) {
+      this.unsubscribeMembership = this.workspaceStore.onMembershipChanged((userId) => {
+        // Fire-and-forget; the refresh is async (disk I/O). Errors are
+        // caught and logged so the workspace mutation that triggered us
+        // never sees an exception bubble out.
+        void this.refreshMembershipsForIdentity(userId).catch((err) => {
+          console.warn("[events] membership refresh failed:", err);
+        });
+      });
+    }
   }
 
-  /** Stop the heartbeat timer and close all clients. */
+  /** Stop timers, unsubscribe membership listener, and close all clients. */
   stop(): void {
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
+    }
+    if (this.unsubscribeMembership) {
+      this.unsubscribeMembership();
+      this.unsubscribeMembership = null;
     }
     for (const client of this.clients.values()) {
       this.closeClient(client);
@@ -121,31 +182,72 @@ export class SseEventManager implements EventSink {
   }
 
   /**
-   * Create a new SSE ReadableStream for a connecting client.
-   * Returns the stream to be used as the Response body.
+   * Create an SSE stream for a legacy workspace-scoped or unfiltered
+   * client.
+   *
+   *   - `addClient()` — no filter; receives every event (used by activity
+   *     dashboards and tests that need the unfiltered firehose).
+   *   - `addClient(wsId)` — single-workspace filter; receives events
+   *     where `event.wsId === wsId` plus all global events.
+   *
+   * Kept for back-compat. New code should use `addIdentityClient`, which
+   * the `/v1/events` route uses — it carries an identity-bound cache that
+   * survives workspace switches and refreshes on membership changes.
    */
   addClient(workspaceId?: string): ReadableStream<Uint8Array> {
-    const id = crypto.randomUUID();
-    let client: SseClient;
+    return this.attachClient({
+      workspaceMemberships: workspaceId ? new Set([workspaceId]) : undefined,
+    });
+  }
 
-    const stream = new ReadableStream<Uint8Array>({
+  /**
+   * Create an SSE stream bound to an identity. The connection receives
+   * events for any workspace currently in the identity's membership set,
+   * plus all global events. The set is refreshed automatically when the
+   * workspace store fires a `membershipChanged` for `identityId`.
+   *
+   * `memberships` is the initial set, typically computed by the caller
+   * via `workspaceStore.getWorkspacesForUser(identityId)`. An empty set
+   * means "global events only" — distinct from legacy `addClient()`
+   * which receives the workspace firehose unfiltered.
+   */
+  addIdentityClient(identityId: string, memberships: Set<string>): ReadableStream<Uint8Array> {
+    return this.attachClient({
+      identityId,
+      workspaceMemberships: memberships,
+    });
+  }
+
+  /** Shared client-attachment path. */
+  private attachClient(opts: {
+    identityId?: string;
+    workspaceMemberships?: Set<string>;
+  }): ReadableStream<Uint8Array> {
+    const id = crypto.randomUUID();
+
+    return new ReadableStream<Uint8Array>({
       start: (controller) => {
-        client = { id, controller, closed: false, workspaceId };
+        const client: SseClient = {
+          id,
+          controller,
+          closed: false,
+          identityId: opts.identityId,
+          workspaceMemberships: opts.workspaceMemberships,
+        };
         this.clients.set(id, client);
       },
       cancel: () => {
         this.removeClient(id);
       },
     });
-
-    return stream;
   }
 
   /**
    * EventSink implementation: forward events to SSE clients per the
    * `SSE_ROUTES` table at the top of this file. Events with no route entry
    * are dropped (kept internal to the runtime); workspace-scoped events
-   * are filtered to clients with a matching workspace id.
+   * are filtered to clients whose cached memberships include the event's
+   * workspace id.
    */
   emit(event: EngineEvent): void {
     const route = SSE_ROUTES[event.type];
@@ -162,7 +264,18 @@ export class SseEventManager implements EventSink {
     this.broadcast(event.type, event.data, wsId);
   }
 
-  /** Broadcast an SSE event to connected clients, optionally filtered by workspace. */
+  /**
+   * Broadcast an SSE event to connected clients, optionally filtered by
+   * workspace.
+   *
+   * Filter rules per client:
+   *   - No `wsId` passed (global / heartbeat) → enqueue unconditionally.
+   *   - `client.workspaceMemberships === undefined` → legacy firehose;
+   *     enqueue. Internal consumers only — the public `/v1/events` route
+   *     never produces this shape.
+   *   - `client.workspaceMemberships.has(wsId)` → enqueue.
+   *   - Otherwise → skip.
+   */
   broadcast(eventType: string, data: Record<string, unknown>, wsId?: string): void {
     const message = `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
     const encoded = encoder.encode(message);
@@ -172,8 +285,12 @@ export class SseEventManager implements EventSink {
         this.clients.delete(id);
         continue;
       }
-      // Skip clients from other workspaces (null wsId = broadcast to all, e.g. heartbeat)
-      if (wsId && client.workspaceId && client.workspaceId !== wsId) continue;
+      if (wsId !== undefined) {
+        const memberships = client.workspaceMemberships;
+        // `undefined` = legacy firehose; any non-undefined set requires
+        // explicit membership to deliver.
+        if (memberships !== undefined && !memberships.has(wsId)) continue;
+      }
       try {
         client.controller.enqueue(encoded);
       } catch (err) {
@@ -216,6 +333,31 @@ export class SseEventManager implements EventSink {
    */
   onEvent(callback: (event: string, data: Record<string, unknown>) => void): void {
     this.localListeners.add(callback);
+  }
+
+  /**
+   * Refresh the cached workspace-memberships set for every identity-bound
+   * client whose identity matches `userId`. Called from the workspace
+   * store's membership-change listener (wired in `start()`). Idempotent
+   * and tolerant of clients disconnecting mid-refresh.
+   */
+  private async refreshMembershipsForIdentity(userId: string): Promise<void> {
+    if (!this.workspaceStore) return;
+    // Collect matching clients up front so we re-query the store once
+    // even if several connections share an identity.
+    const matching: SseClient[] = [];
+    for (const client of this.clients.values()) {
+      if (client.closed) continue;
+      if (client.identityId === userId) matching.push(client);
+    }
+    if (matching.length === 0) return;
+
+    const workspaces = await this.workspaceStore.getWorkspacesForUser(userId);
+    const fresh = new Set(workspaces.map((ws) => ws.id));
+    for (const client of matching) {
+      if (client.closed) continue;
+      client.workspaceMemberships = fresh;
+    }
   }
 
   private removeClient(id: string): void {

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -27,6 +27,7 @@ import { validateToolInput } from "../tools/validate-input.ts";
 import { estimateCost } from "../usage/cost.ts";
 import { bytesToBase64 } from "../util/base64.ts";
 import { PersonalWorkspaceInvariantError } from "../workspace/errors.ts";
+import type { WorkspaceStore } from "../workspace/workspace-store.ts";
 import type { ConversationEventManager } from "./conversation-events.ts";
 import type { SseEventManager } from "./events.ts";
 import { ChatRequestBody, ToolCallRequestEnvelope } from "./schemas/rest.ts";
@@ -1133,11 +1134,27 @@ export async function handleShell(runtime: Runtime, workspaceId: string): Promis
   });
 }
 
-// --- SSE Event Stream (Task 006) ---
+// --- SSE Event Stream ---
 
-/** Handle GET /v1/events — workspace SSE event stream. */
-export function handleEvents(sseManager: SseEventManager, workspaceId?: string): Response {
-  const stream = sseManager.addClient(workspaceId);
+/**
+ * Handle GET /v1/events — identity-scoped SSE event stream.
+ *
+ * The stream is bound to the caller's identity, not their active
+ * workspace. The manager fans out workspace-scoped events to this
+ * connection only when the wsId is in the identity's current membership
+ * set (cached in the manager, refreshed by membership-change events from
+ * the workspace store). Workspace switches in the UI are a no-op on this
+ * transport — the same shape as `/mcp` (identity-bound session, workspace
+ * context per request).
+ */
+export async function handleEvents(
+  sseManager: SseEventManager,
+  workspaceStore: WorkspaceStore,
+  identityId: string,
+): Promise<Response> {
+  const workspaces = await workspaceStore.getWorkspacesForUser(identityId);
+  const memberships = new Set(workspaces.map((ws) => ws.id));
+  const stream = sseManager.addIdentityClient(identityId, memberships);
   return new Response(stream, {
     headers: {
       "Content-Type": "text/event-stream",

--- a/src/api/routes/events.ts
+++ b/src/api/routes/events.ts
@@ -1,14 +1,43 @@
 import { Hono } from "hono";
+import { DEV_IDENTITY } from "../../identity/providers/dev.ts";
 import { handleEvents } from "../handlers.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import { errorLog } from "../middleware/error-log.ts";
-import { requireWorkspace } from "../middleware/workspace.ts";
-import type { AppContext, AppEnv } from "../types.ts";
+import { type AppContext, type AppEnv, apiError } from "../types.ts";
 
+/**
+ * GET /v1/events — identity-scoped SSE event stream.
+ *
+ * Authorization is by identity, not by workspace. The handler computes
+ * the caller's workspace memberships at connect time and caches them on
+ * the SSE client; workspace-scoped events fan out only for member
+ * workspaces, refreshed in-process when the workspace store fires a
+ * `membershipChanged` (see `SseEventManager` and
+ * `WorkspaceStore.onMembershipChanged`).
+ *
+ * Dev-mode parity: when no identity provider is configured, fall back
+ * to `DEV_IDENTITY` (`usr_default`) so `bun run dev` works without an
+ * auth gate. Misconfigured production (provider exists but middleware
+ * didn't populate `c.var.identity`) → 401 instead of silently pooling
+ * reads under the sentinel user — same posture as
+ * `/v1/conversations/:id/events`.
+ *
+ * Middleware is chained per-route (not via `.use("*")`) so a future
+ * sibling route mounted on this sub-app doesn't accidentally inherit
+ * the auth chain — same precedent as `conversation-events.ts`.
+ */
 export function eventRoutes(ctx: AppContext) {
-  return new Hono<AppEnv>()
-    .use("*", requireAuth(ctx.authOptions))
-    .use("*", requireWorkspace(ctx.workspaceStore))
-    .use("*", errorLog(ctx))
-    .get("/v1/events", (c) => handleEvents(ctx.sseManager, c.var.workspaceId));
+  return new Hono<AppEnv>().get(
+    "/v1/events",
+    requireAuth(ctx.authOptions),
+    errorLog(ctx),
+    async (c) => {
+      const identity = c.var.identity;
+      const callerId = identity?.id ?? (ctx.runtime.getIdentityProvider() ? null : DEV_IDENTITY.id);
+      if (!callerId) {
+        return apiError(401, "authentication_required", "Authentication required.");
+      }
+      return handleEvents(ctx.sseManager, ctx.workspaceStore, callerId);
+    },
+  );
 }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -65,8 +65,11 @@ export function startServer(options: ServerOptions): ServerHandle {
   const healthMonitor = new HealthMonitor(mcpSources, runtime.getEventSink());
   healthMonitor.start();
 
-  // SSE event manager — listens to runtime events and broadcasts to clients
-  const sseManager = new SseEventManager();
+  // SSE event manager — listens to runtime events and broadcasts to clients.
+  // Wired with the workspace store so `addIdentityClient` (the /v1/events
+  // route) can compute initial memberships and the manager can refresh a
+  // connected client's cached set on in-process membership-change events.
+  const sseManager = new SseEventManager(undefined, runtime.getWorkspaceStore());
   sseManager.start();
 
   // Per-conversation event manager — streams chat events to conversation participants

--- a/src/workspace/workspace-store.ts
+++ b/src/workspace/workspace-store.ts
@@ -36,6 +36,21 @@ export class MemberConflictError extends Error {
   }
 }
 
+// ── Membership-change subscription ─────────────────────────────────
+
+/**
+ * Fired after a successful mutation that changes which workspaces a
+ * user is a member of: `addMember`, `removeMember`, `delete` (for every
+ * former member), and `create` (for every initial member). NOT fired
+ * for `updateMemberRole` — role changes don't affect set membership,
+ * and the SSE manager's only consumer cares about presence, not role.
+ *
+ * Handlers run synchronously after the atomic write succeeds. Errors
+ * in a handler are caught and logged so a buggy subscriber can't
+ * derail a workspace mutation.
+ */
+export type MembershipChangeHandler = (userId: string) => void;
+
 // ── Workspace ID validation ────────────────────────────────────────
 
 // `WORKSPACE_ID_RE` lives in `./workspace-id-pattern.ts` so the web
@@ -129,6 +144,7 @@ export function personalWorkspaceSlugFor(userId: string): string {
 
 export class WorkspaceStore {
   private workspacesDir: string;
+  private membershipChangeHandlers = new Set<MembershipChangeHandler>();
 
   constructor(workDir: string) {
     this.workspacesDir = join(workDir, "workspaces");
@@ -306,6 +322,11 @@ export class WorkspaceStore {
     await this.atomicWrite(this.wsPath(id), workspace);
     await scaffoldWorkspace(wsDir);
 
+    // Initial members gain a workspace from their POV; notify subscribers
+    // (the SSE manager re-queries memberships for any connected client
+    // whose identity matches).
+    for (const m of members) this.fireMembershipChanged(m.userId);
+
     return workspace;
   }
 
@@ -425,7 +446,14 @@ export class WorkspaceStore {
   async delete(id: string): Promise<boolean> {
     const wsDir = join(this.workspacesDir, id);
     if (!existsSync(wsDir)) return false;
+    // Read members BEFORE removing — we need them to fire change
+    // notifications. A corrupted dir (missing workspace.json) yields
+    // `null` and we simply don't fire; nothing to invalidate.
+    const ws = await this.get(id);
     await rm(wsDir, { recursive: true, force: true });
+    if (ws) {
+      for (const m of ws.members) this.fireMembershipChanged(m.userId);
+    }
     return true;
   }
 
@@ -457,6 +485,7 @@ export class WorkspaceStore {
     };
 
     await this.atomicWrite(this.wsPath(wsId), updated);
+    this.fireMembershipChanged(userId);
     return updated;
   }
 
@@ -472,6 +501,7 @@ export class WorkspaceStore {
       );
     }
 
+    const wasMember = ws.members.some((m) => m.userId === userId);
     const updated: Workspace = {
       ...ws,
       members: ws.members.filter((m) => m.userId !== userId),
@@ -479,6 +509,10 @@ export class WorkspaceStore {
     };
 
     await this.atomicWrite(this.wsPath(wsId), updated);
+    // Only fire if this was an actual removal — a no-op removeMember
+    // (user wasn't a member to start with) shouldn't generate spurious
+    // cache invalidations.
+    if (wasMember) this.fireMembershipChanged(userId);
     return updated;
   }
 
@@ -507,6 +541,38 @@ export class WorkspaceStore {
   async getWorkspacesForUser(userId: string): Promise<Workspace[]> {
     const all = await this.list();
     return all.filter((ws) => ws.members.some((m) => m.userId === userId));
+  }
+
+  // ── Membership-change subscriptions ────────────────────────────
+
+  /**
+   * Subscribe to membership-change notifications. Returns an unsubscribe
+   * function. Fires after `addMember`, `removeMember`, `create`, and
+   * `delete` for every affected `userId` (see `MembershipChangeHandler`).
+   * The SSE event manager uses this to invalidate its per-client cached
+   * workspace-membership set without polling the store on every emit.
+   */
+  onMembershipChanged(handler: MembershipChangeHandler): () => void {
+    this.membershipChangeHandlers.add(handler);
+    return () => {
+      this.membershipChangeHandlers.delete(handler);
+    };
+  }
+
+  /**
+   * Fire all registered membership-change handlers for a userId. Handler
+   * errors are caught and logged so a buggy subscriber can't break a
+   * workspace mutation. Synchronous — handlers themselves may schedule
+   * async work (e.g. the SSE manager refreshes a client's cached set).
+   */
+  private fireMembershipChanged(userId: string): void {
+    for (const handler of this.membershipChangeHandlers) {
+      try {
+        handler(userId);
+      } catch (err) {
+        console.warn("[workspace-store] membership change handler threw:", err);
+      }
+    }
   }
 
   // ── Private helpers ────────────────────────────────────────────

--- a/test/unit/sse-event-manager.test.ts
+++ b/test/unit/sse-event-manager.test.ts
@@ -193,3 +193,184 @@ describe("SseEventManager — routing table", () => {
     expect(wsB.events).not.toContain("bridge.tool.call");
   });
 });
+
+// ── Identity-scoped clients (the /v1/events route) ────────────────
+
+/**
+ * Minimal stand-in for the bits of `WorkspaceStore` the manager touches:
+ * `getWorkspacesForUser` and `onMembershipChanged`. Avoids spinning up a
+ * full store + temp dir for routing-only assertions.
+ *
+ * `setMemberships` mutates the per-user table and synchronously fires
+ * the registered handlers, mirroring how the real store does it post-
+ * write — that's the precise contract the manager depends on.
+ */
+function fakeWorkspaceStore() {
+  const byUser = new Map<string, string[]>();
+  const handlers = new Set<(userId: string) => void>();
+  return {
+    setMemberships(userId: string, wsIds: string[]): void {
+      byUser.set(userId, wsIds);
+      for (const h of handlers) h(userId);
+    },
+    // Subset of WorkspaceStore that SseEventManager uses. Cast at the
+    // injection site to avoid pulling the real store's full surface
+    // into the test.
+    async getWorkspacesForUser(userId: string) {
+      const ids = byUser.get(userId) ?? [];
+      return ids.map((id) => ({ id }) as { id: string });
+    },
+    onMembershipChanged(handler: (userId: string) => void): () => void {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+  };
+}
+
+describe("SseEventManager — identity-scoped clients", () => {
+  let store: ReturnType<typeof fakeWorkspaceStore>;
+  let mgr: SseEventManager;
+  const released: Array<() => void> = [];
+
+  beforeEach(() => {
+    store = fakeWorkspaceStore();
+    // biome-ignore lint/suspicious/noExplicitAny: minimal store stub, see fakeWorkspaceStore docblock
+    mgr = new SseEventManager(1_000_000, store as any);
+    mgr.start();
+  });
+
+  afterEach(() => {
+    for (const r of released.splice(0)) r();
+    mgr.stop();
+  });
+
+  test("identity client receives workspace-scoped events only for member workspaces", async () => {
+    // Alice is in ws_a; Bob is in ws_b. Each opens an identity-scoped
+    // /v1/events stream. The fan-out gate is the cached membership set.
+    const alice = collect(mgr.addIdentityClient("usr_alice", new Set(["ws_a"])));
+    const bob = collect(mgr.addIdentityClient("usr_bob", new Set(["ws_b"])));
+    released.push(alice.release, bob.release);
+
+    mgr.emit({
+      type: "bundle.installed",
+      data: { wsId: "ws_a", serverName: "ipinfo", bundleName: "@nb/ipinfo" },
+    });
+    mgr.emit({
+      type: "bundle.installed",
+      data: { wsId: "ws_b", serverName: "granola", bundleName: "@nb/granola" },
+    });
+    await flush();
+
+    expect(alice.events).toEqual(["bundle.installed"]);
+    expect(bob.events).toEqual(["bundle.installed"]);
+  });
+
+  test("multi-workspace identity client receives events for any member workspace", async () => {
+    // A user with membership in both workspaces — the everyday case for
+    // an operator with a personal and a team workspace.
+    const both = collect(mgr.addIdentityClient("usr_op", new Set(["ws_a", "ws_b"])));
+    released.push(both.release);
+
+    mgr.emit({
+      type: "bundle.installed",
+      data: { wsId: "ws_a", serverName: "ipinfo", bundleName: "@nb/ipinfo" },
+    });
+    mgr.emit({
+      type: "connection.state_changed",
+      data: {
+        wsId: "ws_b",
+        serverName: "granola",
+        bundleName: "https://granola.test/",
+        principalId: "_workspace",
+        state: "running",
+      },
+    });
+    await flush();
+
+    expect(both.events).toEqual(["bundle.installed", "connection.state_changed"]);
+  });
+
+  test("global events still reach identity clients regardless of memberships", async () => {
+    // Even a client with an empty membership set sees global broadcasts —
+    // global events have no `wsId` and skip the membership filter.
+    const empty = collect(mgr.addIdentityClient("usr_x", new Set()));
+    released.push(empty.release);
+
+    mgr.emit({ type: "config.changed", data: { key: "models.default" } });
+    await flush();
+
+    expect(empty.events).toEqual(["config.changed"]);
+  });
+
+  test("membership-change refresh delivers events for newly-added workspaces", async () => {
+    // Alice starts with no workspaces. Workspace add → manager re-queries
+    // and the next emit reaches her. This is the workspace-switch /
+    // newly-invited path post-Stage-2, without an SSE reconnect.
+    store.setMemberships("usr_alice", []);
+    const alice = collect(mgr.addIdentityClient("usr_alice", new Set()));
+    released.push(alice.release);
+
+    mgr.emit({
+      type: "bundle.installed",
+      data: { wsId: "ws_a", serverName: "x", bundleName: "y" },
+    });
+    await flush();
+    expect(alice.events).toEqual([]); // not yet a member
+
+    // The workspace store fires a membership change — manager refreshes.
+    store.setMemberships("usr_alice", ["ws_a"]);
+    // Refresh is async (awaits getWorkspacesForUser); flush twice so the
+    // promise-then microtask runs before the next emit.
+    await flush();
+    await flush();
+
+    mgr.emit({
+      type: "bundle.installed",
+      data: { wsId: "ws_a", serverName: "x", bundleName: "z" },
+    });
+    await flush();
+
+    expect(alice.events).toEqual(["bundle.installed"]);
+  });
+
+  test("membership-change refresh drops events for removed workspaces", async () => {
+    // Alice was a member; removal → manager re-queries to an empty set;
+    // subsequent emits for ws_a no longer reach her.
+    store.setMemberships("usr_alice", ["ws_a"]);
+    const alice = collect(mgr.addIdentityClient("usr_alice", new Set(["ws_a"])));
+    released.push(alice.release);
+
+    store.setMemberships("usr_alice", []);
+    await flush();
+    await flush();
+
+    mgr.emit({
+      type: "bundle.installed",
+      data: { wsId: "ws_a", serverName: "x", bundleName: "y" },
+    });
+    await flush();
+
+    expect(alice.events).toEqual([]);
+  });
+
+  test("identity client unaffected by other identities' membership changes", async () => {
+    // Membership-change fires per-userId; the manager scans only matching
+    // clients. Alice's set must not be churned by Bob's mutations.
+    store.setMemberships("usr_alice", ["ws_a"]);
+    store.setMemberships("usr_bob", ["ws_b"]);
+    const alice = collect(mgr.addIdentityClient("usr_alice", new Set(["ws_a"])));
+    released.push(alice.release);
+
+    store.setMemberships("usr_bob", []);
+    await flush();
+    await flush();
+
+    mgr.emit({
+      type: "bundle.installed",
+      data: { wsId: "ws_a", serverName: "x", bundleName: "y" },
+    });
+    await flush();
+
+    expect(alice.events).toEqual(["bundle.installed"]);
+  });
+});

--- a/test/unit/workspace/workspace-store.test.ts
+++ b/test/unit/workspace/workspace-store.test.ts
@@ -436,3 +436,116 @@ describe("WorkspaceStore.update", () => {
     ).rejects.toThrow(/personal-workspace invariant/i);
   });
 });
+
+// ── Membership-change subscription ─────────────────────────────────
+
+describe("onMembershipChanged", () => {
+  test("fires on create for every initial member", async () => {
+    const seen: string[] = [];
+    store.onMembershipChanged((userId) => seen.push(userId));
+
+    await store.create("Team", undefined, {
+      members: [
+        { userId: "usr_alice", role: "admin" },
+        { userId: "usr_bob", role: "member" },
+      ],
+    });
+
+    expect(seen).toEqual(["usr_alice", "usr_bob"]);
+  });
+
+  test("fires on addMember with the added userId", async () => {
+    const ws = await store.create("Team");
+    const seen: string[] = [];
+    store.onMembershipChanged((userId) => seen.push(userId));
+
+    await store.addMember(ws.id, "usr_charlie", "admin");
+
+    expect(seen).toEqual(["usr_charlie"]);
+  });
+
+  test("does not fire on addMember conflict (already a member)", async () => {
+    const ws = await store.create("Team", undefined, {
+      members: [{ userId: "usr_alice", role: "admin" }],
+    });
+    const seen: string[] = [];
+    store.onMembershipChanged((userId) => seen.push(userId));
+
+    await expect(store.addMember(ws.id, "usr_alice", "member")).rejects.toThrow(
+      MemberConflictError,
+    );
+    expect(seen).toEqual([]);
+  });
+
+  test("fires on removeMember only when the user was actually a member", async () => {
+    const ws = await store.create("Team", undefined, {
+      members: [{ userId: "usr_alice", role: "admin" }],
+    });
+    const seen: string[] = [];
+    store.onMembershipChanged((userId) => seen.push(userId));
+
+    // Real removal — fires.
+    await store.removeMember(ws.id, "usr_alice");
+    expect(seen).toEqual(["usr_alice"]);
+
+    // No-op removal of a non-member — does not fire. Spurious
+    // invalidations would churn every connected client's membership
+    // cache on the SSE side.
+    await store.removeMember(ws.id, "usr_ghost");
+    expect(seen).toEqual(["usr_alice"]);
+  });
+
+  test("fires on delete for every former member", async () => {
+    const ws = await store.create("Team", undefined, {
+      members: [
+        { userId: "usr_alice", role: "admin" },
+        { userId: "usr_bob", role: "member" },
+      ],
+    });
+    const seen: string[] = [];
+    store.onMembershipChanged((userId) => seen.push(userId));
+
+    const ok = await store.delete(ws.id);
+    expect(ok).toBe(true);
+    expect(seen.sort()).toEqual(["usr_alice", "usr_bob"]);
+  });
+
+  test("does not fire on updateMemberRole (role changes don't affect set membership)", async () => {
+    const ws = await store.create("Team", undefined, {
+      members: [{ userId: "usr_alice", role: "member" }],
+    });
+    const seen: string[] = [];
+    store.onMembershipChanged((userId) => seen.push(userId));
+
+    await store.updateMemberRole(ws.id, "usr_alice", "admin");
+
+    expect(seen).toEqual([]);
+  });
+
+  test("unsubscribe stops further notifications", async () => {
+    const ws = await store.create("Team");
+    const seen: string[] = [];
+    const unsub = store.onMembershipChanged((userId) => seen.push(userId));
+
+    await store.addMember(ws.id, "usr_a", "admin");
+    unsub();
+    await store.addMember(ws.id, "usr_b", "admin");
+
+    expect(seen).toEqual(["usr_a"]);
+  });
+
+  test("a throwing handler doesn't break the mutation or other handlers", async () => {
+    const ws = await store.create("Team");
+    const seen: string[] = [];
+    store.onMembershipChanged(() => {
+      throw new Error("boom");
+    });
+    store.onMembershipChanged((userId) => seen.push(userId));
+
+    // Mutation succeeds despite the throwing handler.
+    const updated = await store.addMember(ws.id, "usr_alice", "admin");
+    expect(updated.members.some((m) => m.userId === "usr_alice")).toBe(true);
+    // Non-throwing handler still ran.
+    expect(seen).toEqual(["usr_alice"]);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,8 @@ import {
   setPlatformVersion,
   tryBootstrap,
 } from "./api/client";
+import { closeAllConversationEvents } from "./api/conversation-events-client";
+import { closeEventsClient } from "./api/events-client";
 import { AppWithChat } from "./components/AppWithChat";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Login } from "./components/Login";
@@ -527,6 +529,22 @@ export function App() {
   const [bootstrap, setBootstrap] = useState<BootstrapResponse | null>(null);
   const [authenticated, setAuthenticated] = useState(false);
   const [checking, setChecking] = useState(true);
+
+  // Tab-lifetime cleanup. `pagehide` fires on tab close, navigation away,
+  // and bfcache enter — earlier and more reliable than `beforeunload`,
+  // and it lets the server reclaim the SSE slots immediately rather than
+  // waiting for the TCP teardown to be noticed by the next failed
+  // enqueue. The TCP teardown path still works as a fallback.
+  useEffect(() => {
+    const onPageHide = (): void => {
+      closeEventsClient();
+      closeAllConversationEvents();
+    };
+    window.addEventListener("pagehide", onPageHide);
+    return () => {
+      window.removeEventListener("pagehide", onPageHide);
+    };
+  }, []);
 
   const handleLogout = useCallback(() => {
     logout();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -239,6 +239,14 @@ function AuthenticatedAppContent({
     onBundleLifecycleChanged: () => {
       void refreshShell();
     },
+    // After a reconnect, any bundle / config events emitted during the
+    // disconnect gap were dropped (the workspace stream has no
+    // Last-Event-Id replay). Refetch the two state owners that consume
+    // those events so the UI snaps back to truth.
+    onReconnect: () => {
+      void refreshShell();
+      config.refreshConfig();
+    },
   });
 
   // Sync server-side theme preference to the client theme context

--- a/web/src/__tests__/api-client-lifecycle.test.ts
+++ b/web/src/__tests__/api-client-lifecycle.test.ts
@@ -27,7 +27,12 @@
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { setActiveWorkspaceId, setAuthLifecycleHandler, setAuthToken } from "../api/client";
+import {
+  addAuthLifecycleHandler,
+  setActiveWorkspaceId,
+  setAuthLifecycleHandler,
+  setAuthToken,
+} from "../api/client";
 
 afterEach(() => {
   // Reset module state so tests don't leak handlers / tokens / workspaces
@@ -129,5 +134,71 @@ describe("auth lifecycle handler", () => {
     setActiveWorkspaceId("ws-same");
     setActiveWorkspaceId("ws-different");
     expect(handler).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ── Multi-listener (addAuthLifecycleHandler) ───────────────────────
+
+describe("addAuthLifecycleHandler — multi-listener", () => {
+  test("fires every registered handler on setAuthToken change", () => {
+    // Two stateful clients — the MCP bridge and the SSE event clients —
+    // each register their own teardown. Both must run.
+    const a = mock(() => {});
+    const b = mock(() => {});
+    addAuthLifecycleHandler(a);
+    addAuthLifecycleHandler(b);
+
+    setAuthToken("tok-1");
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+
+    setAuthToken("tok-2");
+    expect(a).toHaveBeenCalledTimes(2);
+    expect(b).toHaveBeenCalledTimes(2);
+  });
+
+  test("returned unsubscribe removes the handler", () => {
+    const a = mock(() => {});
+    const unsub = addAuthLifecycleHandler(a);
+
+    setAuthToken("tok-1");
+    expect(a).toHaveBeenCalledTimes(1);
+
+    unsub();
+    setAuthToken("tok-2");
+    expect(a).toHaveBeenCalledTimes(1);
+  });
+
+  test("a throwing handler does not block other handlers or the token update", () => {
+    // Set-based iteration must continue past a throwing subscriber, and
+    // the token must still be updated. Otherwise a buggy MCP bridge
+    // reset would silently strand the SSE event clients on a stale
+    // identity.
+    const thrower = mock(() => {
+      throw new Error("boom");
+    });
+    const good = mock(() => {});
+    addAuthLifecycleHandler(thrower);
+    addAuthLifecycleHandler(good);
+
+    setAuthToken("tok-1");
+
+    expect(thrower).toHaveBeenCalledTimes(1);
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+
+  test("setAuthLifecycleHandler (deprecated) clears the multi-listener set", () => {
+    // Deprecated alias preserves single-slot semantics for external
+    // callers that haven't migrated: clear-all-and-set. Internal callers
+    // should use `addAuthLifecycleHandler`.
+    const added = mock(() => {});
+    const set = mock(() => {});
+    addAuthLifecycleHandler(added);
+
+    setAuthLifecycleHandler(set);
+
+    setAuthToken("tok-1");
+    expect(added).toHaveBeenCalledTimes(0); // cleared
+    expect(set).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/__tests__/conversation-events-client.test.ts
+++ b/web/src/__tests__/conversation-events-client.test.ts
@@ -1,0 +1,195 @@
+// ---------------------------------------------------------------------------
+// conversation-events-client.ts — keyed conversation SSE singleton
+//
+// Mocks `./api/conversation-sse` so the singleton can be driven without
+// touching the network. Verifies the per-conversation ref-counted
+// open/close semantic, which is the contract that prevents the latent
+// "two consumers → two connections" regression even though today only
+// one consumer (ChatContext) subscribes.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ConversationSseConnection, ConversationSseOptions } from "../api/conversation-sse";
+
+let connectCalls = 0;
+let closeCalls = 0;
+const optionsByConvId = new Map<string, ConversationSseOptions>();
+
+class FakeConvConnection implements ConversationSseConnection {
+  closed = false;
+  conversationId: string;
+  constructor(conversationId: string) {
+    this.conversationId = conversationId;
+  }
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    closeCalls += 1;
+  }
+}
+
+const liveConnections: FakeConvConnection[] = [];
+
+function fakeConnectConversationEvents(options: ConversationSseOptions): ConversationSseConnection {
+  connectCalls += 1;
+  optionsByConvId.set(options.conversationId, options);
+  const conn = new FakeConvConnection(options.conversationId);
+  liveConnections.push(conn);
+  return conn;
+}
+
+mock.module("../api/conversation-sse", () => ({
+  connectConversationEvents: fakeConnectConversationEvents,
+}));
+
+// Import AFTER mocking so the singleton sees the fake.
+import { setAuthLifecycleHandler, setAuthToken } from "../api/client";
+import {
+  __internal__,
+  closeAllConversationEvents,
+  subscribeConversation,
+} from "../api/conversation-events-client";
+
+function resetCounters(): void {
+  connectCalls = 0;
+  closeCalls = 0;
+  optionsByConvId.clear();
+  liveConnections.length = 0;
+}
+
+beforeEach(() => {
+  resetCounters();
+  setAuthToken("tok-initial");
+  __internal__.resetForTest();
+});
+
+afterEach(() => {
+  __internal__.resetForTest();
+  setAuthLifecycleHandler(null);
+  setAuthToken(null);
+});
+
+describe("conversation-events-client — keyed singleton", () => {
+  test("first subscribe for a conversation opens exactly one connection", () => {
+    subscribeConversation("conv_a", { onEvent: () => {} });
+    expect(connectCalls).toBe(1);
+    expect(__internal__.hasConnection("conv_a")).toBe(true);
+    expect(__internal__.connectionCount()).toBe(1);
+  });
+
+  test("multiple subscribers to the same conversation share one connection", () => {
+    subscribeConversation("conv_a", { onEvent: () => {} });
+    subscribeConversation("conv_a", { onEvent: () => {} });
+    subscribeConversation("conv_a", { onEvent: () => {} });
+    expect(connectCalls).toBe(1);
+    expect(__internal__.connectionCount()).toBe(1);
+  });
+
+  test("different conversations get their own connections", () => {
+    subscribeConversation("conv_a", { onEvent: () => {} });
+    subscribeConversation("conv_b", { onEvent: () => {} });
+    expect(connectCalls).toBe(2);
+    expect(__internal__.connectionCount()).toBe(2);
+    expect(__internal__.hasConnection("conv_a")).toBe(true);
+    expect(__internal__.hasConnection("conv_b")).toBe(true);
+  });
+});
+
+describe("conversation-events-client — event fan-out", () => {
+  test("events route to every subscriber of the same conversation", () => {
+    const a = mock(() => {});
+    const b = mock(() => {});
+    const other = mock(() => {});
+    subscribeConversation("conv_a", { onEvent: a });
+    subscribeConversation("conv_a", { onEvent: b });
+    subscribeConversation("conv_b", { onEvent: other });
+
+    optionsByConvId.get("conv_a")?.onEvent("text.delta", { delta: "hi" });
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(other).toHaveBeenCalledTimes(0);
+  });
+
+  test("onReconnect fires for every registered reconnect handler", () => {
+    const a = mock(() => {});
+    const b = mock(() => {});
+    subscribeConversation("conv_a", { onEvent: () => {}, onReconnect: a });
+    subscribeConversation("conv_a", { onEvent: () => {}, onReconnect: b });
+
+    optionsByConvId.get("conv_a")?.onReconnect?.();
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  test("a throwing handler does not block siblings", () => {
+    const thrower = mock(() => {
+      throw new Error("boom");
+    });
+    const good = mock(() => {});
+    subscribeConversation("conv_a", { onEvent: thrower });
+    subscribeConversation("conv_a", { onEvent: good });
+
+    optionsByConvId.get("conv_a")?.onEvent("text.delta", {});
+
+    expect(thrower).toHaveBeenCalledTimes(1);
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("conversation-events-client — ref-counted teardown", () => {
+  test("last unsubscribe closes the conversation's connection", () => {
+    const unsubA = subscribeConversation("conv_a", { onEvent: () => {} });
+    const unsubB = subscribeConversation("conv_a", { onEvent: () => {} });
+    expect(__internal__.connectionCount()).toBe(1);
+
+    unsubA();
+    // Still one subscriber → connection stays.
+    expect(__internal__.hasConnection("conv_a")).toBe(true);
+    expect(closeCalls).toBe(0);
+
+    unsubB();
+    // No subscribers → close.
+    expect(__internal__.hasConnection("conv_a")).toBe(false);
+    expect(closeCalls).toBe(1);
+  });
+
+  test("unsubscribing one conversation doesn't affect others", () => {
+    const unsubA = subscribeConversation("conv_a", { onEvent: () => {} });
+    subscribeConversation("conv_b", { onEvent: () => {} });
+
+    unsubA();
+    expect(__internal__.hasConnection("conv_a")).toBe(false);
+    expect(__internal__.hasConnection("conv_b")).toBe(true);
+  });
+
+  test("unsubscribe is idempotent (calling twice is safe)", () => {
+    const unsub = subscribeConversation("conv_a", { onEvent: () => {} });
+    unsub();
+    expect(() => unsub()).not.toThrow();
+    expect(closeCalls).toBe(1);
+  });
+});
+
+describe("conversation-events-client — auth lifecycle", () => {
+  test("auth-lifecycle fire closes every active conversation stream", () => {
+    subscribeConversation("conv_a", { onEvent: () => {} });
+    subscribeConversation("conv_b", { onEvent: () => {} });
+    expect(__internal__.connectionCount()).toBe(2);
+
+    setAuthToken(null);
+
+    expect(__internal__.connectionCount()).toBe(0);
+    // No auto-rebuild — conversation streams are user-driven.
+  });
+
+  test("closeAllConversationEvents is idempotent", () => {
+    expect(() => closeAllConversationEvents()).not.toThrow();
+    expect(closeCalls).toBe(0);
+    subscribeConversation("conv_a", { onEvent: () => {} });
+    closeAllConversationEvents();
+    expect(closeCalls).toBe(1);
+    expect(() => closeAllConversationEvents()).not.toThrow();
+  });
+});

--- a/web/src/__tests__/events-client.test.ts
+++ b/web/src/__tests__/events-client.test.ts
@@ -43,13 +43,7 @@ mock.module("../api/sse", () => ({
 
 // Import AFTER mocking so the singleton sees the fake.
 import { setAuthLifecycleHandler, setAuthToken } from "../api/client";
-import {
-  __internal__,
-  closeEventsClient,
-  onReconnect,
-  onStatus,
-  subscribe,
-} from "../api/events-client";
+import { __internal__, closeEventsClient, onReconnect, subscribe } from "../api/events-client";
 
 function resetCounters(): void {
   connectCalls = 0;
@@ -166,25 +160,6 @@ describe("events-client — onReconnect", () => {
     lastOptions!.onReconnect?.();
 
     expect(a).toHaveBeenCalledTimes(0);
-  });
-});
-
-describe("events-client — onStatus", () => {
-  test("fires current status synchronously on subscribe", () => {
-    const seen: string[] = [];
-    onStatus((s) => seen.push(s));
-    // Connection hasn't opened yet — initial status is "disconnected".
-    expect(seen).toEqual(["disconnected"]);
-  });
-
-  test("transitions to connecting then open on first subscribe", async () => {
-    const seen: string[] = [];
-    onStatus((s) => seen.push(s));
-    subscribe("data.changed", () => {});
-    // Drain microtasks so the queued onOpen runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(seen).toEqual(["disconnected", "connecting", "open"]);
   });
 });
 

--- a/web/src/__tests__/events-client.test.ts
+++ b/web/src/__tests__/events-client.test.ts
@@ -1,0 +1,245 @@
+// ---------------------------------------------------------------------------
+// events-client.ts — workspace event stream singleton
+//
+// Mocks `./api/sse` so tests don't touch the network. The fake exposes
+// hooks to drive events / reconnects into the singleton and to count
+// real `connectEvents` invocations, which is the property the whole
+// refactor exists to enforce: N subscribers → 1 connection.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ConnectEventsOptions, EventConnection } from "../api/sse";
+
+let connectCalls = 0;
+let closeCalls = 0;
+let lastOptions: ConnectEventsOptions | null = null;
+
+class FakeConnection implements EventConnection {
+  closed = false;
+  close(): void {
+    this.closed = true;
+    closeCalls += 1;
+  }
+}
+
+const liveConnections: FakeConnection[] = [];
+
+function fakeConnectEvents(options: ConnectEventsOptions): EventConnection {
+  connectCalls += 1;
+  lastOptions = options;
+  const conn = new FakeConnection();
+  liveConnections.push(conn);
+  // Fire onOpen async to mimic the real flow where onOpen runs after
+  // headers come back. Tests that need open-state assert on this.
+  queueMicrotask(() => {
+    if (!conn.closed) options.onOpen?.();
+  });
+  return conn;
+}
+
+mock.module("../api/sse", () => ({
+  connectEvents: fakeConnectEvents,
+}));
+
+// Import AFTER mocking so the singleton sees the fake.
+import { setAuthLifecycleHandler, setAuthToken } from "../api/client";
+import {
+  __internal__,
+  closeEventsClient,
+  onReconnect,
+  onStatus,
+  subscribe,
+} from "../api/events-client";
+
+function resetCounters(): void {
+  connectCalls = 0;
+  closeCalls = 0;
+  lastOptions = null;
+  liveConnections.length = 0;
+}
+
+beforeEach(() => {
+  resetCounters();
+  setAuthLifecycleHandler(null);
+  setAuthToken("tok-initial");
+  __internal__.resetForTest();
+});
+
+afterEach(() => {
+  __internal__.resetForTest();
+  setAuthLifecycleHandler(null);
+  setAuthToken(null);
+});
+
+describe("events-client — singleton transport", () => {
+  test("first subscribe opens exactly one underlying connection", () => {
+    subscribe("data.changed", () => {});
+    expect(connectCalls).toBe(1);
+    expect(__internal__.hasConnection()).toBe(true);
+  });
+
+  test("N subscribes across types share the same connection", () => {
+    subscribe("data.changed", () => {});
+    subscribe("config.changed", () => {});
+    subscribe("bundle.installed", () => {});
+    subscribe("data.changed", () => {}); // second handler for same type
+    expect(connectCalls).toBe(1);
+    expect(__internal__.subscriberCount()).toBe(4);
+  });
+
+  test("unsubscribe removes the handler but keeps the connection alive", () => {
+    const unsub = subscribe("data.changed", () => {});
+    expect(__internal__.hasConnection()).toBe(true);
+    expect(__internal__.subscriberCount()).toBe(1);
+
+    unsub();
+    expect(__internal__.subscriberCount()).toBe(0);
+    // Connection stays open — workspace stream is tab-life. The
+    // alternative (close-on-zero) thrashes under StrictMode.
+    expect(__internal__.hasConnection()).toBe(true);
+    expect(closeCalls).toBe(0);
+  });
+});
+
+describe("events-client — event routing", () => {
+  test("event dispatch fans out to every subscriber of that type", () => {
+    const a = mock(() => {});
+    const b = mock(() => {});
+    const c = mock(() => {});
+    subscribe("data.changed", a);
+    subscribe("data.changed", b);
+    subscribe("config.changed", c);
+
+    // Drive an event through the fake's captured onEvent.
+    // biome-ignore lint/style/noNonNullAssertion: lastOptions is set by the first subscribe()
+    lastOptions!.onEvent("data.changed", { server: "x", tool: "y" });
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(c).toHaveBeenCalledTimes(0);
+  });
+
+  test("a throwing handler does not block other handlers for the same event", () => {
+    const thrower = mock(() => {
+      throw new Error("boom");
+    });
+    const good = mock(() => {});
+    subscribe("data.changed", thrower);
+    subscribe("data.changed", good);
+
+    // biome-ignore lint/style/noNonNullAssertion: see prior
+    lastOptions!.onEvent("data.changed", { server: "x" });
+
+    expect(thrower).toHaveBeenCalledTimes(1);
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+
+  test("events for types with no subscribers are dropped without error", () => {
+    subscribe("data.changed", () => {});
+    // biome-ignore lint/style/noNonNullAssertion: see prior
+    expect(() => lastOptions!.onEvent("skill.created", { id: "x" })).not.toThrow();
+  });
+});
+
+describe("events-client — onReconnect", () => {
+  test("fires every registered reconnect handler", () => {
+    const a = mock(() => {});
+    const b = mock(() => {});
+    subscribe("data.changed", () => {}); // ensure connection
+    onReconnect(a);
+    onReconnect(b);
+
+    // biome-ignore lint/style/noNonNullAssertion: see prior
+    lastOptions!.onReconnect?.();
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribed reconnect handler does not fire", () => {
+    const a = mock(() => {});
+    subscribe("data.changed", () => {});
+    const unsub = onReconnect(a);
+
+    unsub();
+    // biome-ignore lint/style/noNonNullAssertion: see prior
+    lastOptions!.onReconnect?.();
+
+    expect(a).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("events-client — onStatus", () => {
+  test("fires current status synchronously on subscribe", () => {
+    const seen: string[] = [];
+    onStatus((s) => seen.push(s));
+    // Connection hasn't opened yet — initial status is "disconnected".
+    expect(seen).toEqual(["disconnected"]);
+  });
+
+  test("transitions to connecting then open on first subscribe", async () => {
+    const seen: string[] = [];
+    onStatus((s) => seen.push(s));
+    subscribe("data.changed", () => {});
+    // Drain microtasks so the queued onOpen runs.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(seen).toEqual(["disconnected", "connecting", "open"]);
+  });
+});
+
+describe("events-client — auth lifecycle", () => {
+  test("auth-lifecycle fire closes the existing connection", () => {
+    subscribe("data.changed", () => {});
+    expect(__internal__.hasConnection()).toBe(true);
+    const initialConn = liveConnections[0];
+
+    // setAuthToken(null) clears auth + fires the lifecycle. With no
+    // token, the re-open guard skips reopening.
+    setAuthToken(null);
+
+    expect(initialConn?.closed).toBe(true);
+    expect(__internal__.hasConnection()).toBe(false);
+  });
+
+  test("auth-lifecycle re-opens when subscribers remain AND token is present", () => {
+    subscribe("data.changed", () => {});
+    expect(connectCalls).toBe(1);
+
+    // Rotate to a different non-null token — close + re-open under the
+    // new identity. This is the post-refresh path.
+    setAuthToken("tok-rotated");
+    expect(connectCalls).toBe(2);
+    expect(__internal__.hasConnection()).toBe(true);
+    // The new fetch reads the rotated token.
+    expect(lastOptions?.token).toBe("tok-rotated");
+  });
+
+  test("auth-lifecycle does NOT re-open after logout (token is null)", () => {
+    subscribe("data.changed", () => {});
+    expect(connectCalls).toBe(1);
+
+    setAuthToken(null);
+    expect(connectCalls).toBe(1);
+    expect(__internal__.hasConnection()).toBe(false);
+  });
+});
+
+describe("events-client — explicit close", () => {
+  test("closeEventsClient drops the connection without removing subscribers", () => {
+    subscribe("data.changed", () => {});
+    expect(__internal__.subscriberCount()).toBe(1);
+    expect(__internal__.hasConnection()).toBe(true);
+
+    closeEventsClient();
+
+    expect(__internal__.hasConnection()).toBe(false);
+    expect(__internal__.subscriberCount()).toBe(1);
+  });
+
+  test("closeEventsClient is idempotent (safe with no connection)", () => {
+    expect(() => closeEventsClient()).not.toThrow();
+    expect(() => closeEventsClient()).not.toThrow();
+    expect(closeCalls).toBe(0);
+  });
+});

--- a/web/src/__tests__/useEvents.test.tsx
+++ b/web/src/__tests__/useEvents.test.tsx
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------------
+// useEvents — hook wiring contract
+//
+// Pins the regression QA caught on the singleton landing PR: the hook
+// must wire its `onReconnect` option through to the singleton's
+// `onReconnect` channel. Without this, a watchdog/visibility-driven
+// reconnect silently resumes the stream and any state derived from
+// missed `bundle.installed` / `config.changed` events drifts.
+//
+// Same shape as the other hook tests in this directory — bun:test +
+// react-dom/client + happy-dom (via web/test/setup.ts), no
+// @testing-library/react. We mock `../api/events-client` so the test
+// drives the dispatch directly instead of trying to fake the SSE.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let reconnectHandler: (() => void) | null = null;
+const subscribeMock = mock(() => () => {});
+const onReconnectMock = mock((handler: () => void) => {
+  reconnectHandler = handler;
+  return () => {
+    if (reconnectHandler === handler) reconnectHandler = null;
+  };
+});
+
+mock.module("../api/events-client", () => ({
+  subscribe: subscribeMock,
+  onReconnect: onReconnectMock,
+}));
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { useEvents } = await import("../hooks/useEvents");
+
+function Probe(props: { onReconnect: () => void }): null {
+  useEvents("tok", undefined, { onReconnect: props.onReconnect });
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof ReactDOMClient.createRoot>;
+
+beforeEach(() => {
+  reconnectHandler = null;
+  subscribeMock.mockClear();
+  onReconnectMock.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = ReactDOMClient.createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("useEvents", () => {
+  test("registers an onReconnect subscription against the singleton", () => {
+    const onReconnect = mock(() => {});
+    act(() => {
+      root.render(<Probe onReconnect={onReconnect} />);
+    });
+
+    expect(onReconnectMock).toHaveBeenCalledTimes(1);
+    expect(reconnectHandler).not.toBeNull();
+  });
+
+  test("singleton onReconnect fires the consumer's onReconnect callback", () => {
+    const onReconnect = mock(() => {});
+    act(() => {
+      root.render(<Probe onReconnect={onReconnect} />);
+    });
+    expect(reconnectHandler).not.toBeNull();
+
+    // Simulate the singleton firing reconnect (as it does after a
+    // successful re-establishment post-watchdog / visibility resume).
+    reconnectHandler?.();
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -32,29 +32,63 @@ export function getAuthToken(): string | null {
 }
 
 /**
- * Hook fired on logout / auth-token change — used by stateful clients that
- * hold a session bound to the identity. The MCP bridge client
- * (`mcp-bridge-client.ts`) registers here at module load so its cached
- * transport gets dropped on logout instead of silently servicing the next
- * identity. Stateless callers (REST helpers, `fetchWithRefresh`) read the
- * current token per-request and need no hook.
+ * Hooks fired on logout / auth-token change — used by stateful clients
+ * that hold a session bound to the identity. Callers register via
+ * `addAuthLifecycleHandler` and unsubscribe via the returned function;
+ * `setAuthToken` iterates the set so multiple stateful clients (the MCP
+ * bridge, the SSE event clients) each drop their identity-bound state
+ * on logout independently. Stateless callers (REST helpers,
+ * `fetchWithRefresh`) read the current token per-request and need no
+ * hook.
  *
  * Stage 2 / Q3 (locked 2026-05-22): the `/mcp` session is identity-bound,
- * not workspace-bound. Workspace switches do NOT drop the bridge session —
- * `setActiveWorkspaceId` therefore no longer fires this hook. Cross-call
+ * not workspace-bound. Workspace switches do NOT drop these hooks —
+ * `setActiveWorkspaceId` therefore does not fire them. Cross-call
  * workspace context is supplied per-request via the `X-Workspace-Id`
- * header read fresh by the custom fetch in `mcp-bridge-client.ts`.
+ * header read fresh by callers (the MCP bridge, REST helpers).
  */
-let onAuthLifecycleChange: (() => void) | null = null;
+const authLifecycleHandlers = new Set<() => void>();
+
+/**
+ * Register a hook to fire whenever the auth token changes (login,
+ * logout, refresh-to-different-token). Returns an unsubscribe function.
+ *
+ * Idempotent: registering the same callback twice has no effect (Set
+ * semantics). Errors in a handler are caught so a buggy registration
+ * can't break others or block the token update.
+ */
+export function addAuthLifecycleHandler(handler: () => void): () => void {
+  authLifecycleHandlers.add(handler);
+  return () => {
+    authLifecycleHandlers.delete(handler);
+  };
+}
+
+/**
+ * @deprecated Use `addAuthLifecycleHandler`. Single-slot semantics
+ * (clear-all-and-set) are preserved for external callers that haven't
+ * migrated, but the multi-listener API is the supported path.
+ */
 export function setAuthLifecycleHandler(handler: (() => void) | null): void {
-  onAuthLifecycleChange = handler;
+  authLifecycleHandlers.clear();
+  if (handler) authLifecycleHandlers.add(handler);
+}
+
+function fireAuthLifecycle(): void {
+  for (const handler of authLifecycleHandlers) {
+    try {
+      handler();
+    } catch (err) {
+      console.warn("[client] auth lifecycle handler threw:", err);
+    }
+  }
 }
 
 /** Set the bearer token used for all authenticated requests. */
 export function setAuthToken(token: string | null): void {
   if (authToken === token) return;
   authToken = token;
-  onAuthLifecycleChange?.();
+  fireAuthLifecycle();
 }
 
 /**

--- a/web/src/api/conversation-events-client.ts
+++ b/web/src/api/conversation-events-client.ts
@@ -1,0 +1,163 @@
+// ---------------------------------------------------------------------------
+// Per-conversation Event Stream — keyed singleton client
+//
+// One `GET /v1/conversations/:id/events` SSE connection per ACTIVE
+// conversation, fanned out to many subscribers via `subscribeConversation`.
+// Same singleton pattern as `events-client.ts`, but keyed by
+// `conversationId` and ref-counted: when the last subscriber for a
+// conversation unsubscribes, that conversation's connection closes.
+// (Conversations are mounted / unmounted as the user navigates; the
+// workspace stream is tab-life because it always has a consumer.)
+//
+// Why this exists. Today only `ChatContext.tsx:170` calls
+// `useConversationEvents`, so it's a singleton by coincidence. The
+// moment a second component starts subscribing — a preview pane, a
+// notification surface, an embedded view — the per-component
+// connectConversationEvents pattern would silently duplicate the
+// connection per conversation. Building the singleton up-front prevents
+// tomorrow's regression at zero ongoing cost.
+//
+// Auth lifecycle: identity rotation closes every active conversation
+// stream. Existing subscribers may re-subscribe after navigation; we
+// don't auto-rebuild like the workspace stream because conversation
+// streams are user-driven (mounted by ChatContext on conversation
+// focus), not always-on substrate.
+// ---------------------------------------------------------------------------
+
+import { addAuthLifecycleHandler, getAuthToken } from "./client";
+import { type ConversationSseConnection, connectConversationEvents } from "./conversation-sse";
+
+type EventHandler = (type: string, data: unknown) => void;
+type ReconnectHandler = () => void;
+
+interface ConversationEntry {
+  connection: ConversationSseConnection;
+  eventHandlers: Set<EventHandler>;
+  reconnectHandlers: Set<ReconnectHandler>;
+}
+
+const entries = new Map<string, ConversationEntry>();
+
+function ensureEntry(conversationId: string): ConversationEntry {
+  const existing = entries.get(conversationId);
+  if (existing) return existing;
+
+  // Create the entry first so the `onEvent` / `onReconnect` closures
+  // below can reference it directly. Closing over `entries.get(...)`
+  // in each callback would re-look-up every event.
+  const entry: ConversationEntry = {
+    connection: null as unknown as ConversationSseConnection,
+    eventHandlers: new Set(),
+    reconnectHandlers: new Set(),
+  };
+  entries.set(conversationId, entry);
+
+  entry.connection = connectConversationEvents({
+    conversationId,
+    token: getAuthToken() ?? undefined,
+    onEvent: (type, data) => {
+      for (const h of entry.eventHandlers) {
+        try {
+          h(type, data);
+        } catch (err) {
+          console.warn("[conv-events-client] event handler threw:", err);
+        }
+      }
+    },
+    onReconnect: () => {
+      for (const h of entry.reconnectHandlers) {
+        try {
+          h();
+        } catch (err) {
+          console.warn("[conv-events-client] reconnect handler threw:", err);
+        }
+      }
+    },
+  });
+
+  return entry;
+}
+
+function closeEntry(conversationId: string): void {
+  const entry = entries.get(conversationId);
+  if (!entry) return;
+  entries.delete(conversationId);
+  try {
+    entry.connection.close();
+  } catch (err) {
+    // The transport already swallows close errors internally; logging
+    // here just in case a future implementation throws.
+    console.warn("[conv-events-client] close threw for", conversationId, err);
+  }
+}
+
+/**
+ * Close every active conversation stream. Used by the auth lifecycle
+ * handler below and by `pagehide` cleanup in `App.tsx`. Idempotent.
+ */
+export function closeAllConversationEvents(): void {
+  for (const id of Array.from(entries.keys())) {
+    closeEntry(id);
+  }
+}
+
+// Identity rotation drops every conversation stream. Unlike the
+// workspace events client, we don't auto-rebuild — conversation streams
+// are user-driven (mounted by ChatContext when a conversation is in
+// focus), so the next conversation focus will open a fresh stream
+// under the new identity.
+const authLifecycleHandler = closeAllConversationEvents;
+addAuthLifecycleHandler(authLifecycleHandler);
+
+export interface ConversationSubscription {
+  /** Fires for every SSE event on this conversation's stream. */
+  onEvent: EventHandler;
+  /** Fires after a reconnect — caller should reload missed messages. */
+  onReconnect?: ReconnectHandler;
+}
+
+/**
+ * Subscribe to a conversation's SSE event stream. The first subscribe
+ * for a given `conversationId` opens the underlying connection; the
+ * last unsubscribe closes it. Ref-counted per conversation.
+ *
+ * Returns an unsubscribe function. Calling it removes this subscription
+ * and, if no subscriptions remain for the conversation, tears down the
+ * connection.
+ */
+export function subscribeConversation(
+  conversationId: string,
+  sub: ConversationSubscription,
+): () => void {
+  const entry = ensureEntry(conversationId);
+  entry.eventHandlers.add(sub.onEvent);
+  if (sub.onReconnect) entry.reconnectHandlers.add(sub.onReconnect);
+
+  return () => {
+    const current = entries.get(conversationId);
+    if (!current) return;
+    current.eventHandlers.delete(sub.onEvent);
+    if (sub.onReconnect) current.reconnectHandlers.delete(sub.onReconnect);
+    if (current.eventHandlers.size === 0 && current.reconnectHandlers.size === 0) {
+      closeEntry(conversationId);
+    }
+  };
+}
+
+// ── Test seams ───────────────────────────────────────────────────────
+
+export const __internal__ = {
+  hasConnection(conversationId: string): boolean {
+    return entries.has(conversationId);
+  },
+  connectionCount(): number {
+    return entries.size;
+  },
+  resetForTest(): void {
+    closeAllConversationEvents();
+    // Other test files may have cleared the global lifecycle Set;
+    // re-register idempotently. See events-client.ts for the same
+    // pattern + rationale.
+    addAuthLifecycleHandler(authLifecycleHandler);
+  },
+};

--- a/web/src/api/conversation-events-client.ts
+++ b/web/src/api/conversation-events-client.ts
@@ -73,6 +73,14 @@ function ensureEntry(conversationId: string): ConversationEntry {
         }
       }
     },
+    // Surface unrecoverable transport errors (403 after participant
+    // removal, persistent auth failure) the way the pre-singleton hook
+    // did — silent failure makes a dying conversation stream
+    // undiagnosable. Drop the entry so a later subscribe re-attempts.
+    onError: (err) => {
+      console.warn(`[conv-events-client] stream error for ${conversationId}:`, err.message);
+      entries.delete(conversationId);
+    },
   });
 
   return entry;

--- a/web/src/api/conversation-sse.ts
+++ b/web/src/api/conversation-sse.ts
@@ -4,9 +4,13 @@
  * Connects to GET /v1/conversations/:id/events to receive real-time
  * chat events from other participants in a shared conversation.
  *
- * Same pattern as sse.ts (fetch + ReadableStream for custom auth headers).
- * Auto-reconnects with exponential backoff. On reconnect, calls onReconnect
- * so the caller can reload the full conversation to catch missed messages.
+ * Same pattern and reliability primitives as `sse.ts`:
+ *   - fetch + ReadableStream (for custom auth headers — EventSource
+ *     doesn't carry them)
+ *   - auto-reconnect with jittered exponential backoff
+ *   - heartbeat watchdog (force-reconnect on stale stream)
+ *   - visibility-resume (immediate reconnect when the tab returns)
+ *   - `onReconnect` for state resync (load missed messages)
  */
 
 import { refreshSession } from "./client";
@@ -40,6 +44,9 @@ export interface ConversationSseConnection {
 const INITIAL_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
 const BACKOFF_MULTIPLIER = 2;
+const BACKOFF_JITTER = 0.2;
+const STALE_THRESHOLD_MS = 75_000;
+const WATCHDOG_TICK_MS = 15_000;
 
 export function connectConversationEvents(
   options: ConversationSseOptions,
@@ -57,8 +64,48 @@ export function connectConversationEvents(
   let closed = false;
   let abortController: AbortController | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let watchdogTimer: ReturnType<typeof setInterval> | null = null;
   let backoff = INITIAL_BACKOFF_MS;
   let hasConnectedBefore = false;
+  let lastFrameAt = Date.now();
+
+  function markFrame(): void {
+    lastFrameAt = Date.now();
+  }
+
+  function isStale(): boolean {
+    return Date.now() - lastFrameAt > STALE_THRESHOLD_MS;
+  }
+
+  function forceReconnect(): void {
+    abortController?.abort();
+  }
+
+  function startWatchdog(): void {
+    if (watchdogTimer) return;
+    watchdogTimer = setInterval(() => {
+      if (closed) return;
+      if (isStale()) forceReconnect();
+    }, WATCHDOG_TICK_MS);
+  }
+
+  function stopWatchdog(): void {
+    if (watchdogTimer) {
+      clearInterval(watchdogTimer);
+      watchdogTimer = null;
+    }
+  }
+
+  function onVisibilityChange(): void {
+    if (closed) return;
+    if (typeof document === "undefined") return;
+    if (document.visibilityState !== "visible") return;
+    if (isStale()) forceReconnect();
+  }
+
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibilityChange);
+  }
 
   async function connect(): Promise<void> {
     if (closed) return;
@@ -101,6 +148,8 @@ export function connectConversationEvents(
 
       // Connected successfully — reset backoff
       backoff = INITIAL_BACKOFF_MS;
+      markFrame();
+      startWatchdog();
 
       // If this is a reconnect, notify so caller can reload missed messages
       if (hasConnectedBefore) {
@@ -117,6 +166,7 @@ export function connectConversationEvents(
       for (;;) {
         const { done, value } = await reader.read();
         if (done || closed) break;
+        markFrame();
 
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split("\n");
@@ -151,13 +201,21 @@ export function connectConversationEvents(
 
       // Stream ended — reconnect unless closed
       if (!closed) {
+        stopWatchdog();
         onDisconnect?.();
         scheduleReconnect();
       }
     } catch (err) {
       if (closed) return;
-      if (err instanceof DOMException && err.name === "AbortError") return;
+      if (err instanceof DOMException && err.name === "AbortError") {
+        // Self-aborted (watchdog / visibility) — reschedule.
+        stopWatchdog();
+        onDisconnect?.();
+        scheduleReconnect();
+        return;
+      }
 
+      stopWatchdog();
       onDisconnect?.();
 
       // 403 is unrecoverable (access denied). 401 — try refresh first.
@@ -181,10 +239,13 @@ export function connectConversationEvents(
 
   function scheduleReconnect(): void {
     if (closed) return;
+    if (reconnectTimer) return;
+    const jittered = backoff * (1 - BACKOFF_JITTER + Math.random() * 2 * BACKOFF_JITTER);
     reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
       backoff = Math.min(backoff * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
       connect();
-    }, backoff);
+    }, jittered);
   }
 
   connect();
@@ -192,6 +253,10 @@ export function connectConversationEvents(
   return {
     close() {
       closed = true;
+      stopWatchdog();
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      }
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;

--- a/web/src/api/events-client.ts
+++ b/web/src/api/events-client.ts
@@ -1,0 +1,207 @@
+// ---------------------------------------------------------------------------
+// Workspace Event Stream — singleton client
+//
+// One `/v1/events` SSE connection per tab, fanned out to many subscribers
+// via the typed `subscribe` API. Same shape as `mcp-bridge-client.ts` —
+// lazy module-level singleton with lifecycle reset.
+//
+// Why this exists. Pre-singleton, `useEvents` opened its own
+// `connectEvents()` inside the hook's `useEffect`. Every component that
+// mounted the hook (App, WorkspaceAppIconsProvider, ConnectorList, …)
+// held an independent SSE connection to the same endpoint, receiving
+// identical broadcasts. On localhost HTTP/1.1 this exhausted Chrome's
+// 6-per-origin connection budget once a second tab joined; in production
+// the duplication still fanned every global event out N× per tab.
+//
+// The contract:
+//   - subscribe<K>(type, handler) → unsubscribe
+//   - onReconnect(handler)        → unsubscribe   (state-resync hook)
+//   - onStatus(handler)           → unsubscribe   (UI banners)
+//   - closeEventsClient()         — for `pagehide` + tests
+//
+// Lifecycle:
+//   - Lazy open on first `subscribe()`.
+//   - **Does NOT close on last unsubscribe.** Closing on momentary zero
+//     thrashes the connection across React StrictMode double-mounts;
+//     there's always a subscriber in practice. Auth lifecycle and
+//     `pagehide` are the only canonical close triggers.
+//   - `addAuthLifecycleHandler` (multi-listener; see api/client.ts)
+//     drops the connection on logout / token rotation, then immediately
+//     re-opens if subscribers remain and a token is present. The next
+//     SSE fetch reads the fresh token via the closure captured at
+//     `ensureOpen()`.
+// ---------------------------------------------------------------------------
+
+import type { SseEventMap, SseEventType } from "../types";
+import { addAuthLifecycleHandler, getAuthToken } from "./client";
+import { connectEvents, type EventConnection } from "./sse";
+
+type Handler<K extends SseEventType> = (data: SseEventMap[K]) => void;
+type ReconnectHandler = () => void;
+type StatusHandler = (status: ConnectionStatus) => void;
+export type ConnectionStatus = "connecting" | "open" | "disconnected";
+
+// biome-ignore lint/suspicious/noExplicitAny: subscriber set is keyed by event type; type-safety is enforced by `subscribe<K>` at the public boundary
+const eventHandlers = new Map<SseEventType, Set<Handler<any>>>();
+const reconnectHandlers = new Set<ReconnectHandler>();
+const statusHandlers = new Set<StatusHandler>();
+
+let connection: EventConnection | null = null;
+let currentStatus: ConnectionStatus = "disconnected";
+
+function setStatus(s: ConnectionStatus): void {
+  if (currentStatus === s) return;
+  currentStatus = s;
+  for (const h of statusHandlers) {
+    try {
+      h(s);
+    } catch (err) {
+      console.warn("[events-client] status handler threw:", err);
+    }
+  }
+}
+
+function hasAnySubscribers(): boolean {
+  if (reconnectHandlers.size > 0) return true;
+  for (const set of eventHandlers.values()) {
+    if (set.size > 0) return true;
+  }
+  return false;
+}
+
+function ensureOpen(): void {
+  if (connection) return;
+  setStatus("connecting");
+  connection = connectEvents({
+    token: getAuthToken() ?? undefined,
+    onEvent: <K extends SseEventType>(type: K, data: SseEventMap[K]) => {
+      const set = eventHandlers.get(type);
+      if (!set) return;
+      for (const h of set) {
+        try {
+          (h as Handler<K>)(data);
+        } catch (err) {
+          console.warn("[events-client] event handler threw for", type, err);
+        }
+      }
+    },
+    onOpen: () => setStatus("open"),
+    onDisconnect: () => setStatus("disconnected"),
+    onReconnect: () => {
+      for (const h of reconnectHandlers) {
+        try {
+          h();
+        } catch (err) {
+          console.warn("[events-client] reconnect handler threw:", err);
+        }
+      }
+    },
+  });
+}
+
+/**
+ * Close the underlying connection. The singleton's subscribers stay
+ * registered — the next `ensureOpen()` (via subscribe or auth-lifecycle
+ * recycle) re-establishes with fresh creds. Safe when no connection
+ * exists.
+ *
+ * Exported for `pagehide` cleanup in `App.tsx` and for test isolation.
+ */
+export function closeEventsClient(): void {
+  const c = connection;
+  connection = null;
+  c?.close();
+  setStatus("disconnected");
+}
+
+// Auth lifecycle: identity rotation closes the connection and (if
+// subscribers remain + we still have a token) immediately re-opens
+// under the new identity. Logout (token → null) closes without
+// re-opening; the next `subscribe()` will lazy-open if a token reappears.
+const authLifecycleHandler = (): void => {
+  closeEventsClient();
+  if (hasAnySubscribers() && getAuthToken() !== null) {
+    ensureOpen();
+  }
+};
+addAuthLifecycleHandler(authLifecycleHandler);
+
+/**
+ * Subscribe a handler to a typed event. The first call across all event
+ * types lazily opens the underlying SSE connection; subsequent calls
+ * share it. Returns an unsubscribe function — calling it removes the
+ * handler but does NOT close the connection (the workspace stream
+ * persists for tab life — see file header).
+ *
+ * Handler errors are caught so a buggy subscriber can't strand
+ * subsequent handlers for the same event.
+ */
+export function subscribe<K extends SseEventType>(type: K, handler: Handler<K>): () => void {
+  ensureOpen();
+  let set = eventHandlers.get(type);
+  if (!set) {
+    set = new Set();
+    eventHandlers.set(type, set);
+  }
+  set.add(handler);
+  return () => {
+    set?.delete(handler);
+  };
+}
+
+/**
+ * Register a handler invoked after every successful reconnection (not
+ * the initial connect). Consumers use this to refetch state that may
+ * have drifted during a gap — bundles, workspace config, skills.
+ */
+export function onReconnect(handler: ReconnectHandler): () => void {
+  reconnectHandlers.add(handler);
+  return () => {
+    reconnectHandlers.delete(handler);
+  };
+}
+
+/**
+ * Register a handler invoked on connection state transitions. The
+ * current status is fired synchronously on subscribe so consumers see
+ * the state immediately without waiting for the next transition.
+ */
+export function onStatus(handler: StatusHandler): () => void {
+  statusHandlers.add(handler);
+  try {
+    handler(currentStatus);
+  } catch (err) {
+    console.warn("[events-client] status handler threw on subscribe:", err);
+  }
+  return () => {
+    statusHandlers.delete(handler);
+  };
+}
+
+// ── Test seams ───────────────────────────────────────────────────────
+// Internal helpers used only by `web/__tests__/events-client.test.ts`.
+// Kept out of the public surface above so production callers don't
+// reach for them; test files import from `__internal__`.
+
+export const __internal__ = {
+  hasConnection(): boolean {
+    return connection !== null;
+  },
+  subscriberCount(): number {
+    let n = reconnectHandlers.size + statusHandlers.size;
+    for (const set of eventHandlers.values()) n += set.size;
+    return n;
+  },
+  resetForTest(): void {
+    closeEventsClient();
+    eventHandlers.clear();
+    reconnectHandlers.clear();
+    statusHandlers.clear();
+    currentStatus = "disconnected";
+    // Other test files in the suite may have called
+    // `setAuthLifecycleHandler(null)` to neutralize the MCP bridge's
+    // handler — which also clears ours. Re-register idempotently so
+    // events-client tests can rely on the lifecycle hook firing.
+    addAuthLifecycleHandler(authLifecycleHandler);
+  },
+};

--- a/web/src/api/events-client.ts
+++ b/web/src/api/events-client.ts
@@ -16,7 +16,6 @@
 // The contract:
 //   - subscribe<K>(type, handler) → unsubscribe
 //   - onReconnect(handler)        → unsubscribe   (state-resync hook)
-//   - onStatus(handler)           → unsubscribe   (UI banners)
 //   - closeEventsClient()         — for `pagehide` + tests
 //
 // Lifecycle:
@@ -38,28 +37,12 @@ import { connectEvents, type EventConnection } from "./sse";
 
 type Handler<K extends SseEventType> = (data: SseEventMap[K]) => void;
 type ReconnectHandler = () => void;
-type StatusHandler = (status: ConnectionStatus) => void;
-export type ConnectionStatus = "connecting" | "open" | "disconnected";
 
 // biome-ignore lint/suspicious/noExplicitAny: subscriber set is keyed by event type; type-safety is enforced by `subscribe<K>` at the public boundary
 const eventHandlers = new Map<SseEventType, Set<Handler<any>>>();
 const reconnectHandlers = new Set<ReconnectHandler>();
-const statusHandlers = new Set<StatusHandler>();
 
 let connection: EventConnection | null = null;
-let currentStatus: ConnectionStatus = "disconnected";
-
-function setStatus(s: ConnectionStatus): void {
-  if (currentStatus === s) return;
-  currentStatus = s;
-  for (const h of statusHandlers) {
-    try {
-      h(s);
-    } catch (err) {
-      console.warn("[events-client] status handler threw:", err);
-    }
-  }
-}
 
 function hasAnySubscribers(): boolean {
   if (reconnectHandlers.size > 0) return true;
@@ -71,7 +54,6 @@ function hasAnySubscribers(): boolean {
 
 function ensureOpen(): void {
   if (connection) return;
-  setStatus("connecting");
   connection = connectEvents({
     token: getAuthToken() ?? undefined,
     onEvent: <K extends SseEventType>(type: K, data: SseEventMap[K]) => {
@@ -85,8 +67,6 @@ function ensureOpen(): void {
         }
       }
     },
-    onOpen: () => setStatus("open"),
-    onDisconnect: () => setStatus("disconnected"),
     onReconnect: () => {
       for (const h of reconnectHandlers) {
         try {
@@ -111,7 +91,6 @@ export function closeEventsClient(): void {
   const c = connection;
   connection = null;
   c?.close();
-  setStatus("disconnected");
 }
 
 // Auth lifecycle: identity rotation closes the connection and (if
@@ -150,31 +129,17 @@ export function subscribe<K extends SseEventType>(type: K, handler: Handler<K>):
 }
 
 /**
- * Register a handler invoked after every successful reconnection (not
- * the initial connect). Consumers use this to refetch state that may
- * have drifted during a gap — bundles, workspace config, skills.
+ * Register a handler invoked after every successful reconnection (NOT
+ * the initial connect). Consumers wire this to refetch state that may
+ * have drifted during the disconnect gap — bundles, workspace config —
+ * since the workspace stream has no `Last-Event-Id` replay. `useEvents`
+ * routes this through to its `onReconnect` option (currently consumed
+ * by `App.tsx` to call `refreshShell` + `refreshConfig`).
  */
 export function onReconnect(handler: ReconnectHandler): () => void {
   reconnectHandlers.add(handler);
   return () => {
     reconnectHandlers.delete(handler);
-  };
-}
-
-/**
- * Register a handler invoked on connection state transitions. The
- * current status is fired synchronously on subscribe so consumers see
- * the state immediately without waiting for the next transition.
- */
-export function onStatus(handler: StatusHandler): () => void {
-  statusHandlers.add(handler);
-  try {
-    handler(currentStatus);
-  } catch (err) {
-    console.warn("[events-client] status handler threw on subscribe:", err);
-  }
-  return () => {
-    statusHandlers.delete(handler);
   };
 }
 
@@ -188,7 +153,7 @@ export const __internal__ = {
     return connection !== null;
   },
   subscriberCount(): number {
-    let n = reconnectHandlers.size + statusHandlers.size;
+    let n = reconnectHandlers.size;
     for (const set of eventHandlers.values()) n += set.size;
     return n;
   },
@@ -196,8 +161,6 @@ export const __internal__ = {
     closeEventsClient();
     eventHandlers.clear();
     reconnectHandlers.clear();
-    statusHandlers.clear();
-    currentStatus = "disconnected";
     // Other test files in the suite may have called
     // `setAuthLifecycleHandler(null)` to neutralize the MCP bridge's
     // handler — which also clears ours. Re-register idempotently so

--- a/web/src/api/sse.ts
+++ b/web/src/api/sse.ts
@@ -7,14 +7,26 @@ export interface ConnectEventsOptions {
   apiBase?: string;
   /** Bearer token for authorization. */
   token?: string;
-  /** Workspace ID sent as X-Workspace-Id header. */
+  /**
+   * @deprecated The `/v1/events` route is identity-scoped server-side
+   * (see `src/api/routes/events.ts`); the server reads memberships from
+   * `WorkspaceStore` and ignores any client-sent `X-Workspace-Id`. The
+   * option is preserved for callers we haven't migrated, but is a no-op.
+   */
   workspaceId?: string;
   /** Called when a typed SSE event is received. */
   onEvent: <K extends SseEventType>(type: K, data: SseEventMap[K]) => void;
-  /** Called when the connection is established. */
+  /** Called when the connection is established (each open, not just the first). */
   onOpen?: () => void;
   /** Called when the connection is lost (before reconnect). */
   onDisconnect?: () => void;
+  /**
+   * Called on successful reconnection (NOT the initial connect). Lets
+   * consumers refetch state that may have drifted during the gap —
+   * bundles, config, skills. Mirrors the same hook on
+   * `conversation-sse.ts` so call sites can route both with one pattern.
+   */
+  onReconnect?: () => void;
   /** Called on unrecoverable error. */
   onError?: (error: Error) => void;
 }
@@ -27,6 +39,22 @@ export interface EventConnection {
 const INITIAL_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
 const BACKOFF_MULTIPLIER = 2;
+/**
+ * ±20% jitter on the reconnect delay. Prevents the thundering-herd
+ * pattern where every tab the server rolled retries on the same beat
+ * after a process bounce.
+ */
+const BACKOFF_JITTER = 0.2;
+/**
+ * Force-disconnect threshold. Server emits a `heartbeat` every 30s
+ * (`SseEventManager.start`), so 75s without any frame means the link
+ * is dead but the TCP socket hasn't reported it yet — common on
+ * laptop wake / wifi resume. Triggering a reconnect from the client
+ * side recovers in seconds instead of minutes.
+ */
+const STALE_THRESHOLD_MS = 75_000;
+/** Watchdog poll interval. */
+const WATCHDOG_TICK_MS = 15_000;
 
 /**
  * Connect to the workspace-level SSE event stream at GET /v1/events.
@@ -34,15 +62,70 @@ const BACKOFF_MULTIPLIER = 2;
  * Uses fetch + ReadableStream to support the Authorization header
  * (EventSource does not support custom headers).
  *
- * Auto-reconnects on disconnect with exponential backoff.
+ * Reliability primitives:
+ *
+ *   - **Auto-reconnect** with exponential backoff (1s → 30s), jittered
+ *     ±20% to avoid thundering herd against a freshly-rolled server.
+ *   - **Heartbeat watchdog** — if no frame arrives for ~75s the
+ *     connection is force-aborted and reconnected. Catches dead links
+ *     that TCP hasn't surfaced yet (laptop wake, wifi resume).
+ *   - **Visibility-resume** — when the tab comes back to the
+ *     foreground, if the last frame is stale we trigger an immediate
+ *     reconnect instead of waiting for the watchdog to tick.
+ *   - **`onReconnect` callback** — fires on every successful
+ *     re-establishment so consumers can refetch state that may have
+ *     drifted during the gap.
  */
 export function connectEvents(options: ConnectEventsOptions): EventConnection {
-  const { apiBase = "", token, workspaceId, onEvent, onOpen, onDisconnect, onError } = options;
+  const { apiBase = "", token, onEvent, onOpen, onDisconnect, onReconnect, onError } = options;
 
   let closed = false;
   let abortController: AbortController | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let watchdogTimer: ReturnType<typeof setInterval> | null = null;
   let backoff = INITIAL_BACKOFF_MS;
+  let hasConnectedBefore = false;
+  let lastFrameAt = Date.now();
+
+  function markFrame(): void {
+    lastFrameAt = Date.now();
+  }
+
+  function isStale(): boolean {
+    return Date.now() - lastFrameAt > STALE_THRESHOLD_MS;
+  }
+
+  function forceReconnect(): void {
+    // Aborting the in-flight fetch unwinds the read loop in `connect()`;
+    // the catch branch reschedules from the aborted state.
+    abortController?.abort();
+  }
+
+  function startWatchdog(): void {
+    if (watchdogTimer) return;
+    watchdogTimer = setInterval(() => {
+      if (closed) return;
+      if (isStale()) forceReconnect();
+    }, WATCHDOG_TICK_MS);
+  }
+
+  function stopWatchdog(): void {
+    if (watchdogTimer) {
+      clearInterval(watchdogTimer);
+      watchdogTimer = null;
+    }
+  }
+
+  function onVisibilityChange(): void {
+    if (closed) return;
+    if (typeof document === "undefined") return;
+    if (document.visibilityState !== "visible") return;
+    if (isStale()) forceReconnect();
+  }
+
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibilityChange);
+  }
 
   async function connect(): Promise<void> {
     if (closed) return;
@@ -52,9 +135,9 @@ export function connectEvents(options: ConnectEventsOptions): EventConnection {
     if (token && token !== "__cookie__") {
       hdrs.Authorization = `Bearer ${token}`;
     }
-    if (workspaceId) {
-      hdrs["X-Workspace-Id"] = workspaceId;
-    }
+    // Note: no `X-Workspace-Id`. `/v1/events` is identity-scoped — the
+    // server reads memberships from the workspace store and broadcasts
+    // accordingly.
 
     try {
       const res = await fetch(`${apiBase}/v1/events`, {
@@ -81,7 +164,11 @@ export function connectEvents(options: ConnectEventsOptions): EventConnection {
 
       // Connected successfully — reset backoff
       backoff = INITIAL_BACKOFF_MS;
+      markFrame();
+      startWatchdog();
       onOpen?.();
+      if (hasConnectedBefore) onReconnect?.();
+      hasConnectedBefore = true;
 
       const reader = res.body?.getReader();
       if (!reader) throw new Error("No response body");
@@ -92,6 +179,7 @@ export function connectEvents(options: ConnectEventsOptions): EventConnection {
       for (;;) {
         const { done, value } = await reader.read();
         if (done || closed) break;
+        markFrame();
 
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split("\n");
@@ -115,15 +203,25 @@ export function connectEvents(options: ConnectEventsOptions): EventConnection {
 
       // Stream ended — reconnect unless closed
       if (!closed) {
+        stopWatchdog();
         onDisconnect?.();
         scheduleReconnect();
       }
     } catch (err) {
       if (closed) return;
 
-      // AbortError means we called close() — don't reconnect
-      if (err instanceof DOMException && err.name === "AbortError") return;
+      // AbortError: either a user-initiated close (handled above via
+      // `closed`) or a watchdog/visibility force-reconnect. In the
+      // latter case the connection is dead and we reschedule a fresh
+      // attempt from the same backoff state.
+      if (err instanceof DOMException && err.name === "AbortError") {
+        stopWatchdog();
+        onDisconnect?.();
+        scheduleReconnect();
+        return;
+      }
 
+      stopWatchdog();
       onDisconnect?.();
 
       // Auth errors: try refresh before giving up
@@ -143,10 +241,13 @@ export function connectEvents(options: ConnectEventsOptions): EventConnection {
 
   function scheduleReconnect(): void {
     if (closed) return;
+    if (reconnectTimer) return;
+    const jittered = backoff * (1 - BACKOFF_JITTER + Math.random() * 2 * BACKOFF_JITTER);
     reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
       backoff = Math.min(backoff * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
       connect();
-    }, backoff);
+    }, jittered);
   }
 
   // Start initial connection
@@ -155,6 +256,10 @@ export function connectEvents(options: ConnectEventsOptions): EventConnection {
   return {
     close() {
       closed = true;
+      stopWatchdog();
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      }
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;

--- a/web/src/hooks/useConversationEvents.ts
+++ b/web/src/hooks/useConversationEvents.ts
@@ -7,14 +7,16 @@
  * conversation). Stage 4 reintroduces multi-user sharing and this
  * hook's audience widens.
  *
- * Disconnects on cleanup or when the conversation changes. On
- * reconnect, triggers a full conversation reload to catch missed
- * messages.
+ * Transport ownership lives in the keyed singleton at
+ * `api/conversation-events-client.ts`. This hook is a thin subscriber:
+ * the first mount for a given `conversationId` opens the underlying
+ * connection, additional mounts share it, and the last unmount tears
+ * it down. On reconnect, the hook fires `onReconnect` so the caller can
+ * reload the full conversation to catch missed messages.
  */
 
 import { useEffect, useRef } from "react";
-import { getAuthToken } from "../api/client";
-import { type ConversationSseConnection, connectConversationEvents } from "../api/conversation-sse";
+import { subscribeConversation } from "../api/conversation-events-client";
 
 export interface ConversationEventCallbacks {
   /** A user message arrived from another participant. */
@@ -34,21 +36,15 @@ export function useConversationEvents(
   conversationId: string | null,
   callbacks: ConversationEventCallbacks,
 ): void {
-  // Keep callbacks in a ref so we don't reconnect on every render
+  // Keep callbacks in a ref so consumers can re-render without churning
+  // the subscription. The effect re-runs only on conversationId change.
   const callbacksRef = useRef(callbacks);
   callbacksRef.current = callbacks;
 
   useEffect(() => {
-    // Subscribe whenever a conversation is open — same-user cross-tab
-    // sync (and, post-Stage-4, multi-user sharing).
     if (!conversationId) return;
 
-    const token = getAuthToken();
-    let connection: ConversationSseConnection | null = null;
-
-    connection = connectConversationEvents({
-      conversationId,
-      token: token ?? undefined,
+    const unsubscribe = subscribeConversation(conversationId, {
       onEvent: (type, data) => {
         if (type === "user.message") {
           callbacksRef.current.onRemoteUserMessage(
@@ -60,7 +56,7 @@ export function useConversationEvents(
             },
           );
         } else if (type === "heartbeat") {
-          // Ignore heartbeats
+          // Ignore heartbeats — they're keep-alive frames, not chat events.
         } else {
           // text.delta, tool.start, tool.done, llm.done, done
           callbacksRef.current.onRemoteStreamEvent(type, data);
@@ -69,13 +65,8 @@ export function useConversationEvents(
       onReconnect: () => {
         callbacksRef.current.onReconnect();
       },
-      onError: (err) => {
-        console.warn("[conversation-sse] Error:", err.message);
-      },
     });
 
-    return () => {
-      connection?.close();
-    };
+    return unsubscribe;
   }, [conversationId]);
 }

--- a/web/src/hooks/useEvents.ts
+++ b/web/src/hooks/useEvents.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { subscribe } from "../api/events-client";
+import { onReconnect, subscribe } from "../api/events-client";
 import type { ConfigChangedEvent, ConnectionStateChangedEvent, DataChangedEvent } from "../types";
 
 export interface UseEventsOptions {
@@ -16,6 +16,15 @@ export interface UseEventsOptions {
    * downstream action is the same.
    */
   onBundleLifecycleChanged?: () => void;
+  /**
+   * Called after every successful reconnection (NOT the initial
+   * connect). The workspace stream has no `Last-Event-Id` replay, so
+   * during the disconnect gap consumers can miss `bundle.installed` /
+   * `config.changed` / state-change events and silently drift out of
+   * sync. Consumers wire this to a refetch of whatever state they
+   * derive from those events (typically the shell + workspace config).
+   */
+  onReconnect?: () => void;
 }
 
 /**
@@ -47,6 +56,8 @@ export function useEvents(
   onConnectionStateChangedRef.current = options?.onConnectionStateChanged;
   const onBundleLifecycleChangedRef = useRef(options?.onBundleLifecycleChanged);
   onBundleLifecycleChangedRef.current = options?.onBundleLifecycleChanged;
+  const onReconnectRef = useRef(options?.onReconnect);
+  onReconnectRef.current = options?.onReconnect;
 
   useEffect(() => {
     // One subscription per event type. Each handler dispatches through
@@ -77,6 +88,11 @@ export function useEvents(
     unsubs.push(
       subscribe("bundle.uninstalled", () => {
         onBundleLifecycleChangedRef.current?.();
+      }),
+    );
+    unsubs.push(
+      onReconnect(() => {
+        onReconnectRef.current?.();
       }),
     );
 

--- a/web/src/hooks/useEvents.ts
+++ b/web/src/hooks/useEvents.ts
@@ -1,13 +1,6 @@
 import { useEffect, useRef } from "react";
-import type { EventConnection } from "../api/sse";
-import { connectEvents } from "../api/sse";
-import type {
-  ConfigChangedEvent,
-  ConnectionStateChangedEvent,
-  DataChangedEvent,
-  SseEventMap,
-  SseEventType,
-} from "../types";
+import { subscribe } from "../api/events-client";
+import type { ConfigChangedEvent, ConnectionStateChangedEvent, DataChangedEvent } from "../types";
 
 export interface UseEventsOptions {
   /** Called when a data.changed SSE event is received. */
@@ -28,15 +21,24 @@ export interface UseEventsOptions {
 /**
  * Subscribe to the workspace-level SSE event stream.
  *
- * This replaces the SSE subscription that was previously inside useWorkspace.
- * Forwards data.changed events to the provided callback (typically from useDataSync).
+ * Transport ownership lives in the singleton at `api/events-client.ts`.
+ * This hook is a thin subscriber: any number of components can call
+ * `useEvents` and they all share **one** `/v1/events` connection per
+ * tab. The previous shape opened a fresh `connectEvents()` per hook
+ * instance, which silently held 2-3 duplicate connections per tab once
+ * `App` + `WorkspaceAppIconsProvider` (+ optionally `ConnectorList`)
+ * each mounted it.
+ *
+ * The `token` and `workspaceId` parameters are vestigial — the
+ * singleton reads the current token internally per (re)connect and
+ * `/v1/events` is identity-scoped server-side. The signature is
+ * preserved so call sites need no edits.
  */
 export function useEvents(
-  token: string,
-  workspaceId: string | undefined,
+  _token: string,
+  _workspaceId: string | undefined,
   options?: UseEventsOptions,
 ): void {
-  const connectionRef = useRef<EventConnection | null>(null);
   const onDataChangedRef = useRef(options?.onDataChanged);
   onDataChangedRef.current = options?.onDataChanged;
   const onConfigChangedRef = useRef(options?.onConfigChanged);
@@ -47,32 +49,39 @@ export function useEvents(
   onBundleLifecycleChangedRef.current = options?.onBundleLifecycleChanged;
 
   useEffect(() => {
-    if (!token || !workspaceId) return;
+    // One subscription per event type. Each handler dispatches through
+    // a ref so consumers can re-render freely without churning the
+    // subscriptions (the underlying connection persists for tab life).
+    const unsubs: Array<() => void> = [];
 
-    const connection = connectEvents({
-      token,
-      workspaceId,
-      onEvent: <K extends SseEventType>(type: K, data: SseEventMap[K]) => {
-        if (type === "data.changed") {
-          onDataChangedRef.current?.(data as DataChangedEvent);
-        }
-        if (type === "config.changed") {
-          onConfigChangedRef.current?.(data as ConfigChangedEvent);
-        }
-        if (type === "connection.state_changed") {
-          onConnectionStateChangedRef.current?.(data as ConnectionStateChangedEvent);
-        }
-        if (type === "bundle.installed" || type === "bundle.uninstalled") {
-          onBundleLifecycleChangedRef.current?.();
-        }
-      },
-    });
-
-    connectionRef.current = connection;
+    unsubs.push(
+      subscribe("data.changed", (data) => {
+        onDataChangedRef.current?.(data);
+      }),
+    );
+    unsubs.push(
+      subscribe("config.changed", (data) => {
+        onConfigChangedRef.current?.(data);
+      }),
+    );
+    unsubs.push(
+      subscribe("connection.state_changed", (data) => {
+        onConnectionStateChangedRef.current?.(data);
+      }),
+    );
+    unsubs.push(
+      subscribe("bundle.installed", () => {
+        onBundleLifecycleChangedRef.current?.();
+      }),
+    );
+    unsubs.push(
+      subscribe("bundle.uninstalled", () => {
+        onBundleLifecycleChangedRef.current?.();
+      }),
+    );
 
     return () => {
-      connection.close();
-      connectionRef.current = null;
+      for (const u of unsubs) u();
     };
-  }, [token, workspaceId]);
+  }, []);
 }

--- a/web/src/mcp-bridge-client.ts
+++ b/web/src/mcp-bridge-client.ts
@@ -14,7 +14,7 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { getActiveWorkspaceId, getAuthToken, setAuthLifecycleHandler } from "./api/client";
+import { addAuthLifecycleHandler, getActiveWorkspaceId, getAuthToken } from "./api/client";
 
 // ---------------------------------------------------------------------------
 // Module-level singleton
@@ -94,8 +94,10 @@ export function resetMcpBridgeClient(): void {
 
 // Register at module load — the side effect runs the first time anything
 // in the bridge dependency graph imports this file (which is exactly when
-// we'd want lifecycle resets to start firing).
-setAuthLifecycleHandler(resetMcpBridgeClient);
+// we'd want lifecycle resets to start firing). Multi-listener registration
+// (`addAuthLifecycleHandler`) so the SSE event clients can register their
+// own teardown alongside ours without one wiping the other.
+addAuthLifecycleHandler(resetMcpBridgeClient);
 
 // ---------------------------------------------------------------------------
 // Session-not-found recovery


### PR DESCRIPTION
## Problem

Running NimbleBrain locally with more than one browser tab open caused one tab to hang. Root cause was two stacked defects:

1. **`useEvents` opened a fresh `/v1/events` SSE per consumer.** At minimum `App.tsx` and `WorkspaceAppIconsProvider` mount it; `ConnectorList` too when the connector panel is open. A single tab carried 2-3 duplicate streams. On localhost HTTP/1.1 this exhausted Chrome's 6-per-origin connection budget the moment a second tab joined and every subsequent fetch stalled.
2. **`/v1/events` was workspace-scoped at the transport layer**, even though Stage 2 / Q3 moved everything else to identity-bound sessions. Every workspace switch silently churned the SSE.

Production is on HTTP/2 via ALB so the multi-tab lag did not surface there, but the duplication still fanned every global event 2-3× per tab.

## Approach

One workspace event stream per tab, identity-scoped, ref-counted teardown for conversation streams, with the reliability primitives the original code lacked. Three layers, mirroring the existing `mcp-bridge-client.ts` singleton pattern:

```
Transport layer  →  events-client.ts        (module-level singleton, lazy open, tab-life)
Subscription     →  subscribe<K>(type, cb)   (pub/sub registry, fan-out)
Hook layer       →  useEvents.ts             (thin wrapper, surface unchanged)
```

## Server changes

- `/v1/events` is identity-scoped. `requireWorkspace` is dropped; the handler computes the caller's workspace memberships at connect time and `SseEventManager` filters fan-out against the cached set.
- New `onMembershipChanged` listener API on `WorkspaceStore`, fired from `create` / `addMember` / `removeMember` / `delete`. `SseEventManager` registers a listener that refreshes affected clients' cached sets, so a mid-stream membership change is reflected without a reconnect.
- `SseClient` unified behind `workspaceMemberships?: Set<string>`. The legacy `addClient(wsId?)` API has identical semantics under the new filter (one-element set), so every prior test passes unchanged.

## Client changes

- New `api/events-client.ts`: lazy module-level singleton. `subscribe<K>(type, handler)` returns an unsubscribe. Persists for tab life (does not close on last unsubscribe, which would thrash under React StrictMode double-mount). Closes on auth lifecycle and `pagehide`.
- New `api/conversation-events-client.ts`: keyed singleton, ref-counted per `conversationId`. Today only `ChatContext` subscribes; building the singleton now prevents the regression the moment a second consumer is added.
- `addAuthLifecycleHandler` multi-listener API. MCP bridge migrates to it; new SSE singletons register their teardown without clobbering each other. `setAuthLifecycleHandler` stays as a deprecated clear-and-set alias.
- Reliability primitives on both SSE transports: heartbeat watchdog (75s stale → force reconnect), jittered backoff ±20%, `visibilitychange → visible` resume, `onReconnect` parity on the workspace stream.
- `pagehide` cleanup in `App.tsx` closes both singletons so the server reclaims slots immediately rather than waiting for TCP teardown.
- `useEvents` / `useConversationEvents` become thin subscribers. Public hook surfaces unchanged so existing call sites need no edits.

## Trust

Authorization for workspace-scoped fan-out moves from connect-time (frozen `X-Workspace-Id` middleware) to emit-time (membership set verified per event). `requireAuth` still gates the connection. The membership set is sourced from the same `WorkspaceStore` that gates every other authorization path. A user cannot receive events for workspaces they are not in.

## Tests

- 6 new `SseEventManager` identity-scoped + invalidation tests (cross-tenant isolation, multi-workspace identity, refresh on add / remove).
- 8 new `WorkspaceStore.onMembershipChanged` tests (fire on create / add / remove / delete, no-fire on role update or conflict, throwing handler does not break mutation).
- New `events-client` and `conversation-events-client` suites covering singleton transport (N subscribers → 1 connection), fan-out, ref-counted teardown, and auth lifecycle close/reopen.
- 4 new multi-listener tests for `addAuthLifecycleHandler`.

`bun run verify` passes (unit, integration, smoke, static).

## Manual verification

1. `bun run dev` from `products/nimblebrain/code`.
2. Open multiple tabs. In `chrome://net-internals/#sockets` each tab shows **one** `/v1/events` socket (not 2-3).
3. Switch workspaces in a tab: no `/v1/events` reconnect (identity-scoped transport).
4. Log out: every `/v1/events` and per-conversation socket closes cleanly.
5. Close a tab: `SseEventManager.clientCount` decrements immediately (server reclaim via `pagehide`).

## Out of scope

- SharedWorker / cross-tab consolidation (one connection per browser).
- Multiplexing workspace and conversation streams onto one wire.
- Centralizing event-driven state via Redux/Zustand. The singleton subscribe API leaves state ownership wherever it currently lives.