### PR TITLE
fix(auth): quiet expected token-refresh rejections

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1503,7 +1503,22 @@ export async function handleOidcRefresh(
 
     return res;
   } catch (err) {
-    console.error("[nimblebrain] Token refresh failed:", err);
+    // invalid_grant = refresh token expired/revoked (e.g. session ended due to
+    // inactivity). Expected; the client re-authenticates. Log terse, no stack.
+    // Anything else is unexpected — log the message (still no bundled-source dump).
+    const reason = err instanceof Error ? err.message : String(err);
+    const expired =
+      typeof err === "object" &&
+      err !== null &&
+      "error" in err &&
+      (err as { error?: unknown }).error === "invalid_grant";
+    if (expired) {
+      console.info(
+        "[nimblebrain] Token refresh rejected (session expired) — client will re-authenticate",
+      );
+    } else {
+      console.error("[nimblebrain] Token refresh failed:", reason);
+    }
     return apiError(401, "refresh_failed", "Token refresh failed");
   }
 }

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1506,17 +1506,17 @@ export async function handleOidcRefresh(
     // invalid_grant = refresh token expired/revoked (e.g. session ended due to
     // inactivity). Expected; the client re-authenticates. Log terse, no stack.
     // Anything else is unexpected — log the message (still no bundled-source dump).
-    const reason = err instanceof Error ? err.message : String(err);
     const expired =
       typeof err === "object" &&
       err !== null &&
       "error" in err &&
       (err as { error?: unknown }).error === "invalid_grant";
     if (expired) {
-      console.info(
+      console.warn(
         "[nimblebrain] Token refresh rejected (session expired) — client will re-authenticate",
       );
     } else {
+      const reason = err instanceof Error ? err.message : String(err);
       console.error("[nimblebrain] Token refresh failed:", reason);
     }
     return apiError(401, "refresh_failed", "Token refresh failed");


### PR DESCRIPTION
## Problem

On startup (and on any page load with a stale `nb_refresh` cookie), the API dumped a multi-line stack trace that looked like an unhandled crash:

```
[api] [nimblebrain] Token refresh failed: 5034 |  ...
[api] OauthException: Error: invalid_grant
[api] Error Description: Session ended due to inactivity.
[api]   at handleHttpError (.../@workos-inc/node/lib/factory-...mjs:5039:51)
[api]   at async refreshToken (src/identity/providers/workos.ts:259)
[api]   at async handleOidcRefresh (src/api/handlers.ts:1477)
...
```

This is **not a crash**. The refresh token simply expired (WorkOS `invalid_grant`, "Session ended due to inactivity"), the handler correctly returns 401, and the client re-authenticates. The catch block at `handlers.ts:1506` passed the whole error object to `console.error`, so Bun rendered the full stack plus bundled WorkOS source. It repeated once per client refresh retry.

## Fix

`handleOidcRefresh` now distinguishes the expected case from real failures:

- `invalid_grant` → single `console.info` line, no stack.
- anything else → `console.error` with the message only (no bundled-source dump).

Behavior is unchanged — still a 401 `refresh_failed`. This is logging-only.

## Test plan

- `bun run check` — passes
- `biome check src/api/handlers.ts` — clean
- Manual: start the API with an expired `nb_refresh` cookie present → one info line instead of the stack trace.