### PR TITLE
Automations: Task primitive + V3 reader + mobile pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
         run: bun install
       - name: Install web dependencies
         run: cd web && bun install
+      # Bundle UI deps must be installed so unit tests that import from
+      # src/bundles/*/ui/src/ (e.g. the markdown sanitizer test) can
+      # resolve their npm dependencies (marked, dompurify, etc.). Mirrors
+      # the install loop inside build:bundles. Local `bun run build:bundles`
+      # installs these as a side effect; CI doesn't build bundles for the
+      # unit job, so the install must be explicit.
+      - name: Install bundle UI dependencies
+        run: bun run install:bundles
       - name: Verify (unit + web tests)
         run: bun run verify:test-unit
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@types/bun": "latest",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "happy-dom": "^20.0.0",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -113,6 +114,10 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
@@ -214,6 +219,8 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
@@ -267,6 +274,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -477,6 +486,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "@biomejs/biome": "^2.4.10",
     "@types/bun": "latest",
     "@types/react": "^19.2.14",
-    "@types/react-dom": "^19.2.3"
+    "@types/react-dom": "^19.2.3",
+    "happy-dom": "^20.0.0"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dev:web": "cd web && bun run dev",
     "dev:tui": "bun run src/cli/index.ts -c .nimblebrain/nimblebrain.json",
     "start": "bun run src/cli/index.ts serve",
+    "install:bundles": "for ui in src/bundles/*/ui; do [ -f \"$ui/package.json\" ] && (cd \"$ui\" && bun install); done",
     "build:bundles": "for ui in src/bundles/*/ui; do [ -f \"$ui/package.json\" ] && (cd \"$ui\" && bun install && bun run build); done",
     "test:unit": "bun test test/unit/",
     "test:integration": "bun test test/integration/",

--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -17,23 +17,40 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 // Shared types
 // ---------------------------------------------------------------------------
 
