### PR TITLE
fix(health-monitor): reset restart counter on sustained recovery

### DIFF
--- a/src/tools/health-monitor.ts
+++ b/src/tools/health-monitor.ts
@@ -83,8 +83,27 @@ export class HealthMonitor {
     // Dead is terminal — no more restart attempts
     if (record.state === "dead") return;
 
-    // Skip if source is alive
-    if (record.source.isAlive()) return;
+    // Skip if source is alive. A source that has stayed up for at least one
+    // full check interval has demonstrably recovered, so clear the
+    // consecutive-failure counter: `MAX_RESTARTS` must bound CONSECUTIVE
+    // failures, not lifetime drops, and the exponential backoff must start
+    // fresh for the next independent crash episode. Without this, a remote
+    // connector that periodically drops and cleanly reconnects (e.g. a
+    // server that idle-closes long-lived streams) accrues restarts across
+    // its whole life and is wrongly killed after `MAX_RESTARTS` total drops
+    // despite every reconnect succeeding. The reset is gated on SUSTAINED
+    // uptime, not a single successful reconnect, on purpose: a source that
+    // recovers then immediately re-drops never earns the reset, so it still
+    // escalates to `dead` instead of looping forever.
+    if (record.source.isAlive()) {
+      if (record.restartCount > 0) {
+        const uptime = record.source.uptime();
+        if (uptime !== null && uptime >= this.checkIntervalMs) {
+          record.restartCount = 0;
+        }
+      }
+      return;
+    }
 
     const remote = isRemoteSource(record.source);
 

--- a/test/unit/health-monitor.test.ts
+++ b/test/unit/health-monitor.test.ts
@@ -4,7 +4,14 @@ import { HealthMonitor } from "../../src/tools/health-monitor.ts";
 import type { McpSource } from "../../src/tools/mcp-source.ts";
 
 /** Minimal mock of McpSource exposing only what HealthMonitor needs. */
-function makeMockSource(name: string): McpSource & { alive: boolean; restartResult: boolean; restartCalls: number } {
+function makeMockSource(
+  name: string,
+): McpSource & {
+  alive: boolean;
+  restartResult: boolean;
+  restartCalls: number;
+  setUptime: (ms: number) => void;
+} {
   let startedAt: number | null = Date.now();
   const mock = {
     name,
@@ -17,6 +24,10 @@ function makeMockSource(name: string): McpSource & { alive: boolean; restartResu
     uptime() {
       return startedAt !== null ? Date.now() - startedAt : null;
     },
+    /** Test helper: age the source so `uptime()` reports `ms` of continuous run. */
+    setUptime(ms: number) {
+      startedAt = Date.now() - ms;
+    },
     async restart() {
       mock.restartCalls++;
       if (mock.restartResult) {
@@ -25,7 +36,12 @@ function makeMockSource(name: string): McpSource & { alive: boolean; restartResu
       }
       return mock.restartResult;
     },
-  } as unknown as McpSource & { alive: boolean; restartResult: boolean; restartCalls: number };
+  } as unknown as McpSource & {
+    alive: boolean;
+    restartResult: boolean;
+    restartCalls: number;
+    setUptime: (ms: number) => void;
+  };
   return mock;
 }
 
@@ -97,6 +113,73 @@ describe("HealthMonitor", () => {
     const restartsBefore = source.restartCalls;
     await monitor.check();
     expect(source.restartCalls).toBe(restartsBefore);
+
+    monitor.stop();
+  });
+
+  it("resets restartCount after sustained recovery so a flapping-but-recovering source never dies", async () => {
+    const source = makeMockSource("flapping-bundle");
+    const sink = makeEventCollector();
+    const checkIntervalMs = 1000;
+    const monitor = new HealthMonitor([source], sink, { checkIntervalMs, baseDelayMs: 1 });
+
+    // Eight independent drop episodes (> MAX_RESTARTS), each followed by a
+    // SUSTAINED recovery: the source stays up beyond one full check interval
+    // before the next drop. Under the lifetime-counter bug this dies at the
+    // 6th episode; with the fix the counter clears on each sustained
+    // recovery, so it never escalates to dead.
+    for (let i = 0; i < 8; i++) {
+      source.alive = false;
+      await monitor.check(); // crashed → restarting → recovered (restartCount = 1)
+      expect(monitor.getStatus()[0]!.state).toBe("healthy");
+      expect(monitor.getStatus()[0]!.restartCount).toBe(1);
+
+      // Source has now stayed up for a full check interval — next sweep
+      // observes it alive + sustained and clears the counter.
+      source.setUptime(checkIntervalMs);
+      await monitor.check();
+      expect(monitor.getStatus()[0]!.restartCount).toBe(0);
+    }
+
+    expect(monitor.getStatus()[0]!.state).toBe("healthy");
+    expect(eventNames(sink)).not.toContain("bundle.dead");
+
+    // Backoff resets between episodes: every restarting attempt fires at the
+    // base delay (2 ** 0), never the escalated delays a climbing counter
+    // would produce.
+    const delays = sink.events
+      .map((e) => e.data as { event: string; delayMs?: number })
+      .filter((d) => d.event === "bundle.restarting")
+      .map((d) => d.delayMs);
+    expect(delays.length).toBe(8);
+    for (const d of delays) expect(d).toBe(1);
+
+    monitor.stop();
+  });
+
+  it("does not reset restartCount when recovery is not sustained — still escalates to dead", async () => {
+    const source = makeMockSource("brief-flapper");
+    const sink = makeEventCollector();
+    const checkIntervalMs = 1000;
+    const monitor = new HealthMonitor([source], sink, { checkIntervalMs, baseDelayMs: 1 });
+
+    // Recovery is real but never sustained: the source is briefly alive with
+    // sub-interval uptime, so it must NOT earn the reset. This guards against
+    // an unconditional reset that would let a fast-flapping source loop
+    // forever instead of escalating to dead.
+    for (let i = 0; i < 5; i++) {
+      source.alive = false;
+      await monitor.check(); // recovers, counter climbs
+      source.setUptime(10); // alive, but only 10ms << 1000ms interval
+      await monitor.check(); // observed alive but NOT sustained → no reset
+      expect(monitor.getStatus()[0]!.restartCount).toBe(i + 1);
+    }
+
+    // 6th drop hits the limit.
+    source.alive = false;
+    await monitor.check();
+    expect(monitor.getStatus()[0]!.state).toBe("dead");
+    expect(eventNames(sink)).toContain("bundle.dead");
 
     monitor.stop();
   });


### PR DESCRIPTION
## Problem

A remote MCP connector that periodically drops and **cleanly reconnects** is wrongly marked `dead` (terminal) after a handful of drops, even though every reconnect succeeded.

Observed in production on the `hq` tenant's shared workspace: the Granola connector connects with a valid token, its remote transport idle-closes every several minutes (server side), the health monitor reconnects it successfully each time — but it eventually goes permanently `dead` and stops working until a pod restart.

## Root cause

`HealthMonitor.restartCount` is incremented on every crash (`health-monitor.ts`) but **never reset on recovery**. So `MAX_RESTARTS` bounds *lifetime* drops, not *consecutive* ones. The exponential backoff (`baseDelayMs * 2 ** restartCount`) confirms the intended semantics is consecutive failures — the reset was simply missing. After `MAX_RESTARTS` lifetime drops, `checkOne` early-returns on `dead` forever.

## Fix

Reset `restartCount` to 0 once a source has stayed up for at least one full check interval, in the `isAlive()` early-return path.

The reset is gated on **sustained** uptime (`uptime() >= checkIntervalMs`), not on a single successful reconnect, on purpose: a source that recovers then immediately re-drops never accrues a full interval of uptime, so it still escalates to `dead` instead of looping forever. This keeps the dead-escalation backstop intact while letting a genuinely-recovered connector run indefinitely, and resets the backoff between independent crash episodes.

## Tests

Two regression tests in `health-monitor.test.ts`:
- 8 independent drop episodes each followed by a sustained recovery → never `dead`, and `bundle.restarting` backoff returns to the base delay each episode.
- Recovery that is **not** sustained (sub-interval uptime) → counter keeps climbing and still escalates to `dead` after `MAX_RESTARTS` (guards against an unconditional reset).

`bun run test:unit` (3198 pass) and `bun run verify:static` both green.

## Follow-ups (separate, not in this PR)

- Health monitor should not auto-reconnect a connector that requires **interactive** OAuth (it currently spins a 30s loop on a stale 15-min flow until `dead`). Needs a `needs_auth` signal from `mcp-source.ts`.
- Remote transports have no keepalive/heartbeat, which is why the idle drops happen at all.