### PR TITLE
feat(engine): loop-brake — trip the supervisor on repeated non-advancing results

### DIFF
--- a/src/engine/supervisor.ts
+++ b/src/engine/supervisor.ts
@@ -192,7 +192,11 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
     // "end the run") — those rot when reread in a later turn where other
     // tools are still callable.
     const directive =
-      `[NB supervisor] Tool \`${toolName}\` returned the same result ${repeats} times in a row; ` +
+      // "made no progress" rather than "returned the same result": accurate
+      // across all three trip modes — identical errors, identical empty
+      // success, AND the non-advancing case where the results vary textually
+      // (different "no match" strings) but represent the same dead end.
+      `[NB supervisor] Tool \`${toolName}\` made no progress ${repeats} times in a row; ` +
       `this tool has been disabled for the rest of this run.\n\n` +
       `Underlying output (last call):\n${originalText}\n\n` +
       `Other tools remain available. Consider an alternative approach or summarize current findings ` +

--- a/src/engine/supervisor.ts
+++ b/src/engine/supervisor.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { extractTextForModel, textContent } from "./content-helpers.ts";
-import type { ToolCall, ToolResult } from "./types.ts";
+import { NON_ADVANCING_META_KEY, type ToolCall, type ToolResult } from "./types.ts";
 
 /**
  * Per-run loop supervisor.
@@ -11,7 +11,7 @@ import type { ToolCall, ToolResult } from "./types.ts";
  * with a synthetic directive instructing the model to stop calling the
  * tool and produce a final response.
  *
- * Two failure modes this catches:
+ * Three failure modes this catches:
  *  - Upstream returns identical 4xx errors on every call (e.g. a tool
  *    whose schema-derived args trigger a deterministic server-side
  *    rejection). The model often retries with cosmetic argument tweaks
@@ -19,9 +19,17 @@ import type { ToolCall, ToolResult } from "./types.ts";
  *  - Upstream returns identical "empty success" payloads to the same
  *    call (pagination dead-ends; idempotent lookups against an
  *    unchanged state).
+ *  - A tool reports it made no progress (a discovery search matching
+ *    nothing) while the model keeps varying the query — so input AND
+ *    content differ every call, defeating the two fingerprints below.
  *
- * Fingerprint composition (success vs. error are different shapes of
- * "stuck"):
+ * Fingerprint composition (three shapes of "stuck"):
+ *
+ *  - NON-ADVANCING: (toolName, NONADVANCING). When `result._meta` carries
+ *    `NON_ADVANCING_META_KEY`, the fingerprint ignores input and content,
+ *    so a tool that keeps reporting no progress trips at N regardless of how
+ *    the model varied the call. Catches the flailing-discovery loop the
+ *    input-aware SUCCESS path deliberately lets through.
  *
  *  - SUCCESS: (toolName, S, content, canonical(input)).
  *    A successful call advances state; "stuck" means the model invoked
@@ -134,6 +142,22 @@ export function createRunSupervisor(config: SupervisorConfig = {}): RunSuperviso
   }
 
   function fingerprint(call: ToolCall, result: ToolResult): string {
+    // A result a tool explicitly flags as non-advancing (a search that
+    // matched nothing, a lookup against unchanged state) collapses to ONE
+    // canonical fingerprint per tool — input- AND content-agnostic. This is
+    // the counterpart to the input-aware success path below: that path treats
+    // a varied input as progress and never trips, which is right for a tool
+    // doing real work but wrong for a discovery loop where the model varies
+    // the query every call and keeps hitting the same dead end. Flagged
+    // results trip after `maxRepeats` no matter how input/content varied.
+    //
+    // The flag is a single explicit opt-in boolean read by key from `_meta`
+    // (the MCP-blessed metadata channel that survives the tool boundary) —
+    // NOT a fold of the whole result into the hash, which would regress the
+    // guard the way the SUCCESS comment below warns against.
+    if (result._meta?.[NON_ADVANCING_META_KEY] === true) {
+      return createHash("sha1").update(`${call.name}\0NONADVANCING`).digest("hex");
+    }
     // Known limitation: hashing only the first `textCap` chars can
     // false-positive on tools that return a long stable preamble (e.g. a
     // verbose header) followed by a short varying field. Two semantically

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -38,7 +38,33 @@ export interface ToolResult {
   content: ContentBlock[];
   structuredContent?: Record<string, unknown>;
   isError: boolean;
+  /**
+   * Free-form out-of-band metadata, mirroring MCP's `CallToolResult._meta`.
+   * Round-trips across the tool boundary in both directions: in-process tools
+   * set it on their `ToolResult`, MCP bundle results carry it from the wire.
+   * It is NOT the tool's data payload (that's `content` / `structuredContent`)
+   * — it's metadata *about* the result, keyed by reverse-DNS namespace per the
+   * MCP convention (`io.modelcontextprotocol/...`, `ai.nimblebrain/...`).
+   */
+  _meta?: Record<string, unknown>;
 }