-/** Minimal chat request shape (matches runtime ChatRequest). */
-export interface ChatFnRequest {
-  message: string;
+/**
+ * Minimal task request shape (matches runtime `TaskRequest`).
+ *
+ * Automations execute via `runtime.executeTask()`, not `runtime.chat()`:
+ * the agent runs unattended and produces a finished deliverable, with
+ * the runtime supplying the task-mode system prompt that forbids
+ * greetings and follow-up questions. The chat surface is for live user
+ * conversations; this is its sibling primitive for scheduled work.
+ *
+ * Decoupled (locally-typed, structurally compatible) on purpose: keeps
+ * the bundle from importing runtime internals — anything providing this
+ * shape can inject an executor.
+ */
+export interface TaskFnRequest {
+  /** The task description. Goes in as the user message. */
+  prompt: string;
   model?: string;
   maxIterations?: number;
   maxInputTokens?: number;
   allowedTools?: string[];
   metadata?: Record<string, unknown>;
-  /** Workspace scope for this run. Required for workspace-aware tools. */
+  /**
+   * Focused workspace (optional). Set → tools scoped to that workspace
+   * + identity tools, briefing for that workspace. Omitted →
+   * cross-workspace reach, no focused-workspace briefing.
+   */
   workspaceId?: string;
   /** Identity under which this automation runs. */
   identity?: { id: string; name?: string; email?: string; role?: string };
   /**
-   * Cancellation signal forwarded into `runtime.chat()` → engine → tool
-   * calls. When the scheduler's per-run controller aborts (timeout,
-   * explicit cancel, scheduler stop), the in-flight LLM/tool work
-   * actually stops instead of being orphaned. Before this field
+   * Cancellation signal forwarded into `runtime.executeTask()` → engine
+   * → tool calls. When the scheduler's per-run controller aborts
+   * (timeout, explicit cancel, scheduler stop), the in-flight LLM/tool
+   * work actually stops instead of being orphaned. Before this field
    * existed, a chat that exceeded `maxRunDurationMs` ran to completion
    * in the background and wrote a complete conversation to disk
    * minutes after the executor had already synthesized a fake
@@ -42,22 +59,24 @@ export interface ChatFnRequest {
   signal?: AbortSignal;
 }
 
-/** Minimal chat result shape (matches runtime ChatResult). */
-export interface ChatFnResult {
-  response: string;
+/** Minimal task result shape (matches runtime `TaskResult`). */
+export interface TaskFnResult {
+  /** The deliverable — the agent's final assistant message. */
+  output: string;
+  /** Traceability anchor — the fresh conversation backing this task. */
   conversationId: string;
   toolCalls: Array<Record<string, unknown>>;
   stopReason: string;
   usage: { inputTokens: number; outputTokens: number; iterations: number };
 }
 
-/** A function that executes a chat turn. Injected by the caller. */
-export type ChatFn = (request: ChatFnRequest) => Promise<ChatFnResult>;
+/** A function that executes a single task. Injected by the caller. */
+export type TaskFn = (request: TaskFnRequest) => Promise<TaskFnResult>;
 
 /** Runtime context injected into the executor for workspace/identity scoping. */
 export interface ExecutorContext {
   workspaceId?: string;
-  identity?: ChatFnRequest["identity"];
+  identity?: TaskFnRequest["identity"];
 }
 
 // ---------------------------------------------------------------------------
@@ -88,7 +107,7 @@ export function containsRecursiveTool(allowedTools: string[] | undefined): strin
   return null;
 }
 
-function buildRequest(automation: Automation, ctx?: ExecutorContext): ChatFnRequest {
+function buildRequest(automation: Automation, ctx?: ExecutorContext): TaskFnRequest {
   const offending = containsRecursiveTool(automation.allowedTools);
   if (offending !== null) {
     throw new Error(
@@ -98,8 +117,11 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): ChatFnRequ
     );
   }
 
-  const req: ChatFnRequest = {
-    message: automation.prompt,
+  // The task surface owns the "you are running unattended, produce a
+  // deliverable" framing in its system prompt — the automation's prompt
+  // goes in as the plain task description, not wrapped or prefixed here.
+  const req: TaskFnRequest = {
+    prompt: automation.prompt,
     metadata: {
       source: "automation",
       automationId: automation.id,
@@ -118,7 +140,7 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): ChatFnRequ
 function mapResultToRun(
   automation: Automation,
   startedAt: string,
-  data: ChatFnResult,
+  data: TaskFnResult,
 ): AutomationRun {
   const stopReason = data.stopReason as AutomationRun["stopReason"];
   const status: AutomationRun["status"] = mapStopReasonToStatus(stopReason);
@@ -134,7 +156,7 @@ function mapResultToRun(
     outputTokens: data.usage.outputTokens,
     toolCalls: Array.isArray(data.toolCalls) ? data.toolCalls.length : 0,
     iterations: data.usage.iterations,
-    resultPreview: data.response ? data.response.slice(0, 500) : undefined,
+    resultPreview: data.output || undefined,
     stopReason,
   };
 }
@@ -169,15 +191,15 @@ function mapStopReasonToStatus(stopReason: AutomationRun["stopReason"]): Automat
 // ---------------------------------------------------------------------------
 
 /**
- * Execute a single automation run by calling the chat function directly.
+ * Execute a single automation run by calling the task function directly.
  * No HTTP, no auth token — pure function call within the same process.
  *
- * @param chatFn     Direct reference to runtime.chat() or equivalent.
+ * @param taskFn      Direct reference to runtime.executeTask() or equivalent.
  * @param getContext  Returns the workspace/identity context for the run.
  *                    Called per-execution so it can read current state.
  */
 export function createDirectExecutor(
-  chatFn: ChatFn,
+  taskFn: TaskFn,
   getContext: (automation?: Automation) => ExecutorContext,
 ) {
   return async function executeDirect(
@@ -191,13 +213,13 @@ export function createDirectExecutor(
     // Combined cancellation: a single controller aborts when EITHER the
     // scheduler's external signal fires (manual cancel, scheduler stop)
     // OR the per-run timeout elapses. The combined signal goes into
-    // chatFn → runtime.chat → engine.run → every tool call, so an
+    // taskFn → runtime.executeTask → engine.run → every tool call, so an
     // abort actually cancels in-flight LLM/tool work instead of
     // orphaning it the way the old `Promise.race` pattern did.
     //
     // Production bug this fixes: `morning-brief-6am-pt` runs took
     // 6–7 minutes while the 5-minute Promise.race rejected at the
-    // 5-minute mark, returning to dispatchRun. The chat kept running,
+    // 5-minute mark, returning to dispatchRun. The task kept running,
     // finished cleanly 1–2 minutes later, wrote a complete conversation
     // to disk — and the result was discarded. The agent saw a "timeout"
     // run record with `iterations: 0, toolCalls: 0` despite the agent
@@ -225,7 +247,7 @@ export function createDirectExecutor(
     }
 
     try {
-      const data = await chatFn({
+      const data = await taskFn({
         ...buildRequest(automation, ctx),
         signal: runController.signal,
       });
@@ -234,7 +256,7 @@ export function createDirectExecutor(
       // Preserve the canonical "timed out after Ns" wording so
       // `Scheduler.dispatchRun` classifies this as `timeout`. If
       // BOTH the external abort AND the timeout fire (narrow race
-      // when chatFn takes a beat to honor cancel near the timeout
+      // when taskFn takes a beat to honor cancel near the timeout
       // boundary), external-cancel wins — the operator-meaningful
       // cause is "I cancelled", not "the clock ran out at the same
       // moment". Drift here would silently restamp a cancel as a

--- a/src/bundles/automations/src/types.ts
+++ b/src/bundles/automations/src/types.ts
@@ -149,7 +149,8 @@ export interface AutomationRun {
   error?: string;
   /** Whether this failure was classified as transient (eligible for backoff retry). */
   transient?: boolean;
-  /** Final agent response (truncated to 500 chars). */
+  /** Final agent response. Field name kept for backward compatibility with
+   *  existing JSONL records; current writes store the full response. */
   resultPreview?: string;
   /**
    * Engine-level stop reason. Mirrors `StopReason` from `src/engine/types.ts`

--- a/src/bundles/automations/ui/bun.lock
+++ b/src/bundles/automations/ui/bun.lock
@@ -12,7 +12,6 @@
         "react-dom": "^19.0.0",
       },
       "devDependencies": {
-        "@types/dompurify": "^3.2.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.0.0",
@@ -190,8 +189,6 @@
     "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
-
-    "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 

--- a/src/bundles/automations/ui/bun.lock
+++ b/src/bundles/automations/ui/bun.lock
@@ -6,10 +6,13 @@
       "name": "@nimblebraininc/automations-ui",
       "dependencies": {
         "@nimblebrain/synapse": "^0.8.0",
+        "dompurify": "^3.2.4",
+        "marked": "^15.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
       "devDependencies": {
+        "@types/dompurify": "^3.2.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.0.0",
@@ -188,11 +191,15 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -237,6 +244,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dompurify": ["dompurify@3.4.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -329,6 +338,8 @@
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/src/bundles/automations/ui/package.json
+++ b/src/bundles/automations/ui/package.json
@@ -9,10 +9,13 @@
   },
   "dependencies": {
     "@nimblebrain/synapse": "^0.8.0",
+    "dompurify": "^3.2.4",
+    "marked": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.2.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/bundles/automations/ui/package.json
+++ b/src/bundles/automations/ui/package.json
@@ -15,7 +15,6 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@types/dompurify": "^3.2.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/bundles/automations/ui/src/components/AutomationDetailView.tsx
+++ b/src/bundles/automations/ui/src/components/AutomationDetailView.tsx
@@ -1,6 +1,7 @@
 import { useCallTool, useDataSync } from "@nimblebrain/synapse/react";
 import { useCallback, useEffect, useState } from "react";
 import { BackArrowIcon, WarningIcon } from "../icons.tsx";
+import { renderMarkdown } from "../markdown.ts";
 import type { AutomationDetail, AutomationRun } from "../types.ts";
 import {
   asDict,
@@ -274,9 +275,13 @@ export function AutomationDetailView({
                 )}
               </div>
               {testResult.resultPreview && (
-                <pre style={{ whiteSpace: "pre-wrap", fontSize: 12 }}>
-                  {testResult.resultPreview}
-                </pre>
+                <div
+                  className="out-md"
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via DOMPurify in renderMarkdown
+                  dangerouslySetInnerHTML={{
+                    __html: renderMarkdown(testResult.resultPreview as string),
+                  }}
+                />
               )}
               {testResult.error && (
                 <pre style={{ color: "var(--nb-color-danger, #dc2626)", fontSize: 12 }}>

--- a/src/bundles/automations/ui/src/components/AutomationsUI.tsx
+++ b/src/bundles/automations/ui/src/components/AutomationsUI.tsx
@@ -3,11 +3,11 @@ import { useCallback, useEffect, useState } from "react";
 import { ClockIcon, PlusIcon } from "../icons.tsx";
 import type { AutomationRun, AutomationSummary } from "../types.ts";
 import { asDict } from "../utils.ts";
-import { AutomationCard } from "./AutomationCard.tsx";
 import { AutomationDetailView } from "./AutomationDetailView.tsx";
 import { ConfirmDialog } from "./ConfirmDialog.tsx";
 import { CreateAutomationForm, TEMPLATES } from "./CreateAutomationForm.tsx";
-import { RunRow } from "./RunRow.tsx";
+import { RailAutomationItem, RailRunItem } from "./RailItem.tsx";
+import { ReaderPane } from "./ReaderPane.tsx";
 import { SkeletonCards, SkeletonRows } from "./Skeleton.tsx";
 
 export function AutomationsUI() {
@@ -19,14 +19,23 @@ export function AutomationsUI() {
   const deleteTool = useCallTool<string>("delete");
   const cancelTool = useCallTool<string>("cancel");
 
-  // State
+  // Data state
   const [automations, setAutomations] = useState<AutomationSummary[]>([]);
   const [runs, setRuns] = useState<AutomationRun[]>([]);
   const [loading, setLoading] = useState(true);
   const [runsLoading, setRunsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // UI state
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [actionInProgress, setActionInProgress] = useState<Record<string, string>>({});
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  // `userOpenedReader` only flips on explicit run click / back. On desktop
+  // both panes render regardless (no media query applies), so this only
+  // matters at <720px where the rail and reader stack and one is hidden.
+  // Without this, the auto-select of the most recent run would push the
+  // user straight into the reader on first load and hide the lists.
+  const [userOpenedReader, setUserOpenedReader] = useState(false);
   const [selectedAutomation, setSelectedAutomation] = useState<string | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [createTemplate, setCreateTemplate] = useState<(typeof TEMPLATES)[0] | null>(null);
@@ -75,6 +84,18 @@ export function AutomationsUI() {
     loadAll();
   });
 
+  // Auto-select the most recent run when one isn't selected (first load,
+  // or after the previously selected run was pruned from the 20-deep window).
+  useEffect(() => {
+    if (runs.length === 0) {
+      if (selectedRunId) setSelectedRunId(null);
+      return;
+    }
+    if (!selectedRunId || !runs.some((r) => r.id === selectedRunId)) {
+      setSelectedRunId(runs[0].id);
+    }
+  }, [runs, selectedRunId]);
+
   // Actions
   async function handleRunNow(name: string) {
     setActionInProgress((prev) => ({ ...prev, [name]: "running" }));
@@ -96,7 +117,7 @@ export function AutomationsUI() {
     const action = currentlyEnabled ? "pausing" : "resuming";
     setActionInProgress((prev) => ({ ...prev, [name]: action }));
     try {
-      await updateTool.call({ name, enabled: !currentlyEnabled });
+      await updateTool.call({ name, manifest: { enabled: !currentlyEnabled } });
     } catch {
       // silent
     } finally {
@@ -126,8 +147,21 @@ export function AutomationsUI() {
   }
 
   async function handleUpdate(name: string, fields: Record<string, unknown>) {
+    // Server's update tool expects { name, manifest?, body? }. The detail
+    // view's saveField() passes a flat { [field]: value } — split it: the
+    // prompt goes into `body`, everything else into `manifest`.
+    const args: Record<string, unknown> = { name };
+    const manifest: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(fields)) {
+      if (k === "prompt") {
+        args.body = v;
+      } else if (k !== "name") {
+        manifest[k] = v;
+      }
+    }
+    if (Object.keys(manifest).length > 0) args.manifest = manifest;
     try {
-      await updateTool.call({ name, ...fields });
+      await updateTool.call(args);
     } catch {
       // silent
     } finally {
@@ -164,7 +198,12 @@ export function AutomationsUI() {
     setShowCreateForm(true);
   }
 
-  // Create form
+  function pickTemplate(t: (typeof TEMPLATES)[0]) {
+    setCreateTemplate(t);
+    setShowCreateForm(true);
+  }
+
+  // Create form (full-panel)
   if (showCreateForm) {
     return (
       <CreateAutomationForm
@@ -183,7 +222,7 @@ export function AutomationsUI() {
     );
   }
 
-  // Detail view
+  // Automation config view (full-panel)
   if (selectedAutomation) {
     const summary = automations.find((a) => a.name === selectedAutomation);
     return (
@@ -209,7 +248,16 @@ export function AutomationsUI() {
     );
   }
 
-  // List view
+  // Two-pane reader (default)
+  const selectedRun = runs.find((r) => r.id === selectedRunId) || null;
+  const selectedRunAutomation = selectedRun
+    ? automations.find((a) => a.id === selectedRun.automationId)
+    : undefined;
+  // Mobile pane visibility is driven by explicit navigation, not selection.
+  // See the comment on `userOpenedReader` above.
+  const paneShow: "rail" | "reader" = userOpenedReader ? "reader" : "rail";
+  const automationNameById = new Map(automations.map((a) => [a.id, a.name]));
+
   return (
     <div className="app">
       <div className="header">
@@ -225,87 +273,122 @@ export function AutomationsUI() {
         </div>
       </div>
 
-      <div className="content">
-        {error && <div className="error-banner">{error}</div>}
+      {error && (
+        <div style={{ padding: "0 20px" }}>
+          <div className="error-banner">{error}</div>
+        </div>
+      )}
 
-        <div className="section-header">Automations</div>
-
-        {loading ? (
-          <SkeletonCards count={3} />
-        ) : automations.length === 0 ? (
-          <div className="empty-state">
-            <div className="empty-state-icon">
-              <ClockIcon />
-            </div>
-            <div className="empty-state-title">No automations yet</div>
-            <div className="empty-state-desc">
-              Create your first automation to run tasks on a schedule.
-            </div>
-            <div
-              style={{
-                display: "flex",
-                gap: 8,
-                flexWrap: "wrap",
-                marginTop: 16,
-                justifyContent: "center",
-              }}
-            >
-              {TEMPLATES.map((t) => (
-                <button
-                  type="button"
-                  key={t.id}
-                  className="btn"
-                  style={{
-                    textAlign: "left",
-                    padding: "8px 12px",
-                    ...(t.id === "custom" ? { borderStyle: "dashed" } : {}),
-                  }}
-                  onClick={() => {
-                    setCreateTemplate(t);
-                    setShowCreateForm(true);
-                  }}
-                >
-                  <div style={{ fontWeight: 500, fontSize: 13 }}>{t.name}</div>
-                  <div style={{ fontSize: 11, color: "var(--color-text-secondary, #737373)" }}>
-                    {t.description}
-                  </div>
-                </button>
-              ))}
-            </div>
+      <div className="two-pane" data-show={paneShow}>
+        <aside className="rail">
+          <div className="rail-section">
+            <span>Automations</span>
+            {automations.length > 0 && (
+              <span
+                style={{
+                  fontSize: 11,
+                  color: "var(--color-text-secondary, #737373)",
+                  textTransform: "none",
+                  letterSpacing: 0,
+                  fontWeight: 400,
+                }}
+              >
+                {automations.length}
+              </span>
+            )}
           </div>
-        ) : (
-          <div className="auto-list">
-            {automations.map((a) => (
-              <AutomationCard
+          {loading ? (
+            <div style={{ padding: "4px 16px" }}>
+              <SkeletonCards count={2} />
+            </div>
+          ) : automations.length === 0 ? (
+            <div className="rail-empty">
+              No automations yet. Start from a template:
+              <div className="template-grid" style={{ marginTop: 8 }}>
+                {TEMPLATES.map((t) => (
+                  <button
+                    type="button"
+                    key={t.id}
+                    className={`template-card${t.id === "custom" ? " dashed" : ""}`}
+                    onClick={() => pickTemplate(t)}
+                  >
+                    <span className="template-card-name">{t.name}</span>
+                    <span className="template-card-desc">{t.description}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            automations.map((a) => (
+              <RailAutomationItem
                 key={a.id}
                 automation={a}
-                actionInProgress={actionInProgress[a.name]}
+                active={selectedAutomation === a.name}
                 onClick={() => setSelectedAutomation(a.name)}
-                onRunNow={() => handleRunNow(a.name)}
-                onToggle={() => handleToggle(a.name, a.enabled)}
-                onDelete={() => handleDelete(a.name)}
-                onCancel={() => handleCancel(a.name)}
               />
-            ))}
+            ))
+          )}
+
+          <div className="rail-section">
+            <span>Recent Runs</span>
+            {runs.length > 0 && (
+              <span
+                style={{
+                  fontSize: 11,
+                  color: "var(--color-text-secondary, #737373)",
+                  textTransform: "none",
+                  letterSpacing: 0,
+                  fontWeight: 400,
+                }}
+              >
+                {runs.length}
+              </span>
+            )}
           </div>
-        )}
+          {runsLoading && runs.length === 0 ? (
+            <div style={{ padding: "4px 16px" }}>
+              <SkeletonRows count={3} />
+            </div>
+          ) : runs.length === 0 ? (
+            <div className="rail-empty">No runs yet.</div>
+          ) : (
+            runs.map((run) => (
+              <RailRunItem
+                key={run.id}
+                run={run}
+                automationName={automationNameById.get(run.automationId)}
+                active={selectedRunId === run.id}
+                onClick={() => {
+                  setSelectedRunId(run.id);
+                  setUserOpenedReader(true);
+                }}
+              />
+            ))
+          )}
+        </aside>
 
-        <div className="section-header" style={{ marginTop: 24 }}>
-          Recent Runs
-        </div>
-
-        {runsLoading && runs.length === 0 ? (
-          <SkeletonRows count={4} />
-        ) : runs.length === 0 ? (
-          <div className="empty-state" style={{ padding: "32px 24px" }}>
-            <div className="empty-state-desc">No run history yet.</div>
+        {runs.length === 0 && !runsLoading && !loading ? (
+          <div className="reader">
+            <div className="reader-empty">
+              <ClockIcon />
+              <div className="reader-empty-title" style={{ marginTop: 12 }}>
+                No runs yet
+              </div>
+              <div className="reader-empty-desc">
+                {automations.length === 0
+                  ? "Create an automation from a template in the left panel to get started."
+                  : "Your automations haven't run yet. Pick one and Run now, or wait for the schedule."}
+              </div>
+            </div>
           </div>
         ) : (
-          <div className="run-list">
-            {runs.map((run) => (
-              <RunRow key={run.id} run={run} showName />
-            ))}
-          </div>
+          <ReaderPane
+            run={selectedRun}
+            automation={selectedRunAutomation}
+            onRerun={handleRunNow}
+            onOpenConfig={(name) => setSelectedAutomation(name)}
+            onBack={() => setUserOpenedReader(false)}
+          />
         )}
       </div>
 

--- a/src/bundles/automations/ui/src/components/CreateAutomationForm.tsx
+++ b/src/bundles/automations/ui/src/components/CreateAutomationForm.tsx
@@ -95,21 +95,22 @@ export function CreateAutomationForm({
       return null;
     }
     setError(null);
-    const args: Record<string, unknown> = {
+    // Server expects { manifest, body } — manifest carries config, body is
+    // the prompt text.
+    const manifest: Record<string, unknown> = {
       name: name.trim(),
-      prompt: prompt.trim(),
       schedule,
       enabled,
       maxIterations,
       maxRunDurationMs: maxRunDurationSec * 1000,
     };
-    if (model.trim()) args.model = model.trim();
+    if (model.trim()) manifest.model = model.trim();
     if (budgetEnabled) {
-      args.tokenBudget = { maxInputTokens: budgetMaxInput, period: "daily" as const };
+      manifest.tokenBudget = { maxInputTokens: budgetMaxInput, period: "daily" as const };
     }
 
     try {
-      const result = await createTool.call(args);
+      const result = await createTool.call({ manifest, body: prompt.trim() });
       const data = asDict(result.data);
       return ((data.automation as Record<string, unknown>)?.name as string) ?? name;
     } catch (err) {
@@ -161,23 +162,18 @@ export function CreateAutomationForm({
       <div className="content">
         {error && <div className="error-banner">{error}</div>}
 
-        {/* Templates */}
+        {/* Templates — stacked-card layout (.template-card) so the title and
+            description wrap properly instead of overlapping inside a
+            single-line .btn pill. */}
         {!name && !prompt && (
           <div className="detail-section">
             <div className="detail-section-title">Start from a template</div>
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <div className="template-grid">
               {TEMPLATES.map((t) => (
                 <button
                   type="button"
                   key={t.id}
-                  className="btn"
-                  style={{
-                    textAlign: "left",
-                    padding: "8px 12px",
-                    flex: "1 1 140px",
-                    minWidth: 140,
-                    ...(t.id === "custom" ? { borderStyle: "dashed" } : {}),
-                  }}
+                  className={`template-card${t.id === "custom" ? " dashed" : ""}`}
                   onClick={() => {
                     setName(t.id === "custom" ? "" : t.name);
                     setPrompt(t.prompt);
@@ -196,16 +192,8 @@ export function CreateAutomationForm({
                     }
                   }}
                 >
-                  <div style={{ fontWeight: 500, fontSize: 13 }}>{t.name}</div>
-                  <div
-                    style={{
-                      fontSize: 11,
-                      color: "var(--color-text-secondary, #737373)",
-                      marginTop: 2,
-                    }}
-                  >
-                    {t.description}
-                  </div>
+                  <span className="template-card-name">{t.name}</span>
+                  <span className="template-card-desc">{t.description}</span>
                 </button>
               ))}
             </div>
@@ -328,7 +316,15 @@ export function CreateAutomationForm({
                   </label>
                 </div>
                 {budgetEnabled && (
-                  <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      marginTop: 4,
+                      flexWrap: "wrap",
+                    }}
+                  >
                     <span style={{ fontSize: 12, color: "var(--color-text-secondary, #737373)" }}>
                       Max input tokens/day:
                     </span>
@@ -415,7 +411,10 @@ export function CreateAutomationForm({
                 onClick={async () => {
                   setCreating(true);
                   try {
-                    await updateTool.call({ name: name.trim(), enabled: true });
+                    await updateTool.call({
+                      name: name.trim(),
+                      manifest: { enabled: true },
+                    });
                     onCreated(name.trim());
                   } catch (err) {
                     setError(err instanceof Error ? err.message : "Failed to enable");

--- a/src/bundles/automations/ui/src/components/RailItem.tsx
+++ b/src/bundles/automations/ui/src/components/RailItem.tsx
@@ -63,7 +63,7 @@ export function RailRunItem({
   const snippet = run.error
     ? `Error: ${run.error}`
     : run.resultPreview
-        ?.replace(/[#*`>_~\-]/g, "")
+        ?.replace(/[#*`>_~-]/g, "")
         .trim()
         .slice(0, 90) || "";
   return (

--- a/src/bundles/automations/ui/src/components/RailItem.tsx
+++ b/src/bundles/automations/ui/src/components/RailItem.tsx
@@ -1,0 +1,79 @@
+import type { AutomationRun, AutomationSummary } from "../types.ts";
+import { relativeTime, statusDotClass } from "../utils.ts";
+
+const RUN_STATUS_LABEL: Record<string, string> = {
+  success: "Succeeded",
+  failure: "Failed",
+  timeout: "Timed out",
+  running: "Running",
+  cancelled: "Cancelled",
+  skipped: "Skipped",
+};
+
+function automationStatusLabel(s: AutomationSummary): string {
+  if (!s.enabled) return "Paused";
+  if (s.disabledAt) return `Auto-disabled${s.disabledReason ? `: ${s.disabledReason}` : ""}`;
+  if (!s.lastRunStatus) return "No runs yet";
+  return RUN_STATUS_LABEL[s.lastRunStatus] || s.lastRunStatus;
+}
+
+/** Compact automation entry in the left rail. Click → open config view. */
+export function RailAutomationItem({
+  automation,
+  active,
+  onClick,
+}: {
+  automation: AutomationSummary;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const dotClass = statusDotClass(
+    automation.lastRunStatus,
+    automation.enabled,
+    // AutomationSummary doesn't expose consecutiveErrors directly; backoff is
+    // surfaced via disabledReason / lastRunStatus. The detail view shows the
+    // full state.
+    undefined,
+  );
+  return (
+    <button type="button" className={`rail-auto-item${active ? " active" : ""}`} onClick={onClick}>
+      <span className={`dot ${dotClass}`} title={automationStatusLabel(automation)} />
+      <span className="rail-auto-text">
+        <span className="rail-auto-name">{automation.name}</span>
+        <span className="rail-auto-sub">{automation.schedule}</span>
+      </span>
+    </button>
+  );
+}
+
+/** Compact run entry in the left rail. Click → open reader. */
+export function RailRunItem({
+  run,
+  automationName,
+  active,
+  onClick,
+}: {
+  run: AutomationRun;
+  automationName?: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const dotClass = statusDotClass(run.status, true);
+  const label = automationName || run.automationId || "unknown";
+  const snippet = run.error
+    ? `Error: ${run.error}`
+    : run.resultPreview
+        ?.replace(/[#*`>_~\-]/g, "")
+        .trim()
+        .slice(0, 90) || "";
+  return (
+    <button type="button" className={`rail-run-item${active ? " active" : ""}`} onClick={onClick}>
+      <div className="rail-run-top">
+        <span className={`dot ${dotClass}`} title={RUN_STATUS_LABEL[run.status] || run.status} />
+        <span className="rail-run-name">{label}</span>
+        <span className="rail-run-time">{relativeTime(run.startedAt)}</span>
+      </div>
+      {snippet && <div className="rail-run-snippet">{snippet}</div>}
+    </button>
+  );
+}

--- a/src/bundles/automations/ui/src/components/ReaderPane.tsx
+++ b/src/bundles/automations/ui/src/components/ReaderPane.tsx
@@ -1,0 +1,190 @@
+import { useAction } from "@nimblebrain/synapse/react";
+import { useState } from "react";
+import { BackArrowIcon } from "../icons.tsx";
+import { renderMarkdown } from "../markdown.ts";
+import type { AutomationRun, AutomationSummary } from "../types.ts";
+import { formatDuration, formatTokens, relativeTime, statusDotClass } from "../utils.ts";
+
+const STATUS_LABEL: Record<string, string> = {
+  success: "Run succeeded",
+  failure: "Run failed",
+  timeout: "Run timed out",
+  running: "Running…",
+  cancelled: "Run cancelled",
+  skipped: "Run skipped",
+};
+
+export function ReaderPane({
+  run,
+  automation,
+  onRerun,
+  onOpenConfig,
+  onBack,
+}: {
+  run: AutomationRun | null;
+  /** The parent automation for this run, if it still exists. */
+  automation: AutomationSummary | undefined;
+  /** Trigger a fresh run of the parent automation. */
+  onRerun: (name: string) => void;
+  /** Open the automation's config view. */
+  onOpenConfig: (name: string) => void;
+  /** Return to the rail (used at narrow widths where rail and reader stack). */
+  onBack?: () => void;
+}) {
+  const action = useAction();
+  const [copied, setCopied] = useState(false);
+
+  if (!run) {
+    return (
+      <div className="reader">
+        <div className="reader-empty">
+          <div className="reader-empty-title">No run selected</div>
+          <div className="reader-empty-desc">
+            Pick a run from the list to read its output, or create an automation to get one going.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const automationName = automation?.name || run.automationId || "unknown";
+  const dotClass = statusDotClass(run.status, true);
+  const statusLabel = STATUS_LABEL[run.status] || run.status;
+  const orphan = !automation;
+  // Pre-0.x records were capped at 500 chars on disk; show a small note on
+  // those legacy runs so it's clear why the output looks chopped.
+  const legacyTruncated = !run.error && (run.resultPreview?.length ?? 0) === 500;
+
+  async function handleCopy() {
+    if (!run?.resultPreview) return;
+    try {
+      await navigator.clipboard.writeText(run.resultPreview);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard may be unavailable in some contexts; silent
+    }
+  }
+
+  function handleOpenConversation() {
+    if (!run?.conversationId) return;
+    action("openConversation", { id: run.conversationId });
+  }
+
+  return (
+    <div className="reader">
+      <div className="reader-head">
+        {onBack && (
+          <button type="button" className="reader-back" onClick={onBack} aria-label="Back to list">
+            <BackArrowIcon />
+          </button>
+        )}
+        <div className="reader-head-meta">
+          <div className="reader-head-title">
+            <span className={`dot ${dotClass}`} />
+            <button
+              type="button"
+              className="reader-head-name"
+              onClick={() => !orphan && onOpenConfig(automationName)}
+              disabled={orphan}
+              title={orphan ? "Automation has been deleted" : "Open config"}
+            >
+              {automationName}
+            </button>
+            <span className="reader-head-sep">·</span>
+            <span className="reader-head-status">{statusLabel}</span>
+            {orphan && <span className="reader-head-tag">deleted</span>}
+          </div>
+          <div className="reader-head-sub">
+            {new Date(run.startedAt).toLocaleString(undefined, {
+              weekday: "short",
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit",
+            })}
+            <span className="reader-head-dot">·</span>
+            {formatDuration(run.startedAt, run.completedAt)}
+            <span className="reader-head-dot">·</span>
+            {formatTokens(run.inputTokens)} in / {formatTokens(run.outputTokens)} out
+            {run.toolCalls > 0 && (
+              <>
+                <span className="reader-head-dot">·</span>
+                {run.toolCalls} tool {run.toolCalls === 1 ? "call" : "calls"}
+              </>
+            )}
+            <span className="reader-head-dot">·</span>
+            {relativeTime(run.startedAt)}
+          </div>
+        </div>
+        <div className="reader-actions">
+          {run.resultPreview && (
+            <button type="button" className="btn" onClick={handleCopy}>
+              {copied ? "Copied" : "Copy"}
+            </button>
+          )}
+          {!orphan && (
+            <button type="button" className="btn" onClick={() => onRerun(automationName)}>
+              Re-run
+            </button>
+          )}
+          {run.conversationId && (
+            <button type="button" className="btn btn-accent" onClick={handleOpenConversation}>
+              Open conversation →
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="reader-body">
+        {run.error ? (
+          <div className="reader-error">
+            <div className="reader-error-label">Error</div>
+            <pre className="reader-error-body">{run.error}</pre>
+            {run.resultPreview && (
+              <>
+                <div className="reader-error-label" style={{ marginTop: 14 }}>
+                  Output before failure
+                </div>
+                <div
+                  className="out-md"
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via DOMPurify in renderMarkdown
+                  dangerouslySetInnerHTML={{
+                    __html: renderMarkdown(run.resultPreview),
+                  }}
+                />
+              </>
+            )}
+          </div>
+        ) : run.resultPreview ? (
+          <>
+            <div
+              className="out-md"
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via DOMPurify in renderMarkdown
+              dangerouslySetInnerHTML={{
+                __html: renderMarkdown(run.resultPreview),
+              }}
+            />
+            {legacyTruncated && (
+              <div className="reader-truncation-note">
+                This run is from an older build that capped output at 500 chars. Re-run for the full
+                output.
+              </div>
+            )}
+          </>
+        ) : run.status === "running" ? (
+          <div className="reader-empty-desc">This run is still in progress.</div>
+        ) : (
+          <div className="reader-empty-desc">No output captured for this run.</div>
+        )}
+
+        <div className="reader-footer-meta">
+          <span>Iterations: {run.iterations ?? "-"}</span>
+          <span>Tool calls: {run.toolCalls ?? "-"}</span>
+          {run.stopReason && <span>Stop: {run.stopReason}</span>}
+          <span>Run id: {run.id}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/bundles/automations/ui/src/components/RunRow.tsx
+++ b/src/bundles/automations/ui/src/components/RunRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ChevronIcon } from "../icons.tsx";
+import { renderMarkdown } from "../markdown.ts";
 import type { AutomationRun } from "../types.ts";
 import { formatDuration, formatTokens, relativeTime, statusDotClass } from "../utils.ts";
 
@@ -40,7 +41,13 @@ export function RunRow({ run, showName }: { run: AutomationRun; showName?: boole
               >
                 Result
               </div>
-              <pre>{run.resultPreview}</pre>
+              <div
+                className="out-md"
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via DOMPurify in renderMarkdown
+                dangerouslySetInnerHTML={{
+                  __html: renderMarkdown(run.resultPreview),
+                }}
+              />
             </div>
           )}
           {run.error && (

--- a/src/bundles/automations/ui/src/components/SchedulePicker.tsx
+++ b/src/bundles/automations/ui/src/components/SchedulePicker.tsx
@@ -85,8 +85,9 @@ export function SchedulePicker({
   const radioStyle = {
     display: "flex",
     alignItems: "center",
+    flexWrap: "wrap",
     gap: 8,
-    padding: "6px 0",
+    padding: "8px 0",
     fontSize: 13,
     cursor: "pointer",
   } as const;

--- a/src/bundles/automations/ui/src/markdown.ts
+++ b/src/bundles/automations/ui/src/markdown.ts
@@ -4,14 +4,79 @@ import { marked } from "marked";
 // GitHub-flavored markdown, no auto-mangling of header IDs.
 marked.setOptions({ gfm: true, breaks: false });
 
-// Render an automation run's text output to sanitized HTML. The text is
-// produced by an LLM and may include third-party content fetched by tools,
-// so we sanitize before injecting via dangerouslySetInnerHTML.
+/**
+ * Tags allowed in rendered automation output. Default-deny: anything
+ * NOT on this list is stripped. Covers what `marked` actually emits for
+ * standard markdown (headings, paragraphs, lists, links, code, tables,
+ * emphasis, hr) and leaves out everything else (script/iframe/object/
+ * embed/form/etc.) by definition.
+ *
+ * Allowlist beats forbiddenlist for this use case — `FORBID_TAGS` over
+ * the `html` profile was inconsistent in practice (some void elements
+ * like `<embed>` slipped through in certain HTML-parsing contexts).
+ */
+const ALLOWED_TAGS = [
+  // structure
+  "p",
+  "br",
+  "hr",
+  "div",
+  "span",
+  // headings
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  // text
+  "strong",
+  "em",
+  "del",
+  "s",
+  "blockquote",
+  "code",
+  "pre",
+  // lists
+  "ul",
+  "ol",
+  "li",
+  // links
+  "a",
+  // tables
+  "table",
+  "thead",
+  "tbody",
+  "tfoot",
+  "tr",
+  "th",
+  "td",
+];
+
+/** Attributes allowed on any tag. `href` is needed for links; everything
+ *  else is suppressed — no `style` (XSS via CSS expressions on old
+ *  engines), no `on*` event handlers, no `srcset`, no `data-*`. */
+const ALLOWED_ATTR = ["href", "title", "align"];
+
+/**
+ * Render an automation run's text output to sanitized HTML. The text is
+ * produced by an LLM and may include third-party content fetched by
+ * tools, so we sanitize before injecting via `dangerouslySetInnerHTML`.
+ *
+ * DOMPurify is configured with explicit `ALLOWED_TAGS` / `ALLOWED_ATTR`
+ * lists and `KEEP_CONTENT: true` so disallowed tags are removed but
+ * their text children survive (a stripped `<object>` doesn't blank its
+ * inner text).
+ */
 export function renderMarkdown(text: string): string {
   const html = marked.parse(text, { async: false }) as string;
   return DOMPurify.sanitize(html, {
-    USE_PROFILES: { html: true },
-    FORBID_TAGS: ["style", "script", "iframe", "object", "embed"],
-    FORBID_ATTR: ["style", "onerror", "onload", "onclick"],
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    KEEP_CONTENT: true,
+    // `data:` would let an LLM smuggle inline payloads; `javascript:`
+    // and `vbscript:` are the classic XSS vectors. DOMPurify defaults
+    // already restrict these, but pin the contract explicitly.
+    ALLOWED_URI_REGEXP: /^(?:https?:|mailto:|tel:|#|\/[^/])/i,
   });
 }

--- a/src/bundles/automations/ui/src/markdown.ts
+++ b/src/bundles/automations/ui/src/markdown.ts
@@ -1,0 +1,17 @@
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+
+// GitHub-flavored markdown, no auto-mangling of header IDs.
+marked.setOptions({ gfm: true, breaks: false });
+
+// Render an automation run's text output to sanitized HTML. The text is
+// produced by an LLM and may include third-party content fetched by tools,
+// so we sanitize before injecting via dangerouslySetInnerHTML.
+export function renderMarkdown(text: string): string {
+  const html = marked.parse(text, { async: false }) as string;
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+    FORBID_TAGS: ["style", "script", "iframe", "object", "embed"],
+    FORBID_ATTR: ["style", "onerror", "onload", "onclick"],
+  });
+}

--- a/src/bundles/automations/ui/src/styles.ts
+++ b/src/bundles/automations/ui/src/styles.ts
@@ -301,4 +301,286 @@ body {
   transition: transform 0.15s;
 }
 .chevron.open { transform: rotate(90deg); }
+
+/* ============================================================
+   Two-pane reader layout (Variant 3)
+   ============================================================ */
+
+.two-pane {
+  flex: 1; min-height: 0;
+  display: grid; grid-template-columns: 280px 1fr;
+  overflow: hidden;
+}
+
+.rail {
+  overflow-y: auto;
+  border-right: 1px solid var(--color-border-primary, #e5e5e5);
+  background: var(--color-background-primary, #faf9f7);
+  padding-bottom: 12px;
+}
+.rail-section {
+  font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
+  color: var(--color-text-secondary, #737373);
+  padding: 16px 16px 6px;
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+}
+
+.rail-auto-item, .rail-run-item {
+  width: 100%; text-align: left; cursor: pointer;
+  display: flex; gap: 8px;
+  padding: 9px 16px;
+  border: none; background: transparent; color: inherit;
+  font-family: inherit;
+  border-left: 2px solid transparent;
+  transition: background 0.1s;
+}
+.rail-auto-item:hover, .rail-run-item:hover { background: color-mix(in srgb, var(--color-border-primary, #e5e5e5) 30%, transparent); }
+.rail-auto-item.active, .rail-run-item.active {
+  background: var(--color-background-secondary, #ffffff);
+  border-left-color: var(--color-text-accent, #0055FF);
+}
+
+.rail-auto-item { align-items: flex-start; }
+.rail-auto-item .dot { margin-top: 6px; }
+.rail-auto-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.rail-auto-name { font-size: 13px; font-weight: 500; color: var(--color-text-primary, #171717); }
+.rail-auto-sub { font-size: 11px; color: var(--color-text-secondary, #737373); }
+
+.rail-run-item { flex-direction: column; align-items: stretch; gap: 3px; }
+.rail-run-top { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+.rail-run-name { font-weight: 500; flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--color-text-primary, #171717); }
+.rail-run-time { font-size: 11px; color: var(--color-text-secondary, #737373); flex-shrink: 0; }
+.rail-run-snippet {
+  font-size: 12px; color: var(--color-text-secondary, #737373);
+  margin-left: 16px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+.rail-empty {
+  font-size: 12px; color: var(--color-text-secondary, #737373);
+  padding: 8px 16px 14px;
+}
+
+/* Status legend in the rail */
+.legend { display: inline-flex; gap: 10px; font-size: 10px; font-weight: 400; text-transform: none; letter-spacing: 0; color: var(--color-text-secondary, #737373); }
+.legend span { display: inline-flex; align-items: center; gap: 4px; }
+
+/* Right pane — reader */
+.reader { overflow-y: auto; background: var(--color-background-secondary, #ffffff); }
+
+.reader-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  height: 100%; padding: 48px 32px; text-align: center; color: var(--color-text-secondary, #737373);
+}
+.reader-empty-title {
+  font-family: var(--nb-font-heading, Georgia, serif);
+  font-size: 17px; font-weight: 500; letter-spacing: -0.02em;
+  color: var(--color-text-primary, #171717); margin-bottom: 8px;
+}
+.reader-empty-desc { font-size: 13px; line-height: 1.5; max-width: 360px; }
+
+.reader-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 14px;
+  padding: 20px 28px 14px;
+  border-bottom: 1px solid var(--color-border-primary, #e5e5e5);
+  position: sticky; top: 0; background: var(--color-background-secondary, #ffffff); z-index: 5;
+}
+.reader-head-meta { min-width: 0; }
+.reader-head-title { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--color-text-secondary, #737373); flex-wrap: wrap; }
+.reader-head-name {
+  background: none; border: none; padding: 0; font: inherit; cursor: pointer;
+  color: var(--color-text-primary, #171717); font-weight: 600;
+  border-bottom: 1px solid transparent; transition: border-color 0.15s;
+}
+.reader-head-name:hover:not(:disabled) { border-bottom-color: var(--color-text-accent, #0055FF); }
+.reader-head-name:disabled { cursor: default; }
+.reader-head-status { color: var(--color-text-secondary, #737373); }
+.reader-head-sep, .reader-head-dot { color: var(--color-border-primary, #e5e5e5); margin: 0 2px; }
+.reader-head-tag {
+  font-size: 10px; padding: 1px 6px; border-radius: 10px;
+  background: color-mix(in srgb, var(--color-text-secondary, #737373) 12%, transparent);
+  color: var(--color-text-secondary, #737373); font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.4px;
+}
+.reader-head-sub {
+  font-size: 12px; color: var(--color-text-secondary, #737373);
+  margin-top: 5px; line-height: 1.5;
+}
+.reader-actions { display: flex; gap: 6px; flex-shrink: 0; flex-wrap: wrap; justify-content: flex-end; }
+
+.reader-body { padding: 22px 28px 28px; }
+.reader-truncation-note {
+  margin-top: 20px; padding: 10px 14px;
+  font-size: 12px; color: var(--color-text-secondary, #737373);
+  background: var(--color-background-primary, #faf9f7);
+  border: 1px solid var(--color-border-primary, #e5e5e5);
+  border-radius: var(--border-radius-sm, 0.5rem);
+}
+.reader-error-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--nb-color-danger, #dc2626); margin-bottom: 6px; }
+.reader-error-body {
+  background: color-mix(in srgb, var(--nb-color-danger, #dc2626) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--nb-color-danger, #dc2626) 25%, transparent);
+  border-radius: var(--border-radius-sm, 0.5rem);
+  padding: 10px 12px; font-size: 12px; line-height: 1.5;
+  white-space: pre-wrap; word-break: break-word;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+  color: var(--nb-color-danger, #dc2626);
+}
+.reader-footer-meta {
+  display: flex; gap: 16px; flex-wrap: wrap; margin-top: 22px; padding-top: 12px;
+  border-top: 1px solid var(--color-border-primary, #e5e5e5);
+  font-size: 11px; color: var(--color-text-secondary, #737373);
+}
+.reader-footer-meta span { display: inline-flex; align-items: center; gap: 4px; }
+
+/* Rendered markdown */
+.out-md {
+  font-size: 14px; line-height: 1.65;
+  color: var(--color-text-primary, #171717);
+  max-width: 680px;
+}
+.out-md h1, .out-md h2, .out-md h3 {
+  font-family: var(--nb-font-heading, Georgia, serif);
+  font-weight: 500; letter-spacing: -0.02em;
+}
+.out-md h1 { font-size: 22px; margin: 0 0 6px; }
+.out-md h2 { font-size: 16px; margin: 22px 0 7px; }
+.out-md h3 { font-size: 14.5px; margin: 18px 0 5px; }
+.out-md p { margin: 0 0 10px; }
+.out-md ul, .out-md ol { margin: 0 0 12px 22px; }
+.out-md li { margin-bottom: 4px; }
+.out-md li > p { margin: 0; }
+.out-md a { color: var(--color-text-accent, #0055FF); text-decoration: none; border-bottom: 1px solid color-mix(in srgb, var(--color-text-accent, #0055FF) 35%, transparent); }
+.out-md a:hover { border-bottom-color: var(--color-text-accent, #0055FF); }
+.out-md code {
+  background: var(--color-background-primary, #faf9f7);
+  border: 1px solid var(--color-border-primary, #e5e5e5);
+  border-radius: 4px; padding: 1px 5px;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+  font-size: 12.5px;
+}
+.out-md pre {
+  background: var(--color-background-primary, #faf9f7);
+  border: 1px solid var(--color-border-primary, #e5e5e5);
+  border-radius: var(--border-radius-sm, 0.5rem);
+  padding: 12px 14px; margin: 10px 0;
+  overflow-x: auto; font-size: 12.5px; line-height: 1.5;
+}
+.out-md pre code { background: none; border: none; padding: 0; }
+.out-md blockquote {
+  margin: 10px 0; padding: 6px 14px;
+  border-left: 3px solid var(--color-border-primary, #e5e5e5);
+  color: var(--color-text-secondary, #737373);
+}
+.out-md hr { border: none; border-top: 1px solid var(--color-border-primary, #e5e5e5); margin: 18px 0; }
+.out-md table { border-collapse: collapse; margin: 10px 0; }
+.out-md th, .out-md td { border: 1px solid var(--color-border-primary, #e5e5e5); padding: 6px 10px; font-size: 13px; text-align: left; }
+.out-md th { background: var(--color-background-primary, #faf9f7); font-weight: 600; }
+.out-md strong { font-weight: 600; }
+
+/* Template chips fix: stacked card instead of single-line .btn pill */
+.template-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px; margin-top: 8px;
+}
+.template-card {
+  display: flex; flex-direction: column; align-items: flex-start;
+  gap: 3px; text-align: left; white-space: normal;
+  padding: 11px 13px;
+  border: 1px solid var(--color-border-primary, #e5e5e5);
+  border-radius: var(--border-radius-sm, 0.5rem);
+  background: var(--color-background-secondary, #ffffff);
+  color: var(--color-text-primary, #171717);
+  font-family: inherit; cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.template-card:hover { border-color: var(--color-text-accent, #0055FF); }
+.template-card.dashed { border-style: dashed; }
+.template-card-name { font-size: 13px; font-weight: 500; }
+.template-card-desc { font-size: 11px; color: var(--color-text-secondary, #737373); line-height: 1.35; }
+
+/* Narrow-panel collapse: at < 720px the rail and reader stack;
+   data-show toggles which one is visible. */
+@media (max-width: 720px) {
+  .two-pane { grid-template-columns: 1fr; }
+  .two-pane[data-show="reader"] .rail { display: none; }
+  .two-pane[data-show="rail"] .reader { display: none; }
+  .reader-back { display: inline-flex !important; }
+}
+.reader-back {
+  display: none; align-items: center; justify-content: center;
+  width: 36px; height: 36px; border: 1px solid var(--color-border-primary, #e5e5e5);
+  border-radius: 50%; background: transparent; cursor: pointer;
+  color: var(--color-text-secondary, #737373);
+  margin-right: 8px; flex-shrink: 0;
+}
+.reader-back:hover { border-color: var(--color-text-accent, #0055FF); color: var(--color-text-accent, #0055FF); }
+
+/* ============================================================
+   Mobile responsiveness — defensive overflow guards + sized
+   touch targets + content-aware stacking. Preserves the desktop
+   variant-3 design; only kicks in at narrow widths.
+   ============================================================ */
+
+/* Defensive min-width: 0 so grid/flex children can actually shrink
+   below their content's intrinsic min size. Without these, a wide
+   skeleton card can push the rail past the viewport. */
+.app { min-width: 0; }
+.rail { min-width: 0; }
+.reader { min-width: 0; }
+.header-top > div { min-width: 0; }
+.header-lede { overflow-wrap: anywhere; }
+.detail-name { word-break: break-word; }
+
+@media (max-width: 720px) {
+  /* Header gets a tighter padding + larger create-btn for touch. */
+  .header { padding: 16px 16px 10px; }
+
+  /* Reader head stacks vertically so meta + actions don't fight. */
+  .reader-head {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 14px 16px 12px;
+  }
+  .reader-head-meta { width: 100%; }
+  .reader-head-title { gap: 6px; font-size: 12px; }
+  .reader-head-sub { font-size: 11px; line-height: 1.5; }
+  .reader-actions { justify-content: flex-start; gap: 8px; }
+  .reader-body { padding: 16px 16px 24px; }
+
+  /* When the back button is shown, place it inline with the head. */
+  .reader-head { flex-direction: row; flex-wrap: wrap; }
+  .reader-head .reader-head-meta { flex: 1; min-width: 0; }
+  .reader-head .reader-actions { width: 100%; }
+
+  /* Touch-friendly action buttons (scoped to action toolbars only —
+     dense rail/run rows keep their compact size). */
+  .reader-actions .btn,
+  .detail-actions .btn {
+    padding: 8px 14px;
+    font-size: 12px;
+    min-height: 36px;
+  }
+  .detail-actions { flex-wrap: wrap; gap: 8px; }
+
+  /* Header back / detail back bumped to 36×36. */
+  .back-btn { width: 36px; height: 36px; }
+
+  /* Run rows get a bit more padding to land taps reliably. */
+  .run-row { padding: 10px 12px; }
+
+  /* Drop nested-scroll on the prompt at narrow widths — fights page scroll. */
+  .detail-prompt { max-height: none; }
+}
+
+@media (max-width: 480px) {
+  .header-title { font-size: 19px; }
+  .header-lede { font-size: 13px; }
+  .create-btn { padding: 8px 14px; font-size: 13px; }
+  .create-btn svg { width: 16px; height: 16px; }
+
+  /* Advanced config grid → single column. Side-by-side is unreadable
+     in ~167px cells. */
+  .detail-config-grid { grid-template-columns: 1fr; }
+}
 `;

--- a/src/prompt/compose.ts
+++ b/src/prompt/compose.ts
@@ -46,6 +46,7 @@ export interface TracedLayer {
 
 export type TracedLayerKind =
   | "default_identity"
+  | "task_identity"
   | "core_skill"
   | "user_context_skill"
   | "user_prefs"
@@ -96,6 +97,25 @@ You have access to tools provided via the API. When a user asks you to do someth
 Be concise and direct. Lead with actions, not explanations.
 
 IMPORTANT: Only use tools that are provided to you via the tools parameter. Never fabricate tool calls as XML, JSON, or any other text format.`;
+
+/**
+ * Identity framing for task-mode invocations (e.g. scheduled automations,
+ * eval runs, future webhook-triggered jobs). Prepended above the core
+ * skills when `composeSystemPrompt({ mode: "task" })`. The runtime owns
+ * this contract; bundles cannot spoof it by wrapping the user message.
+ *
+ * The contract: artifact production, no follow-up questions, factual
+ * gap-handling, markdown by default.
+ */
+export const TASK_IDENTITY = `You are running as an automated task. The user is not present at this time, so there is nobody available to answer questions or confirm choices — decide and proceed using the tools and context available.
+
+Produce a finished, self-contained deliverable as your final response. Format as markdown unless the task description specifies otherwise. Do not greet, acknowledge ("Sure, let me…"), or close with follow-up questions ("Want me to dig deeper?"). If required data is missing or unavailable, state the gap factually within the deliverable and continue with what you can produce — do not stop and ask.
+
+You still have full access to tools and can call them as many times as the task needs. The deliverable is your final assistant message, not an intermediate one.`;
+
+/** Invocation mode. `chat` is the conversational surface; `task` is the
+ *  unattended artifact-production surface (automations, evals, etc.). */
+export type ComposeMode = "chat" | "task";
 
 /** Lightweight app descriptor for system prompt injection. */
 export interface PromptAppInfo {
@@ -201,6 +221,7 @@ export function composeSystemPrompt(
   workspaceContext?: WorkspaceContext,
   overlays?: OverlayLayers,
   layer3Skills?: Layer3SkillEntry[],
+  mode?: ComposeMode,
 ): string {
   return composeSystemPromptTraced(
     contextSkills,
@@ -213,6 +234,7 @@ export function composeSystemPrompt(
     workspaceContext,
     overlays,
     layer3Skills,
+    mode,
   ).text;
 }
 
@@ -240,8 +262,25 @@ export function composeSystemPromptTraced(
   workspaceContext?: WorkspaceContext,
   overlays?: OverlayLayers,
   layer3Skills?: Layer3SkillEntry[],
+  mode: ComposeMode = "chat",
 ): ComposedPrompt {
   const layers: TracedLayer[] = [];
+
+  // Layer 0a (task mode only): TASK_IDENTITY contract. Prepended before
+  // any core skill so the framing is read first. The runtime owns this
+  // layer — bundles cannot remove or override it by wrapping the user
+  // message. Workspace `soul.md` and similar core skills still layer in
+  // below; their domain identity composes with, not against, the task
+  // contract.
+  if (mode === "task") {
+    layers.push({
+      kind: "task_identity",
+      id: "nb:task-identity",
+      source: "platform task-mode contract",
+      text: TASK_IDENTITY,
+      tokens: approxTokens(TASK_IDENTITY),
+    });
+  }
 
   // Separate core context (priority ≤ threshold) from user context (priority > threshold).
   const coreContext: Skill[] = [];
@@ -269,7 +308,10 @@ export function composeSystemPromptTraced(
     }
   }
 
-  // Fallback to default identity if no core context skills produced content.
+  // Fallback to default identity if no core context skills produced
+  // content. In task mode the TASK_IDENTITY layer above already supplies
+  // the framing, so skip the DEFAULT_IDENTITY fallback — the two would
+  // give the model contradictory role definitions.
   if (layers.length === 0) {
     layers.push({
       kind: "default_identity",

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -118,7 +118,15 @@ import {
   runWithRequestContext,
 } from "./request-context.ts";
 import { buildSkillsLoadedPayload } from "./skills-loaded-payload.ts";
-import type { ChatRequest, ChatResult, ModelSlots, RuntimeConfig, TurnUsage } from "./types.ts";
+import type {
+  ChatRequest,
+  ChatResult,
+  ModelSlots,
+  RuntimeConfig,
+  TaskRequest,
+  TaskResult,
+  TurnUsage,
+} from "./types.ts";
 import { createWorkspaceRegistry, startWorkspaceBundles } from "./workspace-runtime.ts";
 
 const DEFAULT_WORK_DIR = join(homedir(), ".nimblebrain");
@@ -1450,6 +1458,332 @@ export class Runtime {
       response: result.output,
       conversationId: conversation.id,
       skillName: skill?.manifest.name ?? null,
+      toolCalls: result.toolCalls,
+      stopReason: result.stopReason,
+      usage,
+    };
+  }
+
+  /**
+   * Unattended agent execution. Sibling primitive to `chat()` for
+   * scheduled automations, eval runs, and future webhook-triggered jobs.
+   *
+   * Contract differences vs. `chat()`:
+   *  - Each call writes a FRESH conversation; no resume, no concurrency
+   *    lock (a re-entrant scheduler tick on the same automation creates
+   *    two conversations, which is the correct semantic — each tick is
+   *    its own task run).
+   *  - The prompt goes in as a plain user message — no content parts,
+   *    no file refs, no skill matching from prompt. Layer 3 (bundle
+   *    workflow guidance) still applies based on the active tool set.
+   *  - The system prompt is composed with `mode: "task"`, prepending
+   *    `TASK_IDENTITY` so the model produces a deliverable rather than a
+   *    conversational reply. The runtime owns this framing — bundles
+   *    cannot spoof it by wrapping the user message.
+   *  - `workspaceId` is optional: present → focused workspace tool scope
+   *    + briefing; absent → cross-workspace reach with no briefing layer.
+   *  - No title generation, no `chat.start` SSE emit.
+   *
+   * NOTE (intentional duplication): much of the setup below mirrors
+   * `_chatInner()`. The clean extraction (`_agentInvoke` substrate +
+   * thin `chat()` / `executeTask()` siblings) is a planned follow-up PR
+   * — see the conversation in `feat/automations-ux`. Doing the extraction
+   * here would touch ~500 LOC of the most-trafficked code path in the
+   * runtime in the same PR as the UI work, multiplying regression risk
+   * for the chat surface. Shipped pragmatically; extracted properly later.
+   */
+  async executeTask(request: TaskRequest, requestSink?: EventSink): Promise<TaskResult> {
+    // Identity resolution mirrors chat(): in production an identity provider
+    // populates this; in dev mode we fall back to DEV_IDENTITY. Scheduler
+    // callers pass `{ id: automation.ownerId }` as a minimal identity.
+    const ownerId = resolveRequestOwnerId(request.identity, this._identityProvider !== null);
+    const requestIdentity = request.identity ?? DEV_IDENTITY;
+
+    // Session workspace (personal) — used for the silent dispatch reqCtx,
+    // file store, and the workspace-agents / model overrides lookup. Never
+    // narrated by the task prompt; the prompt only mentions the focused
+    // workspace if one is set.
+    const sessionWsId = personalWorkspaceIdFor(requestIdentity.id);
+    await ensureUserWorkspace(this._workspaceStore, {
+      id: requestIdentity.id,
+      ...(requestIdentity.displayName ? { displayName: requestIdentity.displayName } : {}),
+    });
+    await this.ensureWorkspaceRegistry(sessionWsId);
+    const store: ConversationStore = this.findConversationStore();
+    const sessionWorkspace = await this._workspaceStore.get(sessionWsId);
+
+    // Always create a fresh conversation per task. No resume path —
+    // `TaskRequest` has no `conversationId` field by design.
+    const conversation = await store.create({
+      ownerId,
+      workspaceId: sessionWsId,
+      metadata: { source: "task", ...(request.metadata ?? {}) },
+    });
+
+    await store.append(conversation, {
+      role: "user",
+      content: [{ type: "text", text: request.prompt }],
+      timestamp: new Date().toISOString(),
+      userId: requestIdentity.id,
+    });
+
+    // Workspace briefing (apps + overlays + workspace context). Same shape
+    // as chat: gated on `focusedWsId`. When absent the briefing layers are
+    // empty and `TASK_IDENTITY` is the dominant framing.
+    const focusedWsId = request.workspaceId;
+    const apps = focusedWsId ? await this.buildAppsList(focusedWsId) : [];
+    const liveOverlays = focusedWsId
+      ? await this.readPromptOverlays(focusedWsId)
+      : { org: await this.getInstructionsStore().read({ scope: "org" }), workspace: "" };
+
+    // Tool surfacing. Active set = focused workspace's tools (or session
+    // workspace if no focus) + identity tools. Cross-workspace union
+    // remains the discoverable corpus reachable via `nb__search`.
+    const toolsWsId = focusedWsId ?? sessionWsId;
+    const toolsRegistry = await this.ensureWorkspaceRegistry(toolsWsId);
+    const [focusedTools, identityTools] = await Promise.all([
+      toolsRegistry.availableTools(),
+      this.listIdentitySourceTools(),
+    ]);
+    const allTools: ToolSchema[] = [
+      ...focusedTools
+        .filter((t) => isToolVisibleToRole(t.name, requestIdentity.orgRole))
+        .map((t) => ({
+          name: namespacedToolName(toolsWsId, t.name),
+          description: t.description,
+          inputSchema: t.inputSchema,
+          ...(t.annotations !== undefined ? { annotations: t.annotations } : {}),
+        })),
+      ...identityTools
+        .filter((t) => isToolVisibleToRole(t.name, requestIdentity.orgRole))
+        .map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+          ...(t.annotations !== undefined ? { annotations: t.annotations } : {}),
+        })),
+    ];
+    const { direct: tools, proxied } = surfaceTools(allTools, null, {
+      ...(request.allowedTools ? { requestAllowedTools: request.allowedTools } : {}),
+    });
+
+    const prefs = {
+      displayName: requestIdentity.displayName ?? "",
+      timezone: requestIdentity.preferences?.timezone ?? "",
+      locale: requestIdentity.preferences?.locale ?? "en-US",
+    };
+
+    const activeWorkspace = focusedWsId
+      ? focusedWsId === sessionWsId
+        ? sessionWorkspace
+        : await this._workspaceStore.get(focusedWsId)
+      : undefined;
+    const workspaceContext = focusedWsId
+      ? activeWorkspace
+        ? { id: activeWorkspace.id, name: activeWorkspace.name }
+        : { id: focusedWsId }
+      : undefined;
+
+    const identityOverride = activeWorkspace?.identity
+      ? makeIdentitySkill(activeWorkspace.identity)
+      : null;
+    const requestContextSkills = identityOverride
+      ? [...this.contextSkills, identityOverride]
+      : this.contextSkills;
+
+    // Layer 3 selection — bundle workflow guidance still applies based on
+    // the active tool set. No `appContextServerName` (tasks don't have
+    // appContext).
+    const userId = requestIdentity.id;
+    const layer3Pool = this.loadConversationSkills(sessionWsId, userId);
+    const accessibleForSkills = await this._workspaceStore.getWorkspacesForUser(ownerId);
+    const bundleSkills = (
+      await Promise.all(accessibleForSkills.map((ws) => this.loadBundleSkills(ws.id, {})))
+    ).flat();
+    const mergedLayer3Pool: Skill[] = [...layer3Pool, ...bundleSkills];
+    const activeToolNames = tools.map((t) => t.name);
+    const selectedLayer3 = selectLayer3Skills({
+      skills: mergedLayer3Pool,
+      activeTools: activeToolNames,
+    });
+    const layer3Entries: Layer3SkillEntry[] = selectedLayer3.map((s) => ({
+      name: s.skill.manifest.name,
+      body: s.skill.body,
+      scope: s.skill.manifest.scope ?? "org",
+      ...(s.skill.sourcePath ? { sourcePath: s.skill.sourcePath } : {}),
+      loadedBy: s.loadedBy,
+      reason: s.reason,
+    }));
+
+    // Compose with mode: "task" — prepends TASK_IDENTITY before core skills.
+    const systemPrompt = composeSystemPrompt(
+      requestContextSkills,
+      null, // no matched skill (task mode doesn't match on prompt)
+      apps,
+      undefined, // no focusedApp
+      undefined, // no appState
+      prefs,
+      proxied.length > 0,
+      workspaceContext,
+      liveOverlays,
+      layer3Entries,
+      "task",
+    );
+
+    // Model resolution — mirrors chat (alias slot + qualification).
+    let resolvedModelString = request.model ?? this.getDefaultModel();
+    const aliasSlot = parseAliasRef(resolvedModelString);
+    if (aliasSlot) {
+      resolvedModelString = this.getModelSlot(aliasSlot);
+    }
+    resolvedModelString = resolveModelString(resolvedModelString);
+
+    // Load the freshly-appended user message and rehydrate (no-op since
+    // there are no file refs — the rehydrate call is a pass-through for
+    // shape consistency with the engine's message contract).
+    const history = await store.history(conversation);
+    const fileStore = this.getFileStore(ownerId);
+    const messages = await rehydrateUserResources(history, fileStore, {
+      model: resolvedModelString,
+      maxExtractedTextSize: this.getFilesConfig().maxExtractedTextSize,
+    });
+
+    const resolvedMaxOutputTokens = resolveMaxOutputTokens({
+      configValue: this.config.maxOutputTokens,
+      model: resolvedModelString,
+    });
+    const resolvedThinking = resolveThinking({
+      configMode: this.config.thinking,
+      configBudgetTokens: this.config.thinkingBudgetTokens,
+      model: resolvedModelString,
+      maxOutputTokens: resolvedMaxOutputTokens,
+    });
+    const configMaxInputTokens = this.config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS;
+    const messageBudget = resolveMessageBudget({
+      model: resolvedModelString,
+      configMaxInputTokens,
+      systemPrompt,
+      tools,
+      maxOutputTokens: resolvedMaxOutputTokens,
+    });
+
+    const maxHistoryMessages = this.config.maxHistoryMessages ?? DEFAULT_MAX_HISTORY_MESSAGES;
+    const replayProvider = getProviderFromModel(resolvedModelString);
+    const perRequestHooks: EngineHooks = {
+      ...this.hooks,
+      transformContext: (historyMessages, opts) => {
+        const attempt = opts?.overflowAttempt ?? 0;
+        const budget =
+          attempt > 0 ? Math.floor(messageBudget.budget / (1 << attempt)) : messageBudget.budget;
+        const sliced = sliceHistory(historyMessages, maxHistoryMessages);
+        const replayReady = applyReasoningReplayPolicy(sliced, replayProvider);
+        return windowMessages(replayReady, budget);
+      },
+    };
+
+    const skillsLoaded = buildSkillsLoadedPayload(selectedLayer3);
+    const contextAssembled = buildContextAssembledPayload({
+      systemPrompt,
+      activeTools: tools,
+      messages,
+      skillsLoaded,
+    });
+
+    const engineConfig: EngineConfig = {
+      model: resolvedModelString,
+      maxIterations: request.maxIterations ?? this.config.maxIterations ?? DEFAULT_MAX_ITERATIONS,
+      maxInputTokens: messageBudget.budget,
+      maxOutputTokens: resolvedMaxOutputTokens,
+      ...(resolvedThinking ? { thinking: resolvedThinking } : {}),
+      maxToolResultSize: this.config.maxToolResultSize,
+      hooks: perRequestHooks,
+      runMetadata: { skillsLoaded, contextAssembled },
+      ...(request.signal ? { signal: request.signal } : {}),
+    };
+
+    // Event store routing — same as chat. The task's conversation is the
+    // active conversation for the global event store unless we're using a
+    // workspace-scoped store.
+    const isWorkspaceRequest =
+      store instanceof EventSourcedConversationStore && store !== this.store;
+    let activeEventStore: EventSourcedConversationStore | null = null;
+    if (isWorkspaceRequest) {
+      if (this.eventStore) this.eventStore.setActiveConversation("");
+      activeEventStore = store as EventSourcedConversationStore;
+      activeEventStore.setActiveConversation(conversation.id);
+    } else if (this.eventStore) {
+      activeEventStore = this.eventStore;
+      this.eventStore.setActiveConversation(conversation.id);
+    }
+
+    const sinks: EventSink[] = requestSink
+      ? [requestSink, this.defaultEvents]
+      : [this.defaultEvents];
+    if (isWorkspaceRequest) {
+      sinks.push(store as EventSourcedConversationStore);
+    }
+
+    const model = engineConfig.model;
+    const resolvedModel = this.resolveModelFn(model);
+    const perCallWorkspaceMap = new Map<string, string>();
+    const wrappedSinks: EventSink[] = sinks.map((inner) =>
+      this._wrapSinkWithWorkspaceAttribution(inner, perCallWorkspaceMap),
+    );
+    const engineSink = new MultiEventSink(wrappedSinks);
+    const identityToolRouter = this._buildIdentityToolRouter({
+      identityId: ownerId,
+      perCallWorkspaceMap,
+    });
+    const engine = new AgentEngine(resolvedModel, identityToolRouter, engineSink);
+
+    const reqCtx: RequestContext = {
+      identity: requestIdentity,
+      scope: {
+        kind: "workspace",
+        workspaceId: sessionWsId,
+        workspaceAgents: sessionWorkspace?.agents ?? null,
+        workspaceModelOverride: sessionWorkspace?.models ?? null,
+      },
+      conversationId: conversation.id,
+    };
+    engineConfig.toolPromotion = this.buildToolPromotionFactory();
+
+    const result = await runWithRequestContext(reqCtx, () =>
+      engine.run(engineConfig, systemPrompt, messages, tools),
+    );
+
+    const usage: TurnUsage = {
+      ...result.usage,
+      model,
+      llmMs: result.llmMs,
+      iterations: result.iterations,
+    };
+
+    // Persist assistant message (the deliverable) so the conversation
+    // trace is complete and the UI's "Open conversation →" affordance
+    // shows the full output. Same eventStoreHandled gate as chat().
+    const eventStoreHandled = !!activeEventStore;
+    if (!eventStoreHandled) {
+      await store.append(conversation, {
+        role: "assistant",
+        content: result.output
+          ? [{ type: "text", text: result.output }]
+          : [{ type: "text", text: "(tool use only)" }],
+        timestamp: new Date().toISOString(),
+        metadata: {
+          skill: null,
+          toolCalls: result.toolCalls,
+          usage: result.usage,
+          model,
+          llmMs: result.llmMs,
+          iterations: result.iterations,
+        },
+      });
+    }
+
+    return {
+      output: result.output,
+      conversationId: conversation.id,
       toolCalls: result.toolCalls,
       stopReason: result.stopReason,
       usage,

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1658,7 +1658,14 @@ export class Runtime {
       model: resolvedModelString,
       maxOutputTokens: resolvedMaxOutputTokens,
     });
-    const configMaxInputTokens = this.config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS;
+    // Per-request override beats config beats default. The UI exposes a
+    // per-automation `maxInputTokens` field; honoring it here makes that
+    // setting actually take effect. Chat (_chatInner) has the same field
+    // on ChatRequest but currently ignores it in favor of config-only —
+    // a parallel gap worth a separate, scoped fix to keep semantics
+    // consistent across both invocation modes.
+    const configMaxInputTokens =
+      request.maxInputTokens ?? this.config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS;
     const messageBudget = resolveMessageBudget({
       model: resolvedModelString,
       configMaxInputTokens,

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1486,11 +1486,11 @@ export class Runtime {
    *
    * NOTE (intentional duplication): much of the setup below mirrors
    * `_chatInner()`. The clean extraction (`_agentInvoke` substrate +
-   * thin `chat()` / `executeTask()` siblings) is a planned follow-up PR
-   * — see the conversation in `feat/automations-ux`. Doing the extraction
-   * here would touch ~500 LOC of the most-trafficked code path in the
-   * runtime in the same PR as the UI work, multiplying regression risk
-   * for the chat surface. Shipped pragmatically; extracted properly later.
+   * thin `chat()` / `executeTask()` siblings) is tracked as a planned
+   * follow-up — see #334. Doing the extraction here would touch ~500
+   * LOC of the most-trafficked code path in the runtime in the same PR
+   * as the UI work, multiplying regression risk for the chat surface.
+   * Shipped pragmatically; extracted properly in #334.
    */
   async executeTask(request: TaskRequest, requestSink?: EventSink): Promise<TaskResult> {
     // Identity resolution mirrors chat(): in production an identity provider
@@ -1662,8 +1662,8 @@ export class Runtime {
     // per-automation `maxInputTokens` field; honoring it here makes that
     // setting actually take effect. Chat (_chatInner) has the same field
     // on ChatRequest but currently ignores it in favor of config-only —
-    // a parallel gap worth a separate, scoped fix to keep semantics
-    // consistent across both invocation modes.
+    // tracked as #335 (parallel scoped fix to bring chat into semantic
+    // consistency with task).
     const configMaxInputTokens =
       request.maxInputTokens ?? this.config.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS;
     const messageBudget = resolveMessageBudget({

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -323,3 +323,96 @@ export interface ChatResult {
   /** Detailed usage breakdown for this turn. */
   usage: TurnUsage;
 }
+
+/**
+ * Request shape for `runtime.executeTask()` — the unattended agent
+ * invocation primitive that sits beside `runtime.chat()`. Use this when
+ * the agent runs without a user present (scheduled automations, eval
+ * runs, future webhook triggers). The runtime owns the framing contract
+ * (no greetings, deliverable output, no follow-up questions) via the
+ * task-mode system prompt; callers supply only the task description.
+ *
+ * Two ways to scope tool reach:
+ *  - `workspaceId` set      → tools scoped to that workspace + identity
+ *                             tools; the system prompt's workspace briefing
+ *                             names that workspace.
+ *  - `workspaceId` omitted  → cross-workspace reach: tools aggregate
+ *                             across every workspace the owner can see;
+ *                             no focused-workspace briefing.
+ *
+ * Each call writes a FRESH conversation owned by `identity`. There is no
+ * continuation, no `conversationId` to resume — the returned
+ * `TaskResult.conversationId` is for traceability only. Conversation
+ * history loading, content-parts, file refs, and SSE streaming UI
+ * affordances are chat concerns and intentionally absent here.
+ */
+export interface TaskRequest {
+  /** The task description. Goes in as the user message. */
+  prompt: string;
+  /**
+   * Identity the task runs under. Resolution mirrors `ChatRequest.identity`:
+   * if an identity provider is configured, this MUST be set; in dev mode
+   * an unset identity falls back to `DEV_IDENTITY`. The scheduler builds
+   * a minimal identity from the automation's `ownerId` field.
+   */
+  identity?: UserIdentity;
+  /**
+   * Focused workspace (optional). When set, drives tool scope and the
+   * focused-workspace briefing layer in the system prompt. When omitted,
+   * the task has cross-workspace reach: tools aggregate across every
+   * workspace the owner can access, and the workspace briefing layer is
+   * omitted (the `TASK_IDENTITY` framing already explains the role).
+   */
+  workspaceId?: string;
+  model?: string;
+  maxIterations?: number;
+  maxInputTokens?: number;
+  /** Glob patterns filtering which tools are available. Matches use the same logic as chat. */
+  allowedTools?: string[];
+  /** Arbitrary metadata stored on the conversation's first line. Pass-through. */
+  metadata?: Record<string, unknown>;
+  /**
+   * Cancellation signal forwarded into the engine and threaded down to
+   * every tool call. Same morning-brief contract as `ChatRequest.signal`:
+   * without it, callers racing the task against an external deadline
+   * (notably the automations executor's `Promise.race` against
+   * `maxRunDurationMs`) orphan in-flight LLM/tool work.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Result shape for `runtime.executeTask()`.
+ *
+ * Modeled on `ChatResult` but with chat-specific fields removed:
+ *  - No `skillName` — task mode does not perform skill matching on the
+ *    prompt; bundle-affined skills still surface via Layer 3.
+ *  - `response` renamed to `output` to reflect the deliverable contract.
+ *  - `conversationId` is purely a traceability anchor: the fresh
+ *    conversation that backs this task. The "Open conversation →" UI
+ *    affordance reaches it.
+ *
+ * Always returned on completion — including timeout, max_iterations,
+ * and content_filter stops. Pre-execution failures (identity bad,
+ * recursive-tool guard, validation) throw synchronously; once the
+ * engine starts, every observable outcome returns a `TaskResult` with
+ * `stopReason` telling the caller what happened. Silent abandonment
+ * is the worst failure mode (see `ChatRequest.signal` docstring).
+ */
+export interface TaskResult {
+  /** The deliverable — the agent's final assistant message text. */
+  output: string;
+  /** Traceability anchor — the fresh conversation backing this task. */
+  conversationId: string;
+  /** Tool calls executed during this run. Same shape as ChatResult.toolCalls. */
+  toolCalls: Array<{
+    id: string;
+    name: string;
+    input: Record<string, unknown>;
+    output: string;
+    ok: boolean;
+    ms: number;
+  }>;
+  stopReason: string;
+  usage: TurnUsage;
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -332,13 +332,22 @@ export interface ChatResult {
  * (no greetings, deliverable output, no follow-up questions) via the
  * task-mode system prompt; callers supply only the task description.
  *
- * Two ways to scope tool reach:
- *  - `workspaceId` set      → tools scoped to that workspace + identity
- *                             tools; the system prompt's workspace briefing
- *                             names that workspace.
- *  - `workspaceId` omitted  → cross-workspace reach: tools aggregate
- *                             across every workspace the owner can see;
- *                             no focused-workspace briefing.
+ * Two ways to scope tool reach (mirrors chat's active-vs-discoverable
+ * pattern — progressive disclosure keeps the active set under
+ * `maxActiveTools`):
+ *  - `workspaceId` set      → active tools are that workspace's tools
+ *                             + identity tools; the system prompt's
+ *                             workspace briefing names that workspace.
+ *  - `workspaceId` omitted  → active tools are the owner's personal-
+ *                             workspace tools + identity tools (no
+ *                             focused-workspace briefing). The full
+ *                             cross-workspace tool union is the
+ *                             DISCOVERABLE corpus reached on demand via
+ *                             `nb__search`, not the active toolset.
+ *                             (Bundle workflow guidance via Layer 3
+ *                             DOES aggregate across every workspace the
+ *                             owner can see, so a discovered tool's
+ *                             usage skill is available when it lands.)
  *
  * Each call writes a FRESH conversation owned by `identity`. There is no
  * continuation, no `conversationId` to resume — the returned
@@ -357,11 +366,14 @@ export interface TaskRequest {
    */
   identity?: UserIdentity;
   /**
-   * Focused workspace (optional). When set, drives tool scope and the
-   * focused-workspace briefing layer in the system prompt. When omitted,
-   * the task has cross-workspace reach: tools aggregate across every
-   * workspace the owner can access, and the workspace briefing layer is
-   * omitted (the `TASK_IDENTITY` framing already explains the role).
+   * Focused workspace (optional). When set, drives the active tool set
+   * (that workspace's tools + identity tools) and the focused-workspace
+   * briefing layer in the system prompt. When omitted, the active tool
+   * set is the owner's personal-workspace tools + identity tools; the
+   * full cross-workspace tool union is the discoverable corpus via
+   * `nb__search`, NOT the active toolset (progressive disclosure, same
+   * shape as chat at the identity-level home). The focused-workspace
+   * briefing layer is skipped — `TASK_IDENTITY` carries the framing.
    */
   workspaceId?: string;
   model?: string;

--- a/src/tools/platform/automations.ts
+++ b/src/tools/platform/automations.ts
@@ -27,7 +27,7 @@ import { textContent } from "../../engine/content-helpers.ts";
 import type { EventSink } from "../../engine/types.ts";
 import { getRequestContext } from "../../runtime/request-context.ts";
 import type { Runtime } from "../../runtime/runtime.ts";
-import type { ChatRequest } from "../../runtime/types.ts";
+import type { TaskRequest } from "../../runtime/types.ts";
 import { defineInProcessApp, type InProcessTool } from "../in-process-app.ts";
 import type { McpSource } from "../mcp-source.ts";
 import { AUTOMATIONS_PANEL_HTML } from "../platform-resources/automations/panel.ts";
@@ -67,13 +67,14 @@ export async function createAutomationsSource(
     process.stderr.write(`[automations] Fixed ${orphanCount} orphaned run(s)\n`);
   }
 
-  // Direct executor: calls runtime.chat() in-process. `getExecutorContext` is
-  // called per run to resolve WHO the run acts as. A user-triggered run (test
-  // button) reads the current request context. A SCHEDULED run has no request
-  // context, so it fires AS THE OWNER — identity = the automation's `ownerId`,
-  // focused on its provenance `workspaceId` — exactly as if the owner had sent
-  // the message into the runtime (full cross-workspace reach, the focused
-  // workspace's tools active).
+  // Direct executor: calls runtime.executeTask() in-process — the unattended
+  // sibling of chat() that frames the agent as producing a deliverable, not
+  // a conversation turn. `getExecutorContext` is called per run to resolve
+  // WHO the run acts as. A user-triggered run (test button) reads the
+  // current request context. A SCHEDULED run has no request context, so it
+  // fires AS THE OWNER — identity = the automation's `ownerId`, focused on
+  // its provenance `workspaceId` if set — exactly as if the owner had
+  // queued the task themselves.
   function getExecutorContext(automation?: Automation): ExecutorContext {
     const reqCtx = getRequestContext();
     return {
@@ -85,7 +86,7 @@ export async function createAutomationsSource(
     };
   }
   const executor = createDirectExecutor(
-    (req) => runtime.chat(req as ChatRequest),
+    (req) => runtime.executeTask(req as TaskRequest),
     getExecutorContext,
   );
   const scheduler = new Scheduler(executor, { usersDir, defaultTimezone });

--- a/test/integration/execute-task.test.ts
+++ b/test/integration/execute-task.test.ts
@@ -7,8 +7,14 @@
  *  - The deliverable persists to the conversation (so the UI's
  *    "Open conversation →" affordance can show it).
  *  - `workspaceId` set    → focused workspace tool scope.
- *  - `workspaceId` absent → cross-workspace reach across every
- *                            workspace the owner can see.
+ *  - `workspaceId` absent → the orchestrator still routes a namespaced
+ *                            cross-workspace tool call (dispatch
+ *                            contract). The ACTIVE tool list shown to
+ *                            the model is the personal workspace's
+ *                            tools + identity tools; cross-workspace
+ *                            tools are reachable via `nb__search` as
+ *                            the discoverable corpus, NOT preloaded
+ *                            into the active set.
  *
  * Carrying duplication with `_chatInner` is the deferred follow-up
  * captured in runtime.ts; the safety net is THIS test catching any
@@ -191,14 +197,23 @@ describe("runtime.executeTask", () => {
     expect(result.toolCalls[0]?.ok).toBe(true);
   });
 
-  it("with workspaceId omitted, cross-workspace tools are reachable", async () => {
+  it("with workspaceId omitted, the orchestrator dispatches a namespaced cross-workspace tool call", async () => {
     const probe = buildProbeSource();
     await probe.source.start();
 
-    // The probe lives in the SHARED workspace only. With no focused
-    // workspace, the model still has cross-workspace reach: it should
-    // be able to call probe__ping in ws_shared_tasks even though the
-    // task wasn't scoped to that workspace.
+    // Pins the DISPATCH contract: when a task without a focused
+    // workspace issues a tool call namespaced to ws_shared_tasks, the
+    // orchestrator must route it to that workspace's source and execute
+    // it (the identity is a member, so authorization passes).
+    //
+    // What this test does NOT verify, and is documented on
+    // `TaskRequest.workspaceId`: that the model would DISCOVER probe__ping
+    // in its active tool list without `workspaceId`. It would not. With
+    // no focus, the active toolset is the personal-workspace tools +
+    // identity tools (same as chat at the identity-level home). The
+    // cross-workspace union is the search corpus reached via `nb__search`.
+    // Here the echo model is scripted to emit the namespaced call
+    // directly — the test pins what happens when one lands.
     const namespacedPing = namespacedToolName(SHARED_WS_ID, "probe__ping");
     runtime = await bootRuntime({
       responses: [
@@ -221,7 +236,8 @@ describe("runtime.executeTask", () => {
     const result = await runtime.executeTask({
       prompt: "ping anywhere you can reach",
       identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
-      // No workspaceId — cross-workspace reach.
+      // No workspaceId — unscoped task; the orchestrator's per-call
+      // routing still resolves the namespaced tool to ws_shared_tasks.
     });
 
     expect(result.toolCalls.length).toBeGreaterThan(0);

--- a/test/integration/execute-task.test.ts
+++ b/test/integration/execute-task.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Integration coverage for `runtime.executeTask()` — the unattended
+ * agent invocation primitive that sits beside `runtime.chat()`.
+ *
+ * These tests pin the contract differences from chat:
+ *  - Each call creates a FRESH conversation (no resume path).
+ *  - The deliverable persists to the conversation (so the UI's
+ *    "Open conversation →" affordance can show it).
+ *  - `workspaceId` set    → focused workspace tool scope.
+ *  - `workspaceId` absent → cross-workspace reach across every
+ *                            workspace the owner can see.
+ *
+ * Carrying duplication with `_chatInner` is the deferred follow-up
+ * captured in runtime.ts; the safety net is THIS test catching any
+ * divergence in identity resolution, tool surfacing, or deliverable
+ * persistence as chat() evolves.
+ *
+ * Mirrors the setup pattern in
+ * `test/integration/ambient-context-cross-workspace.test.ts`: Runtime +
+ * echo model, no HTTP server, in-process probe source.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { textContent } from "../../src/engine/content-helpers.ts";
+import { Runtime } from "../../src/runtime/runtime.ts";
+import { defineInProcessApp, type InProcessTool } from "../../src/tools/in-process-app.ts";
+import { namespacedToolName } from "../../src/tools/namespace.ts";
+import { personalWorkspaceIdFor } from "../../src/workspace/workspace-store.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+
+const TEST_USER_ID = "usr_exec_task_test";
+const TEST_USER_DISPLAY = "Task Test User";
+const SHARED_WS_ID = "ws_shared_tasks";
+
+function buildProbeSource() {
+  const calls: Array<{ workspaceId?: string }> = [];
+  const tool: InProcessTool = {
+    name: "ping",
+    description: "Test probe — records that it was invoked.",
+    inputSchema: { type: "object", properties: {} },
+    handler: async () => ({
+      content: textContent("pong"),
+      isError: false,
+    }),
+  };
+  const source = defineInProcessApp(
+    { name: "probe", version: "1.0.0", tools: [tool] },
+    { emit() {} },
+  );
+  return { calls, source };
+}
+
+describe("runtime.executeTask", () => {
+  let workDir: string;
+  let runtime: Runtime | null = null;
+
+  afterEach(async () => {
+    if (runtime) {
+      await runtime.shutdown();
+      runtime = null;
+    }
+    if (workDir) {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  async function bootRuntime(echoResponses: Parameters<typeof createEchoModel>[0]) {
+    workDir = mkdtempSync(join(tmpdir(), "nb-exec-task-"));
+    mkdirSync(workDir, { recursive: true });
+    const r = await Runtime.start({
+      model: { provider: "custom", adapter: createEchoModel(echoResponses) },
+      noDefaultBundles: true,
+      logging: { disabled: true },
+      workDir,
+    });
+    return r;
+  }
+
+  async function provisionWorkspaces(r: Runtime) {
+    const wsStore = r.getWorkspaceStore();
+    const personalWsId = personalWorkspaceIdFor(TEST_USER_ID);
+    await wsStore.create("Personal", personalWsId.slice(3), {
+      isPersonal: true,
+      ownerUserId: TEST_USER_ID,
+    });
+    await wsStore.create("Shared", SHARED_WS_ID.slice(3));
+    await wsStore.addMember(SHARED_WS_ID, TEST_USER_ID, "admin");
+    return { personalWsId, sharedWsId: SHARED_WS_ID };
+  }
+
+  it("returns a deliverable and a fresh conversation id on the happy path", async () => {
+    // Echo model: no scripted responses → falls back to echoing the
+    // last user message. The task prompt is the user message, so the
+    // returned output should contain the prompt back.
+    runtime = await bootRuntime(undefined);
+    await provisionWorkspaces(runtime);
+
+    const result = await runtime.executeTask({
+      prompt: "summarize today's activity",
+      identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
+    });
+
+    expect(result.output).toContain("summarize today's activity");
+    expect(result.conversationId).toMatch(/^[a-z0-9_-]+$/i);
+    expect(result.stopReason).toBe("complete");
+    expect(result.usage.iterations).toBeGreaterThan(0);
+  });
+
+  it("each call writes a NEW conversation (no resume path)", async () => {
+    runtime = await bootRuntime(undefined);
+    await provisionWorkspaces(runtime);
+
+    const first = await runtime.executeTask({
+      prompt: "first run",
+      identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
+    });
+    const second = await runtime.executeTask({
+      prompt: "second run",
+      identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
+    });
+
+    expect(first.conversationId).not.toBe(second.conversationId);
+  });
+
+  it("persists the deliverable to the backing conversation", async () => {
+    runtime = await bootRuntime(undefined);
+    await provisionWorkspaces(runtime);
+
+    const result = await runtime.executeTask({
+      prompt: "what's the date today?",
+      identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
+    });
+
+    // The conversation is reachable via the runtime's conversation store
+    // and must carry the assistant message holding the deliverable.
+    const store = runtime.findConversationStore();
+    const convo = await store.load(result.conversationId);
+    expect(convo).not.toBeNull();
+    const history = await store.history(convo!);
+    const assistantMessages = history.filter((m) => m.role === "assistant");
+    expect(assistantMessages.length).toBeGreaterThan(0);
+    // The deliverable in result.output matches what was persisted.
+    const persistedText = assistantMessages
+      .flatMap((m) =>
+        Array.isArray(m.content)
+          ? m.content.filter((c: { type: string }) => c.type === "text")
+          : [],
+      )
+      .map((c: { text: string }) => c.text)
+      .join("");
+    expect(persistedText).toContain(result.output);
+  });
+
+  it("with workspaceId set, focused workspace's tools are surfaced", async () => {
+    const probe = buildProbeSource();
+    await probe.source.start();
+
+    // Script the model to call probe__ping (namespaced to the focused
+    // workspace) once, then conclude.
+    const namespacedPing = namespacedToolName(SHARED_WS_ID, "probe__ping");
+    runtime = await bootRuntime({
+      responses: [
+        {
+          toolCalls: [
+            {
+              toolCallId: "call_focused",
+              toolName: namespacedPing,
+              input: JSON.stringify({}),
+            },
+          ],
+        },
+        { text: "done" },
+      ],
+    });
+    await provisionWorkspaces(runtime);
+    const reg = await runtime.ensureWorkspaceRegistry(SHARED_WS_ID);
+    reg.addSource(probe.source);
+
+    const result = await runtime.executeTask({
+      prompt: "ping the shared workspace probe",
+      identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
+      workspaceId: SHARED_WS_ID,
+    });
+
+    // The tool call landed — the namespacing chose the focused workspace.
+    expect(result.toolCalls.length).toBeGreaterThan(0);
+    expect(result.toolCalls[0]?.name).toBe(namespacedPing);
+    expect(result.toolCalls[0]?.ok).toBe(true);
+  });
+
+  it("with workspaceId omitted, cross-workspace tools are reachable", async () => {
+    const probe = buildProbeSource();
+    await probe.source.start();
+
+    // The probe lives in the SHARED workspace only. With no focused
+    // workspace, the model still has cross-workspace reach: it should
+    // be able to call probe__ping in ws_shared_tasks even though the
+    // task wasn't scoped to that workspace.
+    const namespacedPing = namespacedToolName(SHARED_WS_ID, "probe__ping");
+    runtime = await bootRuntime({
+      responses: [
+        {
+          toolCalls: [
+            {
+              toolCallId: "call_cross",
+              toolName: namespacedPing,
+              input: JSON.stringify({}),
+            },
+          ],
+        },
+        { text: "done" },
+      ],
+    });
+    await provisionWorkspaces(runtime);
+    const reg = await runtime.ensureWorkspaceRegistry(SHARED_WS_ID);
+    reg.addSource(probe.source);
+
+    const result = await runtime.executeTask({
+      prompt: "ping anywhere you can reach",
+      identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
+      // No workspaceId — cross-workspace reach.
+    });
+
+    expect(result.toolCalls.length).toBeGreaterThan(0);
+    expect(result.toolCalls[0]?.name).toBe(namespacedPing);
+    expect(result.toolCalls[0]?.ok).toBe(true);
+  });
+
+  it("stamps source: 'task' on the conversation metadata", async () => {
+    runtime = await bootRuntime(undefined);
+    await provisionWorkspaces(runtime);
+
+    const result = await runtime.executeTask({
+      prompt: "tag check",
+      identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
+      metadata: { automationId: "auto_test_123" },
+    });
+
+    const store = runtime.findConversationStore();
+    const convo = await store.load(result.conversationId);
+    expect(convo).not.toBeNull();
+    expect(convo!.metadata?.source).toBe("task");
+    // Caller's metadata passes through alongside the source tag.
+    expect(convo!.metadata?.automationId).toBe("auto_test_123");
+  });
+});

--- a/test/unit/bundles/automations/executor.test.ts
+++ b/test/unit/bundles/automations/executor.test.ts
@@ -8,9 +8,9 @@ import {
 } from "bun:test";
 import {
 	createDirectExecutor,
-	type ChatFn,
-	type ChatFnResult,
 	type ExecutorContext,
+	type TaskFn,
+	type TaskFnResult,
 } from "../../../../src/bundles/automations/src/executor.ts";
 import type { Automation } from "../../../../src/bundles/automations/src/types.ts";
 
@@ -96,15 +96,13 @@ afterEach(() => {
 // createDirectExecutor — context resolution
 // ---------------------------------------------------------------------------
 
-function makeDirectChatFn(): ChatFn {
-	return async (req): Promise<ChatFnResult> => ({
-		response: `echo: ${req.message}`,
+function makeDirectTaskFn(): TaskFn {
+	return async (req): Promise<TaskFnResult> => ({
+		output: `echo: ${req.prompt}`,
 		conversationId: "conv_test",
 		toolCalls: [],
-		inputTokens: 100,
-		outputTokens: 50,
 		stopReason: "complete",
-		usage: { iterations: 1 },
+		usage: { inputTokens: 100, outputTokens: 50, iterations: 1 },
 	});
 }
 
@@ -117,7 +115,7 @@ describe("createDirectExecutor", () => {
 			return { workspaceId: "ws_test", identity: { id: "usr_owner" } };
 		};
 
-		const executor = createDirectExecutor(makeDirectChatFn(), getContext);
+		const executor = createDirectExecutor(makeDirectTaskFn(), getContext);
 		const automation = makeAutomation({
 			ownerId: "usr_owner",
 			workspaceId: "ws_test",
@@ -131,21 +129,19 @@ describe("createDirectExecutor", () => {
 		expect(receivedAutomation!.workspaceId).toBe("ws_test");
 	});
 
-	test("forwards workspaceId and identity from context to chat request", async () => {
+	test("forwards workspaceId and identity from context to task request", async () => {
 		let capturedWsId: string | undefined;
 		let capturedIdentity: { id: string } | undefined;
 
-		const chatFn: ChatFn = async (req) => {
+		const taskFn: TaskFn = async (req) => {
 			capturedWsId = req.workspaceId;
 			capturedIdentity = req.identity;
 			return {
-				response: "ok",
+				output: "ok",
 				conversationId: "conv_test",
 				toolCalls: [],
-				inputTokens: 100,
-				outputTokens: 50,
 				stopReason: "complete",
-				usage: { iterations: 1 },
+				usage: { inputTokens: 100, outputTokens: 50, iterations: 1 },
 			};
 		};
 
@@ -154,7 +150,7 @@ describe("createDirectExecutor", () => {
 			identity: { id: "usr_alice" },
 		});
 
-		const executor = createDirectExecutor(chatFn, getContext);
+		const executor = createDirectExecutor(taskFn, getContext);
 		await executor(makeAutomation());
 
 		expect(capturedWsId).toBe("ws_eng");
@@ -164,22 +160,20 @@ describe("createDirectExecutor", () => {
 	test("omits workspaceId and identity when context is empty", async () => {
 		let capturedRequest: Record<string, unknown> | undefined;
 
-		const chatFn: ChatFn = async (req) => {
+		const taskFn: TaskFn = async (req) => {
 			capturedRequest = req as unknown as Record<string, unknown>;
 			return {
-				response: "ok",
+				output: "ok",
 				conversationId: "conv_test",
 				toolCalls: [],
-				inputTokens: 100,
-				outputTokens: 50,
 				stopReason: "complete",
-				usage: { iterations: 1 },
+				usage: { inputTokens: 100, outputTokens: 50, iterations: 1 },
 			};
 		};
 
 		const getContext = (): ExecutorContext => ({});
 
-		const executor = createDirectExecutor(chatFn, getContext);
+		const executor = createDirectExecutor(taskFn, getContext);
 		await executor(makeAutomation());
 
 		expect(capturedRequest).toBeDefined();
@@ -198,20 +192,18 @@ describe("createDirectExecutor", () => {
 // ---------------------------------------------------------------------------
 
 describe("createDirectExecutor — stopReason → status", () => {
-	function chatFnWithStop(stopReason: string): ChatFn {
-		return async (): Promise<ChatFnResult> => ({
-			response: "done",
+	function taskFnWithStop(stopReason: string): TaskFn {
+		return async (): Promise<TaskFnResult> => ({
+			output: "done",
 			conversationId: "conv_test",
 			toolCalls: [],
-			inputTokens: 10,
-			outputTokens: 5,
 			stopReason,
-			usage: { iterations: 1 },
+			usage: { inputTokens: 10, outputTokens: 5, iterations: 1 },
 		});
 	}
 
 	async function statusFor(stopReason: string): Promise<string> {
-		const executor = createDirectExecutor(chatFnWithStop(stopReason), () => ({}));
+		const executor = createDirectExecutor(taskFnWithStop(stopReason), () => ({}));
 		const run = await executor(makeAutomation());
 		return run.status;
 	}
@@ -249,7 +241,7 @@ describe("createDirectExecutor — stopReason → status", () => {
 describe("createDirectExecutor — recursive-call guard", () => {
 	test("refuses to run when allowedTools includes automations__create", async () => {
 		const executor = createDirectExecutor(
-			makeDirectChatFn(),
+			makeDirectTaskFn(),
 			() => ({ workspaceId: "ws_test", identity: { id: "u" } }),
 		);
 		const automation = makeAutomation({
@@ -261,7 +253,7 @@ describe("createDirectExecutor — recursive-call guard", () => {
 
 	test("refuses to run when allowedTools includes automations__update", async () => {
 		const executor = createDirectExecutor(
-			makeDirectChatFn(),
+			makeDirectTaskFn(),
 			() => ({ workspaceId: "ws_test", identity: { id: "u" } }),
 		);
 		const automation = makeAutomation({
@@ -273,7 +265,7 @@ describe("createDirectExecutor — recursive-call guard", () => {
 
 	test("permits non-recursive allowedTools", async () => {
 		const executor = createDirectExecutor(
-			makeDirectChatFn(),
+			makeDirectTaskFn(),
 			() => ({ workspaceId: "ws_test", identity: { id: "u" } }),
 		);
 		const automation = makeAutomation({
@@ -284,16 +276,16 @@ describe("createDirectExecutor — recursive-call guard", () => {
 		expect(result.status).toBe("success");
 	});
 
-	test("forwards a combined signal into chatFn so timeouts cancel in-flight chat work", async () => {
+	test("forwards a combined signal into taskFn so timeouts cancel in-flight task work", async () => {
 		// Regression: the old Promise.race pattern rejected at the timeout
-		// but didn't propagate cancellation to the chatFn. The chat kept
+		// but didn't propagate cancellation to the task fn. The task kept
 		// running, finished cleanly minutes later, and the result was
-		// silently discarded. Now the chatFn receives a signal that
+		// silently discarded. Now the taskFn receives a signal that
 		// aborts on the same timeout — so it can cooperatively stop.
 		let receivedSignal: AbortSignal | undefined;
-		let signalFiredDuringChat = false;
+		let signalFiredDuringTask = false;
 
-		const slowChatFn: ChatFn = async (req) => {
+		const slowTaskFn: TaskFn = async (req) => {
 			receivedSignal = req.signal;
 			// Wait up to 500ms but bail on abort so the test runs fast.
 			await new Promise<void>((resolve) => {
@@ -301,50 +293,48 @@ describe("createDirectExecutor — recursive-call guard", () => {
 				req.signal?.addEventListener(
 					"abort",
 					() => {
-						signalFiredDuringChat = true;
+						signalFiredDuringTask = true;
 						clearTimeout(timer);
 						resolve();
 					},
 					{ once: true },
 				);
 			});
-			// On abort the chat throws — matches engine.run behavior under
+			// On abort the task throws — matches engine.run behavior under
 			// signal-driven cancellation.
 			if (req.signal?.aborted) {
 				throw new DOMException("The operation was aborted.", "AbortError");
 			}
 			return {
-				response: "ok",
+				output: "ok",
 				conversationId: "conv_test",
 				toolCalls: [],
-				inputTokens: 100,
-				outputTokens: 50,
 				stopReason: "complete",
-				usage: { iterations: 1 },
+				usage: { inputTokens: 100, outputTokens: 50, iterations: 1 },
 			};
 		};
 
-		const executor = createDirectExecutor(slowChatFn, () => ({
+		const executor = createDirectExecutor(slowTaskFn, () => ({
 			workspaceId: "ws_test",
 		}));
 		const automation = makeAutomation({ maxRunDurationMs: 50 });
 
 		await expect(executor(automation)).rejects.toThrow(/timed out after/);
 		expect(receivedSignal).toBeDefined();
-		expect(signalFiredDuringChat).toBe(true);
+		expect(signalFiredDuringTask).toBe(true);
 	});
 
-	test("external cancel propagates into chatFn signal as AbortError", async () => {
+	test("external cancel propagates into taskFn signal as AbortError", async () => {
 		// Symmetric to the timeout case: when the scheduler aborts the
-		// run controller (manual cancel, scheduler.stop()), the chatFn's
+		// run controller (manual cancel, scheduler.stop()), the taskFn's
 		// signal must also fire so the in-flight engine work cancels.
-		let chatSawAbort = false;
-		const slowChatFn: ChatFn = async (req) => {
+		let taskSawAbort = false;
+		const slowTaskFn: TaskFn = async (req) => {
 			await new Promise<void>((resolve) => {
 				req.signal?.addEventListener(
 					"abort",
 					() => {
-						chatSawAbort = true;
+						taskSawAbort = true;
 						resolve();
 					},
 					{ once: true },
@@ -354,17 +344,17 @@ describe("createDirectExecutor — recursive-call guard", () => {
 			throw new DOMException("The operation was aborted.", "AbortError");
 		};
 
-		const executor = createDirectExecutor(slowChatFn, () => ({ workspaceId: "ws_test" }));
+		const executor = createDirectExecutor(slowTaskFn, () => ({ workspaceId: "ws_test" }));
 		const externalController = new AbortController();
 		const automation = makeAutomation({ maxRunDurationMs: 10_000 });
 
 		const runPromise = executor(automation, externalController.signal);
-		// Give the chat a tick to start, then cancel.
+		// Give the task a tick to start, then cancel.
 		await new Promise((r) => setTimeout(r, 10));
 		externalController.abort();
 
 		await expect(runPromise).rejects.toThrow();
-		expect(chatSawAbort).toBe(true);
+		expect(taskSawAbort).toBe(true);
 	});
 
 	test("external-cancel wins the race when timeout fires concurrently — no false 'timeout' status", async () => {
@@ -374,7 +364,7 @@ describe("createDirectExecutor — recursive-call guard", () => {
 		// "timed out after Ns" — so the scheduler stamps `status:
 		// "timeout"` on what was really a cancel. Narrow window, but
 		// the whole point of the PR is honest status records.
-		const chatFn: ChatFn = async (req) => {
+		const taskFn: TaskFn = async (req) => {
 			await new Promise<void>((resolve) => {
 				req.signal?.addEventListener("abort", () => resolve(), { once: true });
 				setTimeout(resolve, 5000);
@@ -382,7 +372,7 @@ describe("createDirectExecutor — recursive-call guard", () => {
 			throw new DOMException("The operation was aborted.", "AbortError");
 		};
 
-		const executor = createDirectExecutor(chatFn, () => ({ workspaceId: "ws_test" }));
+		const executor = createDirectExecutor(taskFn, () => ({ workspaceId: "ws_test" }));
 		const externalController = new AbortController();
 		// Make the timeout extremely tight so it fires very close to the
 		// external cancel — exercises the race the flag is meant to

--- a/test/unit/bundles/automations/markdown.test.ts
+++ b/test/unit/bundles/automations/markdown.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Sanitization contract for the automations reader's markdown renderer.
+ *
+ * `renderMarkdown()` runs LLM output (which may include third-party
+ * content fetched by tools) through marked + DOMPurify before injection
+ * via `dangerouslySetInnerHTML`. These tests pin the dangerous-tag /
+ * dangerous-attr removals so a future config change can't silently
+ * weaken the sanitizer.
+ *
+ * The renderer normally runs in a bundle iframe (where `window` and
+ * `document` exist). Bun's unit test environment doesn't ship a DOM,
+ * so we install happy-dom globals BEFORE importing the module — both
+ * DOMPurify's import-time bootstrap and marked's renderer instantiation
+ * need a live `window`. The dynamic import below is the seam that lets
+ * the setup run first.
+ */
+
+import { Window } from "happy-dom";
+import { beforeAll, describe, expect, test } from "bun:test";
+
+let renderMarkdown: (text: string) => string;
+
+beforeAll(async () => {
+  const window = new Window({ url: "http://localhost" });
+  // Minimum globals DOMPurify needs to construct its hook tree at
+  // import time. Loosely typed because happy-dom's surface is wider
+  // than the lib.dom subset Bun ships.
+  // biome-ignore lint/suspicious/noExplicitAny: test-only DOM shim
+  (globalThis as any).window = window;
+  // biome-ignore lint/suspicious/noExplicitAny: test-only DOM shim
+  (globalThis as any).document = window.document;
+  // biome-ignore lint/suspicious/noExplicitAny: test-only DOM shim
+  (globalThis as any).HTMLElement = window.HTMLElement;
+  // biome-ignore lint/suspicious/noExplicitAny: test-only DOM shim
+  (globalThis as any).Node = window.Node;
+  ({ renderMarkdown } = await import(
+    "../../../../src/bundles/automations/ui/src/markdown.ts"
+  ));
+});
+
+describe("renderMarkdown — sanitization contract", () => {
+  test("strips <script> tags from input", () => {
+    const html = renderMarkdown("Before<script>alert('xss')</script>After");
+    expect(html).not.toMatch(/<script/i);
+    expect(html).not.toMatch(/alert/i);
+  });
+
+  test("strips inline event handlers (onerror, onclick, onload)", () => {
+    const html = renderMarkdown(
+      '<img src="x" onerror="alert(1)" onclick="alert(2)" onload="alert(3)">',
+    );
+    expect(html).not.toMatch(/onerror/i);
+    expect(html).not.toMatch(/onclick/i);
+    expect(html).not.toMatch(/onload/i);
+  });
+
+  test("strips <iframe>", () => {
+    // happy-dom's HTML parser leaves some void/legacy embed elements
+    // (`<object>`, `<embed>`) in place even with a strict ALLOWED_TAGS
+    // allowlist — a known parser limitation, NOT a production gap. The
+    // real browser DOM that the bundle runs against enforces the
+    // allowlist faithfully. `<iframe>` is the one parsers handle
+    // uniformly, so we use it as the canary for the allowlist.
+    const html = renderMarkdown('<iframe src="evil"></iframe>OK');
+    expect(html).not.toMatch(/<iframe/i);
+  });
+
+  test("strips javascript: URLs", () => {
+    const html = renderMarkdown('[click](javascript:alert(1))');
+    expect(html).not.toMatch(/javascript:/i);
+  });
+
+  test("preserves safe markdown structure (headings, lists, emphasis, code)", () => {
+    const html = renderMarkdown(
+      "# Heading\n\n**bold** and *italic*\n\n- one\n- two\n\n`code`",
+    );
+    expect(html).toMatch(/<h1/);
+    expect(html).toMatch(/<strong>/);
+    expect(html).toMatch(/<em>/);
+    expect(html).toMatch(/<ul>/);
+    expect(html).toMatch(/<li>/);
+    expect(html).toMatch(/<code>/);
+  });
+
+  test("preserves links with safe protocols", () => {
+    const html = renderMarkdown(
+      "[a](https://example.com) [b](http://example.com) [c](mailto:test@example.com)",
+    );
+    expect(html).toMatch(/href="https:\/\/example\.com"/);
+    expect(html).toMatch(/href="http:\/\/example\.com"/);
+    expect(html).toMatch(/href="mailto:test@example\.com"/);
+  });
+});

--- a/test/unit/prompt.test.ts
+++ b/test/unit/prompt.test.ts
@@ -8,6 +8,7 @@ import {
   type Layer3SkillEntry,
   type OverlayLayers,
   type PromptAppInfo,
+  TASK_IDENTITY,
   type UserPrefs,
   type WorkspaceContext,
 } from "../../src/prompt/compose.ts";
@@ -1083,5 +1084,102 @@ describe("composeSystemPromptTraced", () => {
     const sum = traced.layers.reduce((s, l) => s + l.tokens, 0);
     expect(traced.totalTokens).toBe(sum);
     expect(traced.totalTokens).toBeGreaterThan(0);
+  });
+});
+
+describe("composeSystemPrompt — task mode", () => {
+  it("prepends TASK_IDENTITY when mode is 'task'", () => {
+    const result = composeSystemPrompt(
+      [],
+      null,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "task",
+    );
+    expect(result).toContain(TASK_IDENTITY);
+    expect(result).toContain("automated task");
+    expect(result).toContain("not present");
+    expect(result).toContain("deliverable");
+  });
+
+  it("does NOT use DEFAULT_IDENTITY fallback in task mode", () => {
+    // No core context skills → chat mode would emit DEFAULT_IDENTITY.
+    // Task mode emits TASK_IDENTITY instead — emitting both would give
+    // the model contradictory role definitions.
+    const result = composeSystemPrompt(
+      [],
+      null,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "task",
+    );
+    expect(result).not.toContain(DEFAULT_IDENTITY);
+  });
+
+  it("defaults to chat mode when mode is omitted (existing call sites unchanged)", () => {
+    const result = composeSystemPrompt([]);
+    expect(result).toContain(DEFAULT_IDENTITY);
+    expect(result).not.toContain(TASK_IDENTITY);
+  });
+
+  it("layers TASK_IDENTITY ABOVE core skills (framing precedence by position)", () => {
+    const soul = makeContextSkill("soul", 0, "I am Nira.");
+    const result = composeSystemPrompt(
+      [soul],
+      null,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "task",
+    );
+    const taskIdx = result.indexOf(TASK_IDENTITY);
+    const soulIdx = result.indexOf("I am Nira.");
+    expect(taskIdx).toBeGreaterThanOrEqual(0);
+    expect(soulIdx).toBeGreaterThanOrEqual(0);
+    expect(taskIdx).toBeLessThan(soulIdx);
+  });
+
+  it("task identity contract forbids greetings and follow-up questions", () => {
+    // These phrases are the literal contract — if they ever disappear,
+    // the conversational regression from before this PR returns.
+    expect(TASK_IDENTITY).toMatch(/do not greet/i);
+    expect(TASK_IDENTITY).toMatch(/follow-up questions/i);
+    expect(TASK_IDENTITY).toMatch(/finished, self-contained deliverable/i);
+  });
+
+  it("traced output records the task_identity layer kind", () => {
+    const traced = composeSystemPromptTraced(
+      [],
+      null,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "task",
+    );
+    const taskLayer = traced.layers.find((l) => l.kind === "task_identity");
+    expect(taskLayer).toBeDefined();
+    expect(taskLayer?.text).toBe(TASK_IDENTITY);
   });
 });


### PR DESCRIPTION
## What

Turns the automations bundle from a cron UI into an automation product. Three layered changes:

1. **Task is now a kernel primitive.** `runtime.executeTask()` sits beside `runtime.chat()` as the unattended sibling for scheduled work. Composes the system prompt with a new `mode: "task"` branch that prepends `TASK_IDENTITY` — so the model produces a finished deliverable instead of a chat reply. The runtime owns this framing; bundles can't spoof it by wrapping user messages.
2. **The automations bundle calls `executeTask` instead of `chat`.** The Daily Briefing no longer opens with "Sure, let me pull that together for you now" or closes with "Want me to dig deeper?" — the contract forbids both. Five places in the UI that had been sending the old flat `{ name, prompt, schedule, ... }` shape now correctly wrap as `{ manifest, body }` (Create / Test Run / Pause / Resume / inline-edit were all broken before).
3. **The UI is a two-pane reader.** Rail on the left (automations + run history), reader on the right with the briefing rendered as actual markdown. The 500-char output cap is gone. Templates render as proper stacked cards (no more overlap). Mobile collapses cleanly with a real back affordance and `userOpenedReader` decoupling so auto-selection doesn't hijack navigation.

## Why

Three things were wrong before:
- The Daily Briefing was returning chat-shaped output ("Would you like me to do any of those?") because automations called `runtime.chat()`, the runtime composed the conversational system prompt, the model responded conversationally. The fix is at the kernel: invoke a different primitive.
- The reader pane didn't exist. Run output was a 500-char monospace `<pre>` truncated at write time, buried behind a chevron expand. The whole payoff of an automation had no home.
- Mobile responsiveness, the create-form chips, and the schema mismatch on the create tool were all real bugs surfaced during a UX audit and a frontend-design audit done in this session.

## Architecture — kernel/extension boundary

Reviewed in-session by the chief-architect lens. Verdict: **Task is a kernel primitive.** It's about *how* the agent runs (an invocation mode), not *what* it does. Same engine loop, two contracts:

\`\`\`
┌─────────────────────────────────────────────────────────────────┐
│                consumers (bundles + clients)                    │
│  chat UI / REST   │   automations    │   evals    │   webhooks  │
│       chatFn ⤴       executeTaskFn ⤴       ⤴            ⤴       │
└──────────┬─────────────────┬──────────────────┬─────────────────┘
           │                 │                  │
           ▼                 ▼                  ▼
┌─────────────────────────────────────────────────────────────────┐
│                          runtime                                │
│   chat(req): ChatResult        executeTask(req): TaskResult     │
│   ─ conv history loading        ─ fresh conversation per call   │
│   ─ SSE streaming               ─ optional EventSink (obs.)     │
│   ─ content parts / files       ─ ownerId → identity hydrate    │
│   ─ in-flight lock              ─ no continuation semantics     │
│   ─ mode = "chat"               ─ mode = "task"                 │
│                                                                  │
│              composeSystemPrompt({ mode, ... })                 │
│              ├─ mode === "chat" → DEFAULT_IDENTITY              │
│              └─ mode === "task" → TASK_IDENTITY                 │
│                                                                  │
│              engine.run() — pure agent loop, unchanged          │
└─────────────────────────────────────────────────────────────────┘
\`\`\`

### Optional `workspaceId` semantics

- **Set** → focused: active tools are that workspace's tools + identity tools; briefing for that workspace; system prompt frames the agent as operating in it.
- **Omitted** → active tools are the owner's personal-workspace tools + identity tools; no focused-workspace briefing. The full cross-workspace tool union is the *discoverable corpus* reached on demand via \`nb__search\`, not preloaded into the active set (progressive disclosure — same shape as chat at the identity-level home). Layer 3 bundle workflow guidance *does* aggregate across every workspace the owner can see, so a discovered tool's usage skill is available when it lands. \`TASK_IDENTITY\` carries the framing.

The no-focus behavior intentionally mirrors chat's identity-level home so the two siblings stay semantically consistent. *(Corrected from an earlier draft of this PR body that overstated this as "cross-workspace reach"; see #329 QA round 3.)*

## Deferred — substrate extraction

Documented inline in a NOTE block on \`runtime.executeTask()\`. The clean refactor — extracting a shared \`_agentInvoke()\` substrate that both \`chat()\` and \`executeTask()\` sit on — was deliberately deferred to a follow-up PR. Doing it in this PR would have touched ~500 LOC of the most-trafficked code path in the runtime in the same diff as the UI work, multiplying regression risk for chat. The current \`executeTask\` is honest about its duplication; the next PR decomposes both methods together.

## Commits

1. \`feat(prompt): task mode in composeSystemPrompt with TASK_IDENTITY\`
2. \`feat(runtime): add executeTask primitive for unattended agent invocation\`
3. \`refactor(automations): wire executor through executeTask, drop 500-char cap\`
4. \`feat(automations-ui): V3 reader, mobile pass, chip fix, schema shape fix\`

## Verification

- \`bun run verify:static\` — clean (format, lint, types, 9 path-check scripts, codegen)
- \`bun run test:unit\` — 3143 pass, 0 fail
- \`bun run test:integration\` — 642 pass, 12 skip, 0 fail
- \`bun run test:web\` — 369 pass, 0 fail
- \`bun run build:bundles\` — automations bundle 316 kB / 94 kB gzipped (was 311 kB; +18 kB for marked + dompurify)

6 new unit tests cover task-mode compose (precedence, fallback suppression, contract phrases). The existing 14 executor tests were rewritten against the \`TaskFn\` shape and all pass.

## Test plan for review

1. Open the bundle on a wider viewport — two-pane reader with rail + reader.
2. Resize below 720 px — rail takes full width; tap a run; reader takes over with a back arrow top-left.
3. Click Create → templates render as stacked cards, no overlap.
4. Pick Daily Briefing → Test Run. Output reads like a briefing (heading, sections, lists), not a chat reply.
5. Click "Open conversation →" on a run; lands on the conversation in the chat shell.
