### PR TITLE
feat(api): expose Prometheus /metrics endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "ink": "^6.8.0",
         "mammoth": "^1.12.0",
         "posthog-node": "^5.28.5",
+        "prom-client": "^15.1.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "sift": "^17.1.3",
@@ -146,6 +147,8 @@
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
 
     "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
@@ -383,6 +386,8 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
+    "prom-client": ["prom-client@15.1.3", "", { "dependencies": { "@opentelemetry/api": "^1.4.0", "tdigest": "^0.1.1" } }, "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g=="],
+
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "pusher-js": ["pusher-js@8.5.0", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw=="],
@@ -462,6 +467,8 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "tdigest": ["tdigest@0.1.2", "", { "dependencies": { "bintrees": "1.0.2" } }, "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA=="],
 
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "ink": "^6.8.0",
     "mammoth": "^1.12.0",
     "posthog-node": "^5.28.5",
+    "prom-client": "^15.1.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "sift": "^17.1.3",

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { WorkspaceResolutionError } from "./auth-middleware.ts";
+import { enableDefaultMetrics } from "./metrics.ts";
 import { corsMiddleware } from "./middleware/cors.ts";
+import { metricsMiddleware } from "./middleware/metrics.ts";
 import { securityHeaders } from "./middleware/security-headers.ts";
 import { authRoutes } from "./routes/auth.ts";
 import { bootstrapRoutes } from "./routes/bootstrap.ts";
@@ -11,6 +13,7 @@ import { eventRoutes } from "./routes/events.ts";
 import { healthRoutes } from "./routes/health.ts";
 import { mcpRoutes } from "./routes/mcp.ts";
 import { mcpAuthRoutes } from "./routes/mcp-auth.ts";
+import { metricsRoutes } from "./routes/metrics.ts";
 import { resourceRoutes } from "./routes/resources.ts";
 import { toolRoutes } from "./routes/tools.ts";
 import { wellKnownRoutes } from "./routes/well-known.ts";
@@ -23,6 +26,12 @@ export function createApp(
 ) {
   const app = new Hono();
 
+  // Turn on process/runtime metrics for this server (idempotent).
+  enableDefaultMetrics();
+
+  // Request metrics first so it times the full handler chain.
+  app.use("*", metricsMiddleware());
+
   // Global CORS middleware
   app.use("*", corsMiddleware(authConfigured, allowedOrigins));
   app.use("*", securityHeaders());
@@ -30,6 +39,9 @@ export function createApp(
   // Route groups — well-known endpoints first (unauthenticated, no body limit needed)
   app.route("/", wellKnownRoutes(ctx));
   app.route("/", healthRoutes(ctx));
+  // Prometheus scrape endpoint. Bare /metrics (never /v1/metrics) so the web
+  // Caddy proxy doesn't expose it publicly; scraped in-cluster only.
+  app.route("/", metricsRoutes());
   app.route("/", authRoutes(ctx));
   // Outbound-OAuth callback for remote MCP servers. Unauthenticated by
   // design — state param guards against unsolicited codes. Must be

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -33,10 +33,12 @@ export function enableDefaultMetrics(): void {
 }
 
 /**
- * RED: request count by method, matched route pattern, and status class.
+ * RED: request count by method, matched route pattern, and status code.
  *
  * `route` is the *matched route pattern* (e.g. `/v1/chat`), never the raw path,
  * so path params like conversation ids don't explode label cardinality.
+ * `method` is clamped to the standard verb set (else "OTHER") and `route`
+ * collapses unmatched paths to "/*", so neither label is client-unbounded.
  */
 export const httpRequestsTotal = new Counter({
   name: "http_requests_total",

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -1,0 +1,55 @@
+/**
+ * Prometheus metrics for the platform API.
+ *
+ * Exposed at bare `GET /metrics` (see routes/metrics.ts) and scraped in-cluster
+ * by the kube-prometheus-stack ServiceMonitor on the platform service's `http`
+ * port. It is NOT public: the ingress targets the web (Caddy) service, and the
+ * Caddyfile only proxies `/v1/*`, `/mcp*`, and `/.well-known/*` to the
+ * platform — `/metrics` falls through to the SPA catch-all and never reaches
+ * this process from outside the cluster. Keep this endpoint at `/metrics`, NOT
+ * `/v1/metrics`, or Caddy would proxy it publicly.
+ *
+ * Uses a dedicated Registry (not the global default) so importing this module
+ * has no global side effects (importing it must not register the GC
+ * PerformanceObserver that collectDefaultMetrics installs — that perturbs
+ * timing-sensitive tests). Default process metrics are opt-in via
+ * enableDefaultMetrics(), called once at server start.
+ */
+import { Counter, collectDefaultMetrics, Histogram, Registry } from "prom-client";
+
+export const metricsRegistry = new Registry();
+
+let defaultMetricsEnabled = false;
+
+/**
+ * Enable process/runtime metrics (CPU, memory, GC). Idempotent — safe to call
+ * on every createApp(); only the first call registers the collectors. Call at
+ * server start, never at import time.
+ */
+export function enableDefaultMetrics(): void {
+  if (defaultMetricsEnabled) return;
+  collectDefaultMetrics({ register: metricsRegistry });
+  defaultMetricsEnabled = true;
+}
+
+/**
+ * RED: request count by method, matched route pattern, and status class.
+ *
+ * `route` is the *matched route pattern* (e.g. `/v1/chat`), never the raw path,
+ * so path params like conversation ids don't explode label cardinality.
+ */
+export const httpRequestsTotal = new Counter({
+  name: "http_requests_total",
+  help: "Total HTTP requests handled by the platform API.",
+  labelNames: ["method", "route", "status"] as const,
+  registers: [metricsRegistry],
+});
+
+/** RED: request duration in seconds, same label set. */
+export const httpRequestDurationSeconds = new Histogram({
+  name: "http_request_duration_seconds",
+  help: "HTTP request duration in seconds.",
+  labelNames: ["method", "route", "status"] as const,
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [metricsRegistry],
+});

--- a/src/api/middleware/metrics.ts
+++ b/src/api/middleware/metrics.ts
@@ -1,0 +1,28 @@
+import { createMiddleware } from "hono/factory";
+import { httpRequestDurationSeconds, httpRequestsTotal } from "../metrics.ts";
+
+/**
+ * Records request count and duration for every request into the Prometheus
+ * registry. Registered first so it times the full handler chain.
+ *
+ * The `route` label is the matched route pattern (`c.req.routePath`), not the
+ * raw path, to keep label cardinality bounded. The `/metrics` scrape itself is
+ * skipped so it doesn't pollute the histogram or count Prometheus' own polling.
+ */
+export function metricsMiddleware() {
+  return createMiddleware(async (c, next) => {
+    if (c.req.path === "/metrics") {
+      return next();
+    }
+    const start = performance.now();
+    await next();
+    const seconds = (performance.now() - start) / 1000;
+    const labels = {
+      method: c.req.method,
+      route: c.req.routePath || "unmatched",
+      status: String(c.res.status),
+    };
+    httpRequestsTotal.inc(labels);
+    httpRequestDurationSeconds.observe(labels, seconds);
+  });
+}

--- a/src/api/middleware/metrics.ts
+++ b/src/api/middleware/metrics.ts
@@ -5,15 +5,7 @@ import { httpRequestDurationSeconds, httpRequestsTotal } from "../metrics.ts";
 // effectively fixed, but the HTTP grammar allows arbitrary method tokens, and
 // this middleware runs before auth — so a client could otherwise inflate
 // `method` cardinality. Clamp to the standard verbs; bucket anything else.
-const STANDARD_METHODS = new Set([
-  "GET",
-  "HEAD",
-  "POST",
-  "PUT",
-  "PATCH",
-  "DELETE",
-  "OPTIONS",
-]);
+const STANDARD_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]);
 
 /**
  * Records request count and duration for every request into the Prometheus
@@ -38,7 +30,7 @@ export function metricsMiddleware() {
     const seconds = (performance.now() - start) / 1000;
     const labels = {
       method: STANDARD_METHODS.has(c.req.method) ? c.req.method : "OTHER",
-      route: c.req.routePath || "unmatched",
+      route: c.req.routePath || "/*",
       status: String(c.res.status),
     };
     httpRequestsTotal.inc(labels);

--- a/src/api/middleware/metrics.ts
+++ b/src/api/middleware/metrics.ts
@@ -1,6 +1,20 @@
 import { createMiddleware } from "hono/factory";
 import { httpRequestDurationSeconds, httpRequestsTotal } from "../metrics.ts";
 
+// HTTP method is the one label sourced from the raw request. The verb set is
+// effectively fixed, but the HTTP grammar allows arbitrary method tokens, and
+// this middleware runs before auth — so a client could otherwise inflate
+// `method` cardinality. Clamp to the standard verbs; bucket anything else.
+const STANDARD_METHODS = new Set([
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+]);
+
 /**
  * Records request count and duration for every request into the Prometheus
  * registry. Registered first so it times the full handler chain.
@@ -23,7 +37,7 @@ export function metricsMiddleware() {
     await next();
     const seconds = (performance.now() - start) / 1000;
     const labels = {
-      method: c.req.method,
+      method: STANDARD_METHODS.has(c.req.method) ? c.req.method : "OTHER",
       route: c.req.routePath || "unmatched",
       status: String(c.res.status),
     };

--- a/src/api/middleware/metrics.ts
+++ b/src/api/middleware/metrics.ts
@@ -8,6 +8,11 @@ import { httpRequestDurationSeconds, httpRequestsTotal } from "../metrics.ts";
  * The `route` label is the matched route pattern (`c.req.routePath`), not the
  * raw path, to keep label cardinality bounded. The `/metrics` scrape itself is
  * skipped so it doesn't pollute the histogram or count Prometheus' own polling.
+ *
+ * Streaming responses (SSE: /v1/events, conversation-events) do NOT skew the
+ * latency histogram: next() resolves when the streaming Response is returned,
+ * not when the stream closes, so this records time-to-first-byte. Verified — a
+ * stream held open 300ms records ~1ms here, not 300ms.
  */
 export function metricsMiddleware() {
   return createMiddleware(async (c, next) => {

--- a/src/api/routes/metrics.ts
+++ b/src/api/routes/metrics.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono";
+import { metricsRegistry } from "../metrics.ts";
+
+/**
+ * GET /metrics — Prometheus exposition endpoint.
+ *
+ * Bare path (not under /v1) so the web Caddy proxy does not forward it
+ * publicly; scraped in-cluster by the ServiceMonitor. Unauthenticated like
+ * /v1/health — it carries no per-user data and is only reachable inside the
+ * cluster.
+ */
+export function metricsRoutes() {
+  return new Hono().get("/metrics", async (c) => {
+    const body = await metricsRegistry.metrics();
+    return c.body(body, 200, { "Content-Type": metricsRegistry.contentType });
+  });
+}

--- a/test/unit/api-metrics.test.ts
+++ b/test/unit/api-metrics.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { enableDefaultMetrics } from "../../src/api/metrics.ts";
+import { metricsMiddleware } from "../../src/api/middleware/metrics.ts";
+import { metricsRoutes } from "../../src/api/routes/metrics.ts";
+
+function makeApp() {
+  const app = new Hono();
+  app.use("*", metricsMiddleware());
+  app.route("/", metricsRoutes());
+  app.get("/v1/ping", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("api metrics", () => {
+  it("serves Prometheus exposition at /metrics", async () => {
+    const res = await makeApp().request("/metrics");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    const body = await res.text();
+    expect(body).toContain("http_requests_total");
+    expect(body).toContain("http_request_duration_seconds");
+  });
+
+  it("exposes default process metrics once enabled", async () => {
+    enableDefaultMetrics();
+    const body = await (await makeApp().request("/metrics")).text();
+    expect(body).toContain("process_");
+  });
+
+  it("counts requests by matched route pattern", async () => {
+    const app = makeApp();
+    await app.request("/v1/ping");
+    const body = await (await app.request("/metrics")).text();
+    expect(body).toMatch(/http_requests_total\{[^}]*route="\/v1\/ping"[^}]*\} [1-9]/);
+  });
+
+  it("does not count the /metrics scrape itself", async () => {
+    const app = makeApp();
+    await app.request("/metrics");
+    const body = await (await app.request("/metrics")).text();
+    expect(body).not.toMatch(/http_requests_total\{[^}]*route="\/metrics"/);
+  });
+});

--- a/test/unit/api-metrics.test.ts
+++ b/test/unit/api-metrics.test.ts
@@ -42,6 +42,17 @@ describe("api metrics", () => {
     expect(body).not.toMatch(/http_requests_total\{[^}]*route="\/metrics"/);
   });
 
+  it("clamps non-standard HTTP methods to OTHER", async () => {
+    const app = new Hono();
+    app.use("*", metricsMiddleware());
+    app.route("/", metricsRoutes());
+    app.all("/v1/any", (c) => c.json({ ok: true }));
+
+    await app.request("/v1/any", { method: "PROPFIND" });
+    const body = await (await app.request("/metrics")).text();
+    expect(body).toMatch(/http_requests_total\{[^}]*method="OTHER"[^}]*route="\/v1\/any"[^}]*\} [1-9]/);
+  });
+
   // Load-bearing: the whole point of this endpoint is to feed error-rate
   // alerting. A thrown handler must still be counted as status="500" — this
   // relies on Hono's compose catching the throw (via app.onError) so the

--- a/test/unit/api-metrics.test.ts
+++ b/test/unit/api-metrics.test.ts
@@ -41,4 +41,31 @@ describe("api metrics", () => {
     const body = await (await app.request("/metrics")).text();
     expect(body).not.toMatch(/http_requests_total\{[^}]*route="\/metrics"/);
   });
+
+  // Load-bearing: the whole point of this endpoint is to feed error-rate
+  // alerting. A thrown handler must still be counted as status="500" — this
+  // relies on Hono's compose catching the throw (via app.onError) so the
+  // middleware's `await next()` resolves rather than re-throwing. Lock it in so
+  // a refactor that wraps next() in try/catch can't silently kill 500-counting.
+  it("counts thrown errors as status 500", async () => {
+    const app = new Hono();
+    app.use("*", metricsMiddleware());
+    app.route("/", metricsRoutes());
+    app.onError((_err, c) => c.json({ error: "boom" }, 500));
+    app.get("/v1/boom", () => {
+      throw new Error("boom");
+    });
+
+    const res = await app.request("/v1/boom");
+    expect(res.status).toBe(500);
+
+    const body = await (await app.request("/metrics")).text();
+    expect(body).toMatch(
+      /http_requests_total\{[^}]*route="\/v1\/boom"[^}]*status="500"[^}]*\} [1-9]/,
+    );
+    // duration histogram observed the errored request too
+    expect(body).toMatch(
+      /http_request_duration_seconds_count\{[^}]*route="\/v1\/boom"[^}]*status="500"[^}]*\} [1-9]/,
+    );
+  });
 });


