### PR TITLE
fix(files): detect text MIME type from filename for unrecognized uploads

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -5,6 +5,7 @@ import { log } from "../cli/log.ts";
 import { isToolEnabled, isToolVisibleToRole, type ResolvedFeatures } from "../config/features.ts";
 import type { EngineEvent, EventSink } from "../engine/types.ts";
 import { ingestFiles, isAllowedMime, type UploadedFile } from "../files/ingest.ts";
+import { resolveMimeType } from "../files/mime.ts";
 import type { FileEntry } from "../files/types.ts";
 import type { IdentityProvider, UserIdentity } from "../identity/provider.ts";
 import {
@@ -1541,7 +1542,10 @@ async function parseMultipartChatBody(
     uploadedFiles.push({
       data: buffer,
       filename: entry.name || "unnamed",
-      mimeType: entry.type || "application/octet-stream",
+      // Browsers leave the part's Content-Type empty for extensions they
+      // don't recognise (.typ etc.); recover a text type from the filename
+      // so the file isn't stored as opaque binary. See resolveMimeType.
+      mimeType: resolveMimeType(entry.name, entry.type),
     });
   }
 
@@ -1663,7 +1667,10 @@ export async function handleResourceUpload(
       uploads.push({
         data: Buffer.from(await entry.arrayBuffer()),
         filename: entry.name || "unnamed",
-        mimeType: entry.type || "application/octet-stream",
+        // Recover a text type from the filename when the browser sent no
+        // usable Content-Type (see resolveMimeType) — same recovery as the
+        // chat-multipart path.
+        mimeType: resolveMimeType(entry.name, entry.type),
       });
     }
   } catch {

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -83,10 +83,16 @@ export function isAllowedMime(mimeType: string): boolean {
  * `handleRead` route PDFs through their own (capability-aware) policy,
  * not the generic ingest extraction path, so the set stays focused on
  * formats where the only useful surface to the model is extracted text.
+ *
+ * Mirrors `isTextMime`'s `text/*` prefix rule: `extractText` UTF-8-decodes
+ * any `text/*` type, so the read gate (`files__read`) must admit the same set
+ * it can actually extract. Without this, a correctly-typed `text/x-*` source
+ * file would pass `isTextMime` inside `extractText` but never reach it,
+ * because this predicate gated it out first.
  */
 export function isExtractable(mimeType: string): boolean {
   const bare = normalizeMime(mimeType);
-  return EXTRACTABLE_TEXT.has(bare) || EXTRACTABLE_DOCS.has(bare);
+  return bare.startsWith("text/") || EXTRACTABLE_TEXT.has(bare) || EXTRACTABLE_DOCS.has(bare);
 }
 
 function isImage(mimeType: string): boolean {

--- a/src/files/mime.ts
+++ b/src/files/mime.ts
@@ -33,3 +33,112 @@ export function isTextMime(mimeType: string): boolean {
   const bare = mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
   return bare.startsWith("text/") || TEXT_MIMES.has(bare);
 }
+
+const GENERIC_BINARY = "application/octet-stream";
+
+/**
+ * Extension → MIME map, consulted only when the upload carries no usable
+ * Content-Type. Browsers populate a file part's Content-Type from a built-in
+ * extension table and leave it empty (which the upload handlers coerce to
+ * `application/octet-stream`) for anything they don't recognise — Typst
+ * (`.typ`) and most source/config formats. Without recovery those files are
+ * stored as opaque binary and every text path (extraction, `isTextMime`
+ * delivery, `files__read`) treats them as un-readable.
+ *
+ * INVARIANT — text/source extensions only. Every value here MUST be `text/*`
+ * or one of the structured `application/*` types already in `TEXT_MIMES`
+ * (`application/json`, `application/xml`, `application/yaml`). Two reasons:
+ *   1. Those are the only values both `isTextMime` AND `isExtractable`
+ *      (`ingest.ts`) accept, so anything else would store, then fail to read.
+ *   2. The map is only ever applied to override a generic/empty type, so
+ *      adding a binary-capable extension (`.doc`, `.png`, `.zip`) here would
+ *      mislabel real binary as text and corrupt it on UTF-8 decode.
+ * Source/code/config formats with no registered text subtype map to
+ * `text/plain` — they are plain UTF-8 and `text/plain` is accepted everywhere.
+ */
+const EXTENSION_MIME: Record<string, string> = {
+  // Structured text formats with a registered type in the allowlists.
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+  jsonl: "text/plain",
+  ndjson: "text/plain",
+  yaml: "application/yaml",
+  yml: "application/yaml",
+  xml: "application/xml",
+  html: "text/html",
+  htm: "text/html",
+  txt: "text/plain",
+  text: "text/plain",
+  log: "text/plain",
+  // Typst.
+  typ: "text/plain",
+  // Source / config / markup — plain UTF-8 with no registered text subtype.
+  py: "text/plain",
+  rb: "text/plain",
+  go: "text/plain",
+  rs: "text/plain",
+  java: "text/plain",
+  c: "text/plain",
+  h: "text/plain",
+  cpp: "text/plain",
+  cc: "text/plain",
+  hpp: "text/plain",
+  cs: "text/plain",
+  php: "text/plain",
+  swift: "text/plain",
+  kt: "text/plain",
+  scala: "text/plain",
+  sh: "text/plain",
+  bash: "text/plain",
+  zsh: "text/plain",
+  sql: "text/plain",
+  js: "text/plain",
+  mjs: "text/plain",
+  cjs: "text/plain",
+  ts: "text/plain",
+  tsx: "text/plain",
+  jsx: "text/plain",
+  css: "text/plain",
+  scss: "text/plain",
+  sass: "text/plain",
+  less: "text/plain",
+  toml: "text/plain",
+  ini: "text/plain",
+  cfg: "text/plain",
+  conf: "text/plain",
+  env: "text/plain",
+  properties: "text/plain",
+  tex: "text/plain",
+  rst: "text/plain",
+  adoc: "text/plain",
+  org: "text/plain",
+};
+
+/** Lowercased extension without the dot, or "" when there isn't one. */
+function fileExtension(filename: string | undefined): string {
+  if (!filename) return "";
+  const dot = filename.lastIndexOf(".");
+  if (dot < 0 || dot === filename.length - 1) return "";
+  return filename.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * Resolve a file's MIME type at ingest time.
+ *
+ * A specific client-supplied Content-Type is trusted as-is. When it is
+ * missing or the generic `application/octet-stream`, the type is re-derived
+ * from the filename extension so text source files the browser doesn't
+ * recognise (e.g. `.typ`) are stored as text rather than opaque binary.
+ * An unknown extension keeps `application/octet-stream` — real binary stays
+ * binary. This is the single recovery point for every mint site (chat upload,
+ * resource upload, `files__create`).
+ */
+export function resolveMimeType(filename: string | undefined, providedType?: string): string {
+  const bare = (providedType ?? "").split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  if (bare && bare !== GENERIC_BINARY) {
+    return providedType!.trim();
+  }
+  return EXTENSION_MIME[fileExtension(filename)] ?? GENERIC_BINARY;
+}

--- a/src/files/mime.ts
+++ b/src/files/mime.ts
@@ -55,8 +55,11 @@ const GENERIC_BINARY = "application/octet-stream";
  *      mislabel real binary as text and corrupt it on UTF-8 decode.
  * Source/code/config formats with no registered text subtype map to
  * `text/plain` — they are plain UTF-8 and `text/plain` is accepted everywhere.
+ *
+ * Exported so a test can assert the invariant over every value (not a
+ * hand-picked sample) — a new entry that breaks it is caught automatically.
  */
-const EXTENSION_MIME: Record<string, string> = {
+export const EXTENSION_MIME: Record<string, string> = {
   // Structured text formats with a registered type in the allowlists.
   md: "text/markdown",
   markdown: "text/markdown",

--- a/src/tools/platform/files.ts
+++ b/src/tools/platform/files.ts
@@ -19,7 +19,7 @@ import { textContent } from "../../engine/content-helpers.ts";
 import type { ContentBlock, EventSink, ToolResult } from "../../engine/types.ts";
 import { extractPdfPages, extractText } from "../../files/extract.ts";
 import { IMAGE_TYPES, isExtractable, PDF_TYPES } from "../../files/ingest.ts";
-import { isTextMime } from "../../files/mime.ts";
+import { isTextMime, resolveMimeType } from "../../files/mime.ts";
 import type { FileStore } from "../../files/store.ts";
 import type { FileEntry } from "../../files/types.ts";
 import { fileIdToUri, uriToFileId } from "../../files/uri.ts";
@@ -325,11 +325,16 @@ async function handleCreate(store: FileStore, args: CreateInput): Promise<object
   // store-unification PR that introduced this comment — track separately.
   const { manifest, body } = args;
   const decoded = Buffer.from(body, "base64");
-  const saved = await store.saveFile(decoded, manifest.filename, manifest.mimeType);
+  // Recover a text type from the filename when the agent supplies a generic
+  // `application/octet-stream` (or empty) for a known text/source extension;
+  // a specific type is trusted as-is. Same recovery as the upload handlers,
+  // so an agent-written `.typ` is readable just like an uploaded one.
+  const mimeType = resolveMimeType(manifest.filename, manifest.mimeType);
+  const saved = await store.saveFile(decoded, manifest.filename, mimeType);
   const entry: FileEntry = {
     id: saved.id,
     filename: manifest.filename,
-    mimeType: manifest.mimeType,
+    mimeType,
     size: saved.size,
     tags: manifest.tags ?? [],
     // The LLM invokes this tool; human-uploaded-via-UI is "manual",

--- a/test/unit/files/extract.test.ts
+++ b/test/unit/files/extract.test.ts
@@ -97,6 +97,13 @@ describe("extractText", () => {
     expect(result).toBeNull();
   });
 
+  test("any text/* subtype is decoded as UTF-8", async () => {
+    // A .typ recovered to a text type extracts its source like any text file.
+    const src = "#set page(width: 10cm)\n= Heading";
+    const result = await extractText(Buffer.from(src), "text/x-typst");
+    expect(result).toEqual({ text: src, truncated: false });
+  });
+
   test("corrupted PDF returns null without throwing", async () => {
     const result = await extractText(Buffer.from("not a real pdf"), "application/pdf");
     expect(result).toBeNull();

--- a/test/unit/files/mime.test.ts
+++ b/test/unit/files/mime.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from "bun:test";
+import { isTextMime, resolveMimeType } from "../../../src/files/mime.ts";
+import { isExtractable } from "../../../src/files/ingest.ts";
+
+describe("resolveMimeType", () => {
+  test("recovers text/plain for a .typ upload with no Content-Type", () => {
+    // The browser leaves Content-Type empty for extensions it doesn't know
+    // (Typst), which is the original bug: stored as opaque binary, unreadable.
+    expect(resolveMimeType("engagement-plan.typ", "")).toBe("text/plain");
+    expect(resolveMimeType("engagement-plan.typ", undefined)).toBe("text/plain");
+  });
+
+  test("recovers text/plain when the type is the generic octet-stream", () => {
+    expect(resolveMimeType("plan.typ", "application/octet-stream")).toBe("text/plain");
+    // Case/charset variants of the generic type still trigger recovery.
+    expect(resolveMimeType("plan.typ", "APPLICATION/OCTET-STREAM")).toBe("text/plain");
+    expect(resolveMimeType("plan.typ", "application/octet-stream; charset=binary")).toBe(
+      "text/plain",
+    );
+  });
+
+  test("maps structured formats to their registered text types", () => {
+    expect(resolveMimeType("a.md", "")).toBe("text/markdown");
+    expect(resolveMimeType("a.json", "application/octet-stream")).toBe("application/json");
+    expect(resolveMimeType("a.yaml", "")).toBe("application/yaml");
+    expect(resolveMimeType("a.csv", "")).toBe("text/csv");
+    expect(resolveMimeType("a.html", "")).toBe("text/html");
+  });
+
+  test("every mapped type passes both read gates (no store-then-fail-to-read)", () => {
+    // INVARIANT guard: anything the map produces must be readable everywhere.
+    for (const ext of ["typ", "md", "json", "yaml", "xml", "html", "csv", "py", "toml", "ts"]) {
+      const resolved = resolveMimeType(`file.${ext}`, "");
+      expect(isTextMime(resolved)).toBe(true);
+      expect(isExtractable(resolved)).toBe(true);
+    }
+  });
+
+  test("trusts a specific client-supplied type as-is", () => {
+    expect(resolveMimeType("photo.png", "image/png")).toBe("image/png");
+    // A specific type wins even when the extension is in the map.
+    expect(resolveMimeType("data.json", "text/markdown")).toBe("text/markdown");
+    // Parameters are preserved (only surrounding whitespace trimmed).
+    expect(resolveMimeType("a.md", "  text/markdown; charset=utf-8  ")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+  });
+
+  test("keeps octet-stream for unknown or extension-less files", () => {
+    // Real binary with an unmapped extension stays binary — not mislabeled.
+    expect(resolveMimeType("archive.bin", "")).toBe("application/octet-stream");
+    expect(resolveMimeType("photo.png", "application/octet-stream")).toBe(
+      "application/octet-stream",
+    );
+    expect(resolveMimeType("README", "")).toBe("application/octet-stream");
+    expect(resolveMimeType(undefined, "")).toBe("application/octet-stream");
+  });
+
+  test("extension match is case-insensitive", () => {
+    expect(resolveMimeType("PLAN.TYP", "")).toBe("text/plain");
+  });
+});
+
+describe("isExtractable text/* consistency", () => {
+  test("admits any text/* subtype, matching isTextMime", () => {
+    // The read gate must accept everything extractText can UTF-8 decode.
+    expect(isExtractable("text/x-typst")).toBe(true);
+    expect(isExtractable("text/plain")).toBe(true);
+    expect(isExtractable("text/markdown; charset=utf-8")).toBe(true);
+  });
+
+  test("still rejects real binary types", () => {
+    expect(isExtractable("application/octet-stream")).toBe(false);
+    expect(isExtractable("image/png")).toBe(false);
+  });
+});

--- a/test/unit/files/mime.test.ts
+++ b/test/unit/files/mime.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { isTextMime, resolveMimeType } from "../../../src/files/mime.ts";
+import { EXTENSION_MIME, isTextMime, resolveMimeType } from "../../../src/files/mime.ts";
 import { isExtractable } from "../../../src/files/ingest.ts";
 
 describe("resolveMimeType", () => {
@@ -28,9 +28,11 @@ describe("resolveMimeType", () => {
   });
 
   test("every mapped type passes both read gates (no store-then-fail-to-read)", () => {
-    // INVARIANT guard: anything the map produces must be readable everywhere.
-    for (const ext of ["typ", "md", "json", "yaml", "xml", "html", "csv", "py", "toml", "ts"]) {
+    // INVARIANT guard: iterate the actual map, not a sample — a new entry
+    // whose value isn't readable everywhere fails here automatically.
+    for (const [ext, expected] of Object.entries(EXTENSION_MIME)) {
       const resolved = resolveMimeType(`file.${ext}`, "");
+      expect(resolved).toBe(expected);
       expect(isTextMime(resolved)).toBe(true);
       expect(isExtractable(resolved)).toBe(true);
     }


### PR DESCRIPTION
## Problem

In production, a user uploaded `engagement-plan.typ` (Typst — plain text) and the agent could not read it: the file store registered it as `application/octet-stream`, so `files__read` refused to extract its contents.

**Root cause:** MIME type was derived solely from the browser-provided per-part `Content-Type`, coerced to `application/octet-stream` when empty. Browsers leave `Content-Type` empty for extensions they don't recognize — `.typ` and most source/config formats. Every text path keys off MIME (`isTextMime`, `isExtractable`, `extractText`, the MCP `resources/read` resolver), so the file was stored as opaque binary and became unreadable everywhere. There was no server-side extension-based detection.

## Fix (right-layer, applied at every mint site)

- **`src/files/mime.ts`** — new `resolveMimeType(filename, providedType)`. A specific client type is trusted as-is; an empty or generic `application/octet-stream` type is re-derived from the filename extension via a text/source extension map. Unknown extensions stay `application/octet-stream`, so real binary is never mislabeled.
- **`src/api/handlers.ts`** — wire `resolveMimeType` into both upload paths: chat multipart (`parseMultipartChatBody`) and `POST /v1/resources` (`handleResourceUpload`).
- **`src/tools/platform/files.ts`** — wire it into `files__create` too, so an agent-written `.typ` is recovered the same way as an uploaded one (the third, previously-uncovered, mint path).
- **`src/files/ingest.ts`** — `isExtractable` now honors the `text/*` prefix, matching `isTextMime`. `extractText` UTF-8-decodes any `text/*`, so the `files__read` gate must admit the same set; previously a `text/x-*` file passed `isTextMime` inside `extractText` but was gated out before reaching it.

### Map invariant
Every value in the extension map is `text/*` or one of `{application/json, application/xml, application/yaml}` — the only types both read gates accept. Source/config formats map to `text/plain`; structured formats to their registered type. A test asserts every mapped value passes both `isTextMime` and `isExtractable`, so a file can never be stored as text then fail to read back. Binary-capable extensions are deliberately kept out of the map.

## Why not the alternatives
- **Allowlist `octet-stream` as text** — would decode real binaries (images, fonts, zips, all `octet-stream`) as UTF-8 garbage, and wouldn't fix the stored type for the resource/download/`resources-read` paths.
- **Content sniffing (`file-type`)** — new dependency + async buffering; `file-type` deliberately doesn't detect plain-text/source formats, so an extension map would still be required.

## Tests
- New `test/unit/files/mime.test.ts` — `resolveMimeType` (recovery, trust, octet-stream retention, case-insensitivity, the map invariant) and the `isExtractable` `text/*` consistency fix. The map-invariant test iterates `Object.entries(EXTENSION_MIME)` (now exported), so a future entry whose value isn't readable by both gates fails automatically rather than slipping past a hand-picked sample.
- `test/unit/files/extract.test.ts` — `text/x-*` end-to-end UTF-8 decode.

## Verification (local)
- `bunx tsc --noEmit` (src) and `check:web` (web): clean.
- `format:check`, `lint`, `check:code-style`, `check:codegen`: clean.
- `test/unit/files/`: pass / 0 fail.
- Full `test:unit`: 3230 pass / 1 fail. The single failure is `Cannot find package 'dompurify'` from `src/bundles/automations/ui/src/markdown.ts` — a missing sub-package dependency in a fresh worktree, in a tree this diff does not touch (the change is confined to `src/files/*`, `src/api/handlers.ts`, `src/tools/platform/files.ts`). Environmental, unrelated to this change.


