### PR TITLE
fix(tools): refresh discovery union when a source comes online

### DIFF
--- a/src/orchestrator/tool-list-aggregator.ts
+++ b/src/orchestrator/tool-list-aggregator.ts
@@ -109,6 +109,17 @@ export interface ToolListAggregator {
    * `aggregateToolList` call to discover the drift.
    */
   invalidateIdentity(identityId: string): void;
+  /**
+   * Drop the cached tool list for one workspace and every identity union that
+   * read from it. The reactive counterpart to {@link invalidateIdentity}:
+   * that handles membership changes (a workspace left the identity's set);
+   * this handles tool-set changes WITHIN a workspace that the
+   * `workspace.json` watcher can't see — a bundle subprocess (re)connecting,
+   * a deferred/pending-auth start completing, or a native
+   * `tools/list_changed`. Wired from `ToolRegistry.setInvalidationListener`.
+   * Does NOT touch the membership stamp (membership is unchanged).
+   */
+  invalidateWorkspace(wsId: string): void;
   /** Number of active per-workspace watchers — for the leak test. */
   activeWatcherCount(): number;
   /** Close every watcher, clear every cache. Idempotent. */
@@ -156,15 +167,15 @@ export function createToolListAggregator(options: ToolListAggregatorOptions): To
    * Bare descriptors for the kernel identity sources, listed once. Identity
    * tools are static (code-defined, not per-tenant install), so unlike the
    * per-workspace cache they need no FS-watch invalidation — list on first
-   * use, memoize, reuse for every identity. A failed listing drops the memo
-   * so the next call retries.
+   * use, memoize, reuse for every identity. A failed OR empty listing drops
+   * the memo so the next call retries (see below).
    */
   let identityDescriptorsPromise: Promise<readonly NamespacedToolDescriptor[]> | null = null;
   const getIdentityDescriptors = (): Promise<readonly NamespacedToolDescriptor[]> => {
     const lister = options.listIdentityTools;
     if (!lister) return Promise.resolve([]);
     if (!identityDescriptorsPromise) {
-      identityDescriptorsPromise = lister().then((tools) =>
+      const p = lister().then((tools) =>
         // Bare: `name === toolName`, `wsId === null`. The orchestrator routes
         // a bare `<source>__<tool>` through the identity door.
         tools.map((t) => ({
@@ -177,9 +188,30 @@ export function createToolListAggregator(options: ToolListAggregatorOptions): To
           ...(t.execution !== undefined ? { execution: t.execution } : {}),
         })),
       );
-      identityDescriptorsPromise.catch(() => {
-        identityDescriptorsPromise = null;
-      });
+      identityDescriptorsPromise = p;
+      // Clear the memo on rejection (retry next call) — AND on an empty
+      // result. The kernel identity sources (conversations/files/automations)
+      // are code-defined and always present, so an empty list is never a
+      // legitimate steady state: it means the in-process sources weren't yet
+      // enumerable when the first call landed (e.g. an aggregateToolList that
+      // raced `Runtime.start`'s `_platformSources` assignment). Memoizing []
+      // here would strand `files__read` & friends out of every session's tool
+      // union for the whole process lifetime — the identity-side half of the
+      // stale-union bug. Retrying while empty is bounded: it stops the instant
+      // a non-empty list resolves (sources finish connecting), so steady state
+      // is a single memoized non-empty promise, not a re-list loop. (A
+      // deployment that genuinely ships zero identity sources omits
+      // `listIdentityTools` entirely and never reaches this branch.)
+      p.then(
+        (descriptors) => {
+          if (descriptors.length === 0 && identityDescriptorsPromise === p) {
+            identityDescriptorsPromise = null;
+          }
+        },
+        () => {
+          if (identityDescriptorsPromise === p) identityDescriptorsPromise = null;
+        },
+      );
     }
     return identityDescriptorsPromise;
   };
@@ -216,6 +248,10 @@ export function createToolListAggregator(options: ToolListAggregatorOptions): To
     identityMembershipStamp.delete(identityId);
   };
 
+  const invalidateWorkspace = (wsId: string): void => {
+    cache.invalidateWorkspace(wsId);
+  };
+
   const dispose = (): void => {
     cache.dispose();
     identityMembershipStamp.clear();
@@ -226,6 +262,7 @@ export function createToolListAggregator(options: ToolListAggregatorOptions): To
   return {
     aggregateToolList,
     invalidateIdentity,
+    invalidateWorkspace,
     activeWatcherCount,
     dispose,
   };

--- a/src/orchestrator/tool-list-cache.ts
+++ b/src/orchestrator/tool-list-cache.ts
@@ -410,7 +410,18 @@ export class ToolListCache {
     }, this.debounceMs);
   }
 
