### PR TITLE
fix(model): deprecate retired gemini-3-pro-preview, hide deprecated models from picker

### DIFF
--- a/src/model/catalog-data.json
+++ b/src/model/catalog-data.json
@@ -2308,7 +2308,8 @@
           "output": ["text"]
         },
         "knowledgeCutoff": "2025-01",
-        "releaseDate": "2025-11-18"
+        "releaseDate": "2025-11-18",
+        "deprecated": true
       },
       "gemini-3.1-flash-image-preview": {
         "id": "gemini-3.1-flash-image-preview",

--- a/src/model/catalog.ts
+++ b/src/model/catalog.ts
@@ -168,14 +168,21 @@ export function isModelAllowed(
 }
 
 /**
- * Get the list of available models for configured providers, respecting allowlists.
+ * Get the list of available models for configured providers, respecting
+ * allowlists. Deprecated models are excluded — this feeds the settings
+ * model picker, and a model the upstream provider has shut down (e.g.
+ * `google:gemini-3-pro-preview`, retired 2026-03-09) must not be
+ * re-selectable. `listModels` stays honest as "all models for a provider";
+ * the "available to pick" filter lives here. Note this does not retroactively
+ * fix a slot already pointing at a deprecated model — that override must be
+ * repointed in workspace/tenant config separately.
  */
 export function getAvailableModels(
   configuredProviders: Record<string, { models?: string[] }>,
 ): Record<string, CatalogModel[]> {
   const result: Record<string, CatalogModel[]> = {};
   for (const [provider, config] of Object.entries(configuredProviders)) {
-    result[provider] = listModels(provider, config.models);
+    result[provider] = listModels(provider, config.models).filter((m) => !m.deprecated);
   }
   return result;
 }

--- a/src/model/sync-models.ts
+++ b/src/model/sync-models.ts
@@ -18,6 +18,8 @@ const OUTPUT_PATH = join(dirname(new URL(import.meta.url).pathname), "catalog-da
 // Models the upstream API hasn't flagged yet but we know are scheduled for shutdown.
 // Format: "<provider>:<modelId>". Remove an entry once models.dev catches up.
 const MANUAL_DEPRECATIONS = new Set<string>([
+  // Google shutdown 2026-03-09 (successor: gemini-3.1-pro-preview)
+  "google:gemini-3-pro-preview",
   // OpenAI shutdown 2026-07-23
   "openai:gpt-5-chat-latest",
   "openai:gpt-5-codex",

--- a/test/unit/catalog.test.ts
+++ b/test/unit/catalog.test.ts
@@ -149,6 +149,20 @@ describe("getAvailableModels", () => {
 		expect(result.anthropic[0].id).toBe("claude-sonnet-4-6");
 		expect(result.openai.length).toBeGreaterThan(1);
 	});
+
+	it("excludes deprecated models from the picker", () => {
+		// gemini-3-pro-preview was retired by Google 2026-03-09. It stays in the
+		// catalog (so existing references still resolve for cost/display) but
+		// must never be offered as a selectable model.
+		const deprecated = getModelByString("google:gemini-3-pro-preview");
+		expect(deprecated?.deprecated).toBe(true);
+
+		const result = getAvailableModels({ google: {} });
+		expect(result.google.length).toBeGreaterThan(0);
+		expect(result.google.some((m) => m.id === "gemini-3-pro-preview")).toBe(false);
+		// The live successor is still offered.
+		expect(result.google.some((m) => m.id === "gemini-3.1-pro-preview")).toBe(true);
+	});
 });
 
 describe("estimateCost from catalog", () => {


### PR DESCRIPTION
## What

Google shut down `google:gemini-3-pro-preview` on **2026-03-09** (successor: `gemini-3.1-pro-preview`). The retired id stayed selectable in the settings model picker, so any slot pointed at it now hard-fails with *"This model models/gemini-3-pro-preview is no longer available"*. It surfaces first via the home **briefing**, which runs on the `fast` slot (`core-source.ts` → `getModelSlot("fast")`).

## Changes

- **Flag the catalog entry deprecated** (`catalog-data.json`) and add `google:gemini-3-pro-preview` to `MANUAL_DEPRECATIONS` in `sync-models.ts` so future syncs preserve the flag until models.dev catches up.
- **Filter deprecated models out of `getAvailableModels`** — the function feeding the settings picker — so a retired model can't be (re)selected. `listModels` stays full-fidelity so existing references still resolve for cost/display.
- Test coverage: deprecated model is flagged and excluded from the picker; live successor `gemini-3.1-pro-preview` is still offered.

## Scope / non-goals

This does **not** retroactively repoint a slot already set to a deprecated model (no runtime fallback in this PR, per decision). A workspace/tenant override currently pointing at the dead id must be repointed in config — tracked separately as the operational fix for the affected tenant.

## Verification

- `bun run verify:static` ✓
- `bun test test/unit/catalog.test.ts` ✓ (26 pass)
- Full unit suite green except a pre-existing local bundle-UI dep gap (`dompurify`/`happy-dom`), unrelated to this change.