### PR TITLE
fix(automations): save-error banner cleared on failure (follow-up to #369)

### DIFF
--- a/src/bundles/automations/ui/src/components/AutomationDetailView.tsx
+++ b/src/bundles/automations/ui/src/components/AutomationDetailView.tsx
@@ -79,10 +79,16 @@ export function AutomationDetailView({
     setError(null);
     try {
       await onUpdate(automationName, { [field]: value });
+      // Refresh ONLY on success. loadDetail() calls setError(null) before its
+      // first await, so calling it after a failed save runs in the same
+      // synchronous continuation as the catch's setError(message) — React
+      // batches them and the null wins, silently clearing the banner. On
+      // failure we keep the error and let the closed editor (setEditing(null))
+      // re-render the field at its unchanged saved value.
+      loadDetail();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save change.");
     }
-    loadDetail();
   }
 
   if (loading && !detail) {


### PR DESCRIPTION
Follow-up to #369. A QA reviewer correctly found that the "surface update errors" half of #369 doesn't actually work — verified against source.

## The bug

`AutomationDetailView.saveField`:

```js
async function saveField(field, value) {
  setEditing(null);
  setError(null);
  try {
    await onUpdate(...);     // rejects
  } catch (err) {
    setError(err.message);   // sets the error
  }
  loadDetail();              // ← runs setError(null) (line 51) before its first await
}
```

When `onUpdate` rejects, the catch runs `setError(message)`, then `loadDetail()` runs synchronously to its first `await` — executing `setError(null)`. Both updates land in the **same microtask continuation**, React batches them, `null` wins, and the banner (`{error && …}`) never renders. (Even without batching, it's two sequential `setError`s and `null` is last.) Net: a rejected save still looks like a silent no-op — the exact symptom #369 set out to fix.

## The fix

Refresh **only on success**:

```js
try {
  await onUpdate(...);
  loadDetail();            // success path only
} catch (err) {
  setError(err.message);   // persists; no refresh to clear it
}
```

On failure the error stays set; the field reverts because `setEditing(null)` closes the inline editor and re-renders the unchanged `detail` value.

## Notes

- The cap-raise half of #369 (15→50, default 5→25) was unaffected and is correct.
- **No regression test:** the bundle UIs have no component-test harness (`@testing-library`); this React state-timing path can't be covered without standing up RTL. Verified manually against the batching trace; `bun run verify:static` green and the automations bundle UI builds clean.