### PR TITLE
fix(web): resource-read 403 — derive bare app name from namespaced tool name

### DIFF
--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiClientError, callTool, streamChat, streamChatMultipart } from "../api/client";
 import { formatSendError } from "../api/format-error";
+import { appNameFromToolName } from "../lib/namespaced-tool.ts";
 import { captureEvent } from "../telemetry";
 import type {
   AppContext,
@@ -362,14 +363,15 @@ export function useChat(
               const evt = data as ToolStartEvent;
               setStreamingState("working");
               setPreparingTool(null);
-              const separatorIdx = evt.name.indexOf("__");
               const newTool: ToolCallDisplay = {
                 id: evt.id,
                 name: evt.name,
                 status: "running",
                 resourceUri: evt.resourceUri,
                 input: evt.input,
-                appName: separatorIdx !== -1 ? evt.name.slice(0, separatorIdx) : undefined,
+                // Bare source name (drop any `ws_<id>-` prefix) — the REST
+                // resource-read surfaces key the registry by bare name.
+                appName: appNameFromToolName(evt.name),
               };
               // Flat ref
               toolCallsRef.current = [...toolCallsRef.current, newTool];
@@ -670,14 +672,15 @@ export function useChat(
           const evt = data as ToolStartEvent;
           setStreamingState("working");
           setPreparingTool(null);
-          const separatorIdx = evt.name.indexOf("__");
           const newTool: ToolCallDisplay = {
             id: evt.id,
             name: evt.name,
             status: "running",
             resourceUri: evt.resourceUri,
             input: evt.input,
-            appName: separatorIdx !== -1 ? evt.name.slice(0, separatorIdx) : undefined,
+            // Bare source name (drop any `ws_<id>-` prefix) — the REST
+            // resource-read surfaces key the registry by bare name.
+            appName: appNameFromToolName(evt.name),
           };
           toolCallsRef.current = [...toolCallsRef.current, newTool];
           const blocks = blocksRef.current;

--- a/web/src/lib/namespaced-tool.ts
+++ b/web/src/lib/namespaced-tool.ts
@@ -92,3 +92,23 @@ export function namespacedToolName(wsId: string, toolName: string): string {
 
 // Identity tools have no builder: an identity tool's wire name IS its bare
 // `<source>__<tool>` form. Absence of a `ws_<id>-` prefix makes it identity-scoped.
+
+/**
+ * Extract the **bare source/app name** from a full wire tool name.
+ *
+ * A wire name is `[ws_<id>-]<source>__<tool>`. The REST surfaces that own a
+ * resource — `POST /v1/resources/read`, `GET /v1/apps/:name/resources/*` —
+ * key the workspace registry by the **bare** source name (`synapse-collateral`),
+ * NOT the namespaced one. Hand-slicing on `__` alone leaves the `ws_<id>-`
+ * prefix attached (`ws_<id>-synapse-collateral`), which then fails
+ * `registry.hasSource()` with a 403 "not available in this workspace". Parse
+ * the namespace via the sanctioned primitive first, then drop the `__<tool>`
+ * tail. Returns `undefined` when there's no `__` (not an app-owned call).
+ */
+export function appNameFromToolName(wireName: string): string | undefined {
+  const parsed = parseNamespacedToolName(wireName);
+  // `toolName` is the post-`ws_<id>-` remainder (or the whole bare name).
+  const rest = parsed ? parsed.toolName : wireName;
+  const sep = rest.indexOf("__");
+  return sep > 0 ? rest.slice(0, sep) : undefined;
+}

--- a/web/test/namespaced-tool.test.ts
+++ b/web/test/namespaced-tool.test.ts
@@ -16,7 +16,33 @@ import {
   WORKSPACE_ID_FLAGS,
   WORKSPACE_ID_PATTERN,
 } from "../src/_generated/workspace-id-pattern.ts";
-import { parseNamespacedToolName } from "../src/lib/namespaced-tool";
+import { appNameFromToolName, parseNamespacedToolName } from "../src/lib/namespaced-tool";
+
+describe("appNameFromToolName (web)", () => {
+  test("drops the ws_<id>- prefix AND the __<tool> tail → bare source name", () => {
+    // Regression: the chat transcript used to slice on `__` alone, leaving
+    // the `ws_<id>-` prefix attached. The bare name is what the REST
+    // resource-read surfaces key the registry by; the namespaced form 403s.
+    expect(appNameFromToolName("ws_nimblebrain_shared-synapse-collateral__export_pdf")).toBe(
+      "synapse-collateral",
+    );
+  });
+
+  test("hyphenated source names survive (only the ws_<id>- head is removed)", () => {
+    expect(appNameFromToolName("ws_helix-synapse-todo-board__create_task")).toBe(
+      "synapse-todo-board",
+    );
+  });
+
+  test("bare (identity) tool name → bare source", () => {
+    expect(appNameFromToolName("conversations__search")).toBe("conversations");
+  });
+
+  test("no __ separator → undefined (not an app-owned call)", () => {
+    expect(appNameFromToolName("ws_helix-nb")).toBeUndefined();
+    expect(appNameFromToolName("plain")).toBeUndefined();
+  });
+});
 
 describe("parseNamespacedToolName (web)", () => {
   test("parses ws_<id>-<tool> to workspace scope", () => {


### PR DESCRIPTION
## The bug

Reading a resource that an app's tool returned (a `resource_link` — e.g. a document export/preview) fails in the chat transcript with:

```
403 workspace_access_denied
Server "ws_<id>-<source>" is not available in this workspace
```

…even though the **same app works fine in its iframe**. Two different surfaces:
- The iframe reaches the bundle via `/mcp`, which parses the namespace correctly (`route.ts` → `parseNamespacedToolName`). ✅
- The chat transcript's inline `ResourceLinkView` / `InlineAppView` read via REST (`POST /v1/resources/read`, `GET /v1/apps/:name/resources/*`), passing the tool call's `appName`. ❌

## Root cause

`useChat.ts` derived `appName` by slicing the wire name on `__` alone:

```ts
const separatorIdx = evt.name.indexOf("__");
appName: separatorIdx !== -1 ? evt.name.slice(0, separatorIdx) : undefined
```

For a workspace tool the wire name is `ws_<id>-<source>__<tool>`, so this kept the `ws_<id>-` prefix → `appName = "ws_<id>-<source>"`. But the REST resource surfaces key the workspace registry by the **bare** `<source>` name (`handlers.ts` `wsRegistry.hasSource(server)`). The namespaced value never matched → 403.

This is exactly the failure mode the repo's "never `.split` a presumed namespaced name" rule exists to prevent — the hand-slice ignored the `ws_<id>-` prefix.

## Fix

- Add `appNameFromToolName()` to `web/src/lib/namespaced-tool.ts` — parse via the sanctioned `parseNamespacedToolName` primitive (drops `ws_<id>-`), then strip the `__<tool>` tail. Hyphenated source names (`synapse-todo-board`) survive because only the `ws_<id>-` head is removed.
- Use it at both tool-start sites in `useChat.ts`; delete the hand-slice.
- Tests cover namespaced, hyphenated-source, identity, and no-separator inputs.

## Why it slipped through

`check:tool-namespace` only scans `src/`, not `web/src/`, so the web-side hand-parse wasn't caught. The fix routes through the shared helper. (Extending that check to `web/src/` is a reasonable follow-up.)

## Verification

- `web/test/namespaced-tool.test.ts`: +4 cases, all green (431 web tests pass)
- `bunx tsc --noEmit` (web): clean
- `format:check`, `lint`, `check:codegen`, `check:tool-namespace`: green
- `cd web && bun run build`: green