### PR TITLE
docs(supervisor): correct fingerprint comment — don't widen to structuredContent

### DIFF
--- a/src/engine/supervisor.ts
+++ b/src/engine/supervisor.ts
@@ -97,8 +97,19 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
     // false-positive on tools that return a long stable preamble (e.g. a
     // verbose header) followed by a short varying field. Two semantically
     // distinct results may collapse to the same fingerprint and trip the
-    // supervisor early. Addressable later by hashing head+tail or
-    // structuredContent when present; out of scope here.
+    // supervisor early. If that bites, hash head+tail rather than head-only.
+    //
+    // Deliberately NOT addressed by folding `structuredContent` into the hash.
+    // Tempting (a mutating tool's varying data often lives there), but it
+    // regresses this guard's core job: a paginated tool with an advancing
+    // cursor, or any tool that stamps a timestamp / request-id into its
+    // structured payload, would then produce a unique fingerprint on every
+    // call and never trip — even in a genuine loop. The contract is the
+    // inverse: a mutating tool must emit a per-call-varying field that reaches
+    // `content`. FastMCP serializes a structured return into both `content`
+    // and `structuredContent`, so a field like synapse-collateral's
+    // WorkspaceState.source_sha (a hash of the edited document) satisfies it.
+    // Fix a falsely-tripping tool at the tool, not by weakening the guard.
     const text = extractTextForModel(result.content).trim().slice(0, textCap);
     return createHash("sha1")
       .update(`${call.name}\0${result.isError ? "E" : "S"}\0${text}`)


### PR DESCRIPTION
## Why

`supervisor.ts`'s fingerprint comment suggested a future fix of *"hashing head+tail or structuredContent when present."* The `structuredContent` half is the wrong path, and it sits right next to the code someone would edit.

Folding `structuredContent` into the fingerprint **regresses the guard's core job**:
- a paginated tool with an advancing cursor → unique fingerprint every call → pagination dead-ends never trip;
- any tool that stamps a timestamp / request-id into its structured payload → never trips, even in a genuine loop.

## What

Replace that line with the real contract: a **mutating tool must emit a per-call-varying field that reaches `content`** (FastMCP serializes a structured return into both `content` and `structuredContent`, so e.g. `synapse-collateral`'s `WorkspaceState.source_sha` satisfies it). Fix a falsely-tripping tool at the tool, not by weakening the supervisor. The head+tail mitigation for the (separate, real) truncation limitation is kept.

Comment-only; no behavior change. This is the consumer-side documentation of the fix shipped in `synapse-collateral` v0.6.4. `format:check` + `lint` clean.