### PR TITLE
Docker image diet + auto-build images on merge to main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@
 .env*
 .nimblebrain
 .DS_Store
-node_modules
+**/node_modules
 web/
 test/
 docs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,51 @@ jobs:
         run: npm install -g @nimblebrain/mpak@latest
       - name: Smoke tests
         run: bun run smoke
+
+  # Build + push a SHA-tagged image for every commit that lands on main, so
+  # `make deploy` can roll out any main commit without a manual local push.
+  # This is the everyday counterpart to release.yml (which builds on `v*`
+  # tags): same ECR repos, same `:<short-sha>` tag — a `v*` release just adds
+  # the version tag and GHCR/`:latest` on top. Gating on every check above
+  # means an image only exists in ECR if it built green, which closes the
+  # "deployed a tag that was never pushed" hole.
+  #
+  # `if` restricts this to direct pushes to main (post-merge), never PRs — so
+  # the OIDC/ECR credentials are never exposed to fork PRs, and only verified
+  # main commits get published.
+  build-and-push:
+    name: Build & Push Images
+    needs: [lint-and-check, test-unit, test-integration, smoke]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: ecr
+      - name: Set image tag
+        id: tag
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Build and push platform image
+        run: |
+          docker build --platform linux/amd64 \
+            --build-arg BUILD_SHA=${{ steps.tag.outputs.sha }} \
+            -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tag.outputs.sha }} \
+            -f Dockerfile .
+          docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tag.outputs.sha }}
+      # NOTE: web is built without VITE_TURNSTILE_SITE_KEY (a build-time Vite
+      # var), matching release.yml. The Makefile `push` target injects a
+      # per-env key from 1Password; if a build-time Turnstile key is required
+      # in prod, this image won't carry it. See the deployments Makefile.
+      - name: Build and push web image
+        run: |
+          docker build --platform linux/amd64 \
+            -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tag.outputs.sha }} \
+            -f web/Dockerfile web/
+          docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tag.outputs.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,15 +33,16 @@ WORKDIR /app
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production --ignore-scripts
 
-COPY src/ src/
-COPY scripts/ scripts/
+COPY --chown=1000:1000 src/ src/
+COPY --chown=1000:1000 scripts/ scripts/
 
-# Build bundle UIs (dist/ is gitignored, must build in container)
+# Build bundle UIs (dist/ is gitignored, must build in container).
+# UI deps are installed fresh here and removed after build — the source tree's
+# nested node_modules are excluded by .dockerignore (**/node_modules) so they
+# never enter the build context or bloat the COPY layer.
 RUN for ui in src/bundles/*/ui; do \
       [ -f "$ui/package.json" ] && (cd "$ui" && bun install && bun run build && rm -rf node_modules); \
     done
-
-RUN chown -R nimblebrain:nimblebrain /app
 
 USER 1000
 


### PR DESCRIPTION
## Why

An hq production deploy pointed at an image tag that was never pushed to ECR. The platform pod rolled, couldn't pull, and hq sat in `ImagePullBackOff` for ~24h with no running replica. Two root causes: image build/push was a manual laptop step (slow, easy to skip), and nothing guaranteed an image existed for a given commit.

This PR removes the manual step and shrinks the image. A companion PR in the deployments repo adds a deploy-time guard that refuses tags missing from ECR.

## Changes

**1. Image diet (1.33 GB → 858 MB)**
- `.dockerignore`: `node_modules` → `**/node_modules`. The bare pattern only matches the context root in Docker, so ~488 MB of `src/bundles/*/[ui/]node_modules` was leaking into the `COPY src/` layer (427 MB). Those UI deps are rebuilt in-container and removed, so they were pure dead weight re-uploaded on every push.
- Dropped `RUN chown -R nimblebrain:nimblebrain /app` (a duplicated ~149 MB layer) in favor of `COPY --chown=1000:1000`. The app reads `/app` and writes to `/data` (`VOLUME /data`), so it doesn't need to own `/app`.
- Verified with a local `linux/amd64` build: `COPY src/` 427 MB → 4.9 MB, chown layer gone, bundle UIs still build and render.

**2. Auto-build on merge (`ci.yml`)**
- New `build-and-push` job builds both images for `linux/amd64` and pushes a `:<short-sha>` tag to ECR on every push to `main`, gated on lint + unit + integration + smoke passing. An image exists in ECR iff the commit built green.
- Restricted to `push` on `main` (not PRs) so OIDC/ECR credentials are never exposed to fork PRs.
- Reuses the existing `vars.AWS_ROLE_ARN` OIDC role (same one `release.yml` uses) — no new AWS setup.
- This is the everyday counterpart to `release.yml`'s `v*` builds; same ECR repos and `:<short-sha>` tag, so `make deploy` works against either.

## ⚠️ Reviewer input needed: web Turnstile

The CI web build omits `VITE_TURNSTILE_SITE_KEY`, matching `release.yml`. But the deployments Makefile injects a **per-env** key from 1Password at build time, and it's a build-time Vite var baked into the static bundle — so a CI-built web image won't carry it, and staging/prod keys differ anyway. **Before relying on CI-built _web_ images in prod, confirm whether login's Turnstile needs that key.** Options: keep building web via `make push`, move Turnstile to runtime config, or accept it if it isn't load-bearing. The platform image has no such concern (only takes `BUILD_SHA`).