### PR TITLE
⌘P command palette for workspaces, apps, and actions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,16 +14,18 @@ import {
 import { AppWithChat } from "./components/AppWithChat";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Login } from "./components/Login";
+import { CommandPalette } from "./components/palette/CommandPalette";
 import { RouteGuard } from "./components/RouteGuard";
 import { ShellLayout } from "./components/ShellLayout";
 import { WorkspaceRouteGuard } from "./components/WorkspaceRouteGuard";
 import { ChatProvider, useChatConfigContext, useChatContext } from "./context/ChatContext";
 import { ChatPanelProvider, useChatPanelContext } from "./context/ChatPanelContext";
+import { PaletteProvider } from "./context/PaletteContext";
 import { SessionProvider } from "./context/SessionContext";
 import { ShellProvider } from "./context/ShellContext";
-import { WorkspaceAppIconsProvider } from "./context/WorkspaceAppIconsProvider";
 import { SidebarProvider } from "./context/SidebarContext";
 import { ThemeProvider, useTheme } from "./context/ThemeContext.tsx";
+import { WorkspaceAppIconsProvider } from "./context/WorkspaceAppIconsProvider";
 import {
   useWorkspaceContext,
   type WorkspaceInfo,
@@ -186,14 +188,16 @@ function BootstrappedShell({
       <WorkspaceAppIconsProvider token={token} workspaceId={activeWorkspace?.id}>
         <ChatProvider initialConfig={initialConfig} currentUserId={currentUserId}>
           <ChatPanelProvider>
-            <AuthenticatedAppContent
-              token={token}
-              forSlot={forSlot}
-              mainRoutes={mainRoutes}
-              shellWorkspaceId={shellWorkspaceId}
-              refreshShell={refreshShell}
-              onLogout={onLogout}
-            />
+            <PaletteProvider>
+              <AuthenticatedAppContent
+                token={token}
+                forSlot={forSlot}
+                mainRoutes={mainRoutes}
+                shellWorkspaceId={shellWorkspaceId}
+                refreshShell={refreshShell}
+                onLogout={onLogout}
+              />
+            </PaletteProvider>
           </ChatPanelProvider>
         </ChatProvider>
       </WorkspaceAppIconsProvider>
@@ -335,6 +339,9 @@ function AuthenticatedAppContent({
       {/* ActionBridge handles iframe action events. It consumes ChatContext
           (streaming) but renders nothing, so its re-renders are free. */}
       <ActionBridge handleNavigate={handleNavigate} resolveAppRoute={resolveAppRoute} />
+      {/* Command palette (⌘P) — global surface, sibling of the shell layout
+          and chat chrome, so it's reachable from any route. */}
+      <CommandPalette onLogout={onLogout} />
       <ShellLayout forSlot={forSlot} onLogout={onLogout}>
         <ErrorBoundary resetKeys={[location.pathname]}>
           <Routes>

--- a/web/src/components/KeyboardShortcutsModal.tsx
+++ b/web/src/components/KeyboardShortcutsModal.tsx
@@ -14,6 +14,10 @@ interface ShortcutGroup {
 
 const shortcutGroups: ShortcutGroup[] = [
   {
+    title: "Navigation",
+    shortcuts: [{ keys: ["⌘", "P"], description: "Open command palette" }],
+  },
+  {
     title: "Chat",
     shortcuts: [
       { keys: ["⌘", "K"], description: "Open / close chat" },

--- a/web/src/components/palette/CommandPalette.tsx
+++ b/web/src/components/palette/CommandPalette.tsx
@@ -1,0 +1,308 @@
+// ---------------------------------------------------------------------------
+// CommandPalette — the ⌘P overlay.
+//
+// Mounts once at shell level (sibling of ChatChrome) so it's reachable from any
+// route. Runs the enabled CommandSources against the query, renders grouped
+// results, and maintains a single flat selection index across groups so ↑↓
+// crosses group boundaries.
+//
+// Constraints honored:
+//   - Shell component: consumes ChatPanelContext (stable), NEVER ChatContext
+//     (streaming) — see AGENTS.md. The palette only ever toggles the panel.
+//   - REST/in-memory data only (WorkspaceContext, ShellContext) — no bridge.
+//   - Escape is handled capture-phase so it beats other Escape handlers (chat).
+//
+// A leading @ / # / > scopes the query to one source and is stripped from the
+// matched term; the active scope shows as a chip in the input.
+// ---------------------------------------------------------------------------
+
+import { Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import { useChatPanelContext } from "../../context/ChatPanelContext";
+import { usePalette } from "../../context/PaletteContext";
+import { useSession } from "../../context/SessionContext";
+import { useShellContext } from "../../context/ShellContext";
+import { useSidebar } from "../../context/SidebarContext";
+import { useTheme } from "../../context/ThemeContext";
+import { useWorkspaceAppIcons } from "../../context/WorkspaceAppIconsContext";
+import { useWorkspaceContext } from "../../context/WorkspaceContext";
+import { workspaceApps } from "../../lib/workspace-apps";
+import { toSlug } from "../../lib/workspace-slug";
+import { KeyboardShortcutsModal } from "../KeyboardShortcutsModal";
+import { CommandRow } from "./CommandRow";
+import { buildResultGroups, parseQuery, SCOPE_LABEL } from "./query";
+import { actionsSource } from "./sources/actions";
+import { appsSource } from "./sources/apps";
+import { workspacesSource } from "./sources/workspaces";
+import type { CommandItem, CommandRunContext, CommandSource, CommandSourceContext } from "./types";
+
+// Source order is the render order of result groups.
+const SOURCES: CommandSource[] = [workspacesSource, appsSource, actionsSource];
+
+export function CommandPalette({ onLogout }: { onLogout: () => void }) {
+  const { open, query, setQuery, closePalette } = usePalette();
+  const wsCtx = useWorkspaceContext();
+  const shell = useShellContext();
+  const { iconFor } = useWorkspaceAppIcons();
+  const session = useSession();
+  const navigate = useNavigate();
+  const chatPanel = useChatPanelContext();
+  const sidebar = useSidebar();
+  const theme = useTheme();
+
+  const [selected, setSelected] = useState(0);
+  const [showShortcuts, setShowShortcuts] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const prevFocusRef = useRef<HTMLElement | null>(null);
+  const rowRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  // Read-only data the sources build from. Apps are gated on shell-readiness:
+  // the shell holds one workspace's placements and lags a switch, so until it
+  // catches up we pass [] rather than the previous workspace's apps.
+  const sourceCtx = useMemo<CommandSourceContext>(() => {
+    const activeId = wsCtx.activeWorkspace?.id;
+    const ready = shell != null && shell.shellWorkspaceId === activeId;
+    const apps = ready && shell ? workspaceApps(shell.forSlot("sidebar")) : [];
+    return {
+      workspaces: wsCtx.workspaces,
+      activeWorkspaceId: activeId,
+      activeWorkspaceName: wsCtx.activeWorkspace?.name,
+      activeWorkspaceSlug: wsCtx.activeWorkspace ? toSlug(wsCtx.activeWorkspace.id) : undefined,
+      apps,
+      iconForApp: iconFor,
+      orgRole: session?.user?.orgRole,
+    };
+  }, [wsCtx.workspaces, wsCtx.activeWorkspace, shell, iconFor, session]);
+
+  // Imperative handles, assembled once. setShowShortcuts is stable, so this is
+  // memoized cheaply.
+  const runCtx = useMemo<CommandRunContext>(
+    () => ({
+      navigate,
+      setActiveWorkspace: wsCtx.setActiveWorkspace,
+      toggleChat: chatPanel.togglePanel,
+      toggleSidebar: sidebar.toggle,
+      toggleTheme: theme.toggle,
+      openKeyboardShortcuts: () => setShowShortcuts(true),
+      logout: onLogout,
+      closePalette,
+    }),
+    [
+      navigate,
+      wsCtx.setActiveWorkspace,
+      chatPanel.togglePanel,
+      sidebar.toggle,
+      theme.toggle,
+      onLogout,
+      closePalette,
+    ],
+  );
+
+  const groups = useMemo(() => buildResultGroups(query, SOURCES, sourceCtx), [query, sourceCtx]);
+
+  const flat = useMemo<CommandItem[]>(() => groups.flatMap((g) => g.items), [groups]);
+  const { scopeId } = parseQuery(query);
+
+  // Keep selection in range as results change.
+  useEffect(() => {
+    setSelected((s) => (flat.length === 0 ? 0 : Math.min(s, flat.length - 1)));
+  }, [flat.length]);
+
+  // Focus the input on open; restore focus to the prior element on close.
+  useEffect(() => {
+    if (open) {
+      prevFocusRef.current = document.activeElement as HTMLElement | null;
+      setSelected(0);
+      // Defer to after portal mount.
+      const id = requestAnimationFrame(() => inputRef.current?.focus());
+      return () => cancelAnimationFrame(id);
+    }
+    prevFocusRef.current?.focus?.();
+  }, [open]);
+
+  // Escape closes, capture-phase so it preempts the chat panel's Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDownCapture(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        closePalette();
+      }
+    }
+    document.addEventListener("keydown", onKeyDownCapture, { capture: true });
+    return () => document.removeEventListener("keydown", onKeyDownCapture, { capture: true });
+  }, [open, closePalette]);
+
+  // Scroll the selected row into view.
+  useEffect(() => {
+    const item = flat[selected];
+    if (!item) return;
+    rowRefs.current.get(item.id)?.scrollIntoView({ block: "nearest" });
+  }, [selected, flat]);
+
+  const runItem = useCallback(
+    (item: CommandItem) => {
+      item.run(runCtx);
+    },
+    [runCtx],
+  );
+
+  const onInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelected((s) => (flat.length === 0 ? 0 : (s + 1) % flat.length));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelected((s) => (flat.length === 0 ? 0 : (s - 1 + flat.length) % flat.length));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const item = flat[selected];
+        if (item) runItem(item);
+      } else if (e.key === "Tab") {
+        // Focus trap: only the input is focusable; keep focus here.
+        e.preventDefault();
+      }
+    },
+    [flat, selected, runItem],
+  );
+
+  if (!open) {
+    // Still render the shortcuts modal slot so an action that opened it before
+    // closing the palette keeps it visible. (Palette closes immediately on the
+    // action; the modal owns its own dismissal.)
+    return showShortcuts ? (
+      <KeyboardShortcutsModal isOpen={true} onClose={() => setShowShortcuts(false)} />
+    ) : null;
+  }
+
+  const activeItemId = flat[selected]?.id;
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-50 flex items-start justify-center">
+        {/* Backdrop */}
+        <button
+          type="button"
+          aria-label="Close command palette"
+          tabIndex={-1}
+          onClick={closePalette}
+          className="absolute inset-0 bg-black/40 backdrop-blur-sm cursor-default"
+        />
+
+        {/* Palette */}
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Command palette"
+          data-testid="command-palette"
+          className="relative mt-[12vh] w-[min(580px,calc(100vw-2rem))] bg-card border border-border rounded-xl shadow-2xl overflow-hidden animate-in"
+        >
+          {/* Input */}
+          <div className="flex items-center gap-3 px-4 py-3.5 border-b border-border">
+            <Search
+              aria-hidden="true"
+              className="text-muted-foreground"
+              style={{ width: 18, height: 18 }}
+            />
+            <input
+              ref={inputRef}
+              // biome-ignore lint/a11y/noAutofocus: palette is a modal opened on demand
+              autoFocus
+              type="text"
+              role="combobox"
+              aria-expanded="true"
+              aria-controls="palette-listbox"
+              aria-activedescendant={activeItemId ? `palette-opt-${activeItemId}` : undefined}
+              value={query}
+              placeholder="Search workspaces, apps, or run a command…"
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={onInputKeyDown}
+              className="flex-1 bg-transparent border-0 outline-none text-[15px] text-foreground placeholder:text-muted-foreground"
+            />
+            {scopeId && (
+              <span
+                data-testid="palette-scope"
+                className="shrink-0 text-[10.5px] font-mono px-1.5 py-0.5 rounded bg-accent text-accent-foreground border border-border"
+              >
+                {SCOPE_LABEL[scopeId]}
+              </span>
+            )}
+          </div>
+
+          {/* Results */}
+          <div
+            id="palette-listbox"
+            role="listbox"
+            aria-label="Results"
+            className="max-h-[min(460px,55vh)] overflow-y-auto p-2"
+          >
+            {flat.length === 0 ? (
+              <div className="px-3 py-8 text-center text-sm text-muted-foreground">No results</div>
+            ) : (
+              groups.map((group) => (
+                <div key={group.source.id} className="pb-1.5">
+                  <div className="px-2.5 pt-2 pb-1 text-[9.5px] font-mono uppercase tracking-[0.12em] text-muted-foreground">
+                    {group.label}
+                  </div>
+                  {group.items.map((item) => {
+                    const index = flat.indexOf(item);
+                    return (
+                      <div
+                        key={item.id}
+                        ref={(el) => {
+                          if (el) {
+                            const btn = el.querySelector("button");
+                            if (btn) rowRefs.current.set(item.id, btn as HTMLButtonElement);
+                          } else {
+                            rowRefs.current.delete(item.id);
+                          }
+                        }}
+                      >
+                        <CommandRow
+                          item={item}
+                          selected={index === selected}
+                          onSelect={() => runItem(item)}
+                          onHover={() => setSelected(index)}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center gap-3.5 px-3.5 py-2.5 border-t border-border bg-muted/40 text-[10.5px] font-mono text-muted-foreground">
+            <span>
+              <Kbd>↑↓</Kbd> navigate
+            </span>
+            <span>
+              <Kbd>↵</Kbd> select
+            </span>
+            <span className="ml-auto">
+              <Kbd>esc</Kbd> close
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {showShortcuts && (
+        <KeyboardShortcutsModal isOpen={true} onClose={() => setShowShortcuts(false)} />
+      )}
+    </>,
+    document.body,
+  );
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="bg-card border border-border px-1.5 py-0.5 rounded text-foreground">
+      {children}
+    </kbd>
+  );
+}

--- a/web/src/components/palette/CommandRow.tsx
+++ b/web/src/components/palette/CommandRow.tsx
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------------
+// CommandRow — one result row in the palette.
+//
+// Renders the leading glyph by CommandIcon kind (letter avatar / lucide /
+// brand icon via ConnectorIcon), the title + optional mono subtitle, and a
+// right-aligned meta tag. Selection is driven by the parent (single flat index
+// across groups), surfaced here via `selected` for the accent background and
+// `aria-selected`.
+// ---------------------------------------------------------------------------
+
+import { memo } from "react";
+import { resolveIcon } from "../../lib/icons";
+import { cn } from "../../lib/utils";
+import { ConnectorIcon } from "../connectors/ConnectorIcon";
+import type { CommandIcon, CommandItem } from "./types";
+
+function RowIcon({ icon }: { icon?: CommandIcon }) {
+  if (!icon) return null;
+  if (icon.kind === "letter") {
+    return (
+      <span
+        aria-hidden="true"
+        className="shrink-0 flex items-center justify-center rounded-md text-white text-[11px] font-semibold"
+        style={{ width: 24, height: 24, backgroundColor: icon.color }}
+      >
+        {icon.letter}
+      </span>
+    );
+  }
+  if (icon.kind === "lucide") {
+    const Icon = resolveIcon(icon.name);
+    return (
+      <span
+        aria-hidden="true"
+        className="shrink-0 flex items-center justify-center rounded-md bg-muted text-muted-foreground"
+        style={{ width: 24, height: 24 }}
+      >
+        <Icon style={{ width: 14, height: 14 }} />
+      </span>
+    );
+  }
+  // brand
+  return (
+    <ConnectorIcon
+      name={icon.fallbackLetter}
+      iconUrl={icon.url}
+      className="h-6 w-6 rounded-md text-[11px]"
+    />
+  );
+}
+
+export const CommandRow = memo(function CommandRow({
+  item,
+  selected,
+  onSelect,
+  onHover,
+}: {
+  item: CommandItem;
+  selected: boolean;
+  onSelect: () => void;
+  onHover: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      id={`palette-opt-${item.id}`}
+      data-testid="palette-row"
+      data-selected={selected ? "true" : "false"}
+      onClick={onSelect}
+      onMouseMove={onHover}
+      className={cn(
+        "w-full flex items-center gap-3 px-2.5 py-2 rounded-md text-left transition-colors",
+        selected ? "bg-accent text-accent-foreground" : "text-foreground hover:bg-accent/50",
+      )}
+    >
+      <RowIcon icon={item.icon} />
+      <span className="flex-1 min-w-0 leading-tight">
+        <span className="block text-sm truncate">{item.title}</span>
+        {item.subtitle && (
+          <span className="block text-[11px] text-muted-foreground font-mono truncate">
+            {item.subtitle}
+          </span>
+        )}
+      </span>
+      {item.meta && (
+        <span className="shrink-0 text-[10.5px] font-mono text-muted-foreground">{item.meta}</span>
+      )}
+    </button>
+  );
+});

--- a/web/src/components/palette/actions.ts
+++ b/web/src/components/palette/actions.ts
@@ -1,0 +1,125 @@
+// ---------------------------------------------------------------------------
+// Actions registry (>) — the palette's command set.
+//
+// Each ActionDef is a static command with an availability predicate (role,
+// focused-workspace presence) and a run closure that receives both the
+// imperative run-context and the read-only source-context (the latter for
+// building workspace-scoped routes). The actions source filters by
+// availability, scores against the query, and projects survivors into
+// CommandItems.
+//
+// The registry shape leaves room for apps/sources to contribute actions later
+// without touching the matcher or container.
+// ---------------------------------------------------------------------------
+
+import type { CommandRunContext, CommandSourceContext } from "./types";
+
+export interface ActionDef {
+  id: string;
+  title: string;
+  keywords?: string[];
+  /** lucide-react icon name. */
+  icon: string;
+  /** Hidden when this returns false (e.g. org-admin-only, needs focused ws). */
+  available?: (ctx: CommandSourceContext) => boolean;
+  run: (run: CommandRunContext, ctx: CommandSourceContext) => void;
+}
+
+const hasWorkspace = (ctx: CommandSourceContext): boolean => Boolean(ctx.activeWorkspaceSlug);
+const isOrgAdmin = (ctx: CommandSourceContext): boolean => ctx.orgRole === "org_admin";
+
+export const ACTIONS: ActionDef[] = [
+  {
+    id: "go-home",
+    title: "Go to Home",
+    keywords: ["home", "dashboard"],
+    icon: "Home",
+    run: (run) => {
+      run.navigate("/");
+      run.closePalette();
+    },
+  },
+  {
+    id: "toggle-chat",
+    title: "Open / close chat",
+    keywords: ["chat", "assistant", "panel"],
+    icon: "MessageSquare",
+    run: (run) => {
+      run.toggleChat();
+      run.closePalette();
+    },
+  },
+  {
+    id: "toggle-sidebar",
+    title: "Toggle sidebar",
+    keywords: ["sidebar", "collapse", "expand"],
+    icon: "PanelLeft",
+    run: (run) => {
+      run.toggleSidebar();
+      run.closePalette();
+    },
+  },
+  {
+    id: "toggle-theme",
+    title: "Toggle theme (light / dark)",
+    keywords: ["theme", "dark", "light", "appearance"],
+    icon: "SunMoon",
+    run: (run) => {
+      run.toggleTheme();
+      run.closePalette();
+    },
+  },
+  {
+    id: "keyboard-shortcuts",
+    title: "Keyboard shortcuts",
+    keywords: ["shortcuts", "keys", "help"],
+    icon: "Keyboard",
+    run: (run) => {
+      run.openKeyboardShortcuts();
+      run.closePalette();
+    },
+  },
+  {
+    id: "workspace-settings",
+    title: "Workspace settings",
+    keywords: ["settings", "workspace", "preferences"],
+    icon: "Settings",
+    available: hasWorkspace,
+    run: (run, ctx) => {
+      run.navigate(`/w/${ctx.activeWorkspaceSlug}/settings`);
+      run.closePalette();
+    },
+  },
+  {
+    id: "manage-connectors",
+    title: "Manage connectors",
+    keywords: ["connectors", "integrations", "mcp", "tools"],
+    icon: "Plug",
+    available: hasWorkspace,
+    run: (run, ctx) => {
+      run.navigate(`/w/${ctx.activeWorkspaceSlug}/settings/connectors`);
+      run.closePalette();
+    },
+  },
+  {
+    id: "org-settings",
+    title: "Organization settings",
+    keywords: ["org", "organization", "admin", "settings"],
+    icon: "Building2",
+    available: isOrgAdmin,
+    run: (run) => {
+      run.navigate("/org");
+      run.closePalette();
+    },
+  },
+  {
+    id: "logout",
+    title: "Log out",
+    keywords: ["logout", "sign out", "log off"],
+    icon: "LogOut",
+    run: (run) => {
+      run.closePalette();
+      run.logout();
+    },
+  },
+];

--- a/web/src/components/palette/match.ts
+++ b/web/src/components/palette/match.ts
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------
+// Command palette — fuzzy matcher (pure, no dependencies)
+//
+// Case-insensitive subsequence match scored by contiguity, start-of-word
+// boundaries, and prefix. Good enough to rank a few dozen workspaces / apps /
+// actions; not a general-purpose search engine. Kept pure so ranking is
+// unit-testable without React.
+// ---------------------------------------------------------------------------
+
+export interface MatchResult {
+  matched: boolean;
+  /** Higher is better. -Infinity when the query is not a subsequence. */
+  score: number;
+}
+
+const NO_MATCH: MatchResult = { matched: false, score: Number.NEGATIVE_INFINITY };
+
+function isWordChar(ch: string): boolean {
+  return /[a-z0-9]/.test(ch);
+}
+
+/**
+ * Score `query` against `text`. Empty query matches everything (score 0) so an
+ * unfiltered palette shows every item. Bonuses: +3 when a matched char begins a
+ * word (start, or after a non-word char), +2 for each consecutive matched char,
+ * +5 for a full prefix match, and a small shortness bonus so "CRM" outranks
+ * "CRM Archive" for the query "crm".
+ */
+export function fuzzyScore(query: string, text: string): MatchResult {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+
+  if (q.length === 0) return { matched: true, score: 0 };
+  if (q.length > t.length) return NO_MATCH;
+
+  let score = 0;
+  let qi = 0;
+  let prevMatchIdx = -2; // so the first match never counts as "consecutive"
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] !== q[qi]) continue;
+
+    let pts = 1;
+    const isBoundary = ti === 0 || !isWordChar(t[ti - 1]!);
+    if (isBoundary) pts += 3;
+    if (ti === prevMatchIdx + 1) pts += 2;
+
+    score += pts;
+    prevMatchIdx = ti;
+    qi++;
+  }
+
+  if (qi < q.length) return NO_MATCH;
+
+  if (t.startsWith(q)) score += 5;
+  // Prefer shorter haystacks for the same match (caps the bonus so a long
+  // title with a great match still beats a short title with a poor one).
+  score += Math.max(0, 5 - (t.length - q.length) * 0.1);
+
+  return { matched: true, score };
+}
+
+/**
+ * Best score for an item across its title and keywords. Keyword matches are
+ * docked 2 points so a title hit always wins a tie. Returns the title result
+ * (possibly NO_MATCH) when nothing matches.
+ */
+export function scoreItem(
+  query: string,
+  fields: { title: string; keywords?: string[] },
+): MatchResult {
+  let best = fuzzyScore(query, fields.title);
+  for (const kw of fields.keywords ?? []) {
+    const r = fuzzyScore(query, kw);
+    if (r.matched) {
+      const docked = r.score - 2;
+      if (!best.matched || docked > best.score) {
+        best = { matched: true, score: docked };
+      }
+    }
+  }
+  return best;
+}

--- a/web/src/components/palette/query.ts
+++ b/web/src/components/palette/query.ts
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------
+// Palette query logic (pure) — prefix scoping + result grouping.
+//
+// Extracted from the CommandPalette component so the parsing/grouping contract
+// is unit-testable without wiring up the eight React contexts the component
+// consumes. The component owns rendering, selection, and keyboard handling;
+// this owns "given a query string, which groups and items show".
+// ---------------------------------------------------------------------------
+
+import { appsGroupLabel } from "./sources/apps";
+import type { CommandItem, CommandSource, CommandSourceContext, SourceId } from "./types";
+
+export const PREFIX_TO_SOURCE: Record<string, SourceId> = {
+  "@": "workspaces",
+  "#": "apps",
+  ">": "actions",
+};
+
+/** Human label for the active scope chip. */
+export const SCOPE_LABEL: Record<SourceId, string> = {
+  workspaces: "workspaces",
+  apps: "apps",
+  actions: "actions",
+};
+
+export interface ResultGroup {
+  source: CommandSource;
+  label: string;
+  items: CommandItem[];
+}
+
+/** Split a leading prefix off the query. `@helix` → scope workspaces, term "helix". */
+export function parseQuery(q: string): { scopeId: SourceId | null; term: string } {
+  const first = q[0];
+  if (first && first in PREFIX_TO_SOURCE) {
+    return { scopeId: PREFIX_TO_SOURCE[first]!, term: q.slice(1) };
+  }
+  return { scopeId: null, term: q };
+}
+
+/**
+ * Run the enabled sources against the query and return non-empty groups in
+ * source order. A prefix narrows to a single source; otherwise all run. The
+ * apps group label names the focused workspace.
+ */
+export function buildResultGroups(
+  query: string,
+  sources: CommandSource[],
+  ctx: CommandSourceContext,
+): ResultGroup[] {
+  const { scopeId, term } = parseQuery(query);
+  // Default view = no prefix + no term. Sources that opt out of the empty view
+  // (actions) are skipped there so the palette opens content-first.
+  const isDefaultView = !scopeId && term.trim() === "";
+  const enabled = scopeId
+    ? sources.filter((s) => s.id === scopeId)
+    : sources.filter((s) => !isDefaultView || s.showOnEmptyQuery !== false);
+  return enabled
+    .map((source) => ({
+      source,
+      label: source.id === "apps" ? appsGroupLabel(ctx.activeWorkspaceName) : source.groupLabel,
+      items: source.getItems(term, ctx),
+    }))
+    .filter((g) => g.items.length > 0);
+}

--- a/web/src/components/palette/sources/actions.ts
+++ b/web/src/components/palette/sources/actions.ts
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------
+// Actions source (>) — projects the actions registry into CommandItems.
+//
+// Filters by availability (role, focused workspace), scores against the query,
+// and closes the source-context into each item's run so workspace-scoped
+// routes resolve. Empty query shows all available actions (curated set is
+// small).
+// ---------------------------------------------------------------------------
+
+import { ACTIONS } from "../actions";
+import { scoreItem } from "../match";
+import type { CommandItem, CommandSource } from "../types";
+
+export const actionsSource: CommandSource = {
+  id: "actions",
+  prefix: ">",
+  groupLabel: "Actions",
+  // Actions are a command mode, not the default view: they appear once the
+  // user types a matching term or scopes with ">", so the empty palette stays
+  // content-first (workspaces, apps) rather than reading as a command menu.
+  showOnEmptyQuery: false,
+  getItems(query, ctx) {
+    const scored: Array<{ item: CommandItem; score: number }> = [];
+    for (const action of ACTIONS) {
+      if (action.available && !action.available(ctx)) continue;
+      const result = scoreItem(query, { title: action.title, keywords: action.keywords });
+      if (!result.matched) continue;
+      scored.push({
+        score: result.score,
+        item: {
+          id: `action:${action.id}`,
+          sourceId: "actions",
+          title: action.title,
+          icon: { kind: "lucide", name: action.icon },
+          keywords: action.keywords,
+          meta: ">",
+          run: (run) => action.run(run, ctx),
+        },
+      });
+    }
+    return scored.sort((a, b) => b.score - a.score).map((s) => s.item);
+  },
+};

--- a/web/src/components/palette/sources/apps.ts
+++ b/web/src/components/palette/sources/apps.ts
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------
+// Apps source (#) — launch an app in the focused workspace.
+//
+// v1 is scoped to the FOCUSED workspace's placements. The shell holds one
+// workspace's placements at a time and lags a switch (ShellContext), so the
+// container passes an empty `apps` array until the shell catches up; this
+// source treats empty as "nothing to show" rather than guessing. Cross-
+// workspace app search is deferred (needs each workspace's placement set).
+//
+// The group label names the workspace so it's never ambiguous which
+// workspace's apps are listed.
+// ---------------------------------------------------------------------------
+
+import { scoreItem } from "../match";
+import type { CommandItem, CommandSource } from "../types";
+
+export const appsSource: CommandSource = {
+  id: "apps",
+  prefix: "#",
+  groupLabel: "Apps",
+  getItems(query, ctx) {
+    if (!ctx.activeWorkspaceSlug || ctx.apps.length === 0) return [];
+    const slug = ctx.activeWorkspaceSlug;
+
+    const scored: Array<{ item: CommandItem; score: number }> = [];
+    for (const p of ctx.apps) {
+      if (!p.route) continue;
+      const label = p.label ?? p.route;
+      const keywords = [p.route, p.serverName].filter(Boolean) as string[];
+      const result = scoreItem(query, { title: label, keywords });
+      if (!result.matched) continue;
+      const letter = (label.trim()[0] ?? "#").toUpperCase();
+      scored.push({
+        score: result.score,
+        item: {
+          id: `app:${p.resourceUri}`,
+          sourceId: "apps",
+          title: label,
+          subtitle: p.serverName,
+          icon: { kind: "brand", url: ctx.iconForApp(p.serverName), fallbackLetter: letter },
+          keywords,
+          meta: "#app",
+          run: (run) => {
+            run.navigate(`/w/${slug}/app/${p.route}`);
+            run.closePalette();
+          },
+        },
+      });
+    }
+
+    return scored.sort((a, b) => b.score - a.score).map((s) => s.item);
+  },
+};
+
+/**
+ * The group label for the apps section, naming the focused workspace so it's
+ * clear which workspace's apps are listed. Falls back to the static label when
+ * no workspace is focused (the source returns no items in that case anyway).
+ */
+export function appsGroupLabel(activeWorkspaceName?: string): string {
+  return activeWorkspaceName ? `Apps in ${activeWorkspaceName}` : "Apps";
+}

--- a/web/src/components/palette/sources/workspaces.ts
+++ b/web/src/components/palette/sources/workspaces.ts
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------
+// Workspaces source (@) — switch the focused workspace.
+//
+// Corpus is the in-memory workspace list (WorkspaceContext), ordered for the
+// sidebar. All workspaces appear (including the focused one — selecting it is a
+// useful "go to its overview", and keeping it means the default empty-query
+// view always has content rather than going blank in a single-workspace org).
+// The focused row is marked "current" and sorted last. Selecting a workspace
+// mirrors WorkspaceSection's equality-guarded setActiveWorkspace, then
+// navigates to its overview.
+// ---------------------------------------------------------------------------
+
+import { getWorkspaceAvatar } from "../../../lib/workspace-avatar";
+import { orderWorkspacesForSidebar } from "../../../lib/workspace-order";
+import { toSlug } from "../../../lib/workspace-slug";
+import { scoreItem } from "../match";
+import type { CommandItem, CommandSource } from "../types";
+
+export const workspacesSource: CommandSource = {
+  id: "workspaces",
+  prefix: "@",
+  groupLabel: "Switch workspace",
+  getItems(query, ctx) {
+    const ordered = orderWorkspacesForSidebar(ctx.workspaces);
+
+    const scored: Array<{ item: CommandItem; score: number; isCurrent: boolean }> = [];
+    for (const ws of ordered) {
+      const isCurrent = ws.id === ctx.activeWorkspaceId;
+      const role = ws.userRole;
+      const appCount = ws.bundles?.length ?? 0;
+      const subtitleParts = [
+        isCurrent ? "current" : undefined,
+        role,
+        appCount > 0 ? `${appCount} apps` : undefined,
+      ].filter(Boolean);
+      const avatar = getWorkspaceAvatar(ws);
+      const result = scoreItem(query, { title: ws.name, keywords: role ? [role] : [] });
+      if (!result.matched) continue;
+      scored.push({
+        score: result.score,
+        isCurrent,
+        item: {
+          id: `workspace:${ws.id}`,
+          sourceId: "workspaces",
+          title: ws.name,
+          subtitle: subtitleParts.join(" · ") || undefined,
+          icon: { kind: "letter", letter: avatar.letter, color: avatar.color },
+          meta: "@workspace",
+          run: (run) => {
+            run.setActiveWorkspace(ws);
+            run.navigate(`/w/${toSlug(ws.id)}/`);
+            run.closePalette();
+          },
+        },
+      });
+    }
+
+    // Higher score first; the current workspace sinks to the bottom of a tie so
+    // switch targets lead.
+    return scored
+      .sort((a, b) => Number(a.isCurrent) - Number(b.isCurrent) || b.score - a.score)
+      .map((s) => s.item);
+  },
+};

--- a/web/src/components/palette/types.ts
+++ b/web/src/components/palette/types.ts
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------------
+// Command palette — core types
+//
+// The palette is a registry of CommandSources. Each source (workspaces, apps,
+// actions) implements one `getItems` method over a read-only context and
+// returns ordered CommandItems. The container runs the enabled sources, scores
+// their items against the query (see match.ts), and renders grouped results
+// with a single flat selection index across groups.
+//
+// Two contexts keep the sources free of React hook wiring (so they're pure and
+// unit-testable):
+//   - CommandSourceContext: the read-only data a source needs to build items.
+//   - CommandRunContext:     the imperative handles an item needs to act on
+//                            Enter. Assembled once by the container from the
+//                            hooks it consumes.
+// ---------------------------------------------------------------------------
+
+import type { WorkspaceInfo } from "../../context/WorkspaceContext";
+import type { PlacementEntry } from "../../types";
+
+export type SourceId = "workspaces" | "apps" | "actions";
+
+/**
+ * How a row's leading glyph is drawn. `letter` is a colored avatar (workspaces),
+ * `lucide` names an icon (actions), `brand` is an app's brand icon URL with a
+ * letter fallback (apps).
+ */
+export type CommandIcon =
+  | { kind: "letter"; letter: string; color: string }
+  | { kind: "lucide"; name: string }
+  | { kind: "brand"; url?: string; fallbackLetter: string };
+
+export interface CommandItem {
+  /** Stable, unique within a single render. */
+  id: string;
+  sourceId: SourceId;
+  /** Primary line. The match corpus (with `keywords`). */
+  title: string;
+  /** Mono sub-line, e.g. "clinician · 3 apps". */
+  subtitle?: string;
+  icon?: CommandIcon;
+  /** Extra match terms beyond the title (e.g. server name, route). */
+  keywords?: string[];
+  /** Right-aligned tag, e.g. "@workspace", "#app", ">". */
+  meta?: string;
+  /** What Enter does. Receives the imperative context. */
+  run: (ctx: CommandRunContext) => void;
+}
+
+/**
+ * Imperative handles a result needs to act. Built once by the palette
+ * container from the hooks it consumes, so individual sources never touch
+ * React context directly.
+ */
+export interface CommandRunContext {
+  navigate: (to: string) => void;
+  setActiveWorkspace: (ws: WorkspaceInfo) => void;
+  toggleChat: () => void;
+  toggleSidebar: () => void;
+  toggleTheme: () => void;
+  openKeyboardShortcuts: () => void;
+  logout: () => void;
+  /** Close the palette. Most `run`s call this last. */
+  closePalette: () => void;
+}
+
+/**
+ * Read-only data a source needs to build its items. Assembled by the container
+ * from the data contexts. Sources must not fetch — everything they need is
+ * here, already loaded.
+ */
+export interface CommandSourceContext {
+  workspaces: WorkspaceInfo[];
+  activeWorkspaceId?: string;
+  activeWorkspaceName?: string;
+  /** URL slug for the focused workspace (toSlug(id)), when one is focused. */
+  activeWorkspaceSlug?: string;
+  /**
+   * The focused workspace's app placements (already filtered via
+   * `workspaceApps`), or an empty array when the shell hasn't caught up to a
+   * workspace switch yet. The apps source treats empty as "no apps to show"
+   * rather than guessing — see sources/apps.ts.
+   */
+  apps: PlacementEntry[];
+  /** Brand icon URL for an app's server name, or undefined for letter fallback. */
+  iconForApp: (serverName: string) => string | undefined;
+  /** Signed-in user's org role, for gating org-admin-only actions. */
+  orgRole?: string;
+}
+
+export interface CommandSource {
+  id: SourceId;
+  /** Leading char that scopes the query to this source. Omit for always-on. */
+  prefix?: string;
+  /** Section header in the results list. */
+  groupLabel: string;
+  /**
+   * Whether this source contributes to the default (empty-query, no-prefix)
+   * view. Content sources (workspaces, apps) default to `true` so the palette
+   * opens content-first. Actions set this `false` so the empty palette doesn't
+   * read as a command menu — they surface once the user types a matching term
+   * or scopes with `>`. Defaults to `true` when omitted.
+   */
+  showOnEmptyQuery?: boolean;
+  getItems: (query: string, ctx: CommandSourceContext) => CommandItem[];
+}

--- a/web/src/components/shell/SidebarSearch.tsx
+++ b/web/src/components/shell/SidebarSearch.tsx
@@ -1,67 +1,37 @@
 // ---------------------------------------------------------------------------
-// SidebarSearch — global search input stub
+// SidebarSearch — the command palette trigger.
 //
-// Visual stub for the eventual command palette ("apps, docs, chats" —
-// the dedicated palette work lands in a separate session). For now this
-// component renders the input + ⌘P keyboard shortcut chip and binds the
-// shortcut to focus the field. Typing populates the input but Enter is
-// a no-op; the palette session will wire query → results / navigation
-// behavior on top of this surface.
-//
-// The shortcut listens for both Cmd+P (Mac) and Ctrl+P (others) so the
-// hint hands off correctly on every platform; the chip displays ⌘P
-// because Mac is the primary platform today.
+// Renders the input-shaped affordance from the mockup (search glyph + prompt +
+// ⌘P chip) as a button that opens the palette. The ⌘P keyboard shortcut itself
+// lives in PaletteProvider (so it works even when the sidebar is collapsed or
+// hidden) — this is purely the click target.
 // ---------------------------------------------------------------------------
 
 import { Search } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { usePalette } from "../../context/PaletteContext";
 
 export function SidebarSearch() {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [value, setValue] = useState("");
-
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      // ⌘P / Ctrl+P focuses the search input. preventDefault so the
-      // browser's Print dialog doesn't steal the shortcut.
-      const isMod = e.metaKey || e.ctrlKey;
-      if (isMod && (e.key === "p" || e.key === "P")) {
-        e.preventDefault();
-        inputRef.current?.focus();
-        inputRef.current?.select();
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  const { openPalette } = usePalette();
 
   return (
     <div className="mx-2 mt-1 mb-2" data-testid="sidebar-search">
-      <div className="relative">
+      <button
+        type="button"
+        onClick={() => openPalette()}
+        aria-label="Open command palette"
+        aria-keyshortcuts="Meta+P Control+P"
+        className="w-full h-8 flex items-center gap-2.5 pl-2.5 pr-1.5 rounded-md text-sm bg-sidebar-foreground/5 border border-transparent hover:bg-sidebar-foreground/10 hover:border-sidebar-foreground/20 transition-colors text-left"
+      >
         <Search
           aria-hidden="true"
-          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sidebar-foreground/50"
+          className="text-sidebar-foreground/50 shrink-0"
           style={{ width: 14, height: 14 }}
         />
-        <input
-          ref={inputRef}
-          type="search"
-          // biome-ignore lint/a11y/noAutofocus: not autofocus — placeholder only
-          placeholder="Search apps, docs, chats..."
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          aria-label="Search apps, docs, chats"
-          // The command palette wires actual submit / results in a later
-          // session. For now the input is purely a stub focus target.
-          className="w-full h-8 pl-7 pr-12 rounded-md text-sm bg-sidebar-foreground/5 border border-transparent focus:border-sidebar-foreground/20 focus:bg-sidebar-foreground/10 focus:outline-none placeholder:text-sidebar-foreground/50 text-sidebar-foreground"
-        />
-        <kbd
-          aria-hidden="true"
-          className="absolute right-1.5 top-1/2 -translate-y-1/2 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-sidebar-foreground/10 text-sidebar-foreground/60 border border-sidebar-border"
-        >
+        <span className="flex-1 truncate text-sidebar-foreground/50">Search or run a command</span>
+        <kbd className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-sidebar-foreground/10 text-sidebar-foreground/60 border border-sidebar-border">
           ⌘P
         </kbd>
-      </div>
+      </button>
     </div>
   );
 }

--- a/web/src/context/PaletteContext.tsx
+++ b/web/src/context/PaletteContext.tsx
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------
+// PaletteContext — single source of truth for the command palette's open state.
+//
+// Owns { open, query } so the sidebar search trigger, the global ⌘P keyboard
+// shortcut, and any ">open palette" action all drive the same state. The
+// keyboard listener lives here (not in SidebarSearch) so the shortcut works
+// even when the sidebar is collapsed or hidden — the palette is global.
+//
+// Trigger is ⌘P (Ctrl+P elsewhere). ⌘K is taken by the chat panel toggle
+// (ChatChrome) and ⌘⇧K by fullscreen chat, so the palette uses ⌘P and
+// preventDefaults to suppress the browser's print dialog.
+//
+// The listener runs in the CAPTURE phase. Cmd+P is a browser accelerator; a
+// bubble-phase listener calls preventDefault late enough that the print dialog
+// can still slip through (notably while focus is inside the palette's own
+// input). Capturing at the window means we cancel the default at the very
+// start of event dispatch, before the browser commits the print action — the
+// standard way command palettes suppress a native shortcut.
+// ---------------------------------------------------------------------------
+
+import type { ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { isPaletteToggleChord } from "../lib/palette-shortcut";
+
+export interface PaletteContextValue {
+  open: boolean;
+  query: string;
+  /** Open the palette, optionally seeding the query (e.g. with a prefix). */
+  openPalette: (initialQuery?: string) => void;
+  closePalette: () => void;
+  setQuery: (query: string) => void;
+}
+
+const PaletteContext = createContext<PaletteContextValue | null>(null);
+
+export function PaletteProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const openPalette = useCallback((initialQuery?: string) => {
+    setQuery(initialQuery ?? "");
+    setOpen(true);
+  }, []);
+
+  const closePalette = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      // ⌘P / Ctrl+P toggles the palette. preventDefault (in capture phase, see
+      // file header) so the browser's Print dialog never steals the shortcut.
+      if (isPaletteToggleChord(e)) {
+        e.preventDefault();
+        e.stopPropagation();
+        setOpen((prev) => {
+          if (!prev) setQuery("");
+          return !prev;
+        });
+      }
+    }
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true });
+  }, []);
+
+  const value = useMemo<PaletteContextValue>(
+    () => ({ open, query, openPalette, closePalette, setQuery }),
+    [open, query, openPalette, closePalette],
+  );
+
+  return <PaletteContext.Provider value={value}>{children}</PaletteContext.Provider>;
+}
+
+export function usePalette(): PaletteContextValue {
+  const ctx = useContext(PaletteContext);
+  if (!ctx) throw new Error("usePalette must be used within a PaletteProvider");
+  return ctx;
+}

--- a/web/src/lib/palette-shortcut.ts
+++ b/web/src/lib/palette-shortcut.ts
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------------------
+// Palette keyboard shortcut predicate (pure).
+//
+// Lives in lib (not the context module) so PaletteContext exports only its
+// provider + hook — keeping React Fast Refresh happy — while the chord logic
+// stays unit-testable on its own.
+// ---------------------------------------------------------------------------
+
+/** True for the ⌘P / Ctrl+P toggle chord (and not ⌘⇧P, which stays reserved). */
+export function isPaletteToggleChord(e: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  key: string;
+}): boolean {
+  const mod = e.metaKey || e.ctrlKey;
+  return mod && !e.shiftKey && (e.key === "p" || e.key === "P");
+}

--- a/web/test/palette-context.test.ts
+++ b/web/test/palette-context.test.ts
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------
+// Palette toggle chord predicate.
+//
+// Pins the ⌘P / Ctrl+P contract (and that ⌘⇧P is NOT it — ⇧ is reserved so the
+// chord can't collide with future shifted shortcuts). The listener using this
+// runs in capture phase to suppress the browser's print accelerator.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test } from "bun:test";
+import { isPaletteToggleChord } from "../src/lib/palette-shortcut";
+
+const base = { metaKey: false, ctrlKey: false, shiftKey: false, key: "p" };
+
+describe("isPaletteToggleChord", () => {
+  test("⌘P matches", () => {
+    expect(isPaletteToggleChord({ ...base, metaKey: true })).toBe(true);
+  });
+
+  test("Ctrl+P matches (non-Mac)", () => {
+    expect(isPaletteToggleChord({ ...base, ctrlKey: true })).toBe(true);
+  });
+
+  test("uppercase P matches (caps lock / shift handling by browser)", () => {
+    expect(isPaletteToggleChord({ ...base, metaKey: true, key: "P" })).toBe(true);
+  });
+
+  test("⌘⇧P does NOT match", () => {
+    expect(isPaletteToggleChord({ ...base, metaKey: true, shiftKey: true })).toBe(false);
+  });
+
+  test("plain P does NOT match", () => {
+    expect(isPaletteToggleChord(base)).toBe(false);
+  });
+
+  test("⌘K does NOT match (reserved for chat)", () => {
+    expect(isPaletteToggleChord({ ...base, metaKey: true, key: "k" })).toBe(false);
+  });
+});

--- a/web/test/palette-match.test.ts
+++ b/web/test/palette-match.test.ts
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// Command palette fuzzy matcher — ranking contract.
+//
+// Pins the behaviors the palette relies on for sensible ordering:
+//   1. Empty query matches everything (unfiltered palette).
+//   2. Non-subsequence queries don't match.
+//   3. Prefix > start-of-word > scattered subsequence.
+//   4. Shorter haystack wins a tie ("CRM" over "CRM Archive" for "crm").
+//   5. scoreItem falls back to keywords, docked below a title hit.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test } from "bun:test";
+import { fuzzyScore, scoreItem } from "../src/components/palette/match";
+
+describe("fuzzyScore", () => {
+  test("empty query matches everything with score 0", () => {
+    expect(fuzzyScore("", "anything")).toEqual({ matched: true, score: 0 });
+  });
+
+  test("non-subsequence does not match", () => {
+    expect(fuzzyScore("zzz", "Pacific Clinic").matched).toBe(false);
+    expect(fuzzyScore("clinicx", "Pacific Clinic").matched).toBe(false);
+  });
+
+  test("query longer than text does not match", () => {
+    expect(fuzzyScore("clinical", "clinic").matched).toBe(false);
+  });
+
+  test("subsequence matches even when scattered", () => {
+    // p-a-c from "Pacific" — in order, so it matches.
+    expect(fuzzyScore("pac", "Pacific Clinic").matched).toBe(true);
+  });
+
+  test("prefix match outranks a mid-word match", () => {
+    const prefix = fuzzyScore("pac", "Pacific Clinic");
+    const mid = fuzzyScore("pac", "Topac Holdings");
+    expect(prefix.score).toBeGreaterThan(mid.score);
+  });
+
+  test("start-of-word match outranks a scattered subsequence", () => {
+    // "Personal Clinic": "pc" hits two word-starts.
+    const boundary = fuzzyScore("pc", "Personal Clinic");
+    // "Topical": "pc" is p(mid)...c(mid), scattered, no boundaries.
+    const scattered = fuzzyScore("pc", "Topical");
+    expect(boundary.matched).toBe(true);
+    expect(scattered.matched).toBe(true);
+    expect(boundary.score).toBeGreaterThan(scattered.score);
+  });
+
+  test("shorter haystack wins a tie", () => {
+    const short = fuzzyScore("crm", "CRM");
+    const long = fuzzyScore("crm", "CRM Archive");
+    expect(short.score).toBeGreaterThan(long.score);
+  });
+
+  test("is case-insensitive", () => {
+    expect(fuzzyScore("CRM", "crm").matched).toBe(true);
+    expect(fuzzyScore("crm", "CRM").matched).toBe(true);
+  });
+});
+
+describe("scoreItem", () => {
+  test("matches on title", () => {
+    const r = scoreItem("crm", { title: "CRM" });
+    expect(r.matched).toBe(true);
+  });
+
+  test("falls back to keywords when title misses", () => {
+    const r = scoreItem("pipeline", { title: "CRM", keywords: ["pipeline", "deals"] });
+    expect(r.matched).toBe(true);
+  });
+
+  test("keyword hit is docked below an equivalent title hit", () => {
+    const titleHit = scoreItem("deals", { title: "deals" });
+    const keywordHit = scoreItem("deals", { title: "CRM", keywords: ["deals"] });
+    expect(titleHit.score).toBeGreaterThan(keywordHit.score);
+  });
+
+  test("no match on title or keywords returns unmatched", () => {
+    expect(scoreItem("zzz", { title: "CRM", keywords: ["deals"] }).matched).toBe(false);
+  });
+});

--- a/web/test/palette-query.test.ts
+++ b/web/test/palette-query.test.ts
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------------
+// Palette query logic — prefix scoping + grouping (pure).
+//
+//   parseQuery: leading @ / # / > sets scope and is stripped.
+//   buildResultGroups: prefix narrows to one source; no prefix runs all;
+//   empty groups dropped; apps group label names the focused workspace.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test } from "bun:test";
+import { buildResultGroups, parseQuery } from "../src/components/palette/query";
+import { actionsSource } from "../src/components/palette/sources/actions";
+import { appsSource } from "../src/components/palette/sources/apps";
+import { workspacesSource } from "../src/components/palette/sources/workspaces";
+import type { CommandSourceContext } from "../src/components/palette/types";
+import type { WorkspaceInfo } from "../src/context/WorkspaceContext";
+import type { PlacementEntry } from "../src/types";
+
+const SOURCES = [workspacesSource, appsSource, actionsSource];
+
+function ws(id: string, name: string, extra?: Partial<WorkspaceInfo>): WorkspaceInfo {
+  return { id, name, memberCount: 1, bundles: [], ...extra };
+}
+
+const apps: PlacementEntry[] = [
+  { serverName: "crm", slot: "sidebar.apps", resourceUri: "ui://crm", priority: 1, label: "CRM", route: "crm" },
+];
+
+const ctx: CommandSourceContext = {
+  workspaces: [ws("ws_aaaaaaaaaaaaaaaa", "Pacific Clinic"), ws("ws_bbbbbbbbbbbbbbbb", "Helix Sales")],
+  activeWorkspaceId: "ws_bbbbbbbbbbbbbbbb",
+  activeWorkspaceName: "Helix Sales",
+  activeWorkspaceSlug: "bbbbbbbbbbbbbbbb",
+  apps,
+  iconForApp: () => undefined,
+  orgRole: "org_admin",
+};
+
+describe("parseQuery", () => {
+  test("no prefix → no scope, full term", () => {
+    expect(parseQuery("crm")).toEqual({ scopeId: null, term: "crm" });
+  });
+
+  test("@ scopes to workspaces and strips prefix", () => {
+    expect(parseQuery("@pac")).toEqual({ scopeId: "workspaces", term: "pac" });
+  });
+
+  test("# scopes to apps", () => {
+    expect(parseQuery("#crm")).toEqual({ scopeId: "apps", term: "crm" });
+  });
+
+  test("> scopes to actions", () => {
+    expect(parseQuery(">settings")).toEqual({ scopeId: "actions", term: "settings" });
+  });
+
+  test("bare prefix → empty term", () => {
+    expect(parseQuery("@")).toEqual({ scopeId: "workspaces", term: "" });
+  });
+});
+
+describe("buildResultGroups", () => {
+  test("empty default view is content-first: workspaces + apps, NOT actions", () => {
+    const groups = buildResultGroups("", SOURCES, ctx);
+    const ids = groups.map((g) => g.source.id);
+    expect(ids).toContain("workspaces");
+    expect(ids).toContain("apps");
+    // Actions are a command mode — hidden until the user types or scopes with >.
+    expect(ids).not.toContain("actions");
+  });
+
+  test("a non-empty term surfaces matching actions alongside content", () => {
+    const groups = buildResultGroups("settings", SOURCES, ctx);
+    expect(groups.some((g) => g.source.id === "actions")).toBe(true);
+  });
+
+  test("> scope shows actions even with no term", () => {
+    const groups = buildResultGroups(">", SOURCES, ctx);
+    expect(groups.map((g) => g.source.id)).toEqual(["actions"]);
+  });
+
+  test("@ prefix narrows to workspaces only", () => {
+    const groups = buildResultGroups("@", SOURCES, ctx);
+    expect(groups.map((g) => g.source.id)).toEqual(["workspaces"]);
+  });
+
+  test("# prefix narrows to apps and labels the group with the workspace", () => {
+    const groups = buildResultGroups("#", SOURCES, ctx);
+    expect(groups.map((g) => g.source.id)).toEqual(["apps"]);
+    expect(groups[0]!.label).toBe("Apps in Helix Sales");
+  });
+
+  test("drops a group whose source returns nothing", () => {
+    // # scope with a non-matching term → apps group is empty → no groups.
+    const groups = buildResultGroups("#zzzz", SOURCES, ctx);
+    expect(groups).toEqual([]);
+  });
+});

--- a/web/test/palette-sources.test.ts
+++ b/web/test/palette-sources.test.ts
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------------------
+// Command palette sources — behavior contracts.
+//
+//   workspaces: excludes the focused workspace; matches by name + role.
+//   apps:       empty when shell not ready (no apps) or no focused workspace;
+//               builds /w/<slug>/app/<route> on run.
+//   actions:    availability gating (focused-ws-only, org-admin-only); run
+//               closes over the source context for workspace routes.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test } from "bun:test";
+import { appsSource } from "../src/components/palette/sources/apps";
+import { actionsSource } from "../src/components/palette/sources/actions";
+import { workspacesSource } from "../src/components/palette/sources/workspaces";
+import type { CommandRunContext, CommandSourceContext } from "../src/components/palette/types";
+import type { WorkspaceInfo } from "../src/context/WorkspaceContext";
+import type { PlacementEntry } from "../src/types";
+
+function ws(id: string, name: string, extra?: Partial<WorkspaceInfo>): WorkspaceInfo {
+  return { id, name, memberCount: 1, bundles: [], ...extra };
+}
+
+const baseCtx: CommandSourceContext = {
+  workspaces: [],
+  apps: [],
+  iconForApp: () => undefined,
+};
+
+function recordRunContext(): {
+  ctx: CommandRunContext;
+  calls: { navigate: string[]; setActiveWorkspace: string[]; closed: number };
+} {
+  const calls = { navigate: [] as string[], setActiveWorkspace: [] as string[], closed: 0 };
+  const ctx: CommandRunContext = {
+    navigate: (to) => calls.navigate.push(to),
+    setActiveWorkspace: (w) => calls.setActiveWorkspace.push(w.id),
+    toggleChat: () => {},
+    toggleSidebar: () => {},
+    toggleTheme: () => {},
+    openKeyboardShortcuts: () => {},
+    logout: () => {},
+    closePalette: () => {
+      calls.closed += 1;
+    },
+  };
+  return { ctx, calls };
+}
+
+describe("workspacesSource", () => {
+  const ctx: CommandSourceContext = {
+    ...baseCtx,
+    workspaces: [
+      ws("ws_aaaaaaaaaaaaaaaa", "Pacific Clinic", { userRole: "member" }),
+      ws("ws_bbbbbbbbbbbbbbbb", "Personal", { userRole: "admin", isPersonal: true }),
+      ws("ws_cccccccccccccccc", "Helix Sales", { userRole: "admin" }),
+    ],
+    activeWorkspaceId: "ws_cccccccccccccccc",
+  };
+
+  test("includes all workspaces with the focused one sorted last", () => {
+    const items = workspacesSource.getItems("", ctx);
+    expect(items.length).toBe(3);
+    // Helix Sales is the focused workspace → sinks to the bottom.
+    expect(items.at(-1)?.title).toBe("Helix Sales");
+    expect(items.at(-1)?.subtitle).toContain("current");
+  });
+
+  test("matches by name", () => {
+    const items = workspacesSource.getItems("pac", ctx);
+    expect(items.map((i) => i.title)).toEqual(["Pacific Clinic"]);
+  });
+
+  test("run switches workspace and navigates to overview", () => {
+    const items = workspacesSource.getItems("pacific", ctx);
+    const { ctx: run, calls } = recordRunContext();
+    items[0]!.run(run);
+    expect(calls.setActiveWorkspace).toEqual(["ws_aaaaaaaaaaaaaaaa"]);
+    expect(calls.navigate).toEqual(["/w/aaaaaaaaaaaaaaaa/"]);
+    expect(calls.closed).toBe(1);
+  });
+});
+
+describe("appsSource", () => {
+  const apps: PlacementEntry[] = [
+    { serverName: "crm", slot: "sidebar.apps", resourceUri: "ui://crm", priority: 1, label: "CRM", route: "crm" },
+    { serverName: "pipeline", slot: "sidebar.apps", resourceUri: "ui://pipe", priority: 2, label: "Pipeline", route: "pipeline" },
+  ];
+
+  test("returns empty when shell not ready (no apps)", () => {
+    const items = appsSource.getItems("", {
+      ...baseCtx,
+      activeWorkspaceSlug: "helix",
+      apps: [],
+    });
+    expect(items).toEqual([]);
+  });
+
+  test("returns empty when no workspace focused", () => {
+    expect(appsSource.getItems("", { ...baseCtx, apps })).toEqual([]);
+  });
+
+  test("matches apps and builds workspace-scoped route on run", () => {
+    const ctx = { ...baseCtx, activeWorkspaceSlug: "helix", apps };
+    const items = appsSource.getItems("crm", ctx);
+    expect(items.map((i) => i.title)).toEqual(["CRM"]);
+    const { ctx: run, calls } = recordRunContext();
+    items[0]!.run(run);
+    expect(calls.navigate).toEqual(["/w/helix/app/crm"]);
+    expect(calls.closed).toBe(1);
+  });
+});
+
+describe("actionsSource", () => {
+  test("hides workspace-scoped actions without a focused workspace", () => {
+    const ids = actionsSource.getItems("", baseCtx).map((i) => i.id);
+    expect(ids).not.toContain("action:workspace-settings");
+    expect(ids).not.toContain("action:manage-connectors");
+  });
+
+  test("shows workspace-scoped actions when a workspace is focused", () => {
+    const ids = actionsSource
+      .getItems("", { ...baseCtx, activeWorkspaceSlug: "helix" })
+      .map((i) => i.id);
+    expect(ids).toContain("action:workspace-settings");
+  });
+
+  test("hides org settings for non-admins, shows for org_admin", () => {
+    expect(actionsSource.getItems("org", baseCtx).map((i) => i.id)).not.toContain(
+      "action:org-settings",
+    );
+    expect(
+      actionsSource.getItems("org", { ...baseCtx, orgRole: "org_admin" }).map((i) => i.id),
+    ).toContain("action:org-settings");
+  });
+
+  test("workspace-settings run builds the scoped route", () => {
+    const items = actionsSource.getItems("workspace settings", {
+      ...baseCtx,
+      activeWorkspaceSlug: "helix",
+    });
+    const item = items.find((i) => i.id === "action:workspace-settings");
+    expect(item).toBeDefined();
+    const { ctx: run, calls } = recordRunContext();
+    item!.run(run);
+    expect(calls.navigate).toEqual(["/w/helix/settings"]);
+  });
+});

--- a/web/test/palette-toggle.test.tsx
+++ b/web/test/palette-toggle.test.tsx
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------
+// PaletteProvider ⌘P toggle — repeated-press behavior + default suppression.
+//
+// Reproduces the "press ⌘P twice" path: the capture-phase window listener must
+// fire AND call preventDefault on BOTH presses (open and close), toggling the
+// open state each time. If defaultPrevented is ever false, the browser's print
+// dialog leaks through — which is the reported bug.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test } from "bun:test";
+import { act, render } from "@testing-library/react";
+import { PaletteProvider, usePalette } from "../src/context/PaletteContext";
+
+// Capture the latest `open` value out of React via a ref-like sink, avoiding
+// testing-library DOM queries (happy-dom's querySelectorAll throws in this
+// preload setup).
+let latestOpen = false;
+function Probe() {
+  const { open } = usePalette();
+  latestOpen = open;
+  return null;
+}
+
+function pressCmdP(): KeyboardEvent {
+  let ev!: KeyboardEvent;
+  act(() => {
+    ev = new KeyboardEvent("keydown", {
+      key: "p",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(ev);
+  });
+  return ev;
+}
+
+describe("PaletteProvider ⌘P toggle", () => {
+  test("toggles open/closed and preventDefaults on each successive press", () => {
+    render(
+      <PaletteProvider>
+        <Probe />
+      </PaletteProvider>,
+    );
+
+    expect(latestOpen).toBe(false);
+
+    const first = pressCmdP();
+    expect(first.defaultPrevented).toBe(true);
+    expect(latestOpen).toBe(true);
+
+    const second = pressCmdP();
+    expect(second.defaultPrevented).toBe(true);
+    expect(latestOpen).toBe(false);
+
+    const third = pressCmdP();
+    expect(third.defaultPrevented).toBe(true);
+    expect(latestOpen).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Replaces the `SidebarSearch` stub with a working keyboard-first **command palette**. **⌘P** (Ctrl+P) opens a global palette: type to search, ↑↓ to move across groups, ↵ to run, Esc to close. Optional prefixes scope the query:

- `@` — switch workspace
- `#` — launch an app in the focused workspace
- `>` — run a command (toggle chat/sidebar/theme, settings, shortcuts, log out…)

The sidebar search affordance now opens the palette and shows the ⌘P chip; a row is added to the keyboard-shortcuts modal.

## Architecture

- **`CommandSource` registry** (`workspaces`, `apps`, `actions`). Each source is pure and hook-free — it builds items from a read-only `CommandSourceContext` and acts via an imperative `CommandRunContext` assembled once by the container. Adding a source later is a new file, not matcher surgery.
- **Pure logic split from the shell**: `match.ts` (dependency-free fuzzy matcher) and `query.ts` (prefix parsing + grouping) are unit-tested without React.
- **`PaletteContext`** owns `{open, query}` and the global shortcut. The keydown listener runs in **capture phase** so it reliably suppresses the browser's print accelerator.
- **`CommandPalette`** mounts once at shell level (sibling of `ChatChrome`). Per `AGENTS.md` it consumes `ChatPanelContext` (never `ChatContext`/streaming) and uses in-memory/REST data only — no MCP bridge.

## Behavior notes

- **Content-first default**: the empty palette shows workspaces + apps; actions surface only on a matching term or the `>` scope, so it doesn't read as a command menu.
- **Apps** are scoped to the focused workspace and gated on shell readiness (`shellWorkspaceId`), so a workspace switch never shows the previous workspace's apps. Uses the same `workspaceApps()` helper as the sidebar/overview grid.
- **Actions** are availability-filtered (focused-workspace-only, org-admin-only).

## Deferred (follow-ups)

- `/` conversation search — needs a new conversation-listing path (preferably a `manage_conversations` tool action).
- Cross-workspace app search — needs each workspace's placement set.

## Tests

40 new unit/component tests: matcher ranking, source behavior (incl. shell-not-ready → empty apps, role gating), prefix scoping/grouping, the shortcut chord, and a repeated-⌘P toggle test asserting `defaultPrevented` on every press (regression guard for the print-dialog bug). Full `bun run verify` green.