+
+/**
+ * Reverse-DNS `_meta` key a tool sets (to `true`) to mark its result as making
+ * no forward progress — e.g. a discovery search that matched nothing, or a
+ * lookup against unchanged state.
+ *
+ * The loop supervisor collapses consecutive non-advancing results from the
+ * same tool to one fingerprint and trips regardless of how input or output
+ * varied between calls — the counterpart to the input-aware success
+ * fingerprint, which treats a varied input as progress and so never trips a
+ * flailing discovery loop (model varies the query every call, same dead end).
+ *
+ * It rides in `_meta` — the MCP-blessed channel for metadata-about-a-result —
+ * rather than `structuredContent` (the tool's data) or a bespoke top-level
+ * field (dropped at the boundary). Any tool, in-process or bundle, can set it.
+ */
+export const NON_ADVANCING_META_KEY = "ai.nimblebrain/non-advancing";
 
 export interface ToolPromotionResult {
   ok: boolean;

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -45,6 +45,13 @@ export interface ToolResult {
    * It is NOT the tool's data payload (that's `content` / `structuredContent`)
    * — it's metadata *about* the result, keyed by reverse-DNS namespace per the
    * MCP convention (`io.modelcontextprotocol/...`, `ai.nimblebrain/...`).
+   *
+   * Forwarding lives at the two serialization boundaries, not per-source:
+   * `defineInProcessApp` (every in-process tool, incl. system tools + delegate)
+   * and `McpSource` (bundle results, inline + task paths). A direct `ToolSource`
+   * that returns a `ToolResult` with no boundary in between (e.g. `UpjackSource`)
+   * carries `_meta` natively — no forwarding needed. So any tool, in-process or
+   * bundle, can opt into a `_meta` hint and have it reach the engine.
    */
   _meta?: Record<string, unknown>;
 }

