### PR TITLE
fix(engine): bound tool results in model context on replay; 1h cache TTL

### DIFF
--- a/src/conversation/event-reconstructor.ts
+++ b/src/conversation/event-reconstructor.ts
@@ -7,6 +7,7 @@
  */
 
 import type { LanguageModelV3Content, LanguageModelV3ReasoningPart } from "@ai-sdk/provider";
+import { boundToolResultForModel } from "../engine/content-helpers.ts";
 import { normalizeForReplay } from "../model/inbound-fit.ts";
 import { estimateCost } from "../usage/cost.ts";
 import type {
@@ -290,7 +291,16 @@ function buildMessagesFromEvents(events: readonly ConversationEvent[]): StoredMe
                   type: "tool-result" as const,
                   toolCallId: tc.toolCallId,
                   toolName: tc.toolName,
-                  output: { type: "text", value: done.output ?? "" },
+                  // Replay the BOUNDED model view, not the full output. New
+                  // events carry `modelOutput` (exactly what the model saw
+                  // live); legacy events without it are bounded here at read
+                  // time. This stops large tool results from re-entering the
+                  // prompt at full size on every subsequent run — the primary
+                  // driver of runaway context growth and cache-write churn.
+                  output: {
+                    type: "text",
+                    value: done.modelOutput ?? boundToolResultForModel(done.output ?? ""),
+                  },
                 },
               ],
               timestamp: done.ts ?? llmResp.ts,

--- a/src/conversation/event-sourced-store.ts
+++ b/src/conversation/event-sourced-store.ts
@@ -530,6 +530,10 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
         // Always persist the text output for conversation history reconstruction.
         // The engine now sends `output` (extracted text) alongside `result` (full structured).
         const output = typeof d.output === "string" ? d.output : undefined;
+        // Bounded model-view text, present only when the result exceeded the
+        // model-context bound. Replay uses it verbatim so the replayed prompt
+        // matches what the model saw live. See boundToolResultForModel.
+        const modelOutput = typeof d.modelOutput === "string" ? d.modelOutput : undefined;
         const e: ToolDoneEvent = {
           ts,
           type: "tool.done",
@@ -539,6 +543,7 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
           ok: (d.ok as boolean) ?? true,
           ms: (d.ms as number) ?? 0,
           ...(output !== undefined ? { output } : {}),
+          ...(modelOutput !== undefined ? { modelOutput } : {}),
         };
         return e;
       }

