### PR TITLE
test(web): fix order-dependent WorkspaceAppIconsProvider SSE test (unblocks CI)

### DIFF
--- a/web/test/WorkspaceAppIconsProvider.test.tsx
+++ b/web/test/WorkspaceAppIconsProvider.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import type { SseEventType } from "../src/types";
 import { realClient } from "./setup";
 
@@ -37,8 +37,12 @@ mock.module("../src/api/sse", () => ({
 }));
 
 // Imported after the mocks are registered so the provider's dependency graph
-// binds to the stubs.
+// binds to the stubs. The events-client import is dynamic for the same reason:
+// it must resolve to the SAME singleton the provider subscribes through (whose
+// `connectEvents` binding is our mock), so `resetForTest()` drops the very
+// connection + subscriber set the provider shares.
 const { WorkspaceAppIconsProvider } = await import("../src/context/WorkspaceAppIconsProvider");
+const { __internal__: eventsClient } = await import("../src/api/events-client");
 
 function fire(type: SseEventType, data: Record<string, unknown> = {}) {
   if (!capturedOnEvent) throw new Error("connectEvents.onEvent was never registered");
@@ -52,6 +56,22 @@ describe("WorkspaceAppIconsProvider — SSE refetch surface (#317)", () => {
     mockGetInstalled.mockClear();
     mockConnectEvents.mockClear();
     capturedOnEvent = null;
+    // The events-client transport is a tab-lifetime singleton: it invokes the
+    // mocked connectEvents() once, on the first subscribe, then reuses that
+    // connection for every later subscribe. Without a reset between tests only
+    // the first test captures onEvent — every subsequent test mounts against
+    // the already-open singleton, connectEvents never re-runs, and
+    // capturedOnEvent stays null (its `fire` then throws). Resetting drops the
+    // connection and the shared subscriber set so each test re-opens (and
+    // re-captures onEvent) with only its own provider subscribed.
+    eventsClient.resetForTest();
+  });
+
+  afterEach(() => {
+    // Unmount the provider so its SSE subscription doesn't survive into the
+    // next test and double-fire refresh() (inflating the manage_connectors
+    // count the assertions depend on).
+    cleanup();
   });
 
   it("does NOT refetch installed connectors on connection.state_changed", async () => {


### PR DESCRIPTION
## Why

`main` CI has been red on Unit Tests since #326 landed (`81b31c3`). The failing test is `WorkspaceAppIconsProvider — SSE refetch surface (#317) > still refetches on bundle.installed / bundle.uninstalled`. Because GitHub tests every PR merged into main, **this red-lights every open PR**, not just #326.

## Root cause — the test, not the provider

The provider change in #326 is correct. The test it shipped is order-dependent:

- It mocks `api/sse#connectEvents` and captures its `onEvent` callback.
- But the provider subscribes through the **`events-client` singleton**, which calls `connectEvents` exactly **once** — on the first subscribe, for the tab's lifetime.
- After the first test the connection stays open, so the second test's mount never re-invokes `connectEvents`. `beforeEach` had already nulled `capturedOnEvent`, so `fire()` threw `connectEvents.onEvent was never registered`.

It passed or failed purely on **test-file ordering**: an earlier file that rotates the auth token closes the singleton (auth lifecycle handler) and lets the next subscribe re-open it. Locally that ordering masked the bug; CI's ordering surfaced it as a hard failure. Reproduces deterministically in isolation:

```
# before this PR, file in isolation:
(fail) … > still refetches on bundle.installed / bundle.uninstalled
 1 pass  1 fail
# after this PR:
 2 pass  0 fail
```

## Fix

- Reset the `events-client` singleton in `beforeEach` via its sanctioned `__internal__.resetForTest()` seam, so each test re-opens the connection and re-captures `onEvent`.
- `afterEach(cleanup)` unmounts the provider so a prior test's subscription can't double-fire `refresh()` and inflate the `manage_connectors` count the assertions depend on.

Each test is now deterministic regardless of file order. No production code changed.

## Verification

- `bun test web/test/WorkspaceAppIconsProvider.test.tsx` → 2 pass / 0 fail
- `bun run test:web` → 402 pass / 0 fail