--- a/src/tools/in-process-app.ts
+++ b/src/tools/in-process-app.ts
@@ -245,6 +245,11 @@ export function defineInProcessApp(
             content: result.content,
             ...(result.structuredContent ? { structuredContent: result.structuredContent } : {}),
             ...(result.isError ? { isError: true } : {}),
+            // Forward result `_meta` onto the wire so it round-trips back to
+            // the caller as `ToolResult._meta` (e.g. the supervisor's
+            // non-advancing hint). `CallToolResult._meta` is a loose object, so
+            // arbitrary reverse-DNS keys survive the round-trip.
+            ...(result._meta ? { _meta: result._meta } : {}),
           };
         });
 

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -1194,6 +1194,10 @@ export class McpSource implements ToolSource {
         | Record<string, unknown>
         | undefined,
       isError: Boolean(result.isError),
+      // Surface result-level `_meta` (loose object on the wire) so out-of-band
+      // hints from the bundle — e.g. the supervisor's non-advancing marker —
+      // reach the engine instead of being dropped at this projection.
+      _meta: (result as { _meta?: Record<string, unknown> })._meta,
     };
     const promoted = promoteHiddenErrors(toolResult);
     if (promoted !== toolResult) {
@@ -1244,6 +1248,9 @@ export class McpSource implements ToolSource {
         : [],
       structuredContent: callToolResult.structuredContent as Record<string, unknown> | undefined,
       isError: Boolean(callToolResult.isError),
+      // Surface result-level `_meta` (loose object on the wire) so out-of-band
+      // hints from the bundle reach the engine — same as the inline path.
+      _meta: (callToolResult as { _meta?: Record<string, unknown> })._meta,
     };
     const promoted = promoteHiddenErrors(toolResult);
     if (promoted !== toolResult) {

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -7,6 +7,7 @@ import { isToolEnabled, type ResolvedFeatures } from "../config/features.ts";
 import type { ConfirmationGate } from "../config/privilege.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { EventSink, ToolPromotionControls, ToolResult, ToolSchema } from "../engine/types.ts";
+import { NON_ADVANCING_META_KEY } from "../engine/types.ts";
 import type { Runtime } from "../runtime/runtime.ts";
 import type { SelectedSkill } from "../skills/select.ts";
 import type { Skill } from "../skills/types.ts";
@@ -158,7 +159,15 @@ export async function createSystemTools(
         if (!q) return groupToolsBySource(all);
         const matches = rankToolSearchResults(all, q);
         if (matches.length === 0)
-          return { content: textContent(`No tools matched "${query}".`), isError: false };
+          // Mark non-advancing (out-of-band, via `_meta`) so repeated empty
+          // searches trip the loop supervisor even as the model varies the
+          // query each call — which otherwise yields a fresh fingerprint every
+          // time and never trips.
+          return {
+            content: textContent(`No tools matched "${query}".`),
+            isError: false,
+            _meta: { [NON_ADVANCING_META_KEY]: true },
+          };
         const shown = matches.slice(0, 25);
         const suffix = matches.length > shown.length ? ` (showing top ${shown.length})` : "";
         const lines = [`Found ${matches.length} tool(s) for "${query}"${suffix}:\n`];

--- a/test/unit/engine/supervisor.test.ts
+++ b/test/unit/engine/supervisor.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { createRunSupervisor } from "../../../src/engine/supervisor.ts";
-import type { ToolCall, ToolResult } from "../../../src/engine/types.ts";
+import {
+  NON_ADVANCING_META_KEY,
+  type ToolCall,
+  type ToolResult,
+} from "../../../src/engine/types.ts";
 
 function call(name: string, input: Record<string, unknown> = {}): ToolCall {
   return { id: `call-${Math.random().toString(36).slice(2, 8)}`, name, input };
@@ -270,5 +274,82 @@ describe("supervisor — input-aware success fingerprinting", () => {
       );
       expect(v.type).toBe("pass");
     }
+  });
+});
+
+describe("supervisor — non-advancing results", () => {
+  const nonAdvancing = (text: string): ToolResult => ({
+    content: [{ type: "text", text }],
+    isError: false,
+    _meta: { [NON_ADVANCING_META_KEY]: true },
+  });
+
+  it("trips after 3 non-advancing results even when input AND output both vary", () => {
+    const sup = createRunSupervisor();
+    // Mirrors the nb__search discovery loop: a fresh query each call and a
+    // distinct "no match" string each time. The input-aware success and
+    // content fingerprints would never collapse these — the `_meta`
+    // non-advancing flag is what does.
+    expect(
+      sup.observe(call("nb__search", { query: "preview" }), nonAdvancing('No tools matched "preview".'))
+        .type,
+    ).toBe("pass");
+    expect(
+      sup.observe(
+        call("nb__search", { query: "collateral" }),
+        nonAdvancing('No tools matched "collateral".'),
+      ).type,
+    ).toBe("pass");
+    const v3 = sup.observe(
+      call("nb__search", { query: "document" }),
+      nonAdvancing('No tools matched "document".'),
+    );
+    expect(v3.type).toBe("synth");
+    if (v3.type === "synth") {
+      expect(v3.trippedTool).toBe("nb__search");
+      expect(v3.consecutiveRepeats).toBe(3);
+    }
+  });
+
+  it("an advancing result between non-advancing ones resets the counter", () => {
+    const sup = createRunSupervisor();
+    expect(
+      sup.observe(call("nb__search", { query: "a" }), nonAdvancing('No tools matched "a".')).type,
+    ).toBe("pass");
+    expect(
+      sup.observe(call("nb__search", { query: "b" }), nonAdvancing('No tools matched "b".')).type,
+    ).toBe("pass");
+    // A real match advances — different fingerprint, resets the streak.
+    expect(
+      sup.observe(call("nb__search", { query: "crm" }), textResult('Found 2 tool(s) for "crm"')).type,
+    ).toBe("pass");
+    expect(
+      sup.observe(call("nb__search", { query: "c" }), nonAdvancing('No tools matched "c".')).type,
+    ).toBe("pass");
+    expect(
+      sup.observe(call("nb__search", { query: "d" }), nonAdvancing('No tools matched "d".')).type,
+    ).toBe("pass");
+    // Only the 3rd CONSECUTIVE non-advancing result trips.
+    expect(
+      sup.observe(call("nb__search", { query: "e" }), nonAdvancing('No tools matched "e".')).type,
+    ).toBe("synth");
+  });
+
+  it("preserves the input-aware success path: varied-input real work never trips", () => {
+    const sup = createRunSupervisor();
+    // patch_source: structurally-uniform success output, distinct inputs each
+    // call — progress, not a loop. The non-advancing flag (absent here) must
+    // not perturb the input-aware success fingerprint.
+    const ok = (): ToolResult => textResult('{"applied":true,"compiled":true}');
+    expect(
+      sup.observe(call("patch_source", { edits: [{ find: "a", replace: "b" }] }), ok()).type,
+    ).toBe("pass");
+    expect(
+      sup.observe(call("patch_source", { edits: [{ find: "c", replace: "d" }] }), ok()).type,
+    ).toBe("pass");
+    expect(
+      sup.observe(call("patch_source", { edits: [{ find: "e", replace: "f" }] }), ok()).type,
+    ).toBe("pass");
+    expect(sup.snapshot().trippedTools).toEqual([]);
   });
 });

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { NoopEventSink } from "../../src/adapters/noop-events.ts";
 import { extractText } from "../../src/engine/content-helpers.ts";