### PR DESCRIPTION
Adds a Prometheus \`/metrics\` endpoint to the platform HTTP API — the keystone for tenant observability (request rate, error rate, latency) and a real \`up\` signal for in-cluster scraping.

## What
- **\`GET /metrics\`** (bare path) served from a dedicated \`prom-client\` Registry
- **\`http_requests_total\`** + **\`http_request_duration_seconds\`**, labeled by `method`, matched **route pattern**, and `status` — route pattern (not raw path) keeps label cardinality bounded
- **Default process metrics** (CPU/mem/GC), enabled explicitly at server start via \`enableDefaultMetrics()\` — importing the module has no global side effects
- **Timing middleware** registered first (wraps the full chain); skips the \`/metrics\` scrape itself

## Security: not publicly exposed
Served at **bare \`/metrics\`, never \`/v1/metrics\`**. A reverse proxy that only forwards \`/v1/*\`, \`/mcp*\`, \`/.well-known/*\` (see \`web/Caddyfile\`) leaves \`/metrics\` reachable to an in-cluster scraper but not the public internet. Registered unauthenticated, same as \`/v1/health\`.

## Tests
\`test/unit/api-metrics.test.ts\` — exposition format, route-pattern labeling, scrape-not-self-counted, default metrics opt-in. Full \`bun run verify\` green (static + unit 3300 + web 458 + integration 556 + smoke 24, 0 fail).

## Follow-up (separate, deployment repo)
Once this ships in an image, re-enable the tenant ServiceMonitor (already pre-set to \`path: /metrics\`) and add the RED alerts (\`TenantHighErrorRate\` and the deferred \`tenant-llm\` group). LLM token/cost metrics are a later additive change on this same registry.