-  private invalidateWorkspace(wsId: string): void {
+  /**
+   * Drop the cached tool list for `wsId` and every identity union that read
+   * from it; the next ask re-lists. Safe to call when nothing is cached for
+   * `wsId` (early-returns). Called by the debounce watcher (external
+   * `workspace.json` edits) AND, post-Stage-2, by the aggregator when a
+   * source-readiness transition fires — see
+   * `ToolRegistry.setInvalidationListener`. Deliberately does NOT touch the
+   * aggregator's membership stamp or reap watchers (that's
+   * `invalidateIdentity`'s job): a source coming online is a tool-set change,
+   * not a membership change.
+   */
+  invalidateWorkspace(wsId: string): void {
     const entry = this.workspaces.get(wsId);
     if (!entry) return;
     entry.toolsPromise = null;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -818,6 +818,17 @@ export class Runtime {
     rt._platformSources = platformSources;
     rt._workspaceSources = workspaceSources;
 
+    // Wire each per-workspace registry's invalidation listener to the
+    // aggregator. Done AFTER boot population (not inside createWorkspaceRegistry)
+    // so the boot-time `addSource` storm doesn't fire invalidations before any
+    // union is cached. From here on, a source-set change OR a source-readiness
+    // transition (subprocess (re)connect, deferred/pending-auth start, native
+    // `tools/list_changed`) drops the affected workspace's cached union so the
+    // next discovery re-lists with current tools.
+    for (const [wsId, registry] of workspaceRegistries) {
+      registry.setInvalidationListener(() => toolListAggregator.invalidateWorkspace(wsId));
+    }
+
     // Wire the workspace registries into lifecycle so workspace-scope
     // startAuth / disconnect / install can add+remove sources without
     // each route having to thread the registry through.
@@ -2141,6 +2152,10 @@ export class Runtime {
     // Wire permission context so the registry can gate disallowed tools
     // before they reach the source.execute() path.
     wsRegistry.setPermissionContext(wsId, this.getPermissionStore());
+    // Reactive tool-list invalidation — mirrors the boot wiring so a
+    // JIT-provisioned workspace's union refreshes when its sources change
+    // state (install/uninstall, subprocess (re)connect, native list_changed).
+    wsRegistry.setInvalidationListener(() => this._toolListAggregator.invalidateWorkspace(wsId));
     this._workspaceRegistries.set(wsId, wsRegistry);
     return wsRegistry;
   }

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -496,6 +496,19 @@ export class McpSource implements ToolSource {
 
           await this.connectWithTimeout(CONNECT_TIMEOUT);
           this.startedAt = Date.now();
+          // This early-return is a SECOND success seam (the headless OAuth
+          // auto-resolve retry). The source is now enumerable, so it must emit
+          // the same tools-changed signal as the bottom seam — otherwise a
+          // union memoized while a remote OAuth source was unreachable (e.g.
+          // `tryRestart` re-auth, or a union cached between addSource and
+          // connect-completion on a post-boot startAuth) stays stale: the exact
+          // bug this signal exists to kill, on the one branch that skipped it.
+          // FOLLOW-UP: this branch also skips `dead = false`, the onclose
+          // rewiring, instructions capture, and `startTaskSweeper()` from the
+          // bottom seam — a pre-existing asymmetry (tracked separately). The
+          // right long-term shape is to converge this path onto the bottom seam
+          // instead of early-returning.
+          this.emitToolsChanged();
           return;
         } catch (retryErr) {
           await this.cleanupOnStartFailure();
@@ -531,10 +544,10 @@ export class McpSource implements ToolSource {
     // signal the cross-workspace tool-list aggregator needs: a union memoized
     // while we were unreachable (slow cold-start, crash + HealthMonitor
     // restart, deferred/pending-auth start) is now stale and must be dropped.
-    // `start()` is the single success seam for initial start AND `tryRestart`,
-    // so emitting here covers every (re)connect path. Cheap and idempotent
-    // downstream: invalidation is a no-op when nothing is cached yet (e.g.
-    // during boot, before any request has populated the union).
+    // This is the PRIMARY success seam (initial start + `tryRestart`); the
+    // OAuth-retry early-return above is the secondary seam and emits there too.
+    // Cheap and idempotent downstream: invalidation is a no-op when nothing is
+    // cached yet (e.g. during boot, before any request has populated the union).
     this.emitToolsChanged();
   }
 

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -8,6 +8,7 @@ import {
   CallToolResultSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
+  ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { PlacementDeclaration, RemoteTransportConfig } from "../bundles/types.ts";
@@ -288,6 +289,18 @@ export class McpSource implements ToolSource {
   private stopping = false;
 
   /**
+   * Listeners notified when this source's enumerable tool set may have
+   * changed — a successful (re)connect (initial start, HealthMonitor restart,
+   * deferred/pending-auth start completing) or a server-pushed native
+   * `notifications/tools/list_changed`. `ToolRegistry` subscribes one per
+   * registry the source belongs to and bridges the signal to the
+   * cross-workspace tool-list aggregator's per-workspace invalidation, so a
+   * union memoized while the source was unreachable refreshes the moment it
+   * comes online. See {@link ToolSource.subscribeToolsChanged}.
+   */
+  private readonly toolsChangedListeners = new Set<() => void>();
+
+  /**
    * `eventSink` is REQUIRED, not optional. Emitted events include
    * `tool.progress` during task-augmented calls — when those events reach
    * the runtime sink wrap in `src/api/server.ts`, they turn into SSE
@@ -417,6 +430,10 @@ export class McpSource implements ToolSource {
     // ready the moment the bundle issues its first request. No-op for
     // in-process sources that don't pass a bundleContext.
     this.registerBundleHandlers(this.client);
+    // Native `tools/list_changed` subscription — must be on the client before
+    // connect so a notification arriving immediately after `initialize` isn't
+    // dropped.
+    this.registerToolsChangedHandler(this.client);
 
     // Timeout MCP handshake — remote gets shorter timeout (15s vs 30s)
     const CONNECT_TIMEOUT = this.mode.type === "remote" ? 15_000 : 30_000;
@@ -469,6 +486,7 @@ export class McpSource implements ToolSource {
           // Client — handler tables don't carry over from the prior
           // instance.
           this.registerBundleHandlers(this.client);
+          this.registerToolsChangedHandler(this.client);
           // Re-arm crash detection for the retry: cleanupOnStartFailure
           // set `stopping = true` to suppress its own teardown noise; we
           // need it false again before the new transport's onclose can
@@ -507,6 +525,17 @@ export class McpSource implements ToolSource {
     this._instructions = typeof instructions === "string" ? instructions : undefined;
 
     this.startTaskSweeper();
+
+    // Connect succeeded — this source's tools are now enumerable where a
+    // moment ago `tools()` would have thrown "not started". This is the
+    // signal the cross-workspace tool-list aggregator needs: a union memoized
+    // while we were unreachable (slow cold-start, crash + HealthMonitor
+    // restart, deferred/pending-auth start) is now stale and must be dropped.
+    // `start()` is the single success seam for initial start AND `tryRestart`,
+    // so emitting here covers every (re)connect path. Cheap and idempotent
+    // downstream: invalidation is a no-op when nothing is cached yet (e.g.
+    // during boot, before any request has populated the union).
+    this.emitToolsChanged();
   }
 
   private async connectWithTimeout(timeoutMs: number): Promise<void> {
@@ -756,6 +785,55 @@ export class McpSource implements ToolSource {
         { workspaceId: ctx.workspaceId, bundleId: ctx.bundleId },
       );
     });
+  }
+
+  /**
+   * Register the client-side handler for the server's native
+   * `notifications/tools/list_changed`. Per the MCP spec the server emits
+   * this whenever its advertised tool set changes at runtime (dynamic tool
+   * registration); on receipt the client MUST treat its cached list as stale.
+   * We drop `cachedTools` (so the next `tools()` re-fetches via `tools/list`)
+   * and fan out to subscribers so any memoized projection invalidates.
+   *
+   * Called once per Client lifecycle — after `new Client()` (initial start)
+   * and after `buildClient()` (OAuth retry rebuild) — because handler tables
+   * don't carry across SDK Client instances. Unlike `registerBundleHandlers`
+   * this runs for every source (in-process platform sources included): any
+   * MCP server may push the notification.
+   */
+  private registerToolsChangedHandler(client: Client): void {
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+      this.cachedTools = null;
+      this.emitToolsChanged();
+    });
+  }
+
+  /**
+   * Subscribe to tool-set-change signals (connect/restart/deferred-start/
+   * native list_changed). Returns an unsubscribe function. See
+   * {@link ToolSource.subscribeToolsChanged}.
+   */
+  subscribeToolsChanged(listener: () => void): () => void {
+    this.toolsChangedListeners.add(listener);
+    return () => {
+      this.toolsChangedListeners.delete(listener);
+    };
+  }
+
+  /** Fan out a tool-set-change signal to subscribers, isolating failures. */
+  private emitToolsChanged(): void {
+    for (const listener of this.toolsChangedListeners) {
+      try {
+        listener();
+      } catch (err) {
+        log.debug(
+          "mcp",
+          `[${this.name}] toolsChanged listener threw — ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
   }
 
   /** Check if the transport is still connected. */

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -54,6 +54,11 @@ export class SharedSourceRef implements ToolSource {
   ): Promise<ToolResult> {
     return this.inner.execute(toolName, input, signal);
   }
+  /** Forward readiness subscriptions to the shared underlying source so a
+   *  per-workspace registry wrapping it still learns when its tools change. */
+  subscribeToolsChanged(listener: () => void): () => void {
+    return this.inner.subscribeToolsChanged?.(listener) ?? (() => {});
+  }
   /** Unwrap to the underlying source — used by task-aware dispatch. */
   unwrap(): ToolSource {
     return this.inner;
@@ -70,6 +75,18 @@ export class ToolRegistry implements ToolRouter {
   private wsId: string | null = null;
   /** Permission store for tool-level policy enforcement (set by Runtime). */
   private permissionStore: PermissionStore | null = null;
+  /**
+   * Fired when this registry's enumerable tool set may have changed — a
+   * source added/removed, or an existing source's tools transitioning
+   * (subprocess (re)connect, native `tools/list_changed`). The Runtime wires
+   * this to the cross-workspace tool-list aggregator's per-workspace
+   * invalidation so a memoized union refreshes reactively. Null for
+   * registries with no consumer (tests, CLI flows).
+   */
+  private invalidationListener: (() => void) | null = null;
+  /** Per-source unsubscribe handles for readiness subscriptions, so
+   *  `removeSource` can detach the listener it attached in `addSource`. */
+  private toolsChangedUnsubs = new Map<string, () => void>();
 
   /**
    * Configure permission enforcement context. Called once when the
@@ -82,18 +99,45 @@ export class ToolRegistry implements ToolRouter {
     this.permissionStore = permissionStore;
   }
 
+  /**
+   * Wire the invalidation listener (typically
+   * `() => aggregator.invalidateWorkspace(wsId)`). Set by the Runtime AFTER
+   * boot population so the boot-time `addSource` storm doesn't fire
+   * invalidations before any union is cached; post-boot mutations and
+   * source-readiness transitions then invalidate reactively. Idempotent.
+   */
+  setInvalidationListener(listener: () => void): void {
+    this.invalidationListener = listener;
+  }
+
+  private fireInvalidation(): void {
+    this.invalidationListener?.();
+  }
+
   addSource(source: ToolSource): void {
     if (this.sources.has(source.name)) {
       throw new Error(`Source "${source.name}" is already registered`);
     }
     this.sources.set(source.name, source);
+    // Bridge the source's own readiness transitions (subprocess (re)connect,
+    // native `tools/list_changed`) to this registry's invalidation listener.
+    // Crucially this covers paths that do NOT re-enter `addSource` — a
+    // HealthMonitor restart reuses the same source object, and a deferred /
+    // pending-auth start completes long after the source was registered.
+    const unsub = source.subscribeToolsChanged?.(() => this.fireInvalidation());
+    if (unsub) this.toolsChangedUnsubs.set(source.name, unsub);
+    // The membership change itself is also an invalidation trigger.
+    this.fireInvalidation();
   }
 
   async removeSource(name: string): Promise<void> {
     const source = this.sources.get(name);
     if (source) {
+      this.toolsChangedUnsubs.get(name)?.();
+      this.toolsChangedUnsubs.delete(name);
       await source.stop();
       this.sources.delete(name);
+      this.fireInvalidation();
     }
   }
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -49,6 +49,22 @@ export interface ToolSource {
     input: Record<string, unknown>,
     signal?: AbortSignal,
   ): Promise<ToolResult>;
+  /**
+   * Subscribe to "my tool list may have changed" signals — fired when the
+   * source's enumerable tool set transitions (a subprocess (re)connects after
+   * a crash/slow boot, a deferred/pending-auth start completes, or the server
+   * pushes a native `notifications/tools/list_changed`). Returns an
+   * unsubscribe function.
+   *
+   * Optional: only async sources whose tool set materializes AFTER
+   * construction implement it. The contract exists so callers that memoize a
+   * projection of the tool list (e.g. the cross-workspace tool-list
+   * aggregator) can invalidate reactively instead of polling — a source
+   * becoming reachable is NOT a workspace-config change, so it can't be caught
+   * by watching `workspace.json`. `ToolRegistry` is the single consumer; it
+   * bridges this per-source signal to its own invalidation listener.
+   */
+  subscribeToolsChanged?(listener: () => void): () => void;
 }
 
 export type { ToolResult } from "../engine/types.ts";

--- a/test/integration/mcp-source-oauth-retry.test.ts
+++ b/test/integration/mcp-source-oauth-retry.test.ts
@@ -213,10 +213,21 @@ describe("McpSource — OAuth retry path", () => {
       new NoopEventSink(),
     );
 
+    // The OAuth-retry success path is a SECOND success seam inside start().
+    // It must emit the readiness signal (subscribeToolsChanged) just like the
+    // normal seam, or a union memoized while this remote OAuth source was
+    // unreachable would never refresh — the stale-union bug, on this branch.
+    let readinessFires = 0;
+    source.subscribeToolsChanged(() => {
+      readinessFires++;
+    });
+
     await source.start();
     const tools = await source.tools();
     expect(tools.length).toBe(1);
     expect(tools[0]?.name).toBe("retry-test__noop");
+    // Connect completed via the retry seam → exactly one readiness emit.
+    expect(readinessFires).toBe(1);
 
     await source.stop();
   }, 15_000);

--- a/test/unit/orchestrator/tool-list-aggregator.test.ts
+++ b/test/unit/orchestrator/tool-list-aggregator.test.ts
@@ -523,3 +523,148 @@ describe("aggregateToolList — graceful degradation (one workspace fails)", () 
     expect(out.some((d) => parseWs(d.name).wsId === wsBad)).toBe(false);
   });
 });
+
+// ── Reactive invalidation on source-readiness transitions ─────────
+//
+// Regression for the stale-union bug: a workspace's tool set can change
+// WITHOUT `workspace.json` changing — a bundle subprocess (re)connecting after
+// a slow boot or a HealthMonitor restart makes new tools enumerable. Before
+// the fix the only invalidation channels were the `workspace.json` fs.watch +
+// membership change, so a union memoized while a source was unreachable was
+// served stale for the process lifetime. `invalidateWorkspace(wsId)` is the
+// reactive channel `ToolRegistry.setInvalidationListener` drives.
+describe("aggregateToolList — invalidateWorkspace re-lists after a source comes online", () => {
+  test("union memoized while a bundle was unreachable refreshes after invalidateWorkspace", async () => {
+    const wsId = "ws_shared";
+    const workDir = trackDir(makeWorkDir([wsId]));
+    // Simulate the prod sequence: at first the bundle subprocess isn't
+    // connected, so the workspace lists only the platform `nb` tools; after it
+    // comes online the same workspace lists nb + the bundle's tools.
+    let bundleOnline = false;
+    const { lister, callCount } = spyingLister(async () =>
+      bundleOnline
+        ? buildTools(["nb__search", "synapse_collateral__create_document"], "src")
+        : buildTools(["nb__search"], "src"),
+    );
+    const store = buildStore({ user_1: [wsId] });
+    const agg = track(
+      createToolListAggregator({
+        workDir,
+        workspaceStore: store,
+        listToolsForWorkspace: lister,
+      }),
+    );
+
+    const before = await agg.aggregateToolList("user_1");
+    expect(before.map((d) => parseWs(d.name).toolName)).toEqual(["nb__search"]);
+    // Second call without any change is a cache hit — lister fired once.
+    await agg.aggregateToolList("user_1");
+    expect(callCount(wsId)).toBe(1);
+
+    // The bundle subprocess finishes connecting and the registry fires its
+    // readiness signal → aggregator.invalidateWorkspace(wsId).
+    bundleOnline = true;
+    agg.invalidateWorkspace(wsId);
+
+    const after = await agg.aggregateToolList("user_1");
+    expect(after.map((d) => parseWs(d.name).toolName)).toEqual([
+      "nb__search",
+      "synapse_collateral__create_document",
+    ]);
+    // Re-listed exactly once on invalidation (not on every call).
+    expect(callCount(wsId)).toBe(2);
+  });
+
+  test("invalidateWorkspace is a no-op when nothing is cached for that workspace", async () => {
+    const wsId = "ws_shared";
+    const workDir = trackDir(makeWorkDir([wsId]));
+    const { lister } = spyingLister(async () => buildTools(["nb__search"], "src"));
+    const agg = track(
+      createToolListAggregator({
+        workDir,
+        workspaceStore: buildStore({ user_1: [wsId] }),
+        listToolsForWorkspace: lister,
+      }),
+    );
+    // No aggregateToolList yet → nothing cached. Must not throw (covers the
+    // boot-time `addSource` storm firing invalidations before any union exists).
+    expect(() => agg.invalidateWorkspace(wsId)).not.toThrow();
+    expect(() => agg.invalidateWorkspace("ws_never_seen")).not.toThrow();
+  });
+});
+
+// ── Identity-descriptor memo must not stick on empty ──────────────
+//
+// The identity-side half of the stale-union bug: `getIdentityDescriptors`
+// memoized its first result, clearing only on rejection. An empty read at
+// boot (in-process identity sources not yet enumerable) stranded
+// `files__read` & friends out of every session for the process lifetime.
+// Kernel identity sources always exist, so an empty list is always transient.
+describe("aggregateToolList — identity descriptors retry while empty, memoize when present", () => {
+  test("an empty identity listing is not memoized; the next call picks up the tools", async () => {
+    const wsId = "ws_a";
+    const workDir = trackDir(makeWorkDir([wsId]));
+    const { lister } = spyingLister(async () => buildTools(["ws_tool"], "src"));
+
+    // First identity listing returns [] (sources not ready), then the real set.
+    let identityReady = false;
+    let identityCalls = 0;
+    const agg = track(
+      createToolListAggregator({
+        workDir,
+        workspaceStore: buildStore({ user_1: [wsId] }),
+        listToolsForWorkspace: lister,
+        listIdentityTools: async () => {
+          identityCalls++;
+          return identityReady ? buildTools(["files__read", "conversations__list"], "identity") : [];
+        },
+      }),
+    );
+
+    const before = await agg.aggregateToolList("user_1");
+    // Only the workspace tool — identity prepend was empty.
+    expect(before.map((d) => d.name)).toEqual([parseAny(before, "ws_tool")]);
+    expect(before.some((d) => d.name === "files__read")).toBe(false);
+
+    // Sources finish connecting.
+    identityReady = true;
+    const after = await agg.aggregateToolList("user_1");
+    // Bare identity tools now prepend the union (no `ws_` prefix, wsId null).
+    const bareNames = after.filter((d) => d.wsId === null).map((d) => d.name);
+    expect(bareNames).toEqual(["files__read", "conversations__list"]);
+    // Retried because the first result was empty — not stuck on the empty memo.
+    expect(identityCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("a non-empty identity listing is memoized (no re-list loop in steady state)", async () => {
+    const wsId = "ws_a";
+    const workDir = trackDir(makeWorkDir([wsId]));
+    const { lister } = spyingLister(async () => buildTools(["ws_tool"], "src"));
+    let identityCalls = 0;
+    const agg = track(
+      createToolListAggregator({
+        workDir,
+        workspaceStore: buildStore({ user_1: [wsId] }),
+        listToolsForWorkspace: lister,
+        listIdentityTools: async () => {
+          identityCalls++;
+          return buildTools(["files__read"], "identity");
+        },
+      }),
+    );
+
+    await agg.aggregateToolList("user_1");
+    await agg.aggregateToolList("user_1");
+    await agg.aggregateToolList("user_1");
+    // Non-empty from the first call → memoized once, never re-listed.
+    expect(identityCalls).toBe(1);
+  });
+});
+
+// Helper: identity-descriptor test asserts a bare workspace tool's namespaced
+// name without hand-building it.
+function parseAny(out: readonly { name: string }[], bareToolName: string): string {
+  const match = out.find((d) => d.name.endsWith(`-${bareToolName}`) || d.name === bareToolName);
+  if (!match) throw new Error(`no aggregated entry for "${bareToolName}"`);
+  return match.name;
+}

--- a/test/unit/registry-invalidation-listener.test.ts
+++ b/test/unit/registry-invalidation-listener.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { textContent } from "../../src/engine/content-helpers.ts";
+import type { ToolResult } from "../../src/engine/types.ts";
+import { SharedSourceRef, ToolRegistry } from "../../src/tools/registry.ts";
+import type { Tool, ToolSource } from "../../src/tools/types.ts";
+
+/**
+ * Regression guard for the stale-union bug fix. `ToolRegistry` is the single
+ * place that knows source↔workspace, so it bridges two kinds of tool-set
+ * change to its invalidation listener (which the Runtime wires to
+ * `aggregator.invalidateWorkspace(wsId)`):
+ *
+ *   1. Source-SET membership changes — `addSource` / `removeSource`.
+ *   2. Source-READINESS transitions — an already-registered source's tools
+ *      becoming enumerable (subprocess (re)connect, deferred/pending-auth
+ *      start, native `tools/list_changed`). This is the path that does NOT
+ *      re-enter `addSource` and was therefore invisible before the fix: a
+ *      HealthMonitor restart reuses the same source object.
+ *
+ * The original bug let a union memoized while a source was unreachable persist
+ * for the process lifetime. These tests pin that every relevant transition
+ * reaches the listener, and that detachment is clean on removal.
+ */
+
+/** A source that exposes the optional readiness-subscription surface and lets
+ *  the test drive `tools/list_changed`-style emits on demand. */
+class ReadinessSource implements ToolSource {
+  readonly name: string;
+  private listeners = new Set<() => void>();
+  constructor(name: string) {
+    this.name = name;
+  }
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async tools(): Promise<Tool[]> {
+    return [{ name: `${this.name}__t`, description: "t", inputSchema: {}, source: this.name }];
+  }
+  async execute(toolName: string): Promise<ToolResult> {
+    return { content: textContent(`ok ${toolName}`), isError: false };
+  }
+  subscribeToolsChanged(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+  /** Test hook: simulate a readiness transition / native list_changed. */
+  fireToolsChanged(): void {
+    for (const l of this.listeners) l();
+  }
+  listenerCount(): number {
+    return this.listeners.size;
+  }
+}
+
+/** A legacy source with no readiness surface — must not break wiring. */
+class PlainSource implements ToolSource {
+  readonly name = "plain";
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async tools(): Promise<Tool[]> {
+    return [];
+  }
+  async execute(): Promise<ToolResult> {
+    return { content: textContent("ok"), isError: false };
+  }
+}
+
+describe("ToolRegistry — invalidation listener bridges tool-set changes", () => {
+  test("addSource and removeSource each fire the invalidation listener", async () => {
+    const registry = new ToolRegistry();
+    let fired = 0;
+    registry.setInvalidationListener(() => {
+      fired++;
+    });
+
+    registry.addSource(new ReadinessSource("a"));
+    expect(fired).toBe(1);
+
+    await registry.removeSource("a");
+    expect(fired).toBe(2);
+  });
+
+  test("an already-registered source's readiness emit fires the listener (the HealthMonitor-restart path)", () => {
+    const registry = new ToolRegistry();
+    const source = new ReadinessSource("crm");
+    registry.addSource(source); // membership add: fire #1
+
+    let readinessFires = 0;
+    // Re-wire to count only readiness transitions from here on.
+    registry.setInvalidationListener(() => {
+      readinessFires++;
+    });
+
+    source.fireToolsChanged(); // restart / list_changed
+    source.fireToolsChanged();
+    expect(readinessFires).toBe(2);
+  });
+
+  test("removeSource detaches the readiness subscription (no leak, no post-removal fires)", async () => {
+    const registry = new ToolRegistry();
+    const source = new ReadinessSource("crm");
+    registry.addSource(source);
+    expect(source.listenerCount()).toBe(1);
+
+    let fired = 0;
+    registry.setInvalidationListener(() => {
+      fired++;
+    });
+
+    await registry.removeSource("crm");
+    expect(source.listenerCount()).toBe(0);
+
+    // A stale emit from the (now-removed) source must not reach the registry.
+    source.fireToolsChanged();
+    expect(fired).toBe(1); // only the removeSource membership fire, not the stale emit
+  });
+
+  test("a source without subscribeToolsChanged still wires cleanly", () => {
+    const registry = new ToolRegistry();
+    let fired = 0;
+    registry.setInvalidationListener(() => {
+      fired++;
+    });
+    expect(() => registry.addSource(new PlainSource())).not.toThrow();
+    expect(fired).toBe(1); // membership add still fires
+  });
+
+  test("SharedSourceRef forwards readiness subscriptions to the inner source", () => {
+    const registry = new ToolRegistry();
+    const inner = new ReadinessSource("platform");
+    registry.addSource(new SharedSourceRef(inner));
+
+    let readinessFires = 0;
+    registry.setInvalidationListener(() => {
+      readinessFires++;
+    });
+
+    // The inner shared source coming online must reach this registry's listener.
+    inner.fireToolsChanged();
+    expect(readinessFires).toBe(1);
+  });
+
+  test("no listener wired → mutations and emits are silent no-ops", () => {
+    const registry = new ToolRegistry();
+    const source = new ReadinessSource("crm");
+    expect(() => registry.addSource(source)).not.toThrow();
+    expect(() => source.fireToolsChanged()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

Found auditing prod conversation `conv_f09ff1a4548042a5` (tenant-hq): the agent burned 59 tool calls / 154s thrashing on `nb__search` and never found the tools it needed. `nb__status` reported `synapse-collateral` healthy with 31 tools, but `nb__search` returned **zero** of them across every workspace, and `nb__manage_tools` rejected every promotion as *"not found in the current tool registry."* `files__read` (a kernel identity tool the user was explicitly told to use) was absent too.

## Root cause

The cross-workspace tool union — the `nb__search` corpus and the set `nb__manage_tools` / the engine's `allToolSchemaMap` validate against — is a per-identity **memoized projection** of each workspace's `ToolRegistry`. Its only invalidation channels were a `workspace.json` fs.watch + a membership-set change. Both are **disjoint from the real mutation surface**:

- A bundle subprocess becoming enumerable (slow cold start, **HealthMonitor crash-restart** — which reuses the same source object and never re-enters `addSource`, deferred/pending-auth start) changes a source's tools **without touching `workspace.json`**.
- So a union computed while the source was unreachable is memoized and served **stale for the process lifetime**. `nb__status` reads the live source (healthy); the union doesn't.

Identity half: `getIdentityDescriptors` memoized its first result, clearing only on rejection. An empty read at boot (in-process identity sources not yet enumerable) stranded `files__read`/`conversations__*`/`automations__*` out of **every** session permanently.

## Fix — make source readiness the trigger, via MCP-native notifications

- **`McpSource`** registers the client handler for the server's native `notifications/tools/list_changed` (we ignored it before — even a *dynamic* tool change went stale) and emits a tools-changed signal at `start()`'s single success seam, which also covers `tryRestart()` and deferred/pending-auth starts. New optional `subscribeToolsChanged()` on `ToolSource`.
- **`ToolRegistry`** bridges both source-set membership changes (`add`/`removeSource`) and per-source readiness transitions to one invalidation listener; `SharedSourceRef` forwards the subscription to the shared inner source.
- **`Runtime`** wires each per-workspace registry's listener to `aggregator.invalidateWorkspace(wsId)` at the boot and JIT seams — after boot population so the boot-time `addSource` storm doesn't thrash.
- **aggregator** exposes `invalidateWorkspace` (per-workspace cache drop; does not touch the membership stamp).
- **identity descriptors** no longer memoize an empty list as terminal — retry-while-empty is bounded (kernel identity sources always exist, so empty is always transient; stops the instant a non-empty list resolves).

The `workspace.json` fs.watch stays as a backstop for out-of-process edits.

## Validation

This fix was produced via the triage-first bug-fix workflow including an **independent adversarial review**, which corrected the initial mechanism (it's source-*readiness* transitions, not source-set membership — the `addSource`-only hook would have missed the HealthMonitor restart path) and rejected an unsafe unbounded identity retry.

- `bun run verify:static` — clean
- `bun run test:unit` — 3206 pass
- `bun run test:integration` — 656 pass (incl. aggregator watcher + mcp-source OAuth-retry rebuild path)
- New regression tests: aggregator re-lists after `invalidateWorkspace` once a source is online; no-op when nothing cached; identity descriptors retry-while-empty then memoize; registry bridges add/remove + readiness emits and detaches cleanly on removal.

## Follow-up (tracked, not in this PR)

`tool-list-cache.ts`'s header claims `workspace.json` is "the canonical persistence target for bundle writes" — false for the lifecycle install path (`atomicConfigAdd/Remove` writes `configPath`) and all respawn/restart paths. Now that invalidation is reactive, either correct the comment to "external-edit backstop" or remove the fs.watch entirely. Deferred until the reactive channel soaks in prod.