### PR TITLE
feat(web): org-admin skills surface at /org/skills (Phase 1)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,6 +44,7 @@ import { ModelTab } from "./pages/settings/ModelTab";
 import { OrgAboutTab } from "./pages/settings/OrgAboutTab";
 import { OrgRegistriesTab } from "./pages/settings/OrgRegistriesTab";
 import { OrgSettingsPage } from "./pages/settings/OrgSettingsPage";
+import { OrgSkillsTab } from "./pages/settings/OrgSkillsTab";
 import { OrgUsageTab } from "./pages/settings/OrgUsageTab";
 import { SettingsAppPanel } from "./pages/settings/SettingsAppPanel";
 import { SkillsTab } from "./pages/settings/SkillsTab";
@@ -447,6 +448,14 @@ function AuthenticatedAppContent({
                 element={
                   <RouteGuard role="org_admin">
                     <OrgRegistriesTab />
+                  </RouteGuard>
+                }
+              />
+              <Route
+                path="skills"
+                element={
+                  <RouteGuard role="org_admin">
+                    <OrgSkillsTab />
                   </RouteGuard>
                 }
               />

--- a/web/src/pages/settings/OrgSettingsPage.tsx
+++ b/web/src/pages/settings/OrgSettingsPage.tsx
@@ -13,6 +13,7 @@ const ORG_ITEMS: SettingsNavItem[] = [
   { id: "org-model", label: "Model", to: "/org/model", minRole: "org_admin" },
   { id: "org-workspaces", label: "Workspaces", to: "/org/workspaces", minRole: "org_admin" },
   { id: "org-users", label: "Users", to: "/org/users", minRole: "org_admin" },
+  { id: "org-skills", label: "Skills", to: "/org/skills", minRole: "org_admin" },
   { id: "org-usage", label: "Usage", to: "/org/usage", minRole: "org_admin" },
   { id: "org-registries", label: "Registries", to: "/org/registries", minRole: "org_admin" },
 ];

--- a/web/src/pages/settings/OrgSkillsTab.tsx
+++ b/web/src/pages/settings/OrgSkillsTab.tsx
@@ -1,0 +1,16 @@
+import { SkillsBrowser } from "./SkillsTab";
+
+/**
+ * Org-admin skills tab — `/org/skills`.
+ *
+ * Renders the shared `SkillsBrowser` locked to org-tier. The route guard
+ * (RouteGuard role="org_admin" in App.tsx) is the access gate; this tab
+ * assumes it has been passed before mount. Backend `checkPathAccess` is
+ * the source of truth — UI gating is defense in depth, not the security
+ * boundary.
+ *
+ * See `nimblebrain-ops/research/SKILLS_SURFACE.md` for the surface design.
+ */
+export function OrgSkillsTab() {
+  return <SkillsBrowser lockedScope="org" />;
+}

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -317,11 +317,10 @@ export function SkillsBrowser({ lockedScope }: { lockedScope?: Scope } = {}) {
           {creating ? (
             <CreateForm
               pending={actionPending}
-              lockedScope={
-                lockedScope === "org" || lockedScope === "workspace" || lockedScope === "user"
-                  ? lockedScope
-                  : undefined
-              }
+              // Only "org" is a live caller today (Phase 1). Phase 2 will
+              // add "workspace" / "user" callers and broaden this narrowing
+              // when those branches actually ship.
+              lockedScope={lockedScope === "org" ? "org" : undefined}
               onCancel={() => {
                 setCreating(false);
                 setError(null);

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -53,21 +53,37 @@ const STATUS_BADGE: Record<Status, string> = {
 export function SkillsTab() {
   return (
     <RequireActiveWorkspace>
-      <Inner />
+      <SkillsBrowser />
     </RequireActiveWorkspace>
   );
 }
 
+/**
+ * Shared skills browser. The workspace tab renders it with no lock so users
+ * can see/filter every scope they have access to; the org-admin tab renders
+ * it with `lockedScope="org"` so only org-tier skills are listed, the scope
+ * filter UI is suppressed, and the create form has no scope picker (org is
+ * the only writable target on that surface).
+ *
+ * Per SKILLS_SURFACE.md, Phase 2 will refactor the workspace tab to grouped
+ * sections (workspace + inherited-org + inherited-bundles + personal-footer).
+ * That work touches this same component; the `lockedScope` param is the
+ * minimal Phase 1 hook so we don't ship duplicated state machines.
+ */
 type DetailMode = "view" | "edit";
 
-function Inner() {
+export function SkillsBrowser({ lockedScope }: { lockedScope?: Scope } = {}) {
   const [skills, setSkills] = useState<ListedSkill[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<ReadSkill | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [scopeFilter, setScopeFilter] = useState<Scope | "all">("all");
+  // When the surface is scope-locked, the filter UI is hidden and the lock
+  // value is the effective filter — `setScopeFilter` becomes a no-op via the
+  // hidden control. Default the state to the lock so the first fetch is
+  // already scoped (no flash of "all").
+  const [scopeFilter, setScopeFilter] = useState<Scope | "all">(lockedScope ?? "all");
   const [statusFilter, setStatusFilter] = useState<Status | "all">("active");
   const [mode, setMode] = useState<DetailMode>("view");
   const [creating, setCreating] = useState(false);
@@ -250,10 +266,21 @@ function Inner() {
         </Button>
       </header>
       <p className="text-xs text-muted-foreground">
-        Layer 3 cross-bundle agent orchestration content (voice, workflow, personal, tool routing)
-        plus Layer 1 vendored bundle skills. The agent uses these to shape its behavior; you can
-        also author them as markdown files under <code>~/.nimblebrain/skills/</code> (org),{" "}
-        <code>workspaces/&lt;wsId&gt;/skills/</code>, or <code>users/&lt;userId&gt;/skills/</code>.
+        {lockedScope === "org" ? (
+          <>
+            Organization-wide skills. These load into every workspace's agent context and apply to
+            every member. Authored here or as markdown files under{" "}
+            <code>~/.nimblebrain/skills/</code>.
+          </>
+        ) : (
+          <>
+            Layer 3 cross-bundle agent orchestration content (voice, workflow, personal, tool
+            routing) plus Layer 1 vendored bundle skills. The agent uses these to shape its
+            behavior; you can also author them as markdown files under{" "}
+            <code>~/.nimblebrain/skills/</code> (org), <code>workspaces/&lt;wsId&gt;/skills/</code>,
+            or <code>users/&lt;userId&gt;/skills/</code>.
+          </>
+        )}
       </p>
 
       <Filters
@@ -261,6 +288,7 @@ function Inner() {
         status={statusFilter}
         onScopeChange={setScopeFilter}
         onStatusChange={setStatusFilter}
+        lockedScope={lockedScope}
       />
 
       {loading && <div className="text-sm text-muted-foreground">Loading skills…</div>}
@@ -289,6 +317,11 @@ function Inner() {
           {creating ? (
             <CreateForm
               pending={actionPending}
+              lockedScope={
+                lockedScope === "org" || lockedScope === "workspace" || lockedScope === "user"
+                  ? lockedScope
+                  : undefined
+              }
               onCancel={() => {
                 setCreating(false);
                 setError(null);
@@ -680,14 +713,18 @@ function SkillEditor({
 
 function CreateForm({
   pending,
+  lockedScope,
   onCancel,
   onSubmit,
 }: {
   pending: boolean;
+  /** When set, force the create scope and hide the picker. Org-tier-only
+   * surfaces pass `"org"` so the form can't author into another scope. */
+  lockedScope?: WritableScope;
   onCancel: () => void;
   onSubmit: (input: CreateInput) => void;
 }) {
-  const [scope, setScope] = useState<WritableScope>("workspace");
+  const [scope, setScope] = useState<WritableScope>(lockedScope ?? "workspace");
   const [name, setName] = useState("");
   const [form, setForm] = useState<EditorFormState>({
     description: "",
@@ -725,22 +762,24 @@ function CreateForm({
           </div>
         </header>
 
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <label className="text-xs font-medium" htmlFor="skill-scope">
-              Scope
-            </label>
-            <select
-              id="skill-scope"
-              value={scope}
-              onChange={(e) => setScope(e.target.value as WritableScope)}
-              className="rounded-md border bg-background px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-ring"
-            >
-              <option value="user">User</option>
-              <option value="workspace">Workspace</option>
-              <option value="org">Org</option>
-            </select>
-          </div>
+        <div className={cn("grid gap-3", lockedScope ? "grid-cols-1" : "grid-cols-2")}>
+          {lockedScope === undefined && (
+            <div className="space-y-1">
+              <label className="text-xs font-medium" htmlFor="skill-scope">
+                Scope
+              </label>
+              <select
+                id="skill-scope"
+                value={scope}
+                onChange={(e) => setScope(e.target.value as WritableScope)}
+                className="rounded-md border bg-background px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="user">User</option>
+                <option value="workspace">Workspace</option>
+                <option value="org">Org</option>
+              </select>
+            </div>
+          )}
           <div className="space-y-1">
             <label className="text-xs font-medium" htmlFor="skill-name">
               Name
@@ -920,28 +959,33 @@ function Filters({
   status,
   onScopeChange,
   onStatusChange,
+  lockedScope,
 }: {
   scope: Scope | "all";
   status: Status | "all";
   onScopeChange: (s: Scope | "all") => void;
   onStatusChange: (s: Status | "all") => void;
+  /** When set, suppress the scope selector — the surface is scope-locked. */
+  lockedScope?: Scope;
 }) {
   const selectClass =
     "rounded-md border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring";
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <select
-        value={scope}
-        onChange={(e) => onScopeChange(e.target.value as Scope | "all")}
-        className={selectClass}
-        aria-label="Filter by scope"
-      >
-        {SCOPE_OPTIONS.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
+      {lockedScope === undefined && (
+        <select
+          value={scope}
+          onChange={(e) => onScopeChange(e.target.value as Scope | "all")}
+          className={selectClass}
+          aria-label="Filter by scope"
+        >
+          {SCOPE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      )}
       <select
         value={status}
         onChange={(e) => onStatusChange(e.target.value as Status | "all")}

--- a/web/test/SkillsBrowser.org.test.tsx
+++ b/web/test/SkillsBrowser.org.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Behavioral tests for `<SkillsBrowser lockedScope="org" />` — the
+ * shared component the org-admin /org/skills surface renders.
+ *
+ * The role-gate test (orgRoleGate.test.ts) covers WHO can reach this
+ * surface. This file covers WHAT the surface does once reached:
+ *
+ *   1. The scope filter is suppressed (only one scope is in view).
+ *   2. The create form has no scope picker.
+ *   3. Submitting the create form sends `scope: "org"` to the tool,
+ *      regardless of what the user did inside the form. This is the
+ *      load-bearing assertion: if a future edit drops the
+ *      `useState<WritableScope>(lockedScope ?? "workspace")` default,
+ *      the org surface would silently author into workspace scope.
+ *      Nothing else catches that — the server's checkPathAccess gate
+ *      rejects MEMBERS writing org skills, but cannot catch an ADMIN
+ *      writing to the wrong scope through a regressed UI.
+ *
+ * The workspace surface (no lock) is covered structurally by the absence
+ * of changes in the unmounted path — both selects render, scope defaults
+ * to "workspace" — see SkillsTab.tsx::SkillsTab.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "./setup";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Patch globals happy-dom forgets to expose on its Window stub. Without
+// these, mounting any `<select>` inside the component graph throws on
+// `HTMLOptionElement[updateSelectedness]` → `new this.window.SyntaxError(...)`,
+// and dispatching events throws on `new this.window.TypeError(...)`. The
+// status filter select alone is enough to trip the first failure on initial
+// render. Setting these on the happy-dom window once at module load avoids
+// per-test scaffolding.
+{
+  const win = (globalThis as unknown as { window: Record<string, unknown> }).window;
+  if (win) {
+    win.SyntaxError ??= SyntaxError;
+    win.TypeError ??= TypeError;
+  }
+}
+
+// Capture every callTool invocation so we can assert against the create
+// payload at the end of the flow. The list call returns an empty catalog so
+// the UI lands on "no skills, click New skill" — the create form is the
+// surface we want to exercise. Spread the preload snapshot so other exports
+// (getAuthToken, getActiveWorkspaceId, …) stay intact for cross-suite safety.
+type CallToolArgs = {
+  server: string;
+  tool: string;
+  args: Record<string, unknown>;
+};
+const callToolCalls: CallToolArgs[] = [];
+
+mock.module("../src/api/client", () => ({
+  ...realClient,
+  callTool: async (server: string, tool: string, args: Record<string, unknown>) => {
+    callToolCalls.push({ server, tool, args });
+    if (server === "skills" && tool === "list") {
+      return { structuredContent: { skills: [] }, isError: false };
+    }
+    if (server === "skills" && tool === "create") {
+      return { structuredContent: { id: "/tmp/test-skill.md" }, isError: false };
+    }
+    return { structuredContent: {}, isError: false };
+  },
+}));
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { SkillsBrowser } = await import("../src/pages/settings/SkillsTab");
+
+interface Mounted {
+  container: HTMLDivElement;
+  unmount(): void;
+}
+
+let mounted: Mounted | null = null;
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+  callToolCalls.length = 0;
+});
+
+async function mount(element: React.ReactElement): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  // Drain the initial fetch + state updates.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return {
+    container,
+    unmount() {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+function clickButtonByText(container: HTMLElement, text: string): boolean {
+  for (const el of Array.from(container.querySelectorAll("button"))) {
+    if (el.textContent?.includes(text)) {
+      el.click();
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("SkillsBrowser with lockedScope='org' (the /org/skills surface)", () => {
+  test("does not render the scope filter selector", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { lockedScope: "org" }));
+    const filterSelect = mounted.container.querySelector('select[aria-label="Filter by scope"]');
+    expect(filterSelect).toBeNull();
+    // Status filter still renders — it's an orthogonal axis.
+    const statusSelect = mounted.container.querySelector('select[aria-label="Filter by status"]');
+    expect(statusSelect).not.toBeNull();
+  });
+
+  test("does not render the scope picker inside the create form", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { lockedScope: "org" }));
+    await act(async () => {
+      clickButtonByText(mounted!.container, "New skill");
+    });
+    const scopePicker = mounted.container.querySelector("#skill-scope");
+    expect(scopePicker).toBeNull();
+    // Name input does render — confirms the form mounted, not just the
+    // entire form was suppressed.
+    const nameInput = mounted.container.querySelector("#skill-name");
+    expect(nameInput).not.toBeNull();
+  });
+
+  test("submitting the create form sends scope='org' regardless of internal state", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { lockedScope: "org" }));
+    await act(async () => {
+      clickButtonByText(mounted!.container, "New skill");
+    });
+
+    // Fill in the name — required to enable the Create button.
+    const nameInput = mounted.container.querySelector("#skill-name") as HTMLInputElement | null;
+    expect(nameInput).not.toBeNull();
+    await act(async () => {
+      // React uses a synthetic event system; fire a native input event and
+      // set the value through the descriptor so React's onChange fires.
+      // Use the happy-dom window's Event constructor — a globalThis.Event
+      // instance fails happy-dom's `instanceof Event` check (it has its
+      // own per-Window Event class).
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(nameInput, "voice-rule");
+      const WindowEvent = (globalThis as unknown as { window: { Event: typeof Event } }).window
+        .Event;
+      nameInput!.dispatchEvent(new WindowEvent("input", { bubbles: true }));
+    });
+
+    await act(async () => {
+      clickButtonByText(mounted!.container, "Create");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const createCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "create");
+    expect(createCall).toBeDefined();
+    // This is THE assertion the gate can't catch — if the form's
+    // `useState<WritableScope>(lockedScope ?? "workspace")` default ever
+    // drops the lock, scope here goes to "workspace" and the org surface
+    // silently authors into the wrong tier. Pin it.
+    expect(createCall!.args.scope).toBe("org");
+    expect((createCall!.args.manifest as { name?: string }).name).toBe("voice-rule");
+  });
+
+  test("initial skills.list fetch is scoped to org-tier", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { lockedScope: "org" }));
+    const listCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "list");
+    expect(listCall).toBeDefined();
+    // The scope filter starts at the locked value, so the first network
+    // call must already be scoped — no flash of cross-tier skills.
+    expect(listCall!.args.scope).toBe("org");
+  });
+});

--- a/web/test/orgRoleGate.test.ts
+++ b/web/test/orgRoleGate.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression test for the org-admin role gate that mounts `/org/skills`.
+ *
+ * Phase 1 of the skills-surface spec adds a new org-admin route at
+ * `/org/skills` gated by the existing `RouteGuard role="org_admin"`
+ * pattern. The gate is two layers deep:
+ *
+ *   1. Pure resolution from session.user.orgRole → ScopedRole
+ *      (`resolveScopedRole`)
+ *   2. Pure comparison against the route's required minimum
+ *      (`roleAtLeast`)
+ *
+ * Both are exported for testing. This test pins the contract so a future
+ * refactor of the role plumbing cannot silently break the org-admin gate
+ * for the new skills surface (or the existing /org/* tabs).
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { SessionInfo } from "../src/context/SessionContext";
+import type { WorkspaceInfo } from "../src/context/WorkspaceContext";
+import { resolveScopedRole, roleAtLeast } from "../src/hooks/useScopedRole";
+
+function makeSession(orgRole: "owner" | "admin" | "member" | undefined): SessionInfo {
+  return {
+    authenticated: true,
+    user: orgRole
+      ? {
+          id: "u_test",
+          email: "u@example.com",
+          displayName: "Test User",
+          orgRole,
+          preferences: { timezone: "UTC", locale: "en-US", theme: "system" },
+        }
+      : null,
+  } as SessionInfo;
+}
+
+describe("org-admin gate for /org/skills (and every other /org/* route)", () => {
+  it("resolves org_owner from session.user.orgRole=owner regardless of workspace context", () => {
+    const role = resolveScopedRole(makeSession("owner"), null);
+    expect(role).toBe("org_owner");
+  });
+
+  it("resolves org_admin from session.user.orgRole=admin regardless of workspace context", () => {
+    const role = resolveScopedRole(makeSession("admin"), null);
+    expect(role).toBe("org_admin");
+  });
+
+  it("never resolves to org_admin from workspace-admin alone", () => {
+    // Workspace admins must not bypass the org-admin gate. Org-tier writes
+    // (org skills, org users, org registries) are reserved to identities
+    // the IDP marked admin/owner, not to any workspace's admin.
+    const session = makeSession("member");
+    const wsAdmin: Partial<WorkspaceInfo> = { id: "ws_x", userRole: "admin" };
+    const role = resolveScopedRole(session, wsAdmin as WorkspaceInfo);
+    expect(role).toBe("ws_admin");
+    expect(roleAtLeast(role, "org_admin")).toBe(false);
+  });
+
+  it("rejects ws_member against org_admin minimum (Phase 1 /org/skills surface)", () => {
+    const session = makeSession("member");
+    const wsMember: Partial<WorkspaceInfo> = { id: "ws_x", userRole: "member" };
+    const role = resolveScopedRole(session, wsMember as WorkspaceInfo);
+    expect(role).toBe("ws_member");
+    expect(roleAtLeast(role, "org_admin")).toBe(false);
+  });
+
+  it("rejects 'none' (unauthenticated) against org_admin minimum", () => {
+    const role = resolveScopedRole({ authenticated: false, user: null } as SessionInfo, null);
+    expect(role).toBe("none");
+    expect(roleAtLeast(role, "org_admin")).toBe(false);
+  });
+
+  it("admits org_admin and org_owner against the org_admin minimum", () => {
+    expect(roleAtLeast("org_admin", "org_admin")).toBe(true);
+    expect(roleAtLeast("org_owner", "org_admin")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of [SKILLS_SURFACE.md](https://github.com/NimbleBrainInc/nimblebrain-ops/blob/main/research/SKILLS_SURFACE.md): split the conflated skills-management UI into one surface per writable audience. This PR ships the org-admin surface only; Phase 2 will refactor the workspace tab; Phase 3 adds the profile/personal tab.

- New "Skills" entry under `/org/*` (mounted at `/org/skills`), alongside Model · Workspaces · Users · Usage · Registries · About. Uses the existing `RouteGuard role="org_admin"` pattern that already gates every other `/org/*` tab.
- Org-admin role comes from the IDP unchanged: WorkOS organization-membership role slug maps to `OrgRole = "admin" | "owner"` in `src/identity/providers/workos.ts::resolveOrgRole`, then `resolveScopedRole` in `web/src/hooks/useScopedRole.ts` lifts it to `org_admin` / `org_owner`. No new role definition or config knob.
- Workspace SkillsTab's internal state machine is lifted into an exported `SkillsBrowser({ lockedScope? })`. The org tab is a 14-line wrapper passing `lockedScope="org"`. Filter UI and create-form scope picker hide when locked. Phase 2 will reuse this shared component for the workspace refactor — the `lockedScope` hook is the minimal Phase 1 lift so we don't ship duplicated state machines.

The server-side `checkPathAccess` gate for org-tier writes is the actual security boundary. UI gating is defense in depth, already covered by `test/unit/tools/platform/skills-mutation.test.ts` ("permission-denied error carries scope + role causation").

## Test plan

- [x] `web/test/orgRoleGate.test.ts` — six cases pinning `resolveScopedRole` and `roleAtLeast` for the org-admin gate. Asserts `ws_admin` does NOT bypass `org_admin` (the regression class the spec called out).
- [x] `bun run verify:static` clean (lint, format, tsc src/, tsc web/, codegen, all the workspace/credential/path lints)
- [x] `bun run test:unit` — 3182 pass / 0 fail
- [x] `cd web && bun run build` — clean Vite production build
- [ ] Manual smoke (post-merge): admin identity sees the nav entry; member identity does not; hand-navigating to `/org/skills` as a non-admin redirects to `/profile`.

## Phase 2 / 3 follow-ups (separate PRs, per spec)

- Phase 2: refactor workspace tab to grouped sections (workspace + inherited-org + inherited-bundles + personal-footer); drop the scope filter and scope picker on that surface.
- Phase 3: promote `/profile` to a tabbed surface; add Skills tab; add personal-footer deep link from workspace tab.
- Phase 2 cleanup: dedupe `ORG_ADMIN_ROLES` (locally redeclared at `src/tools/platform/skills.ts:1065` instead of imported from `src/identity/types.ts`).