### PR TITLE
fix(web): stamp focused-app context on main-composer messages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { ShellLayout } from "./components/ShellLayout";
 import { WorkspaceRouteGuard } from "./components/WorkspaceRouteGuard";
 import { ChatProvider, useChatConfigContext, useChatContext } from "./context/ChatContext";
 import { ChatPanelProvider, useChatPanelContext } from "./context/ChatPanelContext";
+import { FocusedAppProvider } from "./context/FocusedAppContext";
 import { PaletteProvider } from "./context/PaletteContext";
 import { SessionProvider } from "./context/SessionContext";
 import { ShellProvider } from "./context/ShellContext";
@@ -192,14 +193,16 @@ function BootstrappedShell({
         <ChatProvider initialConfig={initialConfig} currentUserId={currentUserId}>
           <ChatPanelProvider>
             <PaletteProvider>
-              <AuthenticatedAppContent
-                token={token}
-                forSlot={forSlot}
-                mainRoutes={mainRoutes}
-                shellWorkspaceId={shellWorkspaceId}
-                refreshShell={refreshShell}
-                onLogout={onLogout}
-              />
+              <FocusedAppProvider>
+                <AuthenticatedAppContent
+                  token={token}
+                  forSlot={forSlot}
+                  mainRoutes={mainRoutes}
+                  shellWorkspaceId={shellWorkspaceId}
+                  refreshShell={refreshShell}
+                  onLogout={onLogout}
+                />
+              </FocusedAppProvider>
             </PaletteProvider>
           </ChatPanelProvider>
         </ChatProvider>

--- a/web/src/components/AppWithChat.tsx
+++ b/web/src/components/AppWithChat.tsx
@@ -13,12 +13,16 @@
 //   - `handleChat` / `handlePromptAction` — iframe→shell channels for
 //     "send this from inside the app". These are the one place a focused
 //     app is known, so they stamp its `AppContext` on outgoing messages.
+//   - publishing the focused app to `FocusedAppContext`, so the globally
+//     mounted chat panel can stamp the same `AppContext` on messages
+//     typed into the main composer (not just the in-app channel).
 // ---------------------------------------------------------------------------
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { UiChatContext } from "../bridge/types";
 import { useChatContext } from "../context/ChatContext";
 import { useChatPanelContext } from "../context/ChatPanelContext";
+import { useFocusedApp } from "../context/FocusedAppContext";
 import type { AppContext, PlacementEntry } from "../types";
 import { SlotRenderer } from "./SlotRenderer";
 
@@ -50,6 +54,7 @@ export function AppWithChat({ placement, onNavigate, forceRefresh }: AppWithChat
 
   const chat = useChatContext();
   const isMobile = useIsMobile();
+  const { setFocusedApp } = useFocusedApp();
 
   const appContext = useMemo<AppContext>(
     () => ({
@@ -58,6 +63,15 @@ export function AppWithChat({ placement, onNavigate, forceRefresh }: AppWithChat
     }),
     [placement.label, placement.serverName],
   );
+
+  // Publish this app as the focused one while it's mounted, so messages
+  // typed into the global chat panel carry its `AppContext` (the panel
+  // can't know the focused app on its own — see ChatChrome's header).
+  // Clear on unmount / route change so non-app routes stamp nothing.
+  useEffect(() => {
+    setFocusedApp(appContext);
+    return () => setFocusedApp(null);
+  }, [appContext, setFocusedApp]);
 
   const handleChat = useCallback(
     (message: string, context?: UiChatContext) => {

--- a/web/src/components/ChatChrome.tsx
+++ b/web/src/components/ChatChrome.tsx
@@ -8,10 +8,13 @@
 // gets chat through this single instance via ChatPanelContext, which is
 // why the panel is identical on home, workspace overview, and app views.
 //
-// App-context stamping ("[App Context: …]" on a message) is deliberately
-// NOT done here: a global mount has no focused app to attach. That
-// stamping lives where the focus is known — AppWithChat's iframe→chat
-// channel. Messages typed into this panel are workspace-agnostic.
+// A global mount can't know the focused app on its own, so the active
+// app view publishes itself to FocusedAppContext (AppWithChat) and this
+// panel reads it to stamp `AppContext` on messages typed into the main
+// composer. Without it, the backend resolves no focused app and the
+// agent can't see the app's visible state (e.g. the open document).
+// The inline "[App Context: …]" text prefix is a separate concern and
+// still lives in AppWithChat's in-app channel.
 // ---------------------------------------------------------------------------
 
 import { MessageSquare } from "lucide-react";
@@ -19,6 +22,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { useChatContext } from "../context/ChatContext";
 import { useChatPanelContext } from "../context/ChatPanelContext";
+import { useFocusedApp } from "../context/FocusedAppContext";
 import { useSidebar } from "../context/SidebarContext";
 import type { ChatPanelRef } from "./ChatPanel";
 import { ChatPanel } from "./ChatPanel";
@@ -49,6 +53,7 @@ export function ChatChrome() {
   const sidebar = useSidebar();
   const isMobile = useIsMobile();
   const location = useLocation();
+  const { focusedApp } = useFocusedApp();
 
   // Collapse fullscreen when the route changes — same logic AppWithChat
   // had; lifting it here makes it work globally.
@@ -152,10 +157,12 @@ export function ChatChrome() {
   const handleFullscreen = useCallback(() => toggleFullscreen(), [toggleFullscreen]);
 
   const handleSendMessage = useCallback(
-    // No app context: this global mount has no focused app (see file
-    // header). Stamping happens in AppWithChat's iframe→chat channel.
-    (text: string, files?: File[]) => chat.sendMessage(text, undefined, files),
-    [chat],
+    // Stamp the focused app (published by the active AppWithChat) so the
+    // backend resolves it and injects its visible state. `null` on
+    // non-app routes → no appContext, same as before. useChat enriches
+    // appContext with the app's latest visible state from the bridge.
+    (text: string, files?: File[]) => chat.sendMessage(text, focusedApp ?? undefined, files),
+    [chat, focusedApp],
   );
 
   const isSidebar = panelState === "sidebar";

--- a/web/src/context/FocusedAppContext.tsx
+++ b/web/src/context/FocusedAppContext.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
+import type { AppContext } from "../types";
+
+/**
+ * Tracks the app the user is currently viewing alongside chat, so the
+ * globally-mounted chat panel (`ChatChrome`) can stamp its `AppContext`
+ * on messages typed into the main composer — not just on the in-app
+ * "ask about this" channel (`AppWithChat.handleChat`).
+ *
+ * Without this, a message typed into the side panel while looking at an
+ * app carries no `appContext`, so the backend never resolves a focused
+ * app (`runtime.ts` gates the whole resolution on `request.appContext`)
+ * and the agent can't see the app's visible state (e.g. which document
+ * the user has open). The app publishes itself here on mount; the panel
+ * reads it on send.
+ *
+ * Deliberately a standalone context (not folded into `ShellContext`) so
+ * focus changes re-render only the two participants — the app view and
+ * the chat panel — and not every shell consumer.
+ */
+export interface FocusedAppContextValue {
+  /** The app the user is currently viewing, or `null` on non-app routes. */
+  focusedApp: AppContext | null;
+  /** Publish (or clear, with `null`) the currently-viewed app. */
+  setFocusedApp: (app: AppContext | null) => void;
+}
+
+const NULL_VALUE: FocusedAppContextValue = {
+  focusedApp: null,
+  setFocusedApp: () => {},
+};
+
+const FocusedAppContext = createContext<FocusedAppContextValue | null>(null);
+
+export function FocusedAppProvider({ children }: { children: ReactNode }) {
+  const [focusedApp, setFocusedApp] = useState<AppContext | null>(null);
+  const value = useMemo<FocusedAppContextValue>(
+    () => ({ focusedApp, setFocusedApp }),
+    [focusedApp],
+  );
+  return <FocusedAppContext.Provider value={value}>{children}</FocusedAppContext.Provider>;
+}
+
+/**
+ * Read the focused-app context. Returns an inert value (no-op setter,
+ * `null` app) when rendered outside a provider, so components like
+ * `ChatChrome` and `AppWithChat` work in isolation (tests, storybook).
+ */
+export function useFocusedApp(): FocusedAppContextValue {
+  return useContext(FocusedAppContext) ?? NULL_VALUE;
+}

--- a/web/test/FocusedAppContext.test.tsx
+++ b/web/test/FocusedAppContext.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { act, render, renderHook } from "@testing-library/react";
+import { useEffect } from "react";
+import { FocusedAppProvider, useFocusedApp } from "../src/context/FocusedAppContext";
+import type { AppContext } from "../src/types";
+
+// --------------------------------------------------------------------------
+// Regression: a message typed into the global chat panel while an app is
+// focused must carry that app's AppContext. The panel (ChatChrome) can't
+// know the focused app on its own — the active app view (AppWithChat)
+// publishes it here and the panel reads it. These tests pin that
+// publish→read contract across two separate components.
+// --------------------------------------------------------------------------
+
+const COLLATERAL: AppContext = {
+  appName: "Collateral Studio",
+  serverName: "synapse-collateral",
+};
+
+describe("FocusedAppContext", () => {
+  it("defaults to no focused app", () => {
+    const { result } = renderHook(() => useFocusedApp(), {
+      wrapper: FocusedAppProvider,
+    });
+    expect(result.current.focusedApp).toBeNull();
+  });
+
+  it("returns an inert value (no throw, no-op setter) outside a provider", () => {
+    const { result } = renderHook(() => useFocusedApp());
+    expect(result.current.focusedApp).toBeNull();
+    // Must not throw — components render in isolation (tests, storybook).
+    expect(() => result.current.setFocusedApp(COLLATERAL)).not.toThrow();
+  });
+
+  it("publishes the focused app from one component to a reader in another", () => {
+    let seen: AppContext | null | undefined;
+
+    // Mimics AppWithChat: publishes itself while mounted, clears on unmount.
+    function Publisher({ app }: { app: AppContext }) {
+      const { setFocusedApp } = useFocusedApp();
+      useEffect(() => {
+        setFocusedApp(app);
+        return () => setFocusedApp(null);
+      }, [app, setFocusedApp]);
+      return null;
+    }
+
+    // Mimics ChatChrome: reads the focused app to stamp on outgoing messages.
+    function Reader() {
+      seen = useFocusedApp().focusedApp;
+      return null;
+    }
+
+    const { rerender } = render(
+      <FocusedAppProvider>
+        <Publisher app={COLLATERAL} />
+        <Reader />
+      </FocusedAppProvider>,
+    );
+
+    expect(seen).toEqual(COLLATERAL);
+
+    // Navigating away unmounts the app view → reader stamps nothing.
+    rerender(
+      <FocusedAppProvider>
+        <Reader />
+      </FocusedAppProvider>,
+    );
+
+    expect(seen).toBeNull();
+  });
+
+  it("clears the focused app when set back to null", () => {
+    const { result } = renderHook(() => useFocusedApp(), {
+      wrapper: FocusedAppProvider,
+    });
+
+    act(() => result.current.setFocusedApp(COLLATERAL));
+    expect(result.current.focusedApp).toEqual(COLLATERAL);
+
+    act(() => result.current.setFocusedApp(null));
+    expect(result.current.focusedApp).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

A user viewing an app (e.g. collateral) and typing into the **main chat panel** got an agent that couldn't see what they were looking at — it would say things like *"I can't read your UI state directly — collateral doesn't expose a 'currently viewing' pointer."*

The bundle is innocent: collateral *does* publish its current view via `useVisibleState` (`activeDocument {id,name}` + a summary). The break is in the web shell.

## Root cause

The globally-mounted chat panel `ChatChrome` sent messages with **no `appContext`**:

```ts
// before
(text, files) => chat.sendMessage(text, undefined, files)
```

The only path that stamped app context was `AppWithChat.handleChat` — the in-app "ask about this" channel — which fires only when the iframe itself initiates a send, not when you type into the side panel.

The backend confirms the consequence: `runtime.ts` gates its **entire** focused-app resolution on `if (request.appContext)` and does *not* derive the focused app from `X-Workspace-Id`. So no `appContext` → no focused app → no *"user is currently viewing X"* section **and** no injected app visible state. Exactly the symptom.

## Fix

A small standalone `FocusedAppContext`:

- The active `AppWithChat` **publishes** its `AppContext` while mounted and **clears** it on unmount / route change.
- `ChatChrome` **reads** it and stamps it on outgoing messages. `useChat` already enriches `appContext` with the app's latest visible state from the bridge store, so the open-document pointer now reaches the agent.

Standalone context (not folded into `ShellContext`) so focus changes re-render only the two participants, not every shell consumer. Non-app routes publish `null` → no `appContext`, unchanged behavior. The in-app channel and its `[App Context: …]` text prefix are untouched.

## Test

`web/test/FocusedAppContext.test.tsx` pins the publish→read contract across two components (the exact link that was broken), the inert out-of-provider default, and clear-on-null.

## Verification

- `bun run verify:static` — pass
- `bun run test:web` — 462 pass / 0 fail
- `cd web && bun run build` — clean

(The unrelated `test:unit` `dompurify` failure is a missing nested dependency in `src/bundles/automations/ui/`, present on a fresh checkout regardless of this change.)