### PR TITLE
fix(engine): resume length-truncated turns; unclamp Opus output (32K→128K)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "nimblebrain-ts",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.64",
+        "@ai-sdk/anthropic": "^3.0.81",
         "@ai-sdk/google": "^3.0.53",
         "@ai-sdk/openai": "^3.0.48",
         "@composio/core": "0.9.1",
@@ -47,7 +47,7 @@
     "@hono/node-server": ">=1.19.13",
   },
   "packages": {
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.64", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-rwLi/Rsuj2pYniQXIrvClHvXDzgM4UQHHnvHTWEF14efnlKclG/1ghpNC+adsRujAbCTr6gRsSbDE2vEqriV7g=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.81", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.80", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uM7kpZB5l977lW7+2X1+klBUxIZQ78+1a9jHlaHFEzcOcmmslTl3sdP0QqfuuBcO0YBM2gwOiqVdp8i4TRQYcw=="],
 
@@ -55,9 +55,9 @@
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.48", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ALmj/53EXpcRqMbGpPJPP4UOSWw0q4VGpnDo7YctvsynjkrKDmoneDG/1a7VQnSPYHnJp6tTRMf5ZdxZ5whulg=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
@@ -514,6 +514,24 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
+
+    "@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
+
+    "@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.64",
+    "@ai-sdk/anthropic": "^3.0.81",
     "@ai-sdk/google": "^3.0.53",
     "@ai-sdk/openai": "^3.0.48",
     "@composio/core": "0.9.1",

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -772,9 +772,23 @@ export class AgentEngine {
           ) {
             lengthContinuations += 1;
             // Seed history with the partial assistant text so the next call
-            // continues from where it stopped (Anthropic resumes an assistant
-            // turn when it's the trailing message). `normalizeForReplay`
-            // fixes the stream→prompt shape, same as the tool path below.
+            // continues from where it stopped. `normalizeForReplay` fixes the
+            // stream→prompt shape, same as the tool path below.
+            //
+            // Provider note: this relies on assistant-message *prefill
+            // continuation* — a trailing assistant message is the turn to
+            // continue. That's Anthropic semantics (the configured default
+            // and the model this fix was written against). OpenAI/Google
+            // instead treat a trailing assistant message as context and start
+            // a fresh turn, which `resumingFromLength` would then glue on with
+            // no separator — a mildly disjoint resume, still bounded by
+            // MAX_LENGTH_CONTINUATIONS and no worse than a crash. We don't gate
+            // by provider here on purpose: this engine is provider-agnostic
+            // (provider-specific replay lives in the runtime hook, e.g.
+            // applyReasoningReplayPolicy). If a non-Anthropic model ever
+            // becomes a default, thread a `supportsAssistantPrefillContinuation`
+            // capability through EngineConfig and gate on it rather than
+            // string-matching the provider in here.
             history.push({ role: "assistant", content: normalizeForReplay(response.content) });
             resumingFromLength = true;
             this.events.emit({

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1,6 +1,7 @@
 import type {
   JSONSchema7,
   LanguageModelV3,
+  LanguageModelV3Content,
   LanguageModelV3FunctionTool,
   LanguageModelV3Message,
   LanguageModelV3ToolCall,
@@ -8,7 +9,7 @@ import type {
   SharedV3ProviderOptions,
 } from "@ai-sdk/provider";
 import { log } from "../cli/log.ts";
-import { DEFAULT_MAX_DIRECT_TOOLS, MAX_ITERATIONS } from "../limits.ts";
+import { DEFAULT_MAX_DIRECT_TOOLS, MAX_ITERATIONS, MAX_LENGTH_CONTINUATIONS } from "../limits.ts";
 import { getProviderFromModel, supportsEnabledThinking } from "../model/catalog.ts";
 import { normalizeForReplay } from "../model/inbound-fit.ts";
 import { callModel, type StreamResult } from "../model/stream.ts";
@@ -130,6 +131,29 @@ function buildThinkingProviderOptions(
   // openai / google: not yet wired. The provider falls back to its own
   // default behavior. Tracked for follow-up.
   return {};
+}
+
+/**
+ * True if any reasoning (extended-thinking) block in the content lacks its
+ * provider signature. A signed thinking block round-trips on replay; an
+ * unsigned one — produced when `finishReason: "length"` cuts the model off
+ * mid-thinking, before the signature arrives (src/model/stream.ts) — cannot
+ * be replayed as the trailing assistant message: Anthropic rejects it
+ * ("thinking blocks in the latest assistant message cannot be modified",
+ * src/model/inbound-fit.ts). The signature lives at
+ * `providerMetadata.anthropic.signature`. Conservative for other providers:
+ * any reasoning block we can't confirm is signed counts as unsigned, so the
+ * caller surfaces the truncation instead of risking a 400.
+ */
+function hasUnsignedReasoning(content: LanguageModelV3Content[]): boolean {
+  for (const block of content) {
+    if (block.type !== "reasoning") continue;
+    const meta = (block as { providerMetadata?: Record<string, unknown> }).providerMetadata;
+    const anthropic = meta?.anthropic as { signature?: unknown } | undefined;
+    const signed = typeof anthropic?.signature === "string" && anthropic.signature.length > 0;
+    if (!signed) return true;
+  }
+  return false;
 }
 
 /**
@@ -477,6 +501,17 @@ export class AgentEngine {
     // content filter, etc.) rather than always reporting "complete".
     let lastFinishReason: FinishReason | undefined;
 
+    // Auto-resume bookkeeping for output-ceiling truncations. When a turn
+    // is cut off at the model's max output tokens (`finishReason: "length"`)
+    // with no pending tool call, the engine re-prompts the model to continue
+    // from its partial text instead of ending the run with a half-written
+    // answer (see the `toolCalls.length === 0` branch). `lengthContinuations`
+    // bounds that to `MAX_LENGTH_CONTINUATIONS`; `resumingFromLength`
+    // suppresses the inter-turn blank line so the resumed text stitches
+    // seamlessly onto the partial.
+    let lengthContinuations = 0;
+    let resumingFromLength = false;
+
     const unregisterToolControls = config.toolPromotion?.registerControls(toolControls);
     try {
       while (iteration < maxIter) {
@@ -647,16 +682,29 @@ export class AgentEngine {
         }
         const llmMs = Math.round(performance.now() - llmStart);
 
-        // Accumulate text output (add newline between turns if needed)
+        // Accumulate text output (add newline between turns if needed).
+        // When this turn is the resumption of a length-truncated one, stitch
+        // directly onto the partial with no separator — the model is
+        // continuing mid-thought, so a blank line would inject a false break.
         for (const block of response.content) {
           if (block.type === "text") {
-            if (output.length > 0 && !output.endsWith("\n") && block.text.length > 0) {
+            if (
+              !resumingFromLength &&
+              output.length > 0 &&
+              !output.endsWith("\n") &&
+              block.text.length > 0
+            ) {
               output += "\n\n";
               this.events.emit({ type: "text.delta", data: { runId, text: "\n\n" } });
             }
             output += block.text;
           }
         }
+        // Consume the resume flag unconditionally: it must not leak into a
+        // later iteration if this resumed turn produced no text block (e.g.
+        // tool-call- or reasoning-only), which would wrongly glue a genuinely
+        // new turn onto the previous one.
+        resumingFromLength = false;
 
         // Map the AI SDK V3 usage shape into our canonical TokenUsage.
         // V3's `inputTokens.total` is the grand total (noCache+cacheRead+
@@ -698,6 +746,44 @@ export class AgentEngine {
         );
 
         if (toolCalls.length === 0) {
+          // A turn with no tool call usually means the model is done — but
+          // `finishReason: "length"` means it was cut off at the output
+          // ceiling mid-answer, not finished. Re-prompt it to continue from
+          // its partial text instead of ending the run with a truncated
+          // response. Bounded by MAX_LENGTH_CONTINUATIONS so a pathologically
+          // long answer can't spin forever (it then ends as stopReason
+          // "length", same as before this fix). Only fires for text
+          // truncation: a length cut with tool calls present takes the normal
+          // tool path below.
+          //
+          // Guard: never resume a turn whose reasoning was cut off mid-stream.
+          // A thinking block only carries its provider signature once the
+          // block completes; a length cut during thinking drains an UNSIGNED
+          // reasoning block (see src/model/stream.ts). Replaying an unsigned
+          // thinking block as the trailing assistant message is exactly what
+          // Anthropic rejects ("thinking blocks in the latest assistant
+          // message cannot be modified" — src/model/inbound-fit.ts). In that
+          // case fall through to `break` and surface stopReason "length"; the
+          // user re-prompts and the model starts a fresh, fully-signed turn.
+          if (
+            lastFinishReason === "length" &&
+            lengthContinuations < MAX_LENGTH_CONTINUATIONS &&
+            !hasUnsignedReasoning(response.content)
+          ) {
+            lengthContinuations += 1;
+            // Seed history with the partial assistant text so the next call
+            // continues from where it stopped (Anthropic resumes an assistant
+            // turn when it's the trailing message). `normalizeForReplay`
+            // fixes the stream→prompt shape, same as the tool path below.
+            history.push({ role: "assistant", content: normalizeForReplay(response.content) });
+            resumingFromLength = true;
+            this.events.emit({
+              type: "context.length_continuation",
+              data: { runId, continuation: lengthContinuations },
+            });
+            iteration++;
+            continue;
+          }
           break; // Model is done
         }
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -114,6 +114,14 @@ export type EngineEventType =
    * Payload: { runId, attempt, previousMessageCount, errorMessage }.
    */
   | "context.overflow_recovery"
+  /**
+   * Emitted when a turn is cut off at the model's output ceiling
+   * (`finishReason: "length"`) with no pending tool call and the engine
+   * auto-resumes it from the partial text rather than ending the run.
+   * Payload: { runId, continuation } where `continuation` is the 1-based
+   * resume count (bounded by MAX_LENGTH_CONTINUATIONS).
+   */
+  | "context.length_continuation"
   | "bundle.installed"
   | "bundle.uninstalled"
   | "bundle.upgraded"

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -6,6 +6,17 @@ export const MAX_ITERATIONS = 50;
 /** Maximum characters in a tool result before truncation for the LLM. */
 export const MAX_TOOL_RESULT_CHARS = 50_000;
 
+/**
+ * Maximum number of times the engine will auto-resume a single assistant
+ * turn that was cut off at the model's output ceiling (`finishReason:
+ * "length"`) with no pending tool call. Each resume re-prompts the model to
+ * continue from its partial text and consumes one iteration. Past this cap
+ * the run ends with `stopReason: "length"` so a pathologically long answer
+ * can't spin forever. Sized so normal long-form answers complete while a
+ * runaway is bounded.
+ */
+export const MAX_LENGTH_CONTINUATIONS = 4;
+
 // --- Runtime Defaults ---
 
 export const DEFAULT_MAX_ITERATIONS = 25;

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -62,7 +62,13 @@ export interface RuntimeConfig {
   /** Max input tokens per request. Default: 500_000. */
   maxInputTokens?: number;
 
-  /** Max output tokens per LLM call. Default: 16_384. */
+  /**
+   * Max output tokens per LLM call. When unset, resolves to the model's
+   * catalog output ceiling (e.g. 128k for Opus 4.6+, 64k for Sonnet 4.6) —
+   * see `resolveMaxOutputTokens`. The static 16_384 is only the last-resort
+   * fallback for a model that isn't in the catalog. Pinning a value here
+   * caps DOWN from the catalog ceiling.
+   */
   maxOutputTokens?: number;
 
   /**

--- a/test/unit/engine-length-continuation.test.ts
+++ b/test/unit/engine-length-continuation.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "bun:test";
+import { AgentEngine } from "../../src/engine/engine.ts";
+import { MAX_LENGTH_CONTINUATIONS } from "../../src/limits.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+import { StaticToolRouter } from "../../src/adapters/static-router.ts";
+import { textContent } from "../../src/engine/content-helpers.ts";
+import type {
+  EngineConfig,
+  EngineEvent,
+  EventSink,
+  ToolCall,
+  ToolResult,
+  ToolSchema,
+} from "../../src/engine/types.ts";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+
+const config: EngineConfig = {
+  model: "test-model",
+  maxIterations: 10,
+  maxInputTokens: 500_000,
+  maxOutputTokens: 16_384,
+};
+
+function collectingSink(): { sink: EventSink; events: EngineEvent[] } {
+  const events: EngineEvent[] = [];
+  return { sink: { emit: (e) => events.push(e) }, events };
+}
+
+function makeEngine(
+  model: LanguageModelV3,
+  sink: EventSink,
+  tools?: { schemas: ToolSchema[]; handler: (call: ToolCall) => ToolResult | Promise<ToolResult> },
+) {
+  return new AgentEngine(
+    model,
+    new StaticToolRouter(
+      tools?.schemas ?? [],
+      tools?.handler ?? (() => ({ content: textContent("ok"), isError: false })),
+    ),
+    sink,
+  );
+}
+
+const userMsg = [{ role: "user" as const, content: [{ type: "text" as const, text: "Write." }] }];
+
+describe("AgentEngine — output-ceiling (length) auto-resume", () => {
+  it("test_length_truncation_no_toolcall_resumes_and_stitches", async () => {
+    // A turn cut off at the output ceiling (finishReason "length") with no
+    // tool call must resume from the partial text, not end the run.
+    const { sink, events } = collectingSink();
+    const model = createEchoModel({
+      responses: [
+        { text: "Part one", finishReason: "length" },
+        { text: " and part two", finishReason: "stop" },
+      ],
+    });
+    const result = await makeEngine(model, sink).run(config, "sys", userMsg, []);
+
+    // Stitched with no injected blank line, run completed normally.
+    expect(result.output).toBe("Part one and part two");
+    expect(result.stopReason).toBe("complete");
+    expect(result.iterations).toBe(2);
+    expect(events.filter((e) => e.type === "context.length_continuation")).toHaveLength(1);
+  });
+
+  it("test_persistent_length_truncation_bounded_then_ends_length", async () => {
+    // A response that never stops growing must not spin forever: after
+    // MAX_LENGTH_CONTINUATIONS resumes the run ends with stopReason "length".
+    const { sink, events } = collectingSink();
+    const responses = Array.from({ length: MAX_LENGTH_CONTINUATIONS + 3 }, () => ({
+      text: "x",
+      finishReason: "length" as const,
+    }));
+    const result = await makeEngine(createEchoModel({ responses }), sink).run(
+      config,
+      "sys",
+      userMsg,
+      [],
+    );
+
+    expect(result.stopReason).toBe("length");
+    expect(events.filter((e) => e.type === "context.length_continuation")).toHaveLength(
+      MAX_LENGTH_CONTINUATIONS,
+    );
+    // Bounded well under the iteration cap — it did not run away.
+    expect(result.iterations).toBeLessThan(config.maxIterations);
+  });
+
+  it("test_normal_stop_no_toolcall_ends_immediately", async () => {
+    // Regression guard: a genuine stop (the common case) still ends the run
+    // in one iteration — auto-resume must not trigger on non-length finishes.
+    const { sink, events } = collectingSink();
+    const model = createEchoModel({ responses: [{ text: "Done.", finishReason: "stop" }] });
+    const result = await makeEngine(model, sink).run(config, "sys", userMsg, []);
+
+    expect(result.output).toBe("Done.");
+    expect(result.stopReason).toBe("complete");
+    expect(result.iterations).toBe(1);
+    expect(events.filter((e) => e.type === "context.length_continuation")).toHaveLength(0);
+  });
+
+  it("test_length_truncation_with_toolcall_takes_tool_path_not_resume", async () => {
+    // A length finish that still carries a tool call is not a text
+    // truncation — it must follow the normal tool path, never the resume.
+    const { sink, events } = collectingSink();
+    const schemas: ToolSchema[] = [
+      { name: "noop", description: "noop", inputSchema: { type: "object", properties: {} } },
+    ];
+    const model = createEchoModel({
+      responses: [
+        {
+          text: "calling",
+          finishReason: "length",
+          toolCalls: [{ toolCallId: "c1", toolName: "noop", input: "{}" }],
+        },
+        { text: "after tool", finishReason: "stop" },
+      ],
+    });
+    const result = await makeEngine(model, sink, {
+      schemas,
+      handler: () => ({ content: textContent("tool ran"), isError: false }),
+    }).run(config, "sys", userMsg, schemas);
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.stopReason).toBe("complete");
+    expect(events.filter((e) => e.type === "context.length_continuation")).toHaveLength(0);
+  });
+
+  it("test_length_truncation_mid_thinking_unsigned_reasoning_surfaces", async () => {
+    // A length cut DURING extended thinking produces a reasoning block with
+    // no signature. Replaying it as the trailing assistant message is what
+    // Anthropic rejects, so the engine must NOT resume — it surfaces
+    // stopReason "length" instead.
+    const { sink, events } = collectingSink();
+    const model = createEchoModel({
+      responses: [{ reasoning: "thinking hard", text: "", finishReason: "length" }],
+    });
+    const result = await makeEngine(model, sink).run(config, "sys", userMsg, []);
+
+    expect(result.stopReason).toBe("length");
+    expect(result.iterations).toBe(1);
+    expect(events.filter((e) => e.type === "context.length_continuation")).toHaveLength(0);
+  });
+
+  it("test_length_truncation_signed_reasoning_then_text_resumes", async () => {
+    // Thinking COMPLETED (signature present) and only the visible text was
+    // truncated — safe to resume from the signed partial.
+    const { sink, events } = collectingSink();
+    const model = createEchoModel({
+      responses: [
+        {
+          reasoning: "done thinking",
+          reasoningProviderMetadata: { anthropic: { signature: "sig123" } },
+          text: "Begin",
+          finishReason: "length",
+        },
+        { text: " end", finishReason: "stop" },
+      ],
+    });
+    const result = await makeEngine(model, sink).run(config, "sys", userMsg, []);
+
+    expect(result.output).toBe("Begin end");
+    expect(result.stopReason).toBe("complete");
+    expect(events.filter((e) => e.type === "context.length_continuation")).toHaveLength(1);
+  });
+});

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -1518,9 +1518,16 @@ describe("AgentEngine", () => {
       expect(result.finishReason).toBe("stop");
     });
 
-    it("derives stopReason='length' when the model is truncated", async () => {
+    it("derives stopReason='length' when truncation persists past auto-resume", async () => {
+      // A single recoverable length-truncation now auto-resumes rather than
+      // ending the run (see engine-length-continuation.test.ts). The run only
+      // surfaces stopReason 'length' once the bounded resume is exhausted, so
+      // drive a model that keeps hitting the ceiling.
       const model = createEchoModel({
-        responses: [{ text: "Building now.", finishReason: "length" }],
+        responses: Array.from({ length: 8 }, () => ({
+          text: "x",
+          finishReason: "length" as const,
+        })),
       });
       const result = await makeEngine(model).run(
         defaultConfig,


### PR DESCRIPTION
## What & why

RCA of a production session where a long agent turn was silently cut off mid-response. Two independent defects at two layers; both fixed here.

### Symptom 1 — turn lost at the output ceiling
- **Magnitude:** `@ai-sdk/anthropic@3.0.64`'s `getModelCapabilities()` predates Opus 4.7/4.8, so `claude-opus-4-7` falls into the `opus-4-` catch-all (**32K**) and the SDK **silently clamps** the platform's 128K request down (`dist/index.js:3168`). A turn truncated at exactly `out=32000, finishReason=length`. Bumped to **3.0.81**, whose table maps `opus-4-7`/`opus-4-8` → 128K. With `maxOutputTokens` unset (the correct default), Opus now gets its real ceiling.
- **Mechanism:** the agent loop ended the run on a `finishReason: "length"` response with no tool call, treating truncation as "done" (`engine.ts`). It now **auto-resumes** from the partial text, bounded by `MAX_LENGTH_CONTINUATIONS` (4) and emitting a `context.length_continuation` event. Past the bound it ends `stopReason: "length"` (unchanged from before).

### Safety: reasoning models
A length cut **mid-thinking** drains an **unsigned** reasoning block; replaying it as the trailing assistant message is what Anthropic rejects (*"thinking blocks in the latest assistant message cannot be modified"*). The resume is **guarded** by `hasUnsignedReasoning()` — that case surfaces `stopReason: "length"` instead of resuming. (Caught by adversarial review; our default model runs with extended thinking.)

### Doc
Corrected the stale `RuntimeConfig.maxOutputTokens` doc ("Default: 16384") — unset resolves to the model's catalog ceiling; 16384 is only the unknown-model fallback.

## Tests
- New `test/unit/engine-length-continuation.test.ts` (6): resume + seamless stitch, continuation bound → `length`, non-length no-regression, tool-call path bypasses resume, unsigned-reasoning surfaces, signed-reasoning resumes.
- Updated one existing `finishReason` test to the corrected behavior.
- `bun run verify:static` ✅, `tsc` ✅, full unit suite green except one **pre-existing** unrelated failure (`dompurify` in an untouched bundle UI, fails identically on `main`).

## Follow-ups (not in this PR)
- #372 — model occasionally emits a list arg as a JSON string that reaches the bundle as `str`; needs a repro with full args before fixing at the right layer.
- The `"Default: 16384"` text also lives in the `schemas` repo (fetched artifact) — small follow-up there.