--- a/src/conversation/types.ts
+++ b/src/conversation/types.ts
@@ -340,8 +340,19 @@ export interface ToolDoneEvent {
   id: string;
   ok: boolean;
   ms: number;
-  /** Present only when logging.level is "debug". */
+  /**
+   * Full tool output text (audience-filtered). Always persisted — it drives
+   * the UI/display and the conversation record.
+   */
   output?: string;
+  /**
+   * Bounded text the MODEL saw on the live turn, present only when it differs
+   * from `output` (i.e. the result exceeded the model-context bound). History
+   * replay uses this verbatim so the model's replayed view matches its live
+   * view; when absent (small result, or a legacy event) replay bounds
+   * `output` at read time. See boundToolResultForModel.
+   */
+  modelOutput?: string;
 }
 
 export interface ToolProgressEvent {

--- a/src/engine/content-helpers.ts
+++ b/src/engine/content-helpers.ts
@@ -1,3 +1,4 @@
+import { MAX_TOOL_RESULT_CHARS } from "../limits.ts";
 import type { ContentBlock, TextContent } from "./types.ts";
 
 /** A resource_link content block surfaced from an MCP tool result. */
@@ -104,4 +105,70 @@ export function extractTextForModel(blocks: ContentBlock[]): string {
     )
     .map((b) => b.text)
     .join("\n");
+}
+
+/**
+ * Trim `text` to at most `limit` chars, preferring a newline boundary so a
+ * record/JSON line is never cut in half. Falls back to a hard slice when the
+ * first line alone already exceeds the limit (e.g. minified JSON on one line).
+ */
+function sliceOnLineBoundary(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const slice = text.slice(0, limit);
+  const lastNewline = slice.lastIndexOf("\n");
+  // Only honor the boundary when it still keeps a meaningful chunk; otherwise
+  // a single huge first line would collapse the result to almost nothing.
+  if (lastNewline > limit * 0.5) return slice.slice(0, lastNewline);
+  return slice;
+}
+
+/**
+ * Bound a tool result's text to the model-context budget.
+ *
+ * Tool results are persisted in full (for the UI and the conversation
+ * record), but they must be bounded before they enter MODEL context — both
+ * in the live engine loop AND on history replay. Without a bound on replay,
+ * a large result re-enters the prompt on every subsequent turn and dominates
+ * token cost (and, with prompt caching, gets re-written into the cache each
+ * time the prefix lapses). This is the single source of truth for that
+ * bound: the engine and the history reconstructor both call it, so the
+ * model's live view and its replayed view of a result are identical.
+ *
+ * Pure and deterministic — the same input always yields the same output, so
+ * the replayed prompt prefix stays byte-stable and cacheable.
+ *
+ * - Text at or under `limit` is returned unchanged.
+ * - With an inline-UI resource, the model gets a short pointer instead of the
+ *   payload (the UI renders the full result), matching the existing inline-UI
+ *   truncation behavior.
+ * - Otherwise the text is trimmed on a line boundary up to `limit`, with an
+ *   explicit, actionable marker so the model knows the result was bounded,
+ *   that the full version is on the user's screen, and how to retrieve
+ *   specific items (filter / narrower scope / pagination) without blindly
+ *   re-calling the same tool.
+ */
+export function boundToolResultForModel(
+  text: string,
+  opts: { hasUiResource?: boolean; limit?: number } = {},
+): string {
+  const limit = opts.limit ?? MAX_TOOL_RESULT_CHARS;
+  if (limit <= 0 || text.length <= limit) return text;
+
+  if (opts.hasUiResource) {
+    return (
+      `[Tool completed successfully. Result (${text.length.toLocaleString()} chars) is ` +
+      `displayed in the inline UI. Do not ask the user to view it separately — it is ` +
+      `already visible.]`
+    );
+  }
+
+  const head = sliceOnLineBoundary(text, limit);
+  const omitted = text.length - head.length;
+  return (
+    head +
+    `\n\n[Result bounded for model context: showing ${head.length.toLocaleString()} of ` +
+    `${text.length.toLocaleString()} chars (${omitted.toLocaleString()} omitted). The full ` +
+    `result is on the user's screen. Re-query with a filter, a narrower scope, or a ` +
+    `pagination cursor to bring specific items into context.]`
+  );
 }

