### PR TITLE
fix(bundles): warm mpak cache before manifest read so cold-install placements register (#60)

### DIFF
--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -265,11 +265,10 @@ export class BundleLifecycleManager {
     wsId: string,
     env?: Record<string, string>,
   ): Promise<BundleInstance> {
-    // Pre-load so the manifest is in the mpak cache before startBundleSource
-    // reads it. (startBundleSource itself only calls prepareServer; it
-    // assumes the manifest is already cached.)
-    const mpak = getMpak(this.mpakHome);
-    await mpak.bundleCache.loadBundle(name);
+    // No cache pre-warm here: startBundleSource warms the mpak cache itself
+    // before reading the manifest (see its named-bundle branch, #60), so a
+    // cold first-install registers placements without a restart on every
+    // path, not just this one.
 
     // Workspace-scoped data dir keeps two workspaces installing the same
     // bundle from stomping on each other's entity data. Slug source is

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -538,29 +538,49 @@ export async function startBundleSource(
     const mpakHome = process.env.MPAK_HOME ?? join(homedir(), ".mpak");
     const mpak = getMpak(mpakHome);
 
+    // Warm the mpak cache so the up-front manifest read below is a hit on a
+    // cold/first-ever install. Without this, getBundleManifest() returns null
+    // the first time a bundle is installed on a pod; meta/manifest stay null,
+    // so placement registration AND user_config resolution silently no-op
+    // until a process restart re-reads the now-warm cache (#60 — the bundle
+    // shows under Connectors but never under Apps). Doing it here, at the one
+    // chokepoint every named install/respawn path funnels through (connector
+    // UI, installNamed, boot reload, JIT), fixes the whole class instead of
+    // relying on each caller to pre-warm — a contract callers silently broke.
+    //
+    // Guard on getBundleManifest (the same manifest.json the read below uses),
+    // NOT on loadBundle's own short-circuit: loadBundle keys its no-op on a
+    // separate .mpak-meta.json, so a manifest-only cache (offline-warm starts,
+    // test fixtures) would wrongly trigger a network pull. Skipping when the
+    // manifest is already on disk keeps warm boots and offline starts
+    // network-free, exactly as today; prepareServer re-reads and re-validates.
+    if (!mpak.bundleCache.getBundleManifest(ref.name)) {
+      await mpak.bundleCache.loadBundle(ref.name);
+    }
+
     // Read cached manifest up-front so we can discover the user_config schema
-    // and resolve credentials BEFORE prepareServer validates them. The mpak
-    // cache is populated during install (see BundleLifecycleManager.installNamed
-    // or mpak install), so we expect the manifest to be present here.
+    // and resolve credentials BEFORE prepareServer validates them. The warm
+    // step above guarantees the manifest is present here on every path that
+    // can reach the registry; a miss now means a genuinely unexpected state.
     let cachedManifest = mpak.bundleCache.getBundleManifest(ref.name) as BundleManifest | null;
     if (cachedManifest) {
       meta = extractBundleMeta(cachedManifest as unknown as Record<string, unknown>);
       manifest = cachedManifest;
     } else {
-      // Same silent-failure shape as the bug this file's helper extraction
-      // was written to fix: with no manifest in cache we can't read `_meta`
-      // capability declarations, so http-proxy and host_capabilities get
-      // silently skipped at spawn. Surface it loudly instead of letting
-      // operators chase phantom UI bugs.
+      // With no manifest in cache we can't read `_meta` capability
+      // declarations, so http-proxy and host_capabilities get silently
+      // skipped at spawn. Surface it loudly instead of letting operators
+      // chase phantom UI bugs.
       //
-      // The host-capability gate is also degraded by this path. Fail-closed
-      // was considered for Phase 2a and reverted: the boot-reload path
-      // (workspace.json carries a bundle ref whose manifest was never
-      // mpak-cached, or whose cache was wiped between sessions) hits this
-      // legitimately, and refusing the spawn there breaks workspaces that
-      // were valid before the platform restart. A proper resolution
-      // requires a cache-warm step before the check; tracked for a
-      // follow-up.
+      // The cache-warm step above (#60) closes the common cause of this —
+      // a cold first-install no longer reaches here, since the warm either
+      // populates the manifest or throws on a truly cold + offline cache.
+      // Reaching this branch now means an unexpected state (e.g. the cache
+      // dir was wiped between the warm and this read), not the normal
+      // first-install path. We still fall through rather than fail-closed:
+      // refusing the spawn would break workspaces that were valid before a
+      // restart, and the terminal host-capability gate below re-checks the
+      // manifest once prepareServer has re-populated it.
       log.warn(
         `[bundles] manifest cache miss for ${ref.name} — capability declarations ` +
           "(http-proxy, host_capabilities, etc.) will be skipped at spawn, including " +

--- a/test/integration/startup-cold-cache-placements.test.ts
+++ b/test/integration/startup-cold-cache-placements.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression test for #60 — "Bundle placements silently fail to register on
+ * cold cache."
+ *
+ * A named bundle declares UI placements under
+ * `_meta["ai.nimblebrain/host"].placements`. `startBundleSource` reads the
+ * manifest from the mpak bundle cache up front to derive that metadata. On a
+ * cold (first-ever) install the cache is empty, so the read returned null and
+ * `meta` stayed null — the bundle spawned (tools worked, it showed under
+ * Connectors) but its `sidebar.apps` placement never registered, so it never
+ * appeared under Apps until a process restart re-read the now-warm cache.
+ *
+ * The fix warms the cache at the start of the named-bundle branch, guarded on
+ * `getBundleManifest` so a manifest-already-present cache (warm boot, offline
+ * start) adds no network call.
+ *
+ * These tests reproduce a cold→warm transition deterministically by stubbing
+ * `bundleCache.loadBundle` to MATERIALIZE the cache on disk (what a real
+ * registry download does) instead of hitting the network.
+ */
+
+import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { getMpak } from "../../src/bundles/mpak.ts";
+import { startBundleSource } from "../../src/bundles/startup.ts";
+import { ToolRegistry } from "../../src/tools/registry.ts";
+
+const BUNDLE_NAME = "@nbtest/cold-cache-app";
+const BUNDLE_SLUG = "nbtest-cold-cache-app";
+const SOURCE_NAME = "cold-cache-app";
+const WS_ID = "ws_cold_cache";
+
+const rootDir = join(tmpdir(), `nb-cold-cache-${Date.now()}-${process.pid}`);
+
+afterAll(() => {
+  rmSync(rootDir, { recursive: true, force: true });
+});
+
+/**
+ * Write the bundle artifacts a real mpak download would produce into the
+ * cache dir: a minimal MCP server, a manifest declaring a `sidebar.apps`
+ * placement, and the `.mpak-meta.json` marker. Idempotent.
+ */
+function materializeCache(cacheDir: string): void {
+  mkdirSync(cacheDir, { recursive: true });
+
+  const nodeModulesPath = join(import.meta.dir, "../..", "node_modules");
+  const serverCode = `
+const { Server } = require("${nodeModulesPath}/@modelcontextprotocol/sdk/dist/cjs/server/index.js");
+const { StdioServerTransport } = require("${nodeModulesPath}/@modelcontextprotocol/sdk/dist/cjs/server/stdio.js");
+const { ListToolsRequestSchema } = require("${nodeModulesPath}/@modelcontextprotocol/sdk/dist/cjs/types.js");
+
+async function main() {
+  const server = new Server(
+    { name: "cold-cache-app", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      { name: "noop", description: "no-op", inputSchema: { type: "object", properties: {} } },
+    ],
+  }));
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+main();
+`;
+  writeFileSync(join(cacheDir, "server.cjs"), serverCode);
+
+  const manifest = {
+    manifest_version: "0.4",
+    name: BUNDLE_NAME,
+    version: "0.1.0",
+    description: "Cold-cache placement regression bundle",
+    author: { name: "Test Author" },
+    server: {
+      type: "node",
+      entry_point: "server.cjs",
+      mcp_config: { command: "node", args: ["${__dirname}/server.cjs"] },
+    },
+    _meta: {
+      "ai.nimblebrain/host": {
+        host_version: "1.0",
+        name: "Cold Cache App",
+        icon: "file-text",
+        placements: [
+          {
+            slot: "sidebar.apps",
+            resourceUri: "ui://cold-cache/main",
+            route: BUNDLE_NAME,
+            label: "Cold Cache",
+            icon: "file-text",
+          },
+        ],
+      },
+    },
+  };
+  writeFileSync(join(cacheDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+
+  writeFileSync(
+    join(cacheDir, ".mpak-meta.json"),
+    JSON.stringify({
+      version: "0.1.0",
+      pulledAt: new Date().toISOString(),
+      platform: { os: process.platform, arch: process.arch },
+    }),
+  );
+}
+
+describe("startBundleSource — cold-cache placement registration (#60)", () => {
+  let mpakHome: string;
+  let workDir: string;
+  let cacheDir: string;
+  let prevMpakHome: string | undefined;
+
+  beforeEach(() => {
+    const dir = join(rootDir, `case-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mpakHome = join(dir, "mpak-home");
+    workDir = join(dir, "nb-home");
+    cacheDir = join(mpakHome, "cache", BUNDLE_SLUG);
+
+    // Point the mpak SDK at this case's home. getMpak caches by mpakHome, so a
+    // unique path per test yields a fresh singleton we can spy on.
+    prevMpakHome = process.env.MPAK_HOME;
+    process.env.MPAK_HOME = mpakHome;
+  });
+
+  function restoreEnv(): void {
+    if (prevMpakHome === undefined) delete process.env.MPAK_HOME;
+    else process.env.MPAK_HOME = prevMpakHome;
+  }
+
+  test(
+    "cold cache: placements register on first start without a restart",
+    async () => {
+      // Cold: nothing on disk yet. loadBundle stands in for the registry
+      // download, materializing the cache the first time it's called.
+      expect(existsSync(cacheDir)).toBe(false);
+
+      const mpak = getMpak(mpakHome);
+      const loadSpy = spyOn(mpak.bundleCache, "loadBundle").mockImplementation(async () => {
+        materializeCache(cacheDir);
+        return { cacheDir, version: "0.1.0", pulled: true };
+      });
+
+      const registry = new ToolRegistry();
+      try {
+        const result = await startBundleSource({ name: BUNDLE_NAME }, registry, new NoopEventSink(), undefined, {
+          wsId: WS_ID,
+          workDir,
+        });
+
+        // The warm step ran (cache was cold → loadBundle invoked)...
+        expect(loadSpy).toHaveBeenCalled();
+        // ...so the up-front manifest read was a hit and meta carries the
+        // placement. Before the fix, meta was null here.
+        expect(result.meta).not.toBeNull();
+        const placements = result.meta?.ui?.placements ?? [];
+        expect(placements).toHaveLength(1);
+        expect(placements[0]?.slot).toBe("sidebar.apps");
+        expect(result.manifest?.name).toBe(BUNDLE_NAME);
+
+        await registry.removeSource(result.sourceName);
+      } finally {
+        loadSpy.mockRestore();
+        restoreEnv();
+      }
+    },
+    20_000,
+  );
+
+  test(
+    "warm cache: the guard adds no extra cache pull (manifest already present)",
+    async () => {
+      // Warm: manifest already on disk before startBundleSource runs.
+      materializeCache(cacheDir);
+
+      const mpak = getMpak(mpakHome);
+      const loadSpy = spyOn(mpak.bundleCache, "loadBundle").mockImplementation(async () => ({
+        cacheDir,
+        version: "0.1.0",
+        pulled: false,
+      }));
+
+      const registry = new ToolRegistry();
+      try {
+        const result = await startBundleSource({ name: BUNDLE_NAME }, registry, new NoopEventSink(), undefined, {
+          wsId: WS_ID,
+          workDir,
+        });
+
+        // The guard keys on getBundleManifest (manifest present) and skips its
+        // pre-warm, so the only loadBundle call is prepareServer's internal
+        // one. An unguarded `await loadBundle` would make this 2 — and would
+        // hit the network on a manifest-only cache.
+        expect(loadSpy).toHaveBeenCalledTimes(1);
+        expect(result.meta?.ui?.placements ?? []).toHaveLength(1);
+
+        await registry.removeSource(result.sourceName);
+      } finally {
+        loadSpy.mockRestore();
+        restoreEnv();
+      }
+    },
+    20_000,
+  );
+});


### PR DESCRIPTION
## Summary

Closes #60. Named bundles that declare UI placements (`_meta["ai.nimblebrain/host"].placements`, e.g. `slot: "sidebar.apps"`) silently failed to register them on a **cold/first-ever install** — the bundle spawned and its tools worked (it showed under **Connectors**), but it never appeared under **Apps** until a full process restart.

Confirmed in prod: tenant `webcaredigital`, bundle `@nimblebraininc/synapse-collateral` — present as a connector, absent from the Apps nav, the platform logging the `manifest cache miss` warning.

## Root cause

`startBundleSource` (`src/bundles/startup.ts`, named-bundle branch) reads the manifest from the mpak bundle cache **once, up front**, to derive placement/UI metadata. On a cold cache that read returns `null`, so `meta`/`manifest` stay null and placement registration (plus `user_config` resolution) silently no-op. `prepareServer` populates the cache as a side effect — but only *after* the read, and nothing re-registers placements. A restart re-reads the now-warm cache and the placement appears.

`installNamed` (admin/CLI path) masked the bug by pre-warming with `loadBundle` before calling `startBundleSource` (lifecycle.ts). The **Connectors-UI** path (`installBundleInWorkspace`) didn't, so UI installs hit it.

The issue's "log a warning when the read misses" recommendation already shipped — that's the `manifest cache miss` warning. This PR lands the actual fix.

## Fix

Warm the cache at the **one chokepoint** every named install/respawn path funnels through (connector UI, `installNamed`, boot reload, JIT), immediately before the up-front read:

```ts
if (!mpak.bundleCache.getBundleManifest(ref.name)) {
  await mpak.bundleCache.loadBundle(ref.name);
}
```

- **Guard on `getBundleManifest`** (the same `manifest.json` the read consumes), **not** on `loadBundle`'s internal `.mpak-meta.json` short-circuit. A manifest-only cache (warm boots, offline starts, test fixtures) therefore adds **no network call** — warm-cache spawns stay network-free, exactly as today.
- Removes the now-redundant pre-warm from `installNamed`; the contract is enforced in one place instead of relied on per-caller.

## Tests

New `test/integration/startup-cold-cache-placements.test.ts` reproduces the cold→warm transition deterministically by stubbing `loadBundle` to *materialize* the cache (no network):

- **cold cache** → placements register on first start without a restart. Proven to **fail without the fix** (`meta === null`, emits the prod warning) and pass with it.
- **warm cache** → the guard adds no extra cache pull (an unguarded `await loadBundle` would make this 2 and hit the network on manifest-only caches).

`verify:static` green; 127/127 across the bundle/placement/install suites pass.

## Review

Root-cause analysis run through the bug-fix workflow with an independent adversarial review (ENDORSE-WITH-REFINEMENTS) — the reviewer caught the `.mpak-meta.json` vs `manifest.json` short-circuit mismatch, which is why the warm is guarded on `getBundleManifest`.