### PR TITLE
fix(automations): scheduled runs must not inherit ambient request context

### DIFF
--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -9,7 +9,7 @@
  * No retry logic — the scheduler handles backoff.
  */
 
-import { isTransientError } from "./scheduler.ts";
+import { type AutomationRunTrigger, isTransientError } from "./scheduler.ts";
 import type { Automation, AutomationRun } from "./types.ts";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -196,20 +196,26 @@ function mapStopReasonToStatus(stopReason: AutomationRun["stopReason"]): Automat
  * No HTTP, no auth token — pure function call within the same process.
  *
  * @param taskFn      Direct reference to runtime.executeTask() or equivalent.
- * @param getContext  Returns the workspace/identity context for the run.
- *                    Called per-execution so it can read current state.
+ * @param getContext  Returns the workspace/identity context for the run. Called
+ *                    per-execution so it can read current state. The `trigger`
+ *                    tells it whether to act as the automation's owner
+ *                    (`scheduled`) or the current request's user (`manual`).
  */
 export function createDirectExecutor(
   taskFn: TaskFn,
-  getContext: (automation?: Automation) => ExecutorContext,
+  getContext: (
+    automation: Automation | undefined,
+    trigger: AutomationRunTrigger,
+  ) => ExecutorContext,
 ) {
   return async function executeDirect(
     automation: Automation,
     externalSignal?: AbortSignal,
+    trigger: AutomationRunTrigger = "scheduled",
   ): Promise<AutomationRun> {
     const startedAt = new Date().toISOString();
     const timeoutMs = automation.maxRunDurationMs ?? DEFAULT_TIMEOUT_MS;
-    const ctx = getContext(automation);
+    const ctx = getContext(automation, trigger);
 
     // Combined cancellation: a single controller aborts when EITHER the
     // scheduler's external signal fires (manual cancel, scheduler stop)

--- a/src/bundles/automations/src/scheduler.ts
+++ b/src/bundles/automations/src/scheduler.ts
@@ -42,8 +42,21 @@ const TRANSIENT_PATTERNS: RegExp[] = [
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * What initiated a run. A `scheduled` run fires from the timer with no user
+ * present, so it must act as the automation's owner/provenance and must NOT
+ * inherit any ambient request context (the timer can capture a stale one — see
+ * `getExecutorContext`). A `manual` run is a user clicking "test", dispatched
+ * synchronously inside that user's request context, which it legitimately uses.
+ */
+export type AutomationRunTrigger = "scheduled" | "manual";
+
 /** The executor function that the scheduler delegates to. */
-export type Executor = (automation: Automation, signal: AbortSignal) => Promise<AutomationRun>;
+export type Executor = (
+  automation: Automation,
+  signal: AbortSignal,
+  trigger: AutomationRunTrigger,
+) => Promise<AutomationRun>;
 
 export interface SchedulerConfig {
   /**
@@ -332,7 +345,7 @@ export class Scheduler {
       return skipped;
     }
 
-    return this.dispatchRun(auto);
+    return this.dispatchRun(auto, "manual");
   }
 
   /**
@@ -429,7 +442,7 @@ export class Scheduler {
         continue;
       }
 
-      dispatched.push(this.dispatchRun(auto));
+      dispatched.push(this.dispatchRun(auto, "scheduled"));
     }
 
     // Wait for all dispatched runs to complete so updateAfterRun sets
@@ -447,7 +460,10 @@ export class Scheduler {
   // Run dispatch
   // -----------------------------------------------------------------------
 
-  private async dispatchRun(auto: Automation): Promise<AutomationRun> {
+  private async dispatchRun(
+    auto: Automation,
+    trigger: AutomationRunTrigger,
+  ): Promise<AutomationRun> {
     const key = Scheduler.keyOf(auto);
     const controller = new AbortController();
     this.activeRuns.set(key, controller);
@@ -459,7 +475,7 @@ export class Scheduler {
     const startedAt = new Date().toISOString();
 
     try {
-      const run = await this.executor(auto, controller.signal);
+      const run = await this.executor(auto, controller.signal, trigger);
       this.activeRuns.delete(key);
       this.updateAfterRun(auto, run);
       return run;

--- a/src/tools/platform/automations.ts
+++ b/src/tools/platform/automations.ts
@@ -38,31 +38,38 @@ import { AUTOMATIONS_PANEL_HTML } from "../platform-resources/automations/panel.
  * without a live AsyncLocalStorage scope — `getExecutorContext` is the thin
  * wrapper that supplies `getRequestContext()`.
  *
- * - `scheduled`: act as the automation's owner, focused on its provenance
- *   workspace. The ambient context is IGNORED — a scheduled run that inherits a
- *   stale timer context (see `getExecutorContext`) must not be steered by it,
- *   which would run one tenant's automation in another tenant's workspace.
  * - `manual`: the clicking user's request context wins (falling back to the
  *   automation's owner/provenance), because a test-button run is dispatched
  *   synchronously inside that user's genuine context.
+ * - everything else (`scheduled`, and any future/unknown value): act as the
+ *   automation's owner, focused on its provenance workspace, with the ambient
+ *   context IGNORED — a scheduled run can inherit a stale timer context (see
+ *   `getExecutorContext`) that would otherwise run one tenant's automation in
+ *   another tenant's workspace.
+ *
+ * Reading ambient context is **fail-closed**: it requires an explicit `manual`
+ * opt-in. Anything else — including `undefined` from an untyped/test caller, or
+ * a trigger added later — falls through to the isolated owner/provenance path,
+ * so a new dispatch path that forgets to opt in can never leak another tenant's
+ * context.
  */
 export function resolveExecutorContext(
   automation: Automation | undefined,
   trigger: AutomationRunTrigger,
   reqCtx: RequestContext | undefined,
 ): ExecutorContext {
-  if (trigger === "scheduled") {
+  if (trigger === "manual") {
     return {
-      workspaceId: automation?.workspaceId ?? undefined,
-      identity: automation?.ownerId ? { id: automation.ownerId } : undefined,
+      workspaceId:
+        (reqCtx?.scope.kind === "workspace" ? reqCtx.scope.workspaceId : undefined) ??
+        automation?.workspaceId ??
+        undefined,
+      identity: reqCtx?.identity ?? (automation?.ownerId ? { id: automation.ownerId } : undefined),
     };
   }
   return {
-    workspaceId:
-      (reqCtx?.scope.kind === "workspace" ? reqCtx.scope.workspaceId : undefined) ??
-      automation?.workspaceId ??
-      undefined,
-    identity: reqCtx?.identity ?? (automation?.ownerId ? { id: automation.ownerId } : undefined),
+    workspaceId: automation?.workspaceId ?? undefined,
+    identity: automation?.ownerId ? { id: automation.ownerId } : undefined,
   };
 }
 

--- a/src/tools/platform/automations.ts
+++ b/src/tools/platform/automations.ts
@@ -4,7 +4,7 @@ import {
   createDirectExecutor,
   type ExecutorContext,
 } from "../../bundles/automations/src/executor.ts";
-import { Scheduler } from "../../bundles/automations/src/scheduler.ts";
+import { type AutomationRunTrigger, Scheduler } from "../../bundles/automations/src/scheduler.ts";
 import { TOOL_SCHEMAS } from "../../bundles/automations/src/schemas.ts";
 import {
   handleCancel,
@@ -25,12 +25,46 @@ import {
 import type { Automation } from "../../bundles/automations/src/types.ts";
 import { textContent } from "../../engine/content-helpers.ts";
 import type { EventSink } from "../../engine/types.ts";
-import { getRequestContext } from "../../runtime/request-context.ts";
+import { getRequestContext, type RequestContext } from "../../runtime/request-context.ts";
 import type { Runtime } from "../../runtime/runtime.ts";
 import type { TaskRequest } from "../../runtime/types.ts";
 import { defineInProcessApp, type InProcessTool } from "../in-process-app.ts";
 import type { McpSource } from "../mcp-source.ts";
 import { AUTOMATIONS_PANEL_HTML } from "../platform-resources/automations/panel.ts";
+
+/**
+ * Resolve WHO an automation run acts as, from the run's trigger and the ambient
+ * request context. Pure (no ALS read) so the isolation contract is unit-testable
+ * without a live AsyncLocalStorage scope — `getExecutorContext` is the thin
+ * wrapper that supplies `getRequestContext()`.
+ *
+ * - `scheduled`: act as the automation's owner, focused on its provenance
+ *   workspace. The ambient context is IGNORED — a scheduled run that inherits a
+ *   stale timer context (see `getExecutorContext`) must not be steered by it,
+ *   which would run one tenant's automation in another tenant's workspace.
+ * - `manual`: the clicking user's request context wins (falling back to the
+ *   automation's owner/provenance), because a test-button run is dispatched
+ *   synchronously inside that user's genuine context.
+ */
+export function resolveExecutorContext(
+  automation: Automation | undefined,
+  trigger: AutomationRunTrigger,
+  reqCtx: RequestContext | undefined,
+): ExecutorContext {
+  if (trigger === "scheduled") {
+    return {
+      workspaceId: automation?.workspaceId ?? undefined,
+      identity: automation?.ownerId ? { id: automation.ownerId } : undefined,
+    };
+  }
+  return {
+    workspaceId:
+      (reqCtx?.scope.kind === "workspace" ? reqCtx.scope.workspaceId : undefined) ??
+      automation?.workspaceId ??
+      undefined,
+    identity: reqCtx?.identity ?? (automation?.ownerId ? { id: automation.ownerId } : undefined),
+  };
+}
 
 /**
  * Create the "automations" platform source — an in-process MCP server.
@@ -68,23 +102,15 @@ export async function createAutomationsSource(
   }
 
   // Direct executor: calls runtime.executeTask() in-process — the unattended
-  // sibling of chat() that frames the agent as producing a deliverable, not
-  // a conversation turn. `getExecutorContext` is called per run to resolve
-  // WHO the run acts as. A user-triggered run (test button) reads the
-  // current request context. A SCHEDULED run has no request context, so it
-  // fires AS THE OWNER — identity = the automation's `ownerId`, focused on
-  // its provenance `workspaceId` if set — exactly as if the owner had
-  // queued the task themselves.
-  function getExecutorContext(automation?: Automation): ExecutorContext {
-    const reqCtx = getRequestContext();
-    return {
-      workspaceId:
-        (reqCtx?.scope.kind === "workspace" ? reqCtx.scope.workspaceId : undefined) ??
-        automation?.workspaceId ??
-        undefined,
-      identity: reqCtx?.identity ?? (automation?.ownerId ? { id: automation.ownerId } : undefined),
-    };
-  }
+  // sibling of chat() that frames the agent as producing a deliverable, not a
+  // conversation turn. `getExecutorContext` resolves WHO each run acts as; the
+  // ALS read is isolated here so the decision logic stays pure and testable in
+  // `resolveExecutorContext`. A `scheduled` run ignores the ambient context
+  // because the timer can carry a stale one (see `resolveExecutorContext`).
+  const getExecutorContext = (
+    automation: Automation | undefined,
+    trigger: AutomationRunTrigger,
+  ): ExecutorContext => resolveExecutorContext(automation, trigger, getRequestContext());
   const executor = createDirectExecutor(
     (req) => runtime.executeTask(req as TaskRequest),
     getExecutorContext,

--- a/test/integration/automation-e2e.test.ts
+++ b/test/integration/automation-e2e.test.ts
@@ -47,7 +47,7 @@ const USERS_DIR = join(TMP_DIR, "users");
 const OWNER_STORE = join(USERS_DIR, OWNER, "automations");
 
 /** Records of what the mock executor received. */
-let executorCalls: Array<{ automation: Automation; signal: AbortSignal }>;
+let executorCalls: Array<{ automation: Automation; signal: AbortSignal; trigger: string }>;
 
 /** Configurable executor result. */
 let executorResult: (auto: Automation) => AutomationRun;
@@ -92,8 +92,9 @@ function createHarness(): ToolContext {
 	const executor = async (
 		automation: Automation,
 		signal: AbortSignal,
+		trigger: string,
 	): Promise<AutomationRun> => {
-		executorCalls.push({ automation, signal });
+		executorCalls.push({ automation, signal, trigger });
 		const run = executorResult(automation);
 		appendRun(automation.id, run, OWNER_STORE);
 		return run;
@@ -207,6 +208,10 @@ describe("automation e2e: create -> run -> verify", () => {
 
 		// Signal should not be aborted
 		expect(executorCalls[0]!.signal.aborted).toBe(false);
+
+		// The `run` tool is a user-triggered (manual) dispatch — it must NOT be
+		// treated as a scheduled run.
+		expect(executorCalls[0]!.trigger).toBe("manual");
 	});
 
 	test("allowedTools passed through to executor when set on the stored automation", async () => {

--- a/test/unit/bundles/automations/scheduler.test.ts
+++ b/test/unit/bundles/automations/scheduler.test.ts
@@ -1487,3 +1487,61 @@ describe("Scheduler — multi-owner", () => {
 		expect(fired).toEqual(["usr_b/shared"]); // only B's automation ran
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Tests: Scheduler — run trigger propagation
+// ---------------------------------------------------------------------------
+
+describe("Scheduler — run trigger", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = makeTmpDir();
+	});
+
+	afterEach(() => {
+		rmSync(join(tmpDir, "..", "..", ".."), { recursive: true, force: true });
+	});
+
+	/** Executor that records the `trigger` it was dispatched with. */
+	function recordingExecutor(triggers: string[]): Executor {
+		return (async (auto: Automation, _signal: AbortSignal, trigger: string) => {
+			triggers.push(trigger);
+			return makeSuccessRun(auto.id);
+		}) as Executor;
+	}
+
+	it("dispatches scheduled (timer) runs with trigger 'scheduled'", async () => {
+		const auto = makeAutomation({
+			schedule: { type: "interval", intervalMs: 60_000 },
+			lastRunAt: new Date(Date.now() - 60_001).toISOString(),
+			nextRunAt: new Date(Date.now() - 1).toISOString(),
+		});
+		const defs = new Map<string, Automation>();
+		defs.set(auto.id, auto);
+		saveDefinitions(defs, tmpDir);
+
+		const triggers: string[] = [];
+		const scheduler = new Scheduler(recordingExecutor(triggers), { usersDir: usersDirOf(tmpDir) });
+		scheduler.start();
+		await scheduler.onTimer();
+		scheduler.stop();
+
+		expect(triggers).toEqual(["scheduled"]);
+	});
+
+	it("dispatches runNow (test button) runs with trigger 'manual'", async () => {
+		const auto = makeAutomation();
+		const defs = new Map<string, Automation>();
+		defs.set(auto.id, auto);
+		saveDefinitions(defs, tmpDir);
+
+		const triggers: string[] = [];
+		const scheduler = new Scheduler(recordingExecutor(triggers), { usersDir: usersDirOf(tmpDir) });
+		scheduler.start();
+		await scheduler.runNow(OWNER, auto.id);
+		scheduler.stop();
+
+		expect(triggers).toEqual(["manual"]);
+	});
+});

--- a/test/unit/tools/platform/automations-executor-context.test.ts
+++ b/test/unit/tools/platform/automations-executor-context.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import type { Automation } from "../../../../src/bundles/automations/src/types.ts";
+import type { UserIdentity } from "../../../../src/identity/provider.ts";
+import { resolveExecutorContext } from "../../../../src/tools/platform/automations.ts";
+import type { RequestContext } from "../../../../src/runtime/request-context.ts";
+
+// The automation under test is owned by, and focused on, workspace A.
+const automation = {
+  id: "nb-morning-sweep",
+  ownerId: "usr_owner_a",
+  workspaceId: "ws_a_shared",
+} as Automation;
+
+// An ambient request context for a DIFFERENT workspace B — the stale context a
+// scheduler timer can capture when an automation is created/edited from a chat
+// in workspace B (AsyncLocalStorage propagates through the re-arm `setTimeout`).
+const otherWorkspaceCtx: RequestContext = {
+  identity: { id: "usr_other_b", email: "b@example.com", displayName: "B", orgRole: "member" } as UserIdentity,
+  scope: {
+    kind: "workspace",
+    workspaceId: "ws_b_other",
+    workspaceAgents: null,
+    workspaceModelOverride: null,
+  },
+};
+
+describe("resolveExecutorContext", () => {
+  // The bug: a scheduled run inheriting workspace B's context ran focused on B,
+  // not its own workspace A. The scheduled path must IGNORE ambient context.
+  test("scheduled run ignores an ambient (leaked) workspace context", () => {
+    const ctx = resolveExecutorContext(automation, "scheduled", otherWorkspaceCtx);
+    expect(ctx.workspaceId).toBe("ws_a_shared");
+    expect(ctx.identity).toEqual({ id: "usr_owner_a" });
+  });
+
+  test("scheduled run uses the automation's owner + provenance when no ambient context", () => {
+    const ctx = resolveExecutorContext(automation, "scheduled", undefined);
+    expect(ctx.workspaceId).toBe("ws_a_shared");
+    expect(ctx.identity).toEqual({ id: "usr_owner_a" });
+  });
+
+  // A manual test-button run is dispatched synchronously inside the clicking
+  // user's genuine context, so it legitimately uses it.
+  test("manual run uses the ambient request context", () => {
+    const ctx = resolveExecutorContext(automation, "manual", otherWorkspaceCtx);
+    expect(ctx.workspaceId).toBe("ws_b_other");
+    expect(ctx.identity).toEqual(otherWorkspaceCtx.identity);
+  });
+
+  test("manual run falls back to the automation's owner + provenance with no ambient context", () => {
+    const ctx = resolveExecutorContext(automation, "manual", undefined);
+    expect(ctx.workspaceId).toBe("ws_a_shared");
+    expect(ctx.identity).toEqual({ id: "usr_owner_a" });
+  });
+
+  // An identity-scoped ambient context (no workspace) must not leak a workspace
+  // into a manual run; it falls back to the automation's provenance.
+  test("manual run with an identity-scope context falls back to provenance workspace", () => {
+    const identityCtx: RequestContext = {
+      identity: { id: "usr_other_b", email: "b@example.com", displayName: "B", orgRole: "member" } as UserIdentity,
+      scope: { kind: "identity" },
+    };
+    const ctx = resolveExecutorContext(automation, "manual", identityCtx);
+    expect(ctx.workspaceId).toBe("ws_a_shared");
+    expect(ctx.identity).toEqual(identityCtx.identity);
+  });
+
+  test("scheduled run with an automation lacking owner/workspace yields undefined fields", () => {
+    const ctx = resolveExecutorContext({ id: "x" } as Automation, "scheduled", otherWorkspaceCtx);
+    expect(ctx.workspaceId).toBeUndefined();
+    expect(ctx.identity).toBeUndefined();
+  });
+});

--- a/test/unit/tools/platform/automations-executor-context.test.ts
+++ b/test/unit/tools/platform/automations-executor-context.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { AutomationRunTrigger } from "../../../../src/bundles/automations/src/scheduler.ts";
 import type { Automation } from "../../../../src/bundles/automations/src/types.ts";
 import type { UserIdentity } from "../../../../src/identity/provider.ts";
 import { resolveExecutorContext } from "../../../../src/tools/platform/automations.ts";
@@ -69,5 +70,19 @@ describe("resolveExecutorContext", () => {
     const ctx = resolveExecutorContext({ id: "x" } as Automation, "scheduled", otherWorkspaceCtx);
     expect(ctx.workspaceId).toBeUndefined();
     expect(ctx.identity).toBeUndefined();
+  });
+
+  // Fail-closed: only an explicit "manual" reads ambient context. An unknown or
+  // missing trigger (e.g. an untyped/test caller, or a future trigger value)
+  // must fall through to the isolated owner/provenance path — never the ambient
+  // workspace — so a new dispatch path that forgets to opt in can't leak.
+  test("an unknown/undefined trigger does NOT read ambient context", () => {
+    const ctx = resolveExecutorContext(
+      automation,
+      undefined as unknown as AutomationRunTrigger,
+      otherWorkspaceCtx,
+    );
+    expect(ctx.workspaceId).toBe("ws_a_shared");
+    expect(ctx.identity).toEqual({ id: "usr_owner_a" });
   });
 });


### PR DESCRIPTION
## Symptom

A scheduled automation owned by one workspace executed **focused on a different workspace** — discovering only the other workspace's tools, with zero matches for its own. A cross-tenant isolation bleed in the scheduled-execution path.

## Root cause

`getExecutorContext` (`src/tools/platform/automations.ts`) resolved *who a run acts as* by preferring the ambient `getRequestContext()` (AsyncLocalStorage) over the automation's own `ownerId`/`workspaceId`. Its comment assumed *"a scheduled run has no request context."* That assumption is violated:

- The scheduler arms its timer with `setTimeout(() => this.onTimer())` (`scheduler.ts`). `AsyncLocalStorage` snapshots propagate through `setTimeout`.
- `reload()` / `runNow()` re-arm the timer and are invoked from **LLM tool handlers**, which run inside `runWithRequestContext(<that chat's workspace>)`.
- So creating/editing an automation from a chat in workspace **B** captures **B's** context in the timer closure. `onTimer` then fires inside B's context, and `getExecutorContext` reads it — overriding the automation's real provenance. It's self-perpetuating (onTimer re-arms from inside the captured context), so once poisoned, **every** scheduled tick for **any** owner runs focused on B until the process restarts.

`runtime.executeTask` derives identity/workspace **solely from the passed `request`** (`runtime.ts` — `resolveRequestOwnerId(request.identity)`, `request.workspaceId`) and establishes its own request context for the engine. So once the resolver is told the correct owner/workspace, the entire run is correctly scoped — fixing the resolver is sufficient; no ALS-clearing gymnastics needed.

## Fix

Make the run trigger **explicit** instead of inferring "scheduled" from the absence of an ambient context (an inference a leaked timer context silently defeats):

- Thread a `trigger: "scheduled" | "manual"` through `Scheduler.dispatchRun` → `Executor` → `createDirectExecutor`'s `getContext`. `onTimer` dispatches `"scheduled"`; `runNow` (test button) dispatches `"manual"`. `executeDirect` defaults to `"scheduled"` (the isolation-safe direction).
- Extract the decision into a pure, exported `resolveExecutorContext(automation, trigger, reqCtx)`. **Scheduled** → automation owner + provenance workspace, ambient context **ignored**. **Manual** → dispatched synchronously inside the user's genuine request context, so it keeps using it (falling back to provenance).

## Tests

- `automations-executor-context.test.ts` (new): scheduled runs **ignore** a leaked workspace-B context; manual runs use it; identity-scope and missing-owner edge cases.
- `scheduler.test.ts` "run trigger" block: timer dispatch is `"scheduled"`, `runNow` is `"manual"`.
- `automation-e2e.test.ts`: updated the mock executor to the 3-arg signature and assert the `run` tool dispatches `"manual"` end to end.

`bun run verify:static` and the full automations suite (208 tests) pass.

## Notes / follow-ups

- **Identity shape:** scheduled runs act as `{ id: ownerId }` (no `orgRole`). This is the **pre-existing** scheduled-run contract — the no-ambient-context path always produced it; this change only removes the wrong-tenant bleed that previously substituted a foreign full identity. If scheduled runs should carry the owner's full role (e.g. for admin-only tools), hydrating the owner's `UserIdentity` by id is a separate, orthogonal improvement.
- **Defense in depth (not in this PR):** the deeper footgun is that the scheduler's timer captures a request-scoped ALS context at all. Severing it at the dispatch boundary (running scheduled dispatch in a cleared context) would harden any future ambient read on the scheduled path. The explicit trigger fully addresses the reported bug; this would be additional hardening.