--- a/src/engine/content-helpers.ts
+++ b/src/engine/content-helpers.ts
@@ -154,9 +154,14 @@ export function boundToolResultForModel(
   const limit = opts.limit ?? MAX_TOOL_RESULT_CHARS;
   if (limit <= 0 || text.length <= limit) return text;
 
+  // Pin the locale so the marker is byte-stable regardless of host locale —
+  // this text lands in the cached prompt prefix on replay, and a locale-
+  // dependent separator would shift the prefix and bust the cache.
+  const n = (v: number) => v.toLocaleString("en-US");
+
   if (opts.hasUiResource) {
     return (
-      `[Tool completed successfully. Result (${text.length.toLocaleString()} chars) is ` +
+      `[Tool completed successfully. Result (${n(text.length)} chars) is ` +
       `displayed in the inline UI. Do not ask the user to view it separately — it is ` +
       `already visible.]`
     );
@@ -166,8 +171,8 @@ export function boundToolResultForModel(
   const omitted = text.length - head.length;
   return (
     head +
-    `\n\n[Result bounded for model context: showing ${head.length.toLocaleString()} of ` +
-    `${text.length.toLocaleString()} chars (${omitted.toLocaleString()} omitted). The full ` +
+    `\n\n[Result bounded for model context: showing ${n(head.length)} of ` +
+    `${n(text.length)} chars (${n(omitted)} omitted). The full ` +
     `result is on the user's screen. Re-query with a filter, a narrower scope, or a ` +
     `pagination cursor to bring specific items into context.]`
   );

--- a/src/engine/content-helpers.ts
+++ b/src/engine/content-helpers.ts
@@ -146,6 +146,10 @@ function sliceOnLineBoundary(text: string, limit: number): string {
  *   that the full version is on the user's screen, and how to retrieve
  *   specific items (filter / narrower scope / pagination) without blindly
  *   re-calling the same tool.
+ *
+ * `limit` is a soft target: when trimming occurs the returned string exceeds
+ * it by the marker length (~200 chars). Callers needing a hard ceiling must
+ * clamp the result themselves.
  */
 export function boundToolResultForModel(
   text: string,

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -560,11 +560,11 @@ export class AgentEngine {
                   prompt: [
                     {
                       role: "system",
+                      // Same ephemeral 1-hour cache control as the last-user
+                      // breakpoint — reuse the const so the TTL lives in one
+                      // place. See CACHE_CONTROL_EPHEMERAL.
                       content: callPrompt,
-                      providerOptions: {
-                        // 1-hour TTL — see CACHE_CONTROL_EPHEMERAL rationale.
-                        anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
-                      },
+                      providerOptions: CACHE_CONTROL_EPHEMERAL,
                     },
                     ...addCacheBreakpoint(msgs),
                   ],

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -8,7 +8,7 @@ import type {
   SharedV3ProviderOptions,
 } from "@ai-sdk/provider";
 import { log } from "../cli/log.ts";
-import { DEFAULT_MAX_DIRECT_TOOLS, MAX_ITERATIONS, MAX_TOOL_RESULT_CHARS } from "../limits.ts";
+import { DEFAULT_MAX_DIRECT_TOOLS, MAX_ITERATIONS } from "../limits.ts";
 import { getProviderFromModel, supportsEnabledThinking } from "../model/catalog.ts";
 import { normalizeForReplay } from "../model/inbound-fit.ts";
 import { callModel, type StreamResult } from "../model/stream.ts";
@@ -18,6 +18,7 @@ import { validateToolInput } from "../tools/validate-input.ts";
 import type { TokenUsage } from "../usage/types.ts";
 import { addUsage, emptyUsage } from "../usage/types.ts";
 import {
+  boundToolResultForModel,
   estimateContentSize,
   extractResourceLinks,
   extractTextForModel,
@@ -189,8 +190,15 @@ function sanitizeMessages(messages: LanguageModelV3Message[]): LanguageModelV3Me
   });
 }
 
+// 1-hour cache TTL (vs Anthropic's 5-minute default). Agentic runs pause
+// between turns far longer than 5 minutes (a user steps away; an automation
+// waits on I/O), so a 5-minute prefix lapses constantly and the next turn
+// re-WRITES the whole cached prefix at the write rate. A 1-hour TTL keeps the
+// prefix alive across those gaps, converting full re-writes into cheap cache
+// reads. The 1-hour write rate is 2x base input vs 1.25x for 5-minute, but
+// that is paid once per write and is dwarfed by the reads it unlocks.
 const CACHE_CONTROL_EPHEMERAL = {
-  anthropic: { cacheControl: { type: "ephemeral" } },
+  anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
 } as const;
 
 /**
@@ -554,7 +562,8 @@ export class AgentEngine {
                       role: "system",
                       content: callPrompt,
                       providerOptions: {
-                        anthropic: { cacheControl: { type: "ephemeral" } },
+                        // 1-hour TTL — see CACHE_CONTROL_EPHEMERAL rationale.
+                        anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
                       },
                     },
                     ...addCacheBreakpoint(msgs),
@@ -833,6 +842,28 @@ export class AgentEngine {
             // text output is always needed for conversation history reconstruction.
             const outputText = extractTextForModel(finalResult.content);
 
+            // Bound the text the MODEL sees. `outputText` (full) is persisted
+            // for the UI and the record; `modelOutput` (bounded) is what enters
+            // the prompt — both on this live turn AND on every replay. Computing
+            // it once here and persisting it keeps the live view and the
+            // replayed view byte-identical. See boundToolResultForModel.
+            const modelOutput = boundToolResultForModel(outputText, {
+              hasUiResource: !!resourceUri,
+            });
+            const bounded = modelOutput !== outputText;
+            if (bounded) {
+              this.events.emit({
+                type: "tool.progress",
+                data: {
+                  runId,
+                  id: gatedCall.id,
+                  message: resourceUri
+                    ? `Tool result bounded for model context (${outputText.length.toLocaleString()} chars → pointer). Full result rendered in inline UI.`
+                    : `Tool result bounded for model context (${outputText.length.toLocaleString()} chars → ${modelOutput.length.toLocaleString()}). Full result persisted for the UI.`,
+                },
+              });
+            }
+
             // Per-call resource_link blocks (MCP 2025-11-25). Distinct from the
             // static `resourceUri` tool annotation used for inline UI binding —
             // resource_link points at a file/resource the client should fetch.
@@ -848,6 +879,10 @@ export class AgentEngine {
                 ms,
                 resourceUri,
                 output: outputText,
+                // Persisted only when it actually differs from `output`, so
+                // small results don't carry a duplicate field. Replay falls
+                // back to bounding `output` for legacy events without it.
+                ...(bounded ? { modelOutput } : {}),
                 result: resourceUri ? finalResult : undefined,
                 ...(resourceLinks.length > 0 ? { resourceLinks } : {}),
                 ...(verdict.type === "synth"
@@ -860,44 +895,30 @@ export class AgentEngine {
               },
             });
 
-            return { toolCall, gatedCall, result: finalResult, ms, resourceUri, resourceLinks };
+            return {
+              toolCall,
+              gatedCall,
+              result: finalResult,
+              ms,
+              resourceUri,
+              resourceLinks,
+              modelOutput,
+            };
           }),
         );
 
-        // Build result arrays from parallel results.
-        // For tools with a UI resource, cap the content sent back to the LLM
-        // to avoid token explosion from large binary payloads (e.g., base64 PNGs).
-        // The full result is still available to the inline UI via tool.done event.
+        // Build result arrays from parallel results. `modelOutput` is the
+        // already-bounded text the model sees (computed once, above, and
+        // persisted on tool.done) — so the live prompt and the replayed
+        // prompt carry the identical bounded result.
         const toolResultParts: LanguageModelV3ToolResultPart[] = [];
 
-        for (const {
-          toolCall,
-          result,
-          ms,
-          resourceUri: uri,
-          resourceLinks: links,
-        } of toolResults) {
-          let llmText = extractTextForModel(result.content);
-
-          if (uri && llmText.length > MAX_TOOL_RESULT_CHARS) {
-            // Tool has inline UI — the UI handles display.
-            // Give the LLM a summary instead of the raw binary payload.
-            this.events.emit({
-              type: "tool.progress",
-              data: {
-                runId,
-                id: toolCall.toolCallId,
-                message: `Tool result truncated for LLM (${llmText.length.toLocaleString()} chars → summary). Full result rendered in inline UI.`,
-              },
-            });
-            llmText = `[Tool completed successfully. Result (${llmText.length.toLocaleString()} chars) is displayed in the inline UI. Do not ask the user to view it separately — it is already visible.]`;
-          } else if (llmText.length > MAX_TOOL_RESULT_CHARS) {
-            // No UI resource — truncate with a warning.
-            llmText =
-              llmText.slice(0, MAX_TOOL_RESULT_CHARS) +
-              `\n\n[Result truncated: ${llmText.length.toLocaleString()} chars exceeded ${MAX_TOOL_RESULT_CHARS.toLocaleString()} char limit.]`;
-          }
-
+        for (const { toolCall, result, ms, resourceUri: uri, resourceLinks: links, modelOutput } of toolResults) {
+          // `modelOutput` is present for every executed tool (bounded once,
+          // above). Early-return paths that skip execution (e.g. policy-denied)
+          // omit it; bound their small result here so the type stays a string.
+          const llmText =
+            modelOutput ?? boundToolResultForModel(extractTextForModel(result.content), { hasUiResource: !!uri });
           allToolCalls.push({
             id: toolCall.toolCallId,
             name: toolCall.toolName,

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -913,12 +913,20 @@ export class AgentEngine {
         // prompt carry the identical bounded result.
         const toolResultParts: LanguageModelV3ToolResultPart[] = [];
 
-        for (const { toolCall, result, ms, resourceUri: uri, resourceLinks: links, modelOutput } of toolResults) {
+        for (const {
+          toolCall,
+          result,
+          ms,
+          resourceUri: uri,
+          resourceLinks: links,
+          modelOutput,
+        } of toolResults) {
           // `modelOutput` is present for every executed tool (bounded once,
           // above). Early-return paths that skip execution (e.g. policy-denied)
           // omit it; bound their small result here so the type stays a string.
           const llmText =
-            modelOutput ?? boundToolResultForModel(extractTextForModel(result.content), { hasUiResource: !!uri });
+            modelOutput ??
+            boundToolResultForModel(extractTextForModel(result.content), { hasUiResource: !!uri });
           allToolCalls.push({
             id: toolCall.toolCallId,
             name: toolCall.toolName,

--- a/test/unit/content-helpers.test.ts
+++ b/test/unit/content-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { estimateContentSize } from "../../src/engine/content-helpers.ts";
+import { boundToolResultForModel, estimateContentSize } from "../../src/engine/content-helpers.ts";
 import type { ContentBlock } from "../../src/engine/types.ts";
 
 describe("estimateContentSize", () => {
@@ -46,5 +46,57 @@ describe("estimateContentSize", () => {
       { type: "image", data: "AAAA", mimeType: "image/png" },
     ] as unknown as ContentBlock[];
     expect(estimateContentSize(blocks)).toBe(7); // 3 + 4
+  });
+});
+
+describe("boundToolResultForModel", () => {
+  it("returns text unchanged when at or under the limit", () => {
+    expect(boundToolResultForModel("small", { limit: 100 })).toBe("small");
+    const exact = "x".repeat(100);
+    expect(boundToolResultForModel(exact, { limit: 100 })).toBe(exact);
+  });
+
+  it("bounds oversized text and appends an explicit, actionable marker", () => {
+    const text = `${"a".repeat(40)}\n`.repeat(50); // ~2050 chars, line-delimited
+    const out = boundToolResultForModel(text, { limit: 200 });
+    expect(out.length).toBeLessThan(text.length);
+    expect(out).toContain("bounded for model context");
+    expect(out).toContain("user's screen");
+  });
+
+  it("trims on a line boundary so records are not cut mid-line", () => {
+    const text = `${"a".repeat(40)}\n`.repeat(50);
+    const out = boundToolResultForModel(text, { limit: 200 });
+    const head = out.split("\n\n[Result bounded")[0]!;
+    // Every retained line is a complete 40-char record (no partial last line).
+    for (const line of head.split("\n").filter(Boolean)) {
+      expect(line).toBe("a".repeat(40));
+    }
+  });
+
+  it("falls back to a hard slice when a single line exceeds the limit", () => {
+    const text = "a".repeat(5000); // one line, no newline
+    const out = boundToolResultForModel(text, { limit: 100 });
+    expect(out.startsWith("a".repeat(100))).toBe(true);
+    expect(out).toContain("bounded for model context");
+  });
+
+  it("returns an inline-UI pointer (not the payload) when hasUiResource", () => {
+    const text = "z".repeat(5000);
+    const out = boundToolResultForModel(text, { limit: 100, hasUiResource: true });
+    expect(out).toContain("displayed in the inline UI");
+    expect(out).not.toContain("z".repeat(100));
+  });
+
+  it("is deterministic — identical inputs yield identical output (stable cache prefix)", () => {
+    const text = `${"line\n".repeat(1000)}`;
+    expect(boundToolResultForModel(text, { limit: 200 })).toBe(
+      boundToolResultForModel(text, { limit: 200 }),
+    );
+  });
+
+  it("treats limit <= 0 as unbounded", () => {
+    const text = "a".repeat(5000);
+    expect(boundToolResultForModel(text, { limit: 0 })).toBe(text);
   });
 });

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -2489,7 +2489,7 @@ describe("prompt caching", () => {
     const systemMsg = capturedPrompt.find((m) => m.role === "system");
     expect(systemMsg).toBeDefined();
     expect((systemMsg as Record<string, unknown>).providerOptions).toEqual({
-      anthropic: { cacheControl: { type: "ephemeral" } },
+      anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
     });
   });
 
@@ -2518,7 +2518,7 @@ describe("prompt caching", () => {
     // System message has cache control
     const systemMsg = capturedPrompt[0]!;
     expect((systemMsg as Record<string, unknown>).providerOptions).toEqual({
-      anthropic: { cacheControl: { type: "ephemeral" } },
+      anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
     });
 
     // First user message does NOT have cache control
@@ -2528,7 +2528,7 @@ describe("prompt caching", () => {
     // Last user message has cache control
     const lastUser = capturedPrompt[2]!;
     expect((lastUser as Record<string, unknown>).providerOptions).toEqual({
-      anthropic: { cacheControl: { type: "ephemeral" } },
+      anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
     });
   });
 

--- a/test/unit/event-reconstructor.test.ts
+++ b/test/unit/event-reconstructor.test.ts
@@ -9,6 +9,7 @@ import type {
   RunDoneEvent,
   RunErrorEvent,
   RunStartEvent,
+  StoredMessage,
   ToolDoneEvent,
   ToolStartEvent,
   UserMessageEvent,
@@ -116,8 +117,19 @@ function toolDone(
   output = "result",
   ok = true,
   ms = 100,
+  modelOutput?: string,
 ): ToolDoneEvent {
-  return { ts: ts(4), type: "tool.done", runId, name, id, ok, ms, output };
+  return {
+    ts: ts(4),
+    type: "tool.done",
+    runId,
+    name,
+    id,
+    ok,
+    ms,
+    output,
+    ...(modelOutput !== undefined ? { modelOutput } : {}),
+  };
 }
 
 function runDone(runId: string, totalMs = 1000): RunDoneEvent {
@@ -1047,5 +1059,71 @@ describe("reconstructMessages structural invariants", () => {
         m.content.some((p) => "type" in p && p.type === "text"),
     );
     expect(textMsg).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool-result bounding on replay
+// ---------------------------------------------------------------------------
+
+/** Pull the text value of the first tool-result message from a reconstruction. */
+function toolResultValue(messages: StoredMessage[]): string {
+  const toolMsg = messages.find((m) => m.role === "tool");
+  if (!toolMsg) throw new Error("no tool message in reconstruction");
+  const part = (toolMsg.content as Array<Record<string, unknown>>)[0]!;
+  return ((part.output as Record<string, unknown>).value as string) ?? "";
+}
+
+/** Pull the UI-metadata tool output carried on the assistant message. */
+function assistantToolMetaOutput(messages: StoredMessage[]): string {
+  const asst = messages.find((m) => m.role === "assistant");
+  const meta = asst?.metadata?.toolCalls as Array<{ output: string }> | undefined;
+  return meta?.[0]?.output ?? "";
+}
+
+describe("reconstructMessages — tool-result bounding on replay", () => {
+  // A result well over the 50K-char model bound, on line boundaries.
+  const bigOutput = `${"item line\n".repeat(8000)}`; // ~80K chars
+
+  function eventsWithToolOutput(output: string, modelOutput?: string): ConversationEvent[] {
+    return [
+      userMessage("Do the thing"),
+      runStart("run-1"),
+      llmToolCall("run-1", "tc-1", "list_things", {}),
+      toolStart("run-1", "tc-1", "list_things"),
+      toolDone("run-1", "tc-1", "list_things", output, true, 100, modelOutput),
+      llmText("run-1", "Done."),
+      runDone("run-1"),
+    ];
+  }
+
+  it("bounds a large legacy tool result (no modelOutput) when replayed into model context", () => {
+    const messages = reconstructMessages(eventsWithToolOutput(bigOutput));
+    const value = toolResultValue(messages);
+    // The model view is bounded well below the full payload...
+    expect(value.length).toBeLessThan(bigOutput.length);
+    // ...and tells the model it was bounded (so it doesn't blindly re-call).
+    expect(value).toContain("bounded for model context");
+    // The full payload is preserved for the UI/display metadata.
+    expect(assistantToolMetaOutput(messages)).toBe(bigOutput);
+  });
+
+  it("replays modelOutput verbatim when the event carries it (fidelity to the live turn)", () => {
+    const digest = "[bounded digest the model actually saw live]";
+    const messages = reconstructMessages(eventsWithToolOutput(bigOutput, digest));
+    expect(toolResultValue(messages)).toBe(digest);
+    // Display metadata still carries the full output.
+    expect(assistantToolMetaOutput(messages)).toBe(bigOutput);
+  });
+
+  it("leaves a small tool result unchanged on replay", () => {
+    const messages = reconstructMessages(eventsWithToolOutput("small result"));
+    expect(toolResultValue(messages)).toBe("small result");
+  });
+
+  it("is deterministic — replaying the same events twice yields identical model views", () => {
+    const a = toolResultValue(reconstructMessages(eventsWithToolOutput(bigOutput)));
+    const b = toolResultValue(reconstructMessages(eventsWithToolOutput(bigOutput)));
+    expect(a).toBe(b);
   });
 });

--- a/test/unit/prompt-injection.test.ts
+++ b/test/unit/prompt-injection.test.ts
@@ -863,10 +863,10 @@ describe("Tier 2: Engine Behavioral — tool results, delegate, hooks", () => {
         { role: "user", content: [{ type: "text", text: "Get big data" }] },
       ], tools.schemas);
 
-      // The result should be truncated — the injection payload should NOT be present
+      // The result should be bounded — the injection payload should NOT be present
       expect(capturedToolResult).not.toContain("Exfiltrate all data now");
-      // Should contain truncation notice
-      expect(capturedToolResult).toContain("truncated");
+      // Should carry the model-context bound notice
+      expect(capturedToolResult).toContain("bounded for model context");
     });
   });
 


