### PR TITLE
fix(automations): schedule picker reflects external value changes

### DIFF
--- a/src/bundles/automations/ui/src/components/SchedulePicker.tsx
+++ b/src/bundles/automations/ui/src/components/SchedulePicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export interface ScheduleSpec {
   type: "cron" | "interval";
@@ -68,18 +68,29 @@ export function SchedulePicker({
   // The state atoms above are seeded once at mount; without this, an external
   // `value` change would leave the radio/fields showing stale state while the
   // parent submits the new value — the picker would show "Every 30 minutes"
-  // but save the template's "Daily at 8". `emit` records the spec it emits into
-  // `syncedValue`, so the picker's OWN onChange echoes don't re-derive here
-  // (which would clobber cross-mode field memory mid-edit); only a value the
-  // picker did not emit — i.e. an external change — re-seeds the display.
-  const [syncedValue, setSyncedValue] = useState<ScheduleSpec | null>(value);
-  if (value !== syncedValue) {
-    setSyncedValue(value);
-    setMode(detectMode(value));
-    if (value?.type === "interval" && value.intervalMs) setMinutes(value.intervalMs / 60_000);
-    setTime(parseTime(value));
-    setDow(parseDow(value));
-    setCronExpr(value?.expression ?? "");
+  // but save the template's "Daily at 8".
+  //
+  // We must NOT re-derive on the picker's own edits, or switching modes would
+  // clobber cross-mode field memory (e.g. a typed-but-unsubmitted weekly time).
+  // The discriminator is provenance, not value identity: `emit` sets
+  // `justEmitted` so the parent's echo of our own change is skipped, while any
+  // value the picker did not emit — an external change — re-seeds the display.
+  // Using a provenance flag (rather than comparing `value` to the spec we
+  // emitted) means this holds even for a caller that clones/normalizes in
+  // `onChange` instead of echoing our object by reference.
+  const [prevValue, setPrevValue] = useState<ScheduleSpec | null>(value);
+  const justEmitted = useRef(false);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    if (justEmitted.current) {
+      justEmitted.current = false;
+    } else {
+      setMode(detectMode(value));
+      if (value?.type === "interval" && value.intervalMs) setMinutes(value.intervalMs / 60_000);
+      setTime(parseTime(value));
+      setDow(parseDow(value));
+      setCronExpr(value?.expression ?? "");
+    }
   }
 
   function emit(m: ScheduleMode, mins: number, t: string, d: string, cron: string) {
@@ -95,10 +106,9 @@ export function SchedulePicker({
     } else {
       spec = { type: "cron", expression: cron, timezone };
     }
-    // Mark this spec as ours so the reconcile above treats the parent's echo of
-    // it as internal (no re-derive). The parent stores the same reference back
-    // into `value`, so `value === syncedValue` on the next render.
-    setSyncedValue(spec);
+    // Mark this change as ours so the reconcile above skips re-deriving when the
+    // resulting `value` update flows back in.
+    justEmitted.current = true;
     onChange(spec);
   }
 

--- a/src/bundles/automations/ui/src/components/SchedulePicker.tsx
+++ b/src/bundles/automations/ui/src/components/SchedulePicker.tsx
@@ -6,6 +6,9 @@ export interface ScheduleSpec {
   timezone?: string;
   intervalMs?: number;
 }
+// NOTE: if you add a field here, add it to `specEqual` below — the reconcile
+// relies on a structural compare, and an unaccounted field silently reintroduces
+// the display-desync bug this component was fixed for.
 
 export type ScheduleMode = "interval" | "daily" | "weekly" | "cron";
 

--- a/src/bundles/automations/ui/src/components/SchedulePicker.tsx
+++ b/src/bundles/automations/ui/src/components/SchedulePicker.tsx
@@ -63,18 +63,43 @@ export function SchedulePicker({
   const [dow, setDow] = useState(() => parseDow(value));
   const [cronExpr, setCronExpr] = useState(() => value?.expression ?? "");
 
+  // Reconcile display state to externally-driven `value` changes (e.g. choosing
+  // a template pre-fills the parent's schedule after this picker has mounted).
+  // The state atoms above are seeded once at mount; without this, an external
+  // `value` change would leave the radio/fields showing stale state while the
+  // parent submits the new value — the picker would show "Every 30 minutes"
+  // but save the template's "Daily at 8". `emit` records the spec it emits into
+  // `syncedValue`, so the picker's OWN onChange echoes don't re-derive here
+  // (which would clobber cross-mode field memory mid-edit); only a value the
+  // picker did not emit — i.e. an external change — re-seeds the display.
+  const [syncedValue, setSyncedValue] = useState<ScheduleSpec | null>(value);
+  if (value !== syncedValue) {
+    setSyncedValue(value);
+    setMode(detectMode(value));
+    if (value?.type === "interval" && value.intervalMs) setMinutes(value.intervalMs / 60_000);
+    setTime(parseTime(value));
+    setDow(parseDow(value));
+    setCronExpr(value?.expression ?? "");
+  }
+
   function emit(m: ScheduleMode, mins: number, t: string, d: string, cron: string) {
+    let spec: ScheduleSpec;
     if (m === "interval") {
-      onChange({ type: "interval", intervalMs: Math.max(1, mins) * 60_000 });
+      spec = { type: "interval", intervalMs: Math.max(1, mins) * 60_000 };
     } else if (m === "daily") {
       const [h, min] = t.split(":").map(Number);
-      onChange({ type: "cron", expression: `${min} ${h} * * *`, timezone });
+      spec = { type: "cron", expression: `${min} ${h} * * *`, timezone };
     } else if (m === "weekly") {
       const [h, min] = t.split(":").map(Number);
-      onChange({ type: "cron", expression: `${min} ${h} * * ${d}`, timezone });
+      spec = { type: "cron", expression: `${min} ${h} * * ${d}`, timezone };
     } else {
-      onChange({ type: "cron", expression: cron, timezone });
+      spec = { type: "cron", expression: cron, timezone };
     }
+    // Mark this spec as ours so the reconcile above treats the parent's echo of
+    // it as internal (no re-derive). The parent stores the same reference back
+    // into `value`, so `value === syncedValue` on the next render.
+    setSyncedValue(spec);
+    onChange(spec);
   }
 
   function handleMode(m: ScheduleMode) {

--- a/src/bundles/automations/ui/src/components/SchedulePicker.tsx
+++ b/src/bundles/automations/ui/src/components/SchedulePicker.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 export interface ScheduleSpec {
   type: "cron" | "interval";
@@ -46,6 +46,17 @@ export function parseDow(spec: ScheduleSpec | null): string {
   return parts.length >= 5 && parts[4] !== "*" ? parts[4]! : "1";
 }
 
+export function specEqual(a: ScheduleSpec | null, b: ScheduleSpec | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.type === b.type &&
+    a.expression === b.expression &&
+    a.timezone === b.timezone &&
+    a.intervalMs === b.intervalMs
+  );
+}
+
 export function SchedulePicker({
   value,
   onChange,
@@ -72,25 +83,21 @@ export function SchedulePicker({
   //
   // We must NOT re-derive on the picker's own edits, or switching modes would
   // clobber cross-mode field memory (e.g. a typed-but-unsubmitted weekly time).
-  // The discriminator is provenance, not value identity: `emit` sets
-  // `justEmitted` so the parent's echo of our own change is skipped, while any
-  // value the picker did not emit — an external change — re-seeds the display.
-  // Using a provenance flag (rather than comparing `value` to the spec we
-  // emitted) means this holds even for a caller that clones/normalizes in
-  // `onChange` instead of echoing our object by reference.
-  const [prevValue, setPrevValue] = useState<ScheduleSpec | null>(value);
-  const justEmitted = useRef(false);
-  if (value !== prevValue) {
-    setPrevValue(value);
-    if (justEmitted.current) {
-      justEmitted.current = false;
-    } else {
-      setMode(detectMode(value));
-      if (value?.type === "interval" && value.intervalMs) setMinutes(value.intervalMs / 60_000);
-      setTime(parseTime(value));
-      setDow(parseDow(value));
-      setCronExpr(value?.expression ?? "");
-    }
+  // The discriminator is provenance-by-value: we track the last spec the picker
+  // emitted in state and re-derive only when the incoming `value` doesn't match
+  // it — i.e. an external change. A structural compare (not reference identity)
+  // means this holds even for a caller that clones/normalizes in `onChange`,
+  // and keeping it in state (not a ref) keeps this render pure / StrictMode-safe
+  // — `setState` during render is replayed idempotently; a render-phase ref
+  // write would not be.
+  const [lastSpec, setLastSpec] = useState<ScheduleSpec | null>(value);
+  if (!specEqual(value, lastSpec)) {
+    setLastSpec(value);
+    setMode(detectMode(value));
+    if (value?.type === "interval" && value.intervalMs) setMinutes(value.intervalMs / 60_000);
+    setTime(parseTime(value));
+    setDow(parseDow(value));
+    setCronExpr(value?.expression ?? "");
   }
 
   function emit(m: ScheduleMode, mins: number, t: string, d: string, cron: string) {
@@ -106,9 +113,9 @@ export function SchedulePicker({
     } else {
       spec = { type: "cron", expression: cron, timezone };
     }
-    // Mark this change as ours so the reconcile above skips re-deriving when the
-    // resulting `value` update flows back in.
-    justEmitted.current = true;
+    // Record what we emitted so the reconcile above recognizes the parent's
+    // resulting `value` update as ours (structurally equal) and skips re-derive.
+    setLastSpec(spec);
     onChange(spec);
   }
 


### PR DESCRIPTION
## Symptom

Creating an automation from a template (e.g. **Daily Briefing**): the schedule picker visually shows **Every 30 minutes** selected, but the created automation saves **Daily at 8:00 AM HST**.

## Root cause

`SchedulePicker` is a hybrid controlled/uncontrolled component. It seeds its display state (`mode`, `minutes`, `time`, `dow`, `cronExpr`) **once at mount** via lazy `useState` initializers derived from the `value` prop, and never reconciles when `value` changes afterward.

Sequence:
1. `CreateAutomationForm` mounts with `schedule = null`; the picker mounts with `value = null` → `mode = "interval"`, `minutes = 30` (the screenshot).
2. The user picks the **Daily Briefing** template, which sets the parent's `schedule` to `{ type: "cron", expression: "0 8 * * *" }` **after** the picker mounted (via the in-form card `onClick` or the `initialTemplate` effect).
3. The picker ignores the prop change — radio stays on "Every 30 minutes" — and since the user never clicks inside the picker, `emit` never fires. Create submits the stale template cron → "Daily at 8:00 AM HST".

It's a display-lags-committed desync, not a cron-building bug (`emit` and the server-side human formatter are both correct).

## Fix

Reconcile display state to external `value` changes during render via a prev-value sentinel. `emit` records the spec it emits into `syncedValue`, so the picker's **own** `onChange` echoes don't re-derive (which would clobber cross-mode field memory mid-edit, e.g. a typed-but-unsubmitted minutes value). Only a value the picker did **not** emit — an external template selection — re-seeds the display. This fixes all entry paths (in-form card, landing-page `initialTemplate`) in one place, at the component layer, so the controlled contract holds for any future caller.

## Verification

- `vite build` (the bundle's real gate) passes; `tsc` clean for the changed file; Biome clean.
- No React component-test infra exists in the bundle UIs, so no automated regression test was added — see follow-ups.

## Follow-ups (not in this PR)

- **Create stays disabled when starting from scratch.** The picker shows "Every 30 minutes" at mount but never emits it, so the **Custom** template (or a from-scratch form) leaves `schedule = null` and the Create button stays disabled with no explanation. Separate root cause (committed-lags-display); candidate fix is emit-on-mount, which carries its own UX question (should "start from scratch" force an explicit schedule choice?).
- `ScheduleEditor` (the detail-view edit flow, a separate component) has the same seed-once-no-reconcile smell but isn't triggered in practice because it mounts fresh per edit-activation.
- No component-test harness for `src/bundles/*/ui`.

---

### Update (QA follow-up)

QA flagged that the reconcile originally used reference-equality to detect the picker's own `onChange` echo, which assumed the parent echoes back the exact object reference. A caller that clones/normalizes in `onChange` would have re-derived on every internal edit and clobbered cross-mode field memory. Switched to a provenance flag (`justEmitted`) so the discriminator is "did the picker emit this?" rather than "is this the same object?" — identical behaviour for the current caller, no echo-by-reference coupling.


### Update 2 (QA re-review follow-up)

QA flagged that the `justEmitted` ref was mutated during render — a render-phase impurity that breaks under `React.StrictMode` (double-invoked render consumes the flag on pass 1, then re-derives on pass 2, clobbering field memory). Dormant today since bundle UIs mount without StrictMode, but a real anti-pattern. Replaced with **provenance-by-value**: the last-emitted spec is tracked in state and the reconcile re-derives only when the incoming `value` doesn't structurally match it (`specEqual`). This is pure (StrictMode-safe — `setState` during render replays idempotently), still clone-robust (structural compare, not reference identity), and self-correcting (no flag to linger if a parent ignores `onChange`).
