### PR TITLE
fix(web): stop redundant connector refetches on Install click (#317)

### DIFF
--- a/web/src/context/WorkspaceAppIconsProvider.tsx
+++ b/web/src/context/WorkspaceAppIconsProvider.tsx
@@ -16,8 +16,8 @@ import { WorkspaceAppIconsContext, type WorkspaceAppIconsValue } from "./Workspa
  *
  * Scoped to the active workspace (the connectors list reads the
  * `X-Workspace-Id` header); refetched on workspace switch and on the
- * same bundle-lifecycle / connection-state SSE signals that refresh the
- * shell placements, so icons stay in lockstep with the app set.
+ * bundle-lifecycle SSE signals (install / uninstall) that change the
+ * app set, so icons stay in lockstep with it.
  */
 export function WorkspaceAppIconsProvider({
   token,
@@ -49,14 +49,17 @@ export function WorkspaceAppIconsProvider({
     void refresh();
   }, [workspaceId, refresh]);
 
-  // Brand icons appear / disappear when a bundle is installed or
-  // uninstalled, or when a connection settles — mirror the shell's
-  // refetch triggers.
+  // Brand icons appear / disappear only when a bundle is installed or
+  // uninstalled. We intentionally do NOT refetch on
+  // connection.state_changed: a single install drives the connection
+  // through starting → pending_auth → running, but the icon for a row
+  // resolves from catalog/mpak metadata that's already present at
+  // bundle.installed time — connection state never changes it. Wiring
+  // those transitions to refresh() turned one Install click into a
+  // 3-4× manage_connectors burst (#317). bundle.installed /
+  // bundle.uninstalled are the only events that change the icon set.
   useEvents(token, workspaceId, {
     onBundleLifecycleChanged: () => {
-      void refresh();
-    },
-    onConnectionStateChanged: () => {
       void refresh();
     },
   });

--- a/web/test/WorkspaceAppIconsProvider.test.tsx
+++ b/web/test/WorkspaceAppIconsProvider.test.tsx
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { act, render, waitFor } from "@testing-library/react";
+import type { SseEventType } from "../src/types";
+import { realClient } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// The provider fans out two dependencies we intercept:
+//   1. api/client.getInstalledConnectors — the manage_connectors RPC we're
+//      counting. Issue #317: each Install click fired this 4-7×, the surplus
+//      coming from SSE-driven refetches racing the click.
+//   2. api/sse.connectEvents — we capture its `onEvent` callback so the test
+//      can fire SSE events synchronously and assert which ones refetch.
+// ---------------------------------------------------------------------------
+
+const mockGetInstalled = mock(() => Promise.resolve({ installed: [], errors: [] }));
+
+// Capture the latest onEvent handler registered via connectEvents so tests can
+// drive SSE events directly.
+let capturedOnEvent: (<K extends SseEventType>(type: K, data: unknown) => void) | null = null;
+const mockConnectEvents = mock((opts: { onEvent: typeof capturedOnEvent }) => {
+  capturedOnEvent = opts.onEvent;
+  return { close: () => {} };
+});
+
+mock.module("../src/api/client", () => ({
+  ...realClient,
+  // Provider calls getInstalledConnectors({ scope: "workspace" }); the mock
+  // ignores args (we only count invocations), so call it bare rather than
+  // spreading an unused arg list.
+  getInstalledConnectors: () => mockGetInstalled(),
+}));
+
+mock.module("../src/api/sse", () => ({
+  connectEvents: (opts: { onEvent: typeof capturedOnEvent }) => mockConnectEvents(opts),
+}));
+
+// Imported after the mocks are registered so the provider's dependency graph
+// binds to the stubs.
+const { WorkspaceAppIconsProvider } = await import("../src/context/WorkspaceAppIconsProvider");
+
+function fire(type: SseEventType, data: Record<string, unknown> = {}) {
+  if (!capturedOnEvent) throw new Error("connectEvents.onEvent was never registered");
+  act(() => {
+    capturedOnEvent?.(type, data);
+  });
+}
+
+describe("WorkspaceAppIconsProvider — SSE refetch surface (#317)", () => {
+  beforeEach(() => {
+    mockGetInstalled.mockClear();
+    mockConnectEvents.mockClear();
+    capturedOnEvent = null;
+  });
+
+  it("does NOT refetch installed connectors on connection.state_changed", async () => {
+    render(
+      <WorkspaceAppIconsProvider token="tok" workspaceId="ws-1">
+        <div />
+      </WorkspaceAppIconsProvider>,
+    );
+
+    // Initial mount fetch (provider's own workspace effect).
+    await waitFor(() => expect(mockGetInstalled).toHaveBeenCalledTimes(1));
+
+    // A bundle install drives the connection through starting → pending_auth →
+    // running. Icons resolve from catalog/mpak metadata available at
+    // bundle.installed time and do NOT depend on connection state, so none of
+    // these transitions should re-hit manage_connectors. Pre-fix the provider
+    // wired onConnectionStateChanged → refresh(), turning one click into a
+    // 3-call burst here.
+    fire("connection.state_changed", { state: "starting" });
+    fire("connection.state_changed", { state: "pending_auth" });
+    fire("connection.state_changed", { state: "running" });
+
+    expect(mockGetInstalled).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refetches on bundle.installed / bundle.uninstalled", async () => {
+    render(
+      <WorkspaceAppIconsProvider token="tok" workspaceId="ws-1">
+        <div />
+      </WorkspaceAppIconsProvider>,
+    );
+
+    await waitFor(() => expect(mockGetInstalled).toHaveBeenCalledTimes(1));
+
+    // These genuinely add/remove an app — the icon set must be refetched.
+    fire("bundle.installed", {});
+    await waitFor(() => expect(mockGetInstalled).toHaveBeenCalledTimes(2));
+
+    fire("bundle.uninstalled", {});
+    await waitFor(() => expect(mockGetInstalled).toHaveBeenCalledTimes(3));
+  });
+});


### PR DESCRIPTION
## What's wrong

Clicking **Install** on the Browse connectors page fired the `manage_connectors` tool 4–7 times in a few hundred ms (#317). Only one call was the actual install — the rest were redundant refetches of the installed-connector list.

## Why

`WorkspaceAppIconsProvider` (mounted app-wide, caches each app's brand icon) refetched the connector list on **every** `connection.state_changed` SSE event. A single install walks one connection through `starting → pending_auth → running`, so each click triggered a burst of refetches — plus one more from `bundle.installed`.

Those refetches were pointless: an icon resolves from static catalog/mpak metadata that never changes with connection state. The only events that change which icons to show are install and uninstall.

## Fix

Drop the `connection.state_changed` refetch from `WorkspaceAppIconsProvider`; keep the `bundle.installed` / `bundle.uninstalled` one (the events that actually add or remove an app).

After: Install fires exactly **2** `manage_connectors` calls — the install itself, plus one refetch to pick up the new app's icon. That second call is necessary and intended.

`ConnectorList` (the Installed-connectors tab) keeps its own `connection.state_changed` refetch — there it's needed to flip a row from "Connecting…" to ready after the OAuth round-trip. It isn't mounted during a Browse install, so it never contributed to the burst.

## Test

`web/test/WorkspaceAppIconsProvider.test.tsx`:
- Fires `connection.state_changed` ×3 → asserts **no** extra refetch (fails before the fix with 4 calls, passes after).
- Fires `bundle.installed` / `bundle.uninstalled` → asserts the refetch **still** happens, so it can't be dropped by accident later.

## Verification

- New test: red before, green after.
- `bun run verify:static` clean; full web suite (374) passes.
- Manual: DevTools Network on Browse, single Install → 2 `manage_connectors` (down from 4–7).

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)