### PR TITLE
test(integration): stop mcp-resources flaking on subprocess-spawn timeout

### DIFF
--- a/test/integration/mcp-resources.test.ts
+++ b/test/integration/mcp-resources.test.ts
@@ -176,23 +176,32 @@ beforeAll(async () => {
 
   handle = startServer({ runtime, port: 0 });
   baseUrl = `http://localhost:${handle.port}`;
-});
+  // Generous hook timeout: this setup starts a Runtime, provisions two
+  // workspaces, and spawns two Node MCP subprocesses. The 5s default hook
+  // timeout is too tight under CI load and flaked on subprocess spawn
+  // ("killed 1 dangling process"). 30s leaves ample headroom without
+  // masking a genuine hang.
+}, 30_000);
 
 afterAll(async () => {
-  handle.stop(true);
+  // Optional-chain every teardown step: if `beforeAll` timed out partway,
+  // these vars may be unassigned. Without the guards a setup flake surfaces
+  // as a misleading `TypeError: undefined is not an object` from teardown,
+  // burying the real cause (the spawn timeout).
+  handle?.stop(true);
   try {
-    await fixtureSource.stop();
+    await fixtureSource?.stop();
   } catch {
     // already stopped
   }
   try {
-    await otherSource.stop();
+    await otherSource?.stop();
   } catch {
     // already stopped
   }
-  await runtime.shutdown();
+  await runtime?.shutdown();
   if (existsSync(testDir)) rmSync(testDir, { recursive: true });
-});
+}, 30_000);
 
 async function createMcpClient(workspaceId: string = TEST_WORKSPACE_ID): Promise<Client> {
   const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {


### PR DESCRIPTION
## What & why

`test/integration/mcp-resources.test.ts` flaked in CI (seen on #374's run): the `beforeAll` hit the **5s default hook timeout** while spawning its MCP subprocesses ("killed 1 dangling process"), and the `afterAll` then threw `TypeError: undefined is not an object (evaluating 'handle.stop')` because `handle` was never assigned — burying the real cause.

That `beforeAll` does a lot under the 5s budget: `Runtime.start`, provisions **two** workspaces, spawns **two** Node MCP subprocesses (`fixtureSource.start()` + `otherSource.start()`), and `startServer`. Under CI load the spawn occasionally exceeds 5s.

## Change (test-only, no production code)

- Give the `beforeAll`/`afterAll` hooks a **30s timeout** — ample headroom for the subprocess spawns without masking a genuine hang.
- **Optional-chain every teardown step** (`handle?.stop`, `fixtureSource?.stop`, `runtime?.shutdown`, …) so a partial setup surfaces its true error instead of a misleading teardown `TypeError`.

## Verification

- `bunx tsc --noEmit` ✅
- Ran the file **3×** locally → pass, 0 fail each.

Merge this first; it removes the flake that intermittently reds the integration job (including on #374).
