### PR TITLE
fix(api): strip workspace prefix from data.changed server so live UI refresh works

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -1,4 +1,5 @@
 import type { EngineEvent, EngineEventType, EventSink } from "../engine/types.ts";
+import { bareToolName } from "../tools/namespace.ts";
 import type { WorkspaceStore } from "../workspace/workspace-store.ts";
 
 /**
@@ -99,6 +100,63 @@ const SSE_ROUTES: Partial<Record<EngineEventType, SseRoute>> = {
   "bridge.tool.call": { scope: "workspace", wsIdField: "workspaceId" },
   "bridge.tool.done": { scope: "workspace", wsIdField: "workspaceId" },
 };
+
+/**
+ * Derive the `data.changed` broadcast target (`{ server, tool }`) from a tool
+ * lifecycle event, or `null` when the event must not broadcast.
+ *
+ * Two event shapes feed this, and they carry the source name differently:
+ *   - `tool.done` (ok) → a single qualified `name`. This is the name the
+ *     MODEL called, which post-Stage-2 is workspace-namespaced
+ *     (`ws_<id>-<source>__<tool>`).
+ *   - `tool.progress` → separate `source` + `tool`; `McpSource` emits the
+ *     bare source name there.
+ *
+ * Both are normalized to the **bare** source name via `bareToolName` before
+ * the `__` split. This is load-bearing: the Synapse `useDataSync` consumer
+ * matches the broadcast `server` against the iframe's `data-app`, which is the
+ * bare placement `serverName` (see `PlacementRegistry` — serverName and wsId
+ * are stored as separate fields). A namespaced `server` never matches, so the
+ * iframe would only refresh on remount (the "click off and back" symptom).
+ * Stripping the prefix also restores the `nb` system-tool guard:
+ * `ws_<id>-nb__x` → `nb__x` → server `nb`, which we skip (system tools don't
+ * mutate app data, and broadcasting for them re-fetches every streaming chunk).
+ *
+ * `data.changed` remains workspace-blind (`scope: "global"`, matched on bare
+ * server) — the pre-Stage-2 contract. Growing `wsId` into the payload for
+ * true per-workspace scoping is tracked separately (see `SSE_ROUTES`).
+ */
+export function deriveDataChangedTarget(
+  event: EngineEvent,
+): { server: string; tool: string } | null {
+  const isBroadcast =
+    (event.type === "tool.done" && event.data.ok === true) || event.type === "tool.progress";
+  if (!isBroadcast) return null;
+
+  const { name, source, tool: toolField } = event.data;
+  const rawName =
+    typeof name === "string"
+      ? name
+      : typeof source === "string" && typeof toolField === "string"
+        ? `${source}__${toolField}`
+        : undefined;
+  if (!rawName) return null;
+
+  // Strip any `ws_<id>-` workspace prefix, then split source from tool on the
+  // first `__`. A bare source name with hyphens (`synapse-db-query`) is left
+  // intact — `bareToolName` only strips a leading segment matching the
+  // workspace-id pattern.
+  const bare = bareToolName(rawName);
+  const sepIndex = bare.indexOf("__");
+  const server = sepIndex !== -1 ? bare.slice(0, sepIndex) : bare;
+  const tool = sepIndex !== -1 ? bare.slice(sepIndex + 2) : bare;
+
+  // System tools (`nb__*`) don't modify app data; broadcasting for them makes
+  // iframes re-fetch on every streaming chunk (flicker + tool-call amplification).
+  if (server === "nb") return null;
+
+  return { server, tool };
+}
 
 /**
  * SSE Event Manager for the workspace-level event stream.

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -8,7 +8,7 @@ import { HealthMonitor } from "../tools/health-monitor.ts";
 import { createApp } from "./app.ts";
 import { resolveAuthMode } from "./auth-middleware.ts";
 import { ConversationEventManager } from "./conversation-events.ts";
-import { SseEventManager } from "./events.ts";
+import { deriveDataChangedTarget, SseEventManager } from "./events.ts";
 import { McpServerHost } from "./mcp-server.ts";
 import { LoginRateLimiter, RequestRateLimiter } from "./rate-limiter.ts";
 import { InMemorySessionRegistry, type SessionRegistry } from "./session-store/index.ts";
@@ -128,42 +128,25 @@ export function startServer(options: ServerOptions): ServerHandle {
     //                             result. Without this, a `useDataSync`-driven
     //                             view stays stale for the full task duration.
     //
-    // System tools (`nb__*`) are filtered out of both paths — they don't
-    // modify app data, and broadcasting data.changed for them would make
-    // iframes re-fetch during every streaming chunk (flicker + tool-call
-    // amplification).
-    const progressOrDone =
-      (event.type === "tool.done" && event.data.ok === true) || event.type === "tool.progress";
-    if (progressOrDone) {
-      const toolName =
-        (event.data.name as string | undefined) ??
-        // tool.progress uses `source`+`tool` (McpSource emits them separately)
-        // while tool.done uses a single qualified `name`. Handle both shapes.
-        ((): string | undefined => {
-          const src = event.data.source as string | undefined;
-          const tool = event.data.tool as string | undefined;
-          return src && tool ? `${src}__${tool}` : undefined;
-        })();
-      if (toolName) {
-        const sepIndex = toolName.indexOf("__");
-        const server = sepIndex !== -1 ? toolName.slice(0, sepIndex) : toolName;
-        const tool = sepIndex !== -1 ? toolName.slice(sepIndex + 2) : toolName;
-        if (server !== "nb") {
-          // Confirms `data.changed` is actually being broadcast, and to how
-          // many clients. If this fires but the browser never sees the
-          // event, the break is in the SSE connection or the
-          // parent `useDataSync` forwarder — not here.
-          log.debug(
-            "sse",
-            `broadcast data.changed from=${event.type} server=${server} tool=${tool} clients=${sseManager.clientCount}`,
-          );
-          sseManager.broadcast("data.changed", {
-            server,
-            tool,
-            timestamp: new Date().toISOString(),
-          });
-        }
-      }
+    // `deriveDataChangedTarget` normalizes both event shapes to the bare
+    // source name (stripping the Stage-2 `ws_<id>-` namespace) and drops
+    // system tools (`nb__*`) — see its doc comment for why the bare form is
+    // required for the iframe data-app match.
+    const target = deriveDataChangedTarget(event);
+    if (target) {
+      // Confirms `data.changed` is actually being broadcast, and to how
+      // many clients. If this fires but the browser never sees the
+      // event, the break is in the SSE connection or the
+      // parent `useDataSync` forwarder — not here.
+      log.debug(
+        "sse",
+        `broadcast data.changed from=${event.type} server=${target.server} tool=${target.tool} clients=${sseManager.clientCount}`,
+      );
+      sseManager.broadcast("data.changed", {
+        server: target.server,
+        tool: target.tool,
+        timestamp: new Date().toISOString(),
+      });
     }
   };
 

--- a/test/unit/api/derive-data-changed-target.test.ts
+++ b/test/unit/api/derive-data-changed-target.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { deriveDataChangedTarget } from "../../../src/api/events.ts";
+import type { EngineEvent } from "../../../src/engine/types.ts";
+
+// A valid opaque workspace id (`ws_` + lowercase hex), matching the shape
+// `generateWorkspaceId()` produces and `WORKSPACE_ID_RE` accepts.
+const WS = "ws_0123456789abcdef";
+
+describe("deriveDataChangedTarget", () => {
+	test("tool.done with a workspace-namespaced name emits the BARE server", () => {
+		// The regression: post-Stage-2 the model calls `ws_<id>-<source>__<tool>`,
+		// and `tool.done` carries that namespaced name. The Synapse `useDataSync`
+		// consumer matches `server` against the iframe's bare `data-app`, so a
+		// namespaced server never matches and the iframe never refreshes live.
+		const event: EngineEvent = {
+			type: "tool.done",
+			data: { name: `${WS}-synapse-db-query__present_result`, ok: true },
+		};
+		expect(deriveDataChangedTarget(event)).toEqual({
+			server: "synapse-db-query",
+			tool: "present_result",
+		});
+	});
+
+	test("a bare, hyphenated source name is left intact (no over-strip)", () => {
+		// `bareToolName` only strips a leading `ws_<id>` segment; `synapse` is not
+		// a workspace id, so a hyphenated source name survives unchanged.
+		const event: EngineEvent = {
+			type: "tool.done",
+			data: { name: "synapse-db-query__present_result", ok: true },
+		};
+		expect(deriveDataChangedTarget(event)).toEqual({
+			server: "synapse-db-query",
+			tool: "present_result",
+		});
+	});
+
+	test("tool.progress (bare source + tool) emits the same bare server", () => {
+		const event: EngineEvent = {
+			type: "tool.progress",
+			data: { source: "synapse-db-query", tool: "run_research" },
+		};
+		expect(deriveDataChangedTarget(event)).toEqual({
+			server: "synapse-db-query",
+			tool: "run_research",
+		});
+	});
+
+	test("namespaced system tool (nb) is filtered out", () => {
+		// Before the bare-name normalization, `ws_<id>-nb__search` parsed to a
+		// server of `ws_<id>-nb` (!== "nb"), so the `nb` guard failed open and
+		// system tools wrongly triggered iframe refreshes.
+		const event: EngineEvent = {
+			type: "tool.done",
+			data: { name: `${WS}-nb__search`, ok: true },
+		};
+		expect(deriveDataChangedTarget(event)).toBeNull();
+	});
+
+	test("bare system tool (nb) is filtered out", () => {
+		const event: EngineEvent = {
+			type: "tool.progress",
+			data: { source: "nb", tool: "search" },
+		};
+		expect(deriveDataChangedTarget(event)).toBeNull();
+	});
+
+	test("tool.done with ok:false does not broadcast", () => {
+		const event: EngineEvent = {
+			type: "tool.done",
+			data: { name: `${WS}-synapse-db-query__present_result`, ok: false },
+		};
+		expect(deriveDataChangedTarget(event)).toBeNull();
+	});
+
+	test("unrelated event types do not broadcast", () => {
+		expect(deriveDataChangedTarget({ type: "run.start", data: {} })).toBeNull();
+	});
+
+	test("a malformed event missing both name and source/tool does not broadcast", () => {
+		expect(deriveDataChangedTarget({ type: "tool.done", data: { ok: true } })).toBeNull();
+	});
+});


### PR DESCRIPTION
## Symptom

On a multi-workspace tenant running the latest build, synapse-db-query's UI does not refresh live when the agent calls `present_result` — you have to click off the app and back to see the result. Affects any Synapse app relying on `useDataSync` for live refresh.

## Root cause (platform, not the bundle)

Stage 2 (#272) namespaced tool names as `ws_<id>-<source>__<tool>`. The `data.changed` SSE broadcast in `server.ts` derived its `server` field by splitting the tool name on `indexOf("__")`, keeping the whole `ws_<id>-<source>` prefix.

The browser `useDataSync` hook matches the broadcast `server` against each iframe's `data-app` attribute, which is the **bare** placement `serverName` (`PlacementRegistry` stores `serverName` and `wsId` as separate fields). Namespaced `server` ≠ bare `data-app` → no `postMessage` → the iframe never refreshes. A remount (click-off/click-back) re-fetches via the widget's mount effect, which is the reported workaround.

Two corroborating details:
- The `tool.done` path carried the **namespaced** name (the name the model called); `tool.progress` already emitted the **bare** source name. The two broadcast paths disagreed on `server`. `present_result` is a fast tool → only the broken `tool.done` path.
- The prefix leak also broke the `nb` system-tool filter: `ws_<id>-nb__search` parsed to server `ws_<id>-nb` (never `=== "nb"`), so system tools wrongly triggered iframe refreshes (flicker / re-fetch amplification).

## Fix

Extract `deriveDataChangedTarget` into `events.ts`, normalizing both event shapes to the bare source name via the existing `bareToolName` helper before the `__` split. This:
- Restores the bare-`server` contract the consumer matches on → live refresh works.
- Re-enables the `nb` system-tool filter.
- Unifies the `tool.done` and `tool.progress` paths on one shape.

`bareToolName` only strips a leading segment matching the workspace-id pattern, so a hyphenated bare source name (`synapse-db-query`) is left intact (covered by a test).

## Tests

New `test/unit/api/derive-data-changed-target.test.ts` (8 cases): namespaced → bare, hyphenated-bare no-over-strip, `tool.progress`, namespaced + bare `nb` filtered, `ok:false`, unrelated event, malformed event. `verify:static` (format / lint / tsc / cycles / tool-namespace) and the api unit suite (223 tests) pass.

## Follow-up (not in this PR)

`data.changed` remains workspace-blind (`scope: "global"`, matched on bare `server`) — the pre-Stage-2 contract. The same bare app installed in two workspaces with both iframes mounted would over-refresh. The complete fix is to grow `wsId` into the payload and match on `(wsId, bare server)`, with the iframe carrying its wsId — already flagged as TODO in `SSE_ROUTES`. Filing separately.