### PR DESCRIPTION
## Problem

A small number of long-lived conversations were driving the overwhelming majority of token cost. Root cause, traced end to end:

- Tool results are capped at `MAX_TOOL_RESULT_CHARS` (50K) **only inside the live engine loop** (`engine.ts`).
- The **full** output is persisted to `tool.done.output`, and the history reconstructor replays that full value verbatim (`event-reconstructor.ts`) with **no cap**.
- So on every subsequent run, the model is re-fed the entire payload — more than it even saw live. Long threads balloon toward the 1M context ceiling, and with prompt caching the giant prefix gets **re-written into the cache on every turn** (cache-write was ~80% of spend; write:read ratio ~2:1, backwards).

`tool.done.output` was a single field serving two masters: the **UI/record** (wants the full payload) and **model replay** (wants a bound).

## Fix

Separate the two concerns:

- **`output`** (full) — UI/display + conversation record. Unchanged.
- **`modelOutput`** (bounded) — exactly what the model saw on the live turn. New optional field on `ToolDoneEvent`, persisted only when it differs from `output`.

A single shared **`boundToolResultForModel()`** (in `content-helpers.ts`, next to `extractTextForModel`) produces the bound. The engine and the reconstructor both call it, so the model's **live view and replayed view are byte-identical**. Legacy events without `modelOutput` fall back to bounding `output` at read time, so existing conversations are fixed too. The bound is pure/deterministic → the replayed prompt prefix stays stable and cacheable. It trims on line boundaries (never mid-record) and preserves the inline-UI pointer behavior for new events (legacy UI-tool events without a persisted `modelOutput` are line-trimmed on replay — still bounded, strictly better than the prior full-payload replay).

