### PR TITLE
fix(skills): report per-request Layer-3 skills in status scope:skills

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -83,7 +83,7 @@ import {
   partitionSkills,
 } from "../skills/loader.ts";
 import { SkillMatcher } from "../skills/matcher.ts";
-import { selectLayer3Skills } from "../skills/select.ts";
+import { type SelectedSkill, selectLayer3Skills } from "../skills/select.ts";
 import { approxTokens } from "../skills/tokens.ts";
 import { truncateMarkdownToBudget } from "../skills/truncate.ts";
 import type { Skill } from "../skills/types.ts";
@@ -1222,30 +1222,14 @@ export class Runtime {
     // to the personal workspace, silently dropping every shared-workspace
     // skill marked `loading_strategy: always`.
     const userId = requestIdentity.id;
-    const layer3Pool = this.loadConversationSkills(focusedWsId ?? sessionWsId, userId);
-    // Stage 2 (T006) — bundle skills are loaded across every workspace
-    // the identity can see, not just the session workspace. A bundle
-    // installed in a shared workspace whose tools land in the
-    // cross-workspace tool list must also surface its `skill://<name>/usage`
-    // body in Layer 3, otherwise the model is given the namespaced
-    // tool name but no workflow guidance.
-    const accessibleForSkills = await this._workspaceStore.getWorkspacesForUser(ownerId);
-    const bundleSkills = (
-      await Promise.all(
-        accessibleForSkills.map((ws) =>
-          this.loadBundleSkills(ws.id, {
-            ...(request.appContext?.serverName
-              ? { appContextServerName: request.appContext.serverName }
-              : {}),
-          }),
-        ),
-      )
-    ).flat();
-    const mergedLayer3Pool: Skill[] = [...layer3Pool, ...bundleSkills];
-    const activeToolNames = tools.map((t) => t.name);
-    const selectedLayer3 = selectLayer3Skills({
-      skills: mergedLayer3Pool,
-      activeTools: activeToolNames,
+    const selectedLayer3 = await this.selectRequestLayer3({
+      wsId: focusedWsId ?? sessionWsId,
+      ownerId,
+      userId,
+      activeToolNames: tools.map((t) => t.name),
+      ...(request.appContext?.serverName
+        ? { appContextServerName: request.appContext.serverName }
+        : {}),
     });
     const layer3Entries: Layer3SkillEntry[] = selectedLayer3.map((s) => ({
       name: s.skill.manifest.name,
@@ -2622,6 +2606,81 @@ export class Runtime {
     }
 
     return mergeScopedSkills(orgPool, workspacePool, userPool);
+  }
+
+  /**
+   * Build the Layer-3 skill pool for a request and run the selection.
+   *
+   * Single source of truth for both prompt composition (`chat`) and the
+   * `nb__status scope:skills` reporter (`describeRequestSkills`). Keeping the
+   * pool construction in one place is deliberate: the bug this method exists to
+   * prevent was status and composition reading skills through two divergent
+   * paths, so the status surface reported only boot-time skills while the
+   * prompt received the workspace/user-tier set.
+   *
+   * The pool merges per-conversation tier skills (org + workspace + user, via
+   * {@link loadConversationSkills}) with bundle-exposed `skill://<name>/usage`
+   * skills across every workspace the identity can reach — a bundle installed
+   * in a shared workspace whose tools land in the cross-workspace tool list
+   * must also surface its workflow guidance, else the model gets the namespaced
+   * tool name with no instructions. `selectLayer3Skills` then filters to the
+   * `always` and `tool_affined` strategies against `activeToolNames`.
+   */
+  async selectRequestLayer3(params: {
+    /** Focused workspace (or session/personal in home mode) for workspace-tier skills. */
+    wsId: string;
+    /** Owner identity for cross-workspace reach (accessible workspaces + bundle skills). */
+    ownerId: string;
+    /** Identity for user-tier skills; null in non-identity-bound paths. */
+    userId: string | null;
+    /** Names of tools in the set tool-affinity is evaluated against. */
+    activeToolNames: string[];
+    /** Skip a server's usage skill when its `<app-guide>` is already injected. */
+    appContextServerName?: string;
+  }): Promise<SelectedSkill[]> {
+    const layer3Pool = this.loadConversationSkills(params.wsId, params.userId);
+    const accessibleForSkills = await this._workspaceStore.getWorkspacesForUser(params.ownerId);
+    const bundleSkills = (
+      await Promise.all(
+        accessibleForSkills.map((ws) =>
+          this.loadBundleSkills(ws.id, {
+            ...(params.appContextServerName
+              ? { appContextServerName: params.appContextServerName }
+              : {}),
+          }),
+        ),
+      )
+    ).flat();
+    return selectLayer3Skills({
+      skills: [...layer3Pool, ...bundleSkills],
+      activeTools: params.activeToolNames,
+    });
+  }
+
+  /**
+   * The Layer-3 skills the CURRENT request would compose into the prompt, plus
+   * the boot-time context skills — for `nb__status scope:skills`.
+   *
+   * Reports through {@link selectRequestLayer3} (the same path `chat` composes
+   * with) so the status surface reflects the workspace- and user-tier skills
+   * actually loaded, not the boot-time cache. Identity and the focused
+   * workspace come from the active request context.
+   *
+   * Active-tool input is the focused workspace's *available* tools. Under
+   * progressive disclosure the live run's active subset may be smaller, but for
+   * a status view "loads when this installed tool is active" is the signal a
+   * reader wants — and it never under-reports an always-loaded skill.
+   */
+  async describeRequestSkills(
+    wsId: string,
+  ): Promise<{ context: readonly Skill[]; layer3: readonly SelectedSkill[] }> {
+    const identity = getRequestContext()?.identity ?? undefined;
+    const ownerId = this.resolveRequestUserId(identity);
+    const userId = identity?.id ?? ownerId;
+    const registry = await this.ensureWorkspaceRegistry(wsId);
+    const activeToolNames = (await registry.availableTools()).map((t) => t.name);
+    const layer3 = await this.selectRequestLayer3({ wsId, ownerId, userId, activeToolNames });
+    return { context: this.contextSkills, layer3 };
   }
 
   /** Get the path to the nimblebrain.json config file (Helm-managed seed). */

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -8,6 +8,7 @@ import type { ConfirmationGate } from "../config/privilege.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { EventSink, ToolPromotionControls, ToolResult, ToolSchema } from "../engine/types.ts";
 import type { Runtime } from "../runtime/runtime.ts";
+import type { SelectedSkill } from "../skills/select.ts";
 import type { Skill } from "../skills/types.ts";
 import { createManageAppsTool } from "./app-tools.ts";
 import { createManageConnectorsTool } from "./connector-tools.ts";
@@ -363,14 +364,11 @@ function createStatusTool(
         }
 
         if (scope === "skills") {
-          if (!getSkills) {
+          const wsId = runtime?.requireWorkspaceId();
+          if (!runtime || !wsId) {
             return { content: textContent("Skill status not available."), isError: false };
           }
-          const wsId = runtime?.requireWorkspaceId();
-          if (!wsId) {
-            return { content: textContent("Workspace context required."), isError: true };
-          }
-          return handleSkillStatus(getSkills, lifecycle, nameQuery, wsId);
+          return await handleSkillStatus(runtime, getSkills, lifecycle, nameQuery, wsId);
         }
 
         if (scope === "config") {
@@ -435,17 +433,25 @@ async function handleBundleStatus(
   return { content: textContent(entries.join("\n\n")), isError: false };
 }
 
-function handleSkillStatus(
-  getSkills: GetSkillsFn,
+async function handleSkillStatus(
+  runtime: Runtime,
+  getSkills: GetSkillsFn | undefined,
   lifecycle: BundleLifecycleManager | undefined,
   nameQuery: string | null,
   wsId: string,
-): ToolResult {
-  const { context, matchable } = getSkills();
+): Promise<ToolResult> {
+  // Report through the SAME per-request path `chat` composes with
+  // (`describeRequestSkills` → `selectRequestLayer3`), so workspace- and
+  // user-tier skills that actually load into the prompt appear here — the old
+  // path read a boot-time cache and reported only platform/core skills.
+  const { context, layer3 } = await runtime.describeRequestSkills(wsId);
+  // Legacy trigger-matched skills still come from the boot matcher cache.
+  const matchable = getSkills?.().matchable ?? [];
+  const layer3Names = new Set(layer3.map((s) => s.skill.manifest.name));
 
   // Single skill detail view
   if (nameQuery) {
-    const all = [...context, ...matchable];
+    const all = [...context, ...layer3.map((s) => s.skill), ...matchable];
     const skill = all.find((s) => s.manifest.name.toLowerCase() === nameQuery.toLowerCase());
     if (!skill) {
       return {
@@ -460,7 +466,13 @@ function handleSkillStatus(
 
   // Overview: categorize all skills
   const coreContext = context.filter((s) => s.sourcePath.includes(CORE_SKILL_MARKER));
-  const userContext = context.filter((s) => !s.sourcePath.includes(CORE_SKILL_MARKER));
+  // Non-core boot context skills, minus any that ALSO surface in the
+  // per-request Layer-3 set below — otherwise the same skill lists twice.
+  const userContext = context.filter(
+    (s) => !s.sourcePath.includes(CORE_SKILL_MARKER) && !layer3Names.has(s.manifest.name),
+  );
+  const alwaysLoaded = layer3.filter((s) => s.loadedBy === "always");
+  const toolAffined = layer3.filter((s) => s.loadedBy === "tool_affinity");
   const sections: string[] = [];
 
   if (coreContext.length > 0) {
@@ -471,6 +483,16 @@ function handleSkillStatus(
   if (userContext.length > 0) {
     const lines = ["## User Context Skills (always active)"];
     for (const s of userContext) lines.push(formatSkillSummary(s));
+    sections.push(lines.join("\n"));
+  }
+  if (alwaysLoaded.length > 0) {
+    const lines = ["## Workspace & User Skills (always loaded)"];
+    for (const s of alwaysLoaded) lines.push(formatLayer3Summary(s));
+    sections.push(lines.join("\n"));
+  }
+  if (toolAffined.length > 0) {
+    const lines = ["## Tool-Affined Skills (active)"];
+    for (const s of toolAffined) lines.push(formatLayer3Summary(s));
     sections.push(lines.join("\n"));
   }
   if (matchable.length > 0) {
@@ -549,6 +571,13 @@ async function handleOverviewStatus(
 function formatSkillSummary(skill: Skill): string {
   const m = skill.manifest;
   return `- ${m.name} (${m.type}, priority ${m.priority}) — ${m.description || "(no description)"}`;
+}
+
+/** Summary line for a per-request Layer-3 skill, including why it loaded. */
+function formatLayer3Summary(selected: SelectedSkill): string {
+  const m = selected.skill.manifest;
+  const scope = m.scope ?? "org";
+  return `- ${m.name} (${scope}, priority ${m.priority}) — ${m.description || "(no description)"}\n  Loaded: ${selected.reason}`;
 }
 
 function formatMatchableSummary(

--- a/test/integration/workspace-tier-skills.test.ts
+++ b/test/integration/workspace-tier-skills.test.ts
@@ -107,6 +107,20 @@ describe("Layer 3 — workspace-tier `loading_strategy: always` skills", () => {
     expect(entry?.loadedBy).toBe("always");
   });
 
+  it("reports the focused workspace's `always` skill on the status surface (describeRequestSkills)", async () => {
+    // Regression for the second half of the shared-workspace report: a
+    // workspace-tier `always` skill composed into the prompt (asserted above)
+    // but `nb__status scope:skills` showed only platform/core skills, because
+    // the status path read a boot-time cache instead of the per-request Layer-3
+    // set. `describeRequestSkills` now reports through the SAME path `chat`
+    // composes with, so the two surfaces can no longer disagree.
+    const { layer3 } = await runtime.describeRequestSkills(TEST_WORKSPACE_ID);
+    const entry = layer3.find((s) => s.skill.manifest.name === SHARED_SKILL_NAME);
+    expect(entry).toBeDefined();
+    expect(entry?.skill.manifest.scope).toBe("workspace");
+    expect(entry?.loadedBy).toBe("always");
+  });
+
   it("does NOT load the focused workspace's skill when chatting from home (no focus)", async () => {
     // Home control panel = no `workspaceId` on the request. Layer 3
     // workspace-tier skills should fall back to the session (personal)

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -520,10 +520,17 @@ describe("status tool — scope: skills", () => {
 	async function makeStatusSource(
 		skills: { context: Skill[]; matchable: Skill[] },
 		lifecycleMock?: { getInstance: (name: string, wsId: string) => unknown },
+		layer3?: Array<{ skill: Skill; loadedBy: "always" | "tool_affinity"; reason: string }>,
 	) {
 		const registry = await makeRegistry();
 		const getSkills = () => skills;
-		const runtimeMock = { requireWorkspaceId: () => "ws_test" } as unknown as import("../../src/runtime/runtime.ts").Runtime;
+		// Status reads workspace/user-tier skills through `describeRequestSkills`
+		// (the same per-request path `chat` composes with); `context` carries the
+		// boot context skills, `layer3` the per-request selection.
+		const runtimeMock = {
+			requireWorkspaceId: () => "ws_test",
+			describeRequestSkills: async () => ({ context: skills.context, layer3: layer3 ?? [] }),
+		} as unknown as import("../../src/runtime/runtime.ts").Runtime;
 		return await createSystemTools(
 			() => registry,
 			undefined,
@@ -555,6 +562,30 @@ describe("status tool — scope: skills", () => {
 		expect(extractText(result.content)).toContain("User Context");
 		expect(extractText(result.content)).toContain("spanish");
 		expect(extractText(result.content)).toContain("priority 20");
+	});
+
+	it("shows per-request Layer-3 workspace/user skills (regression: status read a boot cache)", async () => {
+		const workspaceSkill: Skill = {
+			manifest: {
+				name: "team-voice",
+				description: "Team voice rules",
+				version: "1.0.0",
+				type: "context",
+				priority: 30,
+				scope: "workspace",
+			},
+			body: "Match the team voice.",
+			sourcePath: "/home/.nimblebrain/workspaces/ws_test/skills/team-voice.md",
+		};
+		const source = await makeStatusSource({ context: [coreSkill], matchable: [] }, undefined, [
+			{ skill: workspaceSkill, loadedBy: "always", reason: "loading_strategy: always" },
+		]);
+		const result = await source.execute("status", { scope: "skills" });
+		expect(result.isError).toBe(false);
+		const text = extractText(result.content);
+		expect(text).toContain("Workspace & User Skills (always loaded)");
+		expect(text).toContain("team-voice");
+		expect(text).toContain("workspace");
 	});
 
 	it("shows matchable skills with triggers", async () => {


### PR DESCRIPTION
## Problem

`nb__status scope:skills` reported only the boot-time platform/core skills, even when workspace- and user-tier Layer-3 skills (`loading_strategy: always`) had been composed into the prompt. Surfaced in a shared-workspace report: the agent's prompt received 7 workspace skills, but `status:skills` showed only the 5 platform defaults.

## Root cause

Two paths read skills from two sources:

- **Prompt composition** (`chat()`) loads the per-request Layer-3 pool fresh — org + workspace + user tier (`loadConversationSkills`) plus bundle `skill://<name>/usage` skills — then runs `selectLayer3Skills`.
- **`handleSkillStatus`** read a boot-time static cache (`getContextSkills()` / `getMatchableSkills()`), which never contains per-request workspace/user-tier skills.

So the status surface and the prompt could disagree — the reporting half of the same divergence class as the tool-discovery cache bug (#331).

## Fix

- Extract pool construction + selection into `Runtime.selectRequestLayer3(...)`, now the **single source of truth** for both `chat()` composition and status reporting — the two surfaces can't drift again.
- Add `Runtime.describeRequestSkills(wsId)`, which reports through that same path (active-tool input = the focused workspace's available tools).
- `handleSkillStatus` now renders the composed **Workspace & User Skills (always loaded)** and **Tool-Affined Skills (active)** sections alongside the existing core / context / matchable sections, deduped by name.

## Scope

Reporting only. Prompt composition behavior is unchanged (`chat()` calls the extracted method with identical inputs). Does not address tool-affined skills failing to load when their bundle's tools are down — that is the separate tool-discovery cache fix in #331.

## Tests

- `workspace-tier-skills.test.ts`: asserts the focused workspace's `always` skill is reported by `describeRequestSkills` (the status surface), not just `skills.loaded`.
- `system-tools.test.ts`: new case for rendering per-request Layer-3 workspace skills; existing skill-status cases updated for the `describeRequestSkills` seam.
- `bun run verify` green.