### PR TITLE
fix(prompt): files/conversations are identity-owned, not workspace-scoped

### DIFF
--- a/src/prompt/compose.ts
+++ b/src/prompt/compose.ts
@@ -671,6 +671,19 @@ function formatLayer3SkillsSection(entries: Layer3SkillEntry[]): string | null {
   return `## Skills\n\n${blocks.join("\n\n")}`;
 }
 
+/**
+ * Workspace-scoping applies to TOOLS, not to files or conversations. Both
+ * workspace blocks narrate that tools are workspace-scoped (find others with
+ * `nb__search`); without an explicit counter-statement an agent overgeneralises
+ * that model onto files and asks the user "which workspace does this file live
+ * in?" — a real failure observed in production. Files and conversations are
+ * identity-owned (one store at `users/{userId}/files/`, regardless of
+ * workspace), so the always-loaded `files__*`/`conversations__*` tools already
+ * see all of them. State that plainly in both blocks.
+ */
+const IDENTITY_SCOPE_NOTE =
+  "Files and conversations are NOT workspace-scoped — they're identity-owned and the same in every workspace. The `files__*` and `conversations__*` tools are always loaded and search across all of your files/conversations at once. Never ask the user which workspace a file lives in, and don't use `nb__search` to find files — just call `files__search`/`files__list`.";
+
 function formatWorkspaceContext(ws: WorkspaceContext): string {
   const lines = ["## Workspace", ""];
   lines.push(`- ID: ${sanitizeLineField(ws.id)}`);
@@ -679,6 +692,8 @@ function formatWorkspaceContext(ws: WorkspaceContext): string {
   lines.push(
     "Your active tools are this workspace's — its apps plus the platform tools. Tools in the user's OTHER workspaces, and their personal tools (e.g. email), are NOT loaded right now. Find any tool across all of the user's workspaces with `nb__search`; matches are added to your tools on demand. Don't assume a tool is missing — search first.",
   );
+  lines.push("");
+  lines.push(IDENTITY_SCOPE_NOTE);
   return lines.join("\n");
 }
 
@@ -696,6 +711,8 @@ function formatNoWorkspaceContext(): string {
     "The user is at their identity-level home — **not in any single workspace**. There is no current workspace. If the user asks which workspace they're in, tell them they're at their home view, not a specific one.",
     "",
     "Your active tools are the platform tools and the user's own (conversations, personal). Tools that belong to a specific workspace are NOT loaded here. Find any tool across all of the user's workspaces with `nb__search`; matches are added to your tools on demand. Don't assume a tool is missing — search first.",
+    "",
+    IDENTITY_SCOPE_NOTE,
   ].join("\n");
 }
 

--- a/test/unit/prompt.test.ts
+++ b/test/unit/prompt.test.ts
@@ -1087,6 +1087,35 @@ describe("composeSystemPromptTraced", () => {
   });
 });
 
+describe("composeSystemPrompt — files are identity-scoped, not workspace-scoped", () => {
+  // Regression: an agent told a user "which workspace does <file> live in? I
+  // can check all three." Files are identity-owned; the workspace blocks must
+  // say so explicitly so the workspace TOOL-scoping model isn't generalised
+  // onto files.
+  const wsCtx: WorkspaceContext = { id: "ws_test", name: "Test" };
+
+  it("focused-workspace block states files/conversations are not workspace-scoped", () => {
+    const result = composeSystemPrompt(
+      [],
+      null,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      wsCtx,
+    );
+    expect(result).toContain("Files and conversations are NOT workspace-scoped");
+    expect(result).toContain("Never ask the user which workspace a file lives in");
+  });
+
+  it("identity-home block (no focused workspace) states the same", () => {
+    const result = composeSystemPrompt([]);
+    expect(result).toContain("Files and conversations are NOT workspace-scoped");
+    expect(result).toContain("Never ask the user which workspace a file lives in");
+  });
+});
+
 describe("composeSystemPrompt — task mode", () => {
   it("prepends TASK_IDENTITY when mode is 'task'", () => {
     const result = composeSystemPrompt(


### PR DESCRIPTION
## Problem

A multi-workspace agent told a user, verbatim:

> Also, do you know which workspace \`ipsdi-engagement-plan.typ\` lives in? I can search for it once you confirm a workspace, or I can check all three.

Files are **identity-owned** — one store at \`users/{userId}/files/\`, identical in every workspace (\`src/files/store.ts:59-64\`, \`AGENTS.md:145\`). The \`files__*\` tools are always-loaded platform tools that search the whole store with **no workspace parameter** (\`src/tools/platform/files.ts:74-115\`). There is no workspace to "confirm" and nothing to "check three times."

## Root cause

Both workspace-context blocks teach the agent that **tools** are workspace-scoped ("Tools in the user's OTHER workspaces … are NOT loaded right now. Find any tool … with \`nb__search\`") but say nothing about files or conversations. The agent generalised the tool-scoping model onto files.

## Fix

Add one explicit counter-statement (\`IDENTITY_SCOPE_NOTE\`) to **both** \`formatWorkspaceContext\` and \`formatNoWorkspaceContext\`, stating files/conversations are identity-owned, the \`files__*\`/\`conversations__*\` tools are always loaded and span all of them, and the agent should never ask which workspace a file is in (nor route file lookups through \`nb__search\`).

The correction lives in the prompt block — the same place that creates the wrong model — not in tool descriptions, which the agent only reads *after* it has already formed the belief.

## Test

`composeSystemPrompt — files are identity-scoped` asserts the note appears in both the focused-workspace and identity-home prompts.

Companion PR fixes the second bug from the same conversation (the \`.typ\` stored as \`application/octet-stream\` and never re-typed).