+import { NON_ADVANCING_META_KEY } from "../../src/engine/types.ts";
 import { createSystemTools } from "../../src/tools/system-tools.ts";
 import type {
 	GetSkillsFn,
@@ -225,6 +226,9 @@ describe("System Tools", () => {
 		});
 		expect(result.isError).toBe(false);
 		expect(extractText(result.content)).toContain('No tools matched "nonexistent"');
+		// Flagged non-advancing (via `_meta`) so repeated empty searches trip
+		// the loop supervisor even as the model varies the query each call.
+		expect(result._meta?.[NON_ADVANCING_META_KEY]).toBe(true);
 	});
 
 	it("search with scope=tools excludes internal tools from results", async () => {
@@ -257,6 +261,8 @@ describe("System Tools", () => {
 		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toEqual([
 			{ name: "test__visible" },
 		]);
+		// A search that matched is advancing — must not be flagged.
+		expect(result._meta?.[NON_ADVANCING_META_KEY]).toBeUndefined();
 	});
 
 	it("search with scope=tools excludes tools that are not eligible", async () => {

--- a/test/unit/tools/non-advancing-meta.test.ts
+++ b/test/unit/tools/non-advancing-meta.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { textContent } from "../../../src/engine/content-helpers.ts";
+import { NON_ADVANCING_META_KEY } from "../../../src/engine/types.ts";
+import { makeInProcessSource } from "../../helpers/in-process-source.ts";
+
+/**
+ * Round-trip guard for the non-advancing `_meta` channel.
+ *
+ * `makeInProcessSource` runs a real in-process MCP server + client transport,
+ * so a tool result here crosses the same `CallToolResult` serialization a
+ * bundle's would. These tests prove a reverse-DNS `_meta` key set by a tool
+ * survives that boundary and lands on the engine-side `ToolResult._meta` —
+ * the assumption the loop supervisor's non-advancing trip depends on.
+ */
+describe("_meta round-trips across the tool boundary", () => {
+  it("a tool's result `_meta` reaches the engine-side ToolResult", async () => {
+    const source = await makeInProcessSource("test", [
+      {
+        name: "deadend",
+        description: "Always reports no progress",
+        inputSchema: { type: "object", properties: {} },
+        handler: async () => ({
+          content: textContent("nothing found"),
+          isError: false,
+          _meta: { [NON_ADVANCING_META_KEY]: true },
+        }),
+      },
+    ]);
+
+    const result = await source.execute("deadend", {});
+    expect(result.isError).toBe(false);
+    // The flag survived handler -> CallToolResult -> transport -> McpSource.
+    expect(result._meta?.[NON_ADVANCING_META_KEY]).toBe(true);
+  });
+
+  it("a tool that sets no `_meta` yields no `_meta` on the result", async () => {
+    const source = await makeInProcessSource("test", [
+      {
+        name: "plain",
+        description: "Ordinary tool",
+        inputSchema: { type: "object", properties: {} },
+        handler: async () => ({ content: textContent("ok"), isError: false }),
+      },
+    ]);
+
+    const result = await source.execute("plain", {});
+    expect(result._meta?.[NON_ADVANCING_META_KEY]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #361. That PR fixed the cache bug that made a bundle's tools invisible; this adds the behavioral brake for the *other* half of the same incident — an agent that re-searches for a capability that genuinely isn't there instead of stopping.

## Problem

The loop supervisor fingerprints `(toolName, isError, content[, input])` and trips after N identical fingerprints. A discovery loop slips through every axis: the model calls `nb__search` with a fresh query each turn and gets a distinct `No tools matched "<query>"` back, so content **and** input vary and the fingerprint never repeats — the run burns iterations to the cap. Input-aware success fingerprinting (#324) makes this structural: a varied input reads as progress.

## Fix

A third "stuck" axis: a tool may mark a result **non-advancing**. The supervisor collapses consecutive non-advancing results from one tool to a single canonical fingerprint, so N in a row trip regardless of how input/content varied; the tool is then disabled for the run and the model is nudged to surface the gap.

### Why `_meta` (and not `structuredContent` or a top-level field)

The signal is *metadata about a result*, not the tool's data — so it belongs in MCP's `_meta`, the blessed out-of-band channel, under a reverse-DNS key (`ai.nimblebrain/non-advancing`, matching the spec's own `io.modelcontextprotocol/…` convention). A top-level `ToolResult` field is dropped at the MCP boundary every tool result crosses (in-process system tools included); `structuredContent` is the tool's data payload and overloading it is a smell. `_meta` is the correct container and round-trips by construction.

To make it reachable end-to-end:
- `ToolResult` gains a `_meta` slot mirroring `CallToolResult._meta`.
- The in-process tool boundary forwards result `_meta` onto the wire; `McpSource` reads result-level `_meta` back on **both** the inline and task paths. `_meta` is a `looseObject` per the MCP schema, so arbitrary reverse-DNS keys survive — **verified by a round-trip test through a real in-process MCP transport** (not just schema-reading).
- `nb__search`'s no-match branch sets the key. Any tool, in-process or bundle, opts in the same way.

The supervisor reads the flag **by key**, not by folding `_meta` into the hash — so the input-aware success path is untouched.

## Composition

- With #324 (input-aware success fingerprint): that fixed *false trips on progress*; this fixes *missed trips on no-progress*. The two are the false-positive and false-negative halves of the same "is this call advancing?" question.
- With #260 (ranked search): fewer reasonable queries come back empty in the first place, so this brake fires only when a capability is genuinely absent.

## Tests

- **Round-trip** (`non-advancing-meta.test.ts`): a tool's `_meta` set in its handler survives the in-process MCP boundary and lands on the engine-side `ToolResult._meta`. Empirical proof the channel works.
- **Supervisor**: 3 non-advancing results trip even with input+content varying every call; an advancing result resets the streak; varied-input real work (`patch_source`-style) still never trips. Verified red without the `_meta` fingerprint branch.
- **`nb__search`**: no-match sets the `_meta` key; a match does not.

Full `verify` green locally: static checks, 3316 unit + 666 integration tests, 0 failures.