### PR TITLE
fix(api): resolve cross-workspace resource reads + tool calls by qualified name

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -22,6 +22,7 @@ import type { Runtime } from "../runtime/runtime.ts";
 import type { ChatRequest } from "../runtime/types.ts";
 import { coerceInputForSchema } from "../tools/coerce-input.ts";
 import type { HealthMonitor } from "../tools/health-monitor.ts";
+import { parseNamespacedSourceName } from "../tools/namespace.ts";
 import type { ToolRegistry } from "../tools/registry.ts";
 import type { ResourceData, ToolSource } from "../tools/types.ts";
 import { validateToolInput } from "../tools/validate-input.ts";
@@ -513,6 +514,7 @@ export async function handleResourceProxy(
   resourcePath: string,
   runtime: Runtime,
   workspaceId?: string,
+  identity?: UserIdentity,
 ): Promise<Response> {
   // Dev mode: redirect to local Vite dev server when --app flag is active.
   // Applies to both identity and workspace apps, so it runs first.
@@ -545,17 +547,18 @@ export async function handleResourceProxy(
     return json({ contents: [buildResourceEnvelopeEntry(`ui://${resolvedPath}`, resource)] });
   }
 
-  // Workspace apps — require a workspace and authorize membership. Both
+  // Workspace apps — resolve the workspace and authorize membership. Both
   // platform built-ins and user-installed bundles are MCP servers reachable
   // through the workspace registry; registry membership is the authoritative
-  // "is this app available to this workspace?" check.
-  if (!workspaceId) {
-    return apiError(400, "workspace_required", `App "${appName}" requires a workspace`, {
-      app: appName,
-    });
-  }
-  const wsRegistry = await runtime.ensureWorkspaceRegistry(workspaceId);
-  if (!wsRegistry.hasSource(appName)) {
+  // "is this app available to this workspace?" check. A qualified
+  // `ws_<id>-<app>` (a cross-workspace app icon / primary preview surfaced
+  // from another workspace) resolves to its own workspace by name + member-
+  // ship; a bare app name uses the ambient X-Workspace-Id.
+  const resolved = await resolveRestSourceWorkspace(runtime, appName, identity, workspaceId);
+  if (!resolved.ok) return resolved.response;
+  const { workspaceId: wsId, sourceName } = resolved;
+  const wsRegistry = await runtime.ensureWorkspaceRegistry(wsId);
+  if (!wsRegistry.hasSource(sourceName)) {
     return apiError(
       403,
       "workspace_access_denied",
@@ -566,13 +569,13 @@ export async function handleResourceProxy(
 
   let resolvedPath = resourcePath;
   if (resourcePath === "primary") {
-    const primaryUri = await resolvePrimaryResourceUri(runtime, appName, workspaceId);
+    const primaryUri = await resolvePrimaryResourceUri(runtime, sourceName, wsId);
     if (primaryUri) {
       resolvedPath = primaryUri.replace(/^ui:\/\//, "");
     }
   }
 
-  const resource = await runtime.readAppResource(appName, resolvedPath, workspaceId);
+  const resource = await runtime.readAppResource(sourceName, resolvedPath, wsId);
   if (resource === null) {
     return apiError(404, "resource_not_found", `Resource "ui://${resourcePath}" not found`, {
       resource: `ui://${resourcePath}`,
@@ -667,6 +670,80 @@ export function buildResourceEnvelopeEntry(
 }
 
 /**
+ * Resolve which workspace + bare source a REST resource/tool request targets.
+ *
+ * The first-party web shell speaks stateless REST and names a source one of
+ * two ways:
+ *
+ *   - **Qualified** `ws_<id>-<source>` — a cross-workspace tool surfaced by
+ *     `nb__search` (the aggregator namespaces tool names; the surfaced
+ *     `appName`/`server` carries the workspace). The NAME is authoritative:
+ *     resolve the owning workspace from it and authorize by MEMBERSHIP —
+ *     exactly as the engine's `routeToolCall` does ("derived ONLY from the
+ *     parsed wsId; we never reach for any ambient current-workspace
+ *     pointer"). The ambient `X-Workspace-Id` is irrelevant here — a preview
+ *     link minted in one workspace must read back from a conversation focused
+ *     on another. This is the same principle that already lets identity
+ *     sources (`files`, `conversations`) ignore the header.
+ *
+ *   - **Bare** `<source>` — a focused-workspace tool; its workspace is the
+ *     ambient `X-Workspace-Id` (unchanged legacy behavior).
+ *
+ * Returns the bare source name the workspace registry is keyed on (registry
+ * sources keep their bare name; only tool names get the `ws_<id>-` prefix), so
+ * callers must use `sourceName` — never the raw qualified `server` — for
+ * `hasSource` / `getSources` / `readAppResource`.
+ *
+ * Identity sources are handled by the caller BEFORE this and never reach here.
+ */
+async function resolveRestSourceWorkspace(
+  runtime: Runtime,
+  server: string,
+  identity: UserIdentity | null | undefined,
+  ambientWorkspaceId: string | undefined,
+): Promise<
+  { ok: true; workspaceId: string; sourceName: string } | { ok: false; response: Response }
+> {
+  let qualified: { wsId: string; sourceName: string } | null;
+  try {
+    qualified = parseNamespacedSourceName(server);
+  } catch {
+    // A `ws_`-prefixed but malformed id is a probe/typo, not a bare name.
+    return {
+      ok: false,
+      response: apiError(400, "bad_request", `Invalid server "${server}"`, { server }),
+    };
+  }
+
+  if (!qualified) {
+    // Bare source — ambient-workspace behavior.
+    if (!ambientWorkspaceId) {
+      return { ok: false, response: apiError(400, "bad_request", "Workspace ID required") };
+    }
+    return { ok: true, workspaceId: ambientWorkspaceId, sourceName: server };
+  }
+
+  // Qualified — the name names its workspace; authorize by membership and
+  // ignore the ambient X-Workspace-Id.
+  if (!identity) {
+    return { ok: false, response: apiError(401, "unauthorized", "Authentication required") };
+  }
+  const accessible = await runtime.getWorkspaceStore().getWorkspacesForUser(identity.id);
+  if (!accessible.some((w) => w.id === qualified.wsId)) {
+    return {
+      ok: false,
+      response: apiError(
+        403,
+        "workspace_access_denied",
+        `Server "${server}" is not available in this workspace`,
+        { server },
+      ),
+    };
+  }
+  return { ok: true, workspaceId: qualified.wsId, sourceName: qualified.sourceName };
+}
+
+/**
  * Handle POST /v1/resources/read — MCP resources/read proxy.
  *
  * Body: { server, uri }
@@ -708,14 +785,21 @@ export async function handleReadResource(
     return json({ contents: [buildResourceEnvelopeEntry(uri, resource)] });
   }
 
-  const workspaceId = options?.workspaceId;
-  if (!workspaceId) {
-    return apiError(400, "bad_request", "Workspace ID required");
-  }
+  // Workspace scoping. A qualified `ws_<id>-<source>` server resolves to its
+  // OWN workspace by name + membership (cross-workspace preview links); a bare
+  // source uses the ambient X-Workspace-Id. `sourceName` is the bare name the
+  // registry is keyed on.
+  const resolved = await resolveRestSourceWorkspace(
+    runtime,
+    server,
+    identity,
+    options?.workspaceId,
+  );
+  if (!resolved.ok) return resolved.response;
+  const { workspaceId, sourceName } = resolved;
 
-  // Workspace scoping — reject servers not in the active workspace.
   const wsRegistry = await runtime.ensureWorkspaceRegistry(workspaceId);
-  if (!wsRegistry.hasSource(server)) {
+  if (!wsRegistry.hasSource(sourceName)) {
     return apiError(
       403,
       "workspace_access_denied",
@@ -735,7 +819,7 @@ export async function handleReadResource(
     scope: { kind: "workspace", workspaceId, workspaceAgents: null, workspaceModelOverride: null },
   };
   const resource = await runWithRequestContext(reqCtx, () =>
-    runtime.readAppResource(server, uri, workspaceId),
+    runtime.readAppResource(sourceName, uri, workspaceId),
   );
   if (resource === null) {
     return apiError(404, "resource_not_found", `Resource "${uri}" not found`, {
@@ -790,30 +874,45 @@ export async function handleToolCall(
   let workspaceRegistry: ToolRegistry | undefined;
   let source: ToolSource | undefined;
   let scope: RequestScope;
+  // The bare source name the registry is keyed on. For a qualified
+  // `ws_<id>-<source>` server it's the `<source>` portion; for a bare
+  // identity/workspace source it's `server` unchanged.
+  let resolvedSourceName = server;
   if (identitySource) {
     source = identitySource;
     scope = { kind: "identity" };
   } else {
-    if (!workspaceId) {
-      return apiError(400, "workspace_required", `Tool "${tool}" requires a workspace`, {
-        server,
-        tool,
-      });
-    }
-    workspaceRegistry = await runtime.ensureWorkspaceRegistry(workspaceId);
-    if (!workspaceRegistry.hasSource(server)) {
+    // A qualified `ws_<id>-<source>` resolves to its own workspace by name +
+    // membership (cross-workspace tool surfaced via nb__search); a bare source
+    // uses the ambient X-Workspace-Id. Same resolution as the resource read.
+    const resolved = await resolveRestSourceWorkspace(runtime, server, identity, workspaceId);
+    if (!resolved.ok) return resolved.response;
+    resolvedSourceName = resolved.sourceName;
+    workspaceRegistry = await runtime.ensureWorkspaceRegistry(resolved.workspaceId);
+    if (!workspaceRegistry.hasSource(resolvedSourceName)) {
       return apiError(404, "tool_not_found", `Tool "${tool}" not found on server "${server}"`, {
         server,
         tool,
       });
     }
-    source = workspaceRegistry.getSources().find((s) => s.name === server);
-    scope = { kind: "workspace", workspaceId, workspaceAgents: null, workspaceModelOverride: null };
+    source = workspaceRegistry.getSources().find((s) => s.name === resolvedSourceName);
+    scope = {
+      kind: "workspace",
+      workspaceId: resolved.workspaceId,
+      workspaceAgents: null,
+      workspaceModelOverride: null,
+    };
   }
 
-  // The tool name may already be prefixed (e.g., "home__briefing" from the
-  // bridge) or bare (e.g., "briefing"). Normalize to the full name.
-  const toolName = tool.startsWith(`${server}__`) ? tool : `${server}__${tool}`;
+  // Normalize `tool` to the registry's `<bareSource>__<tool>` form. It may
+  // arrive bare ("preview"), source-prefixed ("calendar__main"), or fully
+  // qualified ("ws_<id>-calendar__main" from the bridge) — strip a leading
+  // qualified-server prefix first, then ensure the bare-source prefix.
+  let innerTool = tool;
+  if (innerTool.startsWith(`${server}__`)) innerTool = innerTool.slice(server.length + 2);
+  const toolName = innerTool.startsWith(`${resolvedSourceName}__`)
+    ? innerTool
+    : `${resolvedSourceName}__${innerTool}`;
 
   // Coerced args flow through to execute below — validation and execution must
   // see the same shape. Defaults to the raw args; replaced with the

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -554,7 +554,9 @@ export async function handleResourceProxy(
   // `ws_<id>-<app>` (a cross-workspace app icon / primary preview surfaced
   // from another workspace) resolves to its own workspace by name + member-
   // ship; a bare app name uses the ambient X-Workspace-Id.
-  const resolved = await resolveRestSourceWorkspace(runtime, appName, identity, workspaceId);
+  const resolved = await resolveRestSourceWorkspace(runtime, appName, identity, workspaceId, () =>
+    apiError(400, "workspace_required", `App "${appName}" requires a workspace`, { app: appName }),
+  );
   if (!resolved.ok) return resolved.response;
   const { workspaceId: wsId, sourceName } = resolved;
   const wsRegistry = await runtime.ensureWorkspaceRegistry(wsId);
@@ -701,6 +703,11 @@ async function resolveRestSourceWorkspace(
   server: string,
   identity: UserIdentity | null | undefined,
   ambientWorkspaceId: string | undefined,
+  // Each endpoint had its own error for "bare source, no ambient workspace"
+  // before this resolver existed (read: `bad_request`; tool-call / proxy:
+  // `workspace_required` with a server/app detail). Let callers keep their
+  // original contract so this refactor doesn't silently change error codes.
+  missingWorkspaceError?: () => Response,
 ): Promise<
   { ok: true; workspaceId: string; sourceName: string } | { ok: false; response: Response }
 > {
@@ -718,7 +725,11 @@ async function resolveRestSourceWorkspace(
   if (!qualified) {
     // Bare source — ambient-workspace behavior.
     if (!ambientWorkspaceId) {
-      return { ok: false, response: apiError(400, "bad_request", "Workspace ID required") };
+      return {
+        ok: false,
+        response:
+          missingWorkspaceError?.() ?? apiError(400, "bad_request", "Workspace ID required"),
+      };
     }
     return { ok: true, workspaceId: ambientWorkspaceId, sourceName: server };
   }
@@ -885,7 +896,9 @@ export async function handleToolCall(
     // A qualified `ws_<id>-<source>` resolves to its own workspace by name +
     // membership (cross-workspace tool surfaced via nb__search); a bare source
     // uses the ambient X-Workspace-Id. Same resolution as the resource read.
-    const resolved = await resolveRestSourceWorkspace(runtime, server, identity, workspaceId);
+    const resolved = await resolveRestSourceWorkspace(runtime, server, identity, workspaceId, () =>
+      apiError(400, "workspace_required", `Tool "${tool}" requires a workspace`, { server, tool }),
+    );
     if (!resolved.ok) return resolved.response;
     resolvedSourceName = resolved.sourceName;
     workspaceRegistry = await runtime.ensureWorkspaceRegistry(resolved.workspaceId);

--- a/src/api/routes/resources.ts
+++ b/src/api/routes/resources.ts
@@ -50,7 +50,13 @@ export function resourceRoutes(ctx: AppContext) {
         const url = new URL(c.req.url);
         const prefix = `/v1/apps/${c.req.param("name")}/resources/`;
         const resourcePath = decodeURIComponent(url.pathname.slice(prefix.length));
-        return handleResourceProxy(name, resourcePath, ctx.runtime, c.var.workspaceId);
+        return handleResourceProxy(
+          name,
+          resourcePath,
+          ctx.runtime,
+          c.var.workspaceId,
+          c.var.identity,
+        );
       })
   );
 }

--- a/src/tools/namespace.ts
+++ b/src/tools/namespace.ts
@@ -252,3 +252,30 @@ export function bareToolName(s: string): string {
     return s;
   }
 }
+
+/**
+ * Parse a workspace-qualified **source** (server) name.
+ *
+ * A source name has the same `ws_<id>-<rest>` shape as a tool name, but its
+ * `<rest>` is a bare source name (`synapse-collateral`) with no `__<tool>`
+ * suffix — the cross-workspace aggregator namespaces *tool* names while
+ * registry *sources* keep their bare name. So a cross-workspace tool
+ * `ws_<id>-synapse-collateral__preview` surfaces an `appName`/`server` of
+ * `ws_<id>-synapse-collateral`, which the REST resource/tool endpoints must
+ * split into its owning workspace (`ws_<id>`) and the bare source the
+ * registry is keyed on (`synapse-collateral`).
+ *
+ * Returns `null` for a bare (unqualified) source name — the caller falls back
+ * to the ambient request workspace. Throws (via `parseNamespacedToolName`)
+ * only for a malformed `ws_`-prefixed id, which is a probe/typo the caller
+ * should reject rather than treat as bare.
+ *
+ * Built on `parseNamespacedToolName` so the separator and `WORKSPACE_ID_RE`
+ * boundary stay defined once (and `check:tool-namespace` keeps the parse in
+ * this module).
+ */
+export function parseNamespacedSourceName(s: string): { wsId: string; sourceName: string } | null {
+  const parsed = parseNamespacedToolName(s);
+  if (parsed.scope.kind !== "workspace") return null;
+  return { wsId: parsed.scope.wsId, sourceName: parsed.toolName };
+}

--- a/test/unit/api/read-resource-handler.test.ts
+++ b/test/unit/api/read-resource-handler.test.ts
@@ -8,6 +8,8 @@ interface StubOptions {
   sources?: string[];
   identitySources?: string[];
   resource?: ResourceData | null;
+  /** Workspace ids the calling identity is a member of (for qualified-name resolution). */
+  memberOf?: string[];
   captureCall?: (args: { server: string; uri: string; workspaceId: string }) => void;
   captureIdentityCall?: (args: { server: string; uri: string }) => void;
 }
@@ -15,12 +17,16 @@ interface StubOptions {
 function makeStubRuntime(opts: StubOptions = {}): Runtime {
   const sources = new Set(opts.sources ?? ["calendar"]);
   const identitySources = new Set(opts.identitySources ?? []);
+  const memberOf = opts.memberOf ?? [];
   const registry = {
     hasSource: (name: string) => sources.has(name),
   };
   return {
     getIdentitySource: (name: string) => (identitySources.has(name) ? { name } : undefined),
     ensureWorkspaceRegistry: async () => registry,
+    getWorkspaceStore: () => ({
+      getWorkspacesForUser: async () => memberOf.map((id) => ({ id })),
+    }),
     readAppResource: async (server: string, uri: string, workspaceId: string) => {
       opts.captureCall?.({ server, uri, workspaceId });
       return opts.resource === undefined ? null : opts.resource;
@@ -181,6 +187,57 @@ describe("handleReadResource", () => {
       { workspaceId: "w1" },
     );
     expect(res.status).toBe(400);
+  });
+
+  // Cross-workspace: a qualified `ws_<id>-<source>` server names its OWN
+  // workspace. The owning workspace — not the ambient X-Workspace-Id — is
+  // authoritative, and the registry/readAppResource are keyed on the BARE
+  // source name. Regression for the preview-from-another-workspace 403.
+  it("resolves a qualified server to its owning workspace, ignoring X-Workspace-Id", async () => {
+    const calls: Array<{ server: string; uri: string; workspaceId: string }> = [];
+    const runtime = makeStubRuntime({
+      sources: ["synapse-collateral"], // registry keyed on the bare source name
+      memberOf: ["ws_nimblebrain_shared"],
+      resource: { text: "ok", mimeType: "text/plain" },
+      captureCall: (c) => calls.push(c),
+    });
+    const res = await handleReadResource(
+      req({ server: "ws_nimblebrain_shared-synapse-collateral", uri: "collateral://exports/e.pdf" }),
+      runtime,
+      // Ambient workspace is the user's PERSONAL workspace, not where the doc lives.
+      { workspaceId: "ws_user_u1", identity: { id: "u1" } as never },
+    );
+    expect(res.status).toBe(200);
+    // readAppResource gets the bare source + the workspace parsed from the name.
+    expect(calls).toEqual([
+      { server: "synapse-collateral", uri: "collateral://exports/e.pdf", workspaceId: "ws_nimblebrain_shared" },
+    ]);
+  });
+
+  it("returns 403 for a qualified server the caller is not a member of", async () => {
+    const runtime = makeStubRuntime({
+      sources: ["synapse-collateral"],
+      memberOf: ["ws_some_other"], // not a member of ws_nimblebrain_shared
+      resource: { text: "ok", mimeType: "text/plain" },
+    });
+    const res = await handleReadResource(
+      req({ server: "ws_nimblebrain_shared-synapse-collateral", uri: "collateral://exports/e.pdf" }),
+      runtime,
+      { workspaceId: "ws_user_u1", identity: { id: "u1" } as never },
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("workspace_access_denied");
+  });
+
+  it("returns 401 for a qualified server with no identity", async () => {
+    const runtime = makeStubRuntime({ sources: ["synapse-collateral"], memberOf: ["ws_x"] });
+    const res = await handleReadResource(
+      req({ server: "ws_x-synapse-collateral", uri: "collateral://exports/e.pdf" }),
+      runtime,
+      { workspaceId: "ws_x" },
+    );
+    expect(res.status).toBe(401);
   });
 });
 

--- a/test/unit/api/tool-call-handler.test.ts
+++ b/test/unit/api/tool-call-handler.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "bun:test";
+import { handleResourceProxy, handleToolCall } from "../../../src/api/handlers.ts";
+import type { ResolvedFeatures } from "../../../src/config/features.ts";
+import type { Runtime } from "../../../src/runtime/runtime.ts";
+import type { UserIdentity } from "../../../src/identity/provider.ts";
+
+// Cross-workspace coverage for the OTHER two endpoints the qualified-name
+// resolver was wired into (handleReadResource is covered separately). A
+// qualified `ws_<id>-<source>` names its own workspace: it must resolve there
+// by membership (not the ambient X-Workspace-Id) and address the registry by
+// the BARE source name. handleToolCall additionally normalizes the tool name.
+
+const features = {} as unknown as ResolvedFeatures; // our tool isn't feature-mapped → always enabled
+const identityU1 = { id: "u1", orgRole: "member" } as unknown as UserIdentity;
+
+// ── handleToolCall ──────────────────────────────────────────────────
+
+interface ToolCallStub {
+  memberOf?: string[];
+  sourceName?: string;
+  toolNames?: string[];
+}
+
+function makeToolCallRuntime(opts: ToolCallStub = {}): { runtime: Runtime; executed: string[] } {
+  const memberOf = opts.memberOf ?? [];
+  const sourceName = opts.sourceName ?? "synapse-collateral";
+  const toolNames = opts.toolNames ?? [`${sourceName}__preview`];
+  const executed: string[] = [];
+  const source = {
+    name: sourceName,
+    tools: async () => toolNames.map((name) => ({ name })),
+  };
+  const registry = {
+    hasSource: (n: string) => n === sourceName,
+    getSources: () => [source],
+    execute: async (call: { name: string }) => {
+      executed.push(call.name);
+      return { content: [{ type: "text", text: "ok" }], structuredContent: {}, isError: false };
+    },
+  };
+  const runtime = {
+    getIdentitySource: () => undefined,
+    getWorkspaceStore: () => ({
+      getWorkspacesForUser: async () => memberOf.map((id) => ({ id })),
+    }),
+    ensureWorkspaceRegistry: async () => registry,
+  } as unknown as Runtime;
+  return { runtime, executed };
+}
+
+function toolReq(body: unknown): Request {
+  return new Request("http://x/v1/tools/call", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("handleToolCall — qualified cross-workspace server", () => {
+  it("resolves to the owning workspace (ignoring X-Workspace-Id) and normalizes the tool name", async () => {
+    const { runtime, executed } = makeToolCallRuntime({ memberOf: ["ws_nimblebrain_shared"] });
+    const res = await handleToolCall(
+      toolReq({ server: "ws_nimblebrain_shared-synapse-collateral", tool: "preview" }),
+      runtime,
+      features,
+      // Ambient workspace is the user's PERSONAL ws — not where the tool lives.
+      { workspaceId: "ws_user_u1", identity: identityU1 },
+    );
+    expect(res.status).toBe(200);
+    // Bare tool ("preview") normalized to the registry's `<bareSource>__<tool>`.
+    expect(executed).toEqual(["synapse-collateral__preview"]);
+  });
+
+  it("normalizes a source-prefixed tool name", async () => {
+    const { runtime, executed } = makeToolCallRuntime({ memberOf: ["ws_nimblebrain_shared"] });
+    await handleToolCall(
+      toolReq({
+        server: "ws_nimblebrain_shared-synapse-collateral",
+        tool: "synapse-collateral__preview",
+      }),
+      runtime,
+      features,
+      { workspaceId: "ws_user_u1", identity: identityU1 },
+    );
+    expect(executed).toEqual(["synapse-collateral__preview"]);
+  });
+
+  it("normalizes a fully-qualified tool name (strips the ws_<id>- server prefix)", async () => {
+    const { runtime, executed } = makeToolCallRuntime({ memberOf: ["ws_nimblebrain_shared"] });
+    await handleToolCall(
+      toolReq({
+        server: "ws_nimblebrain_shared-synapse-collateral",
+        tool: "ws_nimblebrain_shared-synapse-collateral__preview",
+      }),
+      runtime,
+      features,
+      { workspaceId: "ws_user_u1", identity: identityU1 },
+    );
+    expect(executed).toEqual(["synapse-collateral__preview"]);
+  });
+
+  it("403s a non-member of the named workspace", async () => {
+    const { runtime, executed } = makeToolCallRuntime({ memberOf: ["ws_some_other"] });
+    const res = await handleToolCall(
+      toolReq({ server: "ws_nimblebrain_shared-synapse-collateral", tool: "preview" }),
+      runtime,
+      features,
+      { workspaceId: "ws_user_u1", identity: identityU1 },
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("workspace_access_denied");
+    expect(executed).toEqual([]);
+  });
+
+  it("401s a qualified call with no identity", async () => {
+    const { runtime } = makeToolCallRuntime({ memberOf: ["ws_nimblebrain_shared"] });
+    const res = await handleToolCall(
+      toolReq({ server: "ws_nimblebrain_shared-synapse-collateral", tool: "preview" }),
+      runtime,
+      features,
+      { workspaceId: "ws_nimblebrain_shared" },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("keeps the workspace_required contract for a bare source with no workspace", async () => {
+    // Regression guard: the shared resolver must not silently downgrade this
+    // endpoint's original `workspace_required` error to `bad_request`.
+    const { runtime } = makeToolCallRuntime();
+    const res = await handleToolCall(toolReq({ server: "calendar", tool: "main" }), runtime, features, {
+      identity: identityU1,
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("workspace_required");
+  });
+});
+
+// ── handleResourceProxy (GET /v1/apps/:name/resources/*) ────────────
+
+function makeProxyRuntime(opts: { memberOf?: string[]; sourceName?: string }): {
+  runtime: Runtime;
+  calls: Array<{ server: string; uri: string; wsId: string }>;
+} {
+  const memberOf = opts.memberOf ?? [];
+  const sourceName = opts.sourceName ?? "synapse-collateral";
+  const calls: Array<{ server: string; uri: string; wsId: string }> = [];
+  const registry = { hasSource: (n: string) => n === sourceName };
+  const runtime = {
+    getIdentitySource: () => undefined,
+    getWorkspaceStore: () => ({
+      getWorkspacesForUser: async () => memberOf.map((id) => ({ id })),
+    }),
+    ensureWorkspaceRegistry: async () => registry,
+    readAppResource: async (server: string, uri: string, wsId: string) => {
+      calls.push({ server, uri, wsId });
+      return { text: "ok", mimeType: "text/plain" };
+    },
+  } as unknown as Runtime;
+  return { runtime, calls };
+}
+
+describe("handleResourceProxy — qualified cross-workspace app", () => {
+  it("resolves to the owning workspace and reads via the bare source name", async () => {
+    const { runtime, calls } = makeProxyRuntime({ memberOf: ["ws_nimblebrain_shared"] });
+    const res = await handleResourceProxy(
+      "ws_nimblebrain_shared-synapse-collateral",
+      "main", // not "primary" — avoids the lifecycle/placement lookup
+      runtime,
+      "ws_user_u1", // ambient personal ws, must be overridden by the name
+      identityU1,
+    );
+    expect(res.status).toBe(200);
+    expect(calls).toEqual([{ server: "synapse-collateral", uri: "main", wsId: "ws_nimblebrain_shared" }]);
+  });
+
+  it("403s a non-member of the named workspace", async () => {
+    const { runtime, calls } = makeProxyRuntime({ memberOf: ["ws_some_other"] });
+    const res = await handleResourceProxy(
+      "ws_nimblebrain_shared-synapse-collateral",
+      "main",
+      runtime,
+      "ws_user_u1",
+      identityU1,
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("workspace_access_denied");
+    expect(calls).toEqual([]);
+  });
+});

--- a/test/unit/tools/namespace.test.ts
+++ b/test/unit/tools/namespace.test.ts
@@ -22,6 +22,7 @@ import { describe, expect, test } from "bun:test";
 import {
   InvalidNamespacedToolNameInput,
   namespacedToolName,
+  parseNamespacedSourceName,
   parseNamespacedToolName,
   UnknownNamespacedToolName,
 } from "../../../src/tools/namespace.ts";
@@ -207,5 +208,37 @@ describe("identity scope (bare names)", () => {
       scope: { kind: "workspace", wsId: "ws_helix" },
       toolName: "nb__search",
     });
+  });
+});
+
+describe("parseNamespacedSourceName — server (source) names", () => {
+  test("splits a qualified source into wsId + bare source name", () => {
+    // A cross-workspace tool `ws_<id>-synapse-collateral__preview` surfaces a
+    // server `ws_<id>-synapse-collateral` (no `__tool`). The bare source is
+    // what the registry is keyed on.
+    expect(parseNamespacedSourceName("ws_nimblebrain_shared-synapse-collateral")).toEqual({
+      wsId: "ws_nimblebrain_shared",
+      sourceName: "synapse-collateral",
+    });
+  });
+
+  test("keeps hyphenated source names intact (first hyphen is the ws boundary)", () => {
+    expect(parseNamespacedSourceName("ws_helix-crm-plus")).toEqual({
+      wsId: "ws_helix",
+      sourceName: "crm-plus",
+    });
+  });
+
+  test("returns null for a bare source name (caller uses the ambient workspace)", () => {
+    expect(parseNamespacedSourceName("synapse-collateral")).toBeNull();
+    expect(parseNamespacedSourceName("calendar")).toBeNull();
+  });
+
+  test("throws on a malformed ws_-prefixed id (probe/typo, not a bare name)", () => {
+    // Mirrors parseNamespacedToolName: a `ws_` head that isn't a valid id is
+    // surfaced, never silently treated as a bare source.
+    expect(() => parseNamespacedSourceName("ws_BAD ID-collateral")).toThrow(
+      UnknownNamespacedToolName,
+    );
   });
 });


### PR DESCRIPTION
## Problem

A chat **preview** minted by a cross-workspace tool failed with:

> Failed to load Preview of Engagement Plan: Server \`ws_nimblebrain_shared-synapse-collateral\` is not available in this workspace

Repro (from prod conv `conv_f358134f14fe45d7`): a conversation anchored to the user's **personal** workspace reached Collateral Studio cross-workspace via `nb__search` (`ws_nimblebrain_shared-nb__search` → `ws_nimblebrain_shared-synapse-collateral__create_document/__preview`). The tool *calls* succeeded (document created in NimbleBrain Shared), but rendering the preview `resource_link` POSTs `/v1/resources/read` with `X-Workspace-Id: <personal>` → `handleReadResource` checks `ensureWorkspaceRegistry(personal).hasSource("ws_nimblebrain_shared-synapse-collateral")` → false → **403**.

## Root cause

REST resource reads / tool calls resolve the source **only against the ambient `X-Workspace-Id`**. But a qualified `ws_<id>-<source>` name already names its owning workspace. The engine's `routeToolCall` (`orchestrator/route.ts:233`) resolves it correctly — parse wsId from the name, authorize by **membership**, "derived ONLY from the parsed wsId; we never reach for any ambient current-workspace pointer." The REST surface didn't, so a cross-workspace tool can mint a preview the reader refuses.

## Fix

`resolveRestSourceWorkspace` (shared by all three endpoints):
- **Qualified** `ws_<id>-<source>` → resolve workspace from the name, authorize by membership, **ignore `X-Workspace-Id`**.
- **Bare** `<source>` → ambient `X-Workspace-Id` (unchanged legacy behavior).

Wired into `handleReadResource` (reported symptom), `handleToolCall`, and **`handleResourceProxy`** (GET `/v1/apps/:name/resources/*` — the iframe/app-icon sibling with the identical gap, surfaced by adversarial review). Identity threaded into the proxy route.

Registry **sources are keyed on the bare name** (only *tool* names get the `ws_<id>-` prefix), so the resolver returns the bare source for `hasSource`/`getSources`/`readAppResource` — using the qualified string there would 404/403 even in the correct workspace. New `parseNamespacedSourceName` lives in `src/tools/namespace.ts` (the single legal parse site).

## On `X-Workspace-Id` (evaluation)

This **narrows** the header's authority to legacy bare-name sources — matching the existing direction where self-describing requests already bypass it (identity sources; Phase B/C `files`/`conversations`; `/v1/conversations/:id/events`). It is **not** a wholesale removal: per `AGENTS.md:316/335` the web shell deliberately uses `X-Workspace-Id` as the stateless ambient default for focused-workspace (bare) tools. Full removal is a separate, larger effort (every REST call + `/w/<slug>` routing + web client) and isn't warranted today.

## Tests

- `parseNamespacedSourceName`: qualified / hyphenated-source / bare→null / malformed-id→throws.
- `handleReadResource`: qualified name resolves to its owning workspace with the **bare** source (asserts `readAppResource` gets `synapse-collateral` + `ws_nimblebrain_shared`, not the ambient personal ws); non-member → 403; no identity → 401. Existing bare-name tests unchanged. Full `api`+`tools`+`orchestrator` suites green (514 tests).

## QA (#353) follow-ups addressed
- Added endpoint-level tests for the two newly-wired paths (`handleToolCall`, `handleResourceProxy`) — previously only `handleReadResource` exercised the resolver.
- **Error contract preserved**: folding the bare/no-workspace check into the shared resolver had quietly changed `handleToolCall`/`handleResourceProxy` from `workspace_required` to `bad_request`. The resolver now takes a per-caller `missingWorkspaceError` so each endpoint keeps its original code/message (pinned by a test). Nothing consumed the change, but the surface no longer shifts silently.
- Dup membership check vs `routeToolCall` remains a tracked follow-up (both check the same canonical predicate).

## Follow-ups (tracked, not in this PR)
- Converge REST + orchestrator on one resolver (teach `routeToolCall` an ambient-fallback mode, or migrate the shell to always-qualified names) so there's a single cross-workspace authZ implementation.