### PR TITLE
test(bundles): make remote-lifecycle name-ref test hermetic

### DIFF
--- a/test/integration/remote-lifecycle.test.ts
+++ b/test/integration/remote-lifecycle.test.ts
@@ -263,14 +263,36 @@ describe("BundleLifecycleManager — remote connection failure", () => {
 
 describe("startBundleSource — remote url entries", () => {
 	let mockServer: MockRemoteServer;
+	let prevMpakHome: string | undefined;
 
 	beforeEach(() => {
 		setupTestDir();
 		mockServer = startMockRemoteServer(2);
+
+		// Isolate mpak so an unresolvable `{ name }` ref fails fast and
+		// offline. Without this, resolving a name cache-misses and the SDK
+		// fetches the public registry (https://registry.mpak.dev); under a
+		// slow CI network that round-trip blows the test's 15s budget and
+		// flakes. Point the registry at a closed local port so the lookup
+		// returns ECONNREFUSED immediately instead of hanging.
+		const mpakHome = join(testDir, "mpak-home");
+		mkdirSync(mpakHome, { recursive: true });
+		writeFileSync(
+			join(mpakHome, "config.json"),
+			JSON.stringify({
+				version: "1.0.0",
+				lastUpdated: new Date(0).toISOString(),
+				registryUrl: "http://127.0.0.1:1",
+			}),
+		);
+		prevMpakHome = process.env.MPAK_HOME;
+		process.env.MPAK_HOME = mpakHome;
 	});
 
 	afterEach(() => {
 		mockServer?.close();
+		if (prevMpakHome === undefined) delete process.env.MPAK_HOME;
+		else process.env.MPAK_HOME = prevMpakHome;
 	});
 
 	it("starts a remote bundle from a url BundleRef", async () => {


### PR DESCRIPTION
## Summary

The `startBundleSource — remote url entries > handles mix of name, path, and url entries via allSettled` integration test flakes intermittently in CI with a 15s timeout (seen most recently on #300's CI).

## Root cause

The test passes an unresolvable `{ name: "@nonexistent/bundle" }` ref through `startBundleSource` and asserts it rejects. An uncached name cache-misses, so the mpak SDK falls through to a **public-registry fetch** (`https://registry.mpak.dev/v1/bundles/...`). When that fetch 404s quickly the test passes; under a slow CI network the round-trip exceeds the test's 15s budget and the test times out. It's a non-hermetic test reaching the public internet.

## Fix

Isolate `MPAK_HOME` to a temp dir whose `config.json` points `registryUrl` at a closed local port (`http://127.0.0.1:1`). The name lookup now returns `ECONNREFUSED` immediately instead of hanging — the ref still rejects (preserving the test's intent: a mix of failing name/path refs alongside a succeeding url ref), but fast and offline.

Scoped to the one `describe` block that uses a name ref; `MPAK_HOME` is saved and restored in `beforeEach`/`afterEach` so sibling tests and other files are unaffected.

## Verification

- Previously-flaky test: **170ms** (was a 15s timeout)
- `bun run test:integration`: 654 pass / 12 skip / 0 fail
- `bun run lint` / `format:check` / `check`: clean

This is a test-only change — no production code touched.