### PR TITLE
fix(skills): keep core skills out of Layer-3 status sections; test dedup

### DIFF
--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -471,8 +471,12 @@ async function handleSkillStatus(
   const userContext = context.filter(
     (s) => !s.sourcePath.includes(CORE_SKILL_MARKER) && !layer3Names.has(s.manifest.name),
   );
-  const alwaysLoaded = layer3.filter((s) => s.loadedBy === "always");
-  const toolAffined = layer3.filter((s) => s.loadedBy === "tool_affinity");
+  // A core skill is shown only under "Core Skills (immutable)", the more
+  // meaningful category. Should one ever carry a Layer-3 loading strategy,
+  // drop it from the Layer-3 sections so it can't list twice — Core wins.
+  const layer3Visible = layer3.filter((s) => !s.skill.sourcePath?.includes(CORE_SKILL_MARKER));
+  const alwaysLoaded = layer3Visible.filter((s) => s.loadedBy === "always");
+  const toolAffined = layer3Visible.filter((s) => s.loadedBy === "tool_affinity");
   const sections: string[] = [];
 
   if (coreContext.length > 0) {

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -466,15 +466,17 @@ async function handleSkillStatus(
 
   // Overview: categorize all skills
   const coreContext = context.filter((s) => s.sourcePath.includes(CORE_SKILL_MARKER));
+  const coreNames = new Set(coreContext.map((s) => s.manifest.name));
   // Non-core boot context skills, minus any that ALSO surface in the
   // per-request Layer-3 set below — otherwise the same skill lists twice.
   const userContext = context.filter(
     (s) => !s.sourcePath.includes(CORE_SKILL_MARKER) && !layer3Names.has(s.manifest.name),
   );
-  // A core skill is shown only under "Core Skills (immutable)", the more
-  // meaningful category. Should one ever carry a Layer-3 loading strategy,
-  // drop it from the Layer-3 sections so it can't list twice — Core wins.
-  const layer3Visible = layer3.filter((s) => !s.skill.sourcePath?.includes(CORE_SKILL_MARKER));
+  // A skill already shown under "Core Skills (immutable)" is not repeated in
+  // the Layer-3 sections — Core is authoritative. Deduped BY NAME (not by a
+  // `/skills/core/` path marker), so a non-core skill that merely lives under
+  // a `core/` subfolder keeps its own name and is never wrongly hidden.
+  const layer3Visible = layer3.filter((s) => !coreNames.has(s.skill.manifest.name));
   const alwaysLoaded = layer3Visible.filter((s) => s.loadedBy === "always");
   const toolAffined = layer3Visible.filter((s) => s.loadedBy === "tool_affinity");
   const sections: string[] = [];

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -588,6 +588,33 @@ describe("status tool — scope: skills", () => {
 		expect(text).toContain("workspace");
 	});
 
+	it("lists a skill present in both boot context and the Layer-3 set exactly once", async () => {
+		// A boot-context skill (non-core) whose name also surfaces in the
+		// per-request Layer-3 set must render once — under the Layer-3 section,
+		// not duplicated in "User Context". Guards the userContext dedup branch.
+		const dup: Skill = {
+			manifest: {
+				name: "dual-listed",
+				description: "Appears in both sources",
+				version: "1.0.0",
+				type: "context",
+				priority: 25,
+				scope: "workspace",
+			},
+			body: "Body.",
+			sourcePath: "/home/.nimblebrain/workspaces/ws_test/skills/dual-listed.md",
+		};
+		const source = await makeStatusSource({ context: [coreSkill, dup], matchable: [] }, undefined, [
+			{ skill: dup, loadedBy: "always", reason: "loading_strategy: always" },
+		]);
+		const result = await source.execute("status", { scope: "skills" });
+		expect(result.isError).toBe(false);
+		const text = extractText(result.content);
+		expect(text.split("dual-listed").length - 1).toBe(1);
+		expect(text).toContain("Workspace & User Skills (always loaded)");
+		expect(text).not.toContain("User Context");
+	});
+
 	it("shows matchable skills with triggers", async () => {
 		const source = await makeStatusSource({ context: [], matchable: [matchableSkill] });
 		const result = await source.execute("status", { scope: "skills" });

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -615,6 +615,22 @@ describe("status tool — scope: skills", () => {
 		expect(text).not.toContain("User Context");
 	});
 
+	it("shows a core skill that also enters the Layer-3 set once, under Core", async () => {
+		// If a core skill ever carries a Layer-3 loading strategy it can appear in
+		// both the boot context (Core) and the per-request Layer-3 set. Core is
+		// authoritative: it must render once, under "Core Skills", never also in
+		// the Layer-3 sections. Guards the name-based coreNames dedup.
+		const source = await makeStatusSource({ context: [coreSkill], matchable: [] }, undefined, [
+			{ skill: coreSkill, loadedBy: "always", reason: "loading_strategy: always" },
+		]);
+		const result = await source.execute("status", { scope: "skills" });
+		expect(result.isError).toBe(false);
+		const text = extractText(result.content);
+		expect(text.split("soul").length - 1).toBe(1);
+		expect(text).toContain("Core Skills");
+		expect(text).not.toContain("Workspace & User Skills");
+	});
+
 	it("shows matchable skills with triggers", async () => {
 		const source = await makeStatusSource({ context: [], matchable: [matchableSkill] });
 		const result = await source.execute("status", { scope: "skills" });


### PR DESCRIPTION
Follow-up to #338 (merged) — applies the two QA-review suggestions that didn't make it into the squash before merge.

## Changes

1. **Core is authoritative in `status:skills`.** Core-marker skills are excluded from the Layer-3 (`always` / `tool_affined`) sections, so a core skill that ever carried a Layer-3 loading strategy lists only under *Core Skills (immutable)* — never twice. Removes the dedup asymmetry between the core and `userContext` branches the reviewer flagged.
2. **Test the dedup path.** New unit case: a skill present in both boot context and the per-request Layer-3 set renders exactly once (under Layer-3, not also under User Context).

## Not done (deliberately)

The reviewer's third suggestion — sort each section by name for byte-stable output — is intentionally declined. Status section order currently mirrors the prompt's composition order, which is what makes `status:skills` a faithful view of what the agent received; sorting would break that mirror for marginal byte-stability on a diagnostic surface. Pre-existing FS-order behavior, not introduced here.

## Tests

`bun run verify` green. Display-only change; no behavior change to prompt composition.