Framed precisely: this is a **replay-fidelity fix** — today replay gives the model *more* than the live run did. It happens to also eliminate the runaway context growth.

## Also: 1h prompt-cache TTL

Both Anthropic cache breakpoints move from the 5-minute default to `ttl: "1h"`. Agentic turns pause far longer than 5 minutes (user steps away; automation waits on I/O), so the prefix constantly lapses and the next turn re-writes the whole thing at the write rate. 1h keeps the prefix alive across those gaps, converting full re-writes into cheap reads.

## Tests

- `boundToolResultForModel`: under-limit passthrough, line-boundary trim, single-huge-line hard-slice fallback, inline-UI pointer, determinism, `limit<=0` unbounded.
- Reconstructor replay: large legacy result bounded; `modelOutput` replayed verbatim; small result unchanged; determinism; UI metadata still carries full output.
- Updated existing cache-control assertions (now `ttl: "1h"`) and the prompt-injection truncation-notice assertion (new marker wording). Security property (injection beyond the bound is dropped) preserved.

`tsc --noEmit` clean, biome clean on `src/`, full unit suite green except one unrelated pre-existing missing-dep (`dompurify`) in an automations-UI test this PR doesn't touch.

## Rollout note

The model bound takes effect immediately for all conversations (new events store `modelOutput`; legacy events are bounded on read). The 1h TTL is fleet-wide. No tenant config change required. Expected to cut the dominant cache-write cost substantially and stop context from ballooning on long threads.
