### PR TITLE
feat: rip-and-replace skills UI — sentence-first rules, single On/Off

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -62,13 +62,12 @@ export const FEATURE_TOOL_MAP: Record<string, keyof FeatureFlags> = {
   // Identity & workspace tools
   nb__manage_users: "userManagement",
   nb__manage_workspaces: "workspaceManagement",
-  // Skill mutation surface — all six gated by `skillManagement`.
+  // Skill mutation surface — all five gated by `skillManagement`.
   skills__create: "skillManagement",
   skills__update: "skillManagement",
   skills__delete: "skillManagement",
   skills__activate: "skillManagement",
   skills__deactivate: "skillManagement",
-  skills__move_scope: "skillManagement",
   // Unprefixed names (used during system tool registration)
   delegate: "delegation",
   manage_users: "userManagement",

--- a/src/config/privilege.ts
+++ b/src/config/privilege.ts
@@ -31,11 +31,10 @@ export interface ConfirmationGate {
  *
  * The set is small on purpose: only ops with persistent or destructive
  * effects make it here. Read tools and idempotent state changes don't
- * need confirmation. `skills__delete` and `skills__move_scope` qualify
- * because both can lose data (delete removes the live file, move_scope
- * replaces the source location's skill); `skills__update` does too,
- * but its versioning snapshot makes it trivially recoverable so we lean
- * on description-as-policy there.
+ * need confirmation. `skills__delete` qualifies because it removes the
+ * live file; `skills__update` does too, but its versioning snapshot
+ * makes it trivially recoverable so we lean on description-as-policy
+ * there.
  */
 interface PrivilegeEntry {
   tool: string;
@@ -59,12 +58,6 @@ const PRIVILEGE_CANDIDATES: PrivilegeEntry[] = [
     tool: "skills__delete",
     feature: "skillManagement",
     describe: (input) => `Delete skill ${input.id}? Snapshots to _versions/ before removal.`,
-  },
-  {
-    tool: "skills__move_scope",
-    feature: "skillManagement",
-    describe: (input) =>
-      `Move skill ${input.id} to ${input.target_scope} scope? Source location is removed.`,
   },
 ];
 
@@ -97,8 +90,8 @@ export function createPrivilegeHook(
     const description = entry.describe(call.input);
     const approved = await gate.confirm(description, call.input);
     if (!approved) {
-      // Audit label: the unprefixed tool name (`create`, `delete`,
-      // `move_scope`) so consumers always see a non-empty action.
+      // Audit label: the unprefixed tool name (`create`, `delete`)
+      // so consumers always see a non-empty action.
       const action = call.name.split("__").pop() ?? call.name;
       const target = call.input.name ?? call.input.id ?? null;
       eventSink.emit({

--- a/src/engine/schemas/events.ts
+++ b/src/engine/schemas/events.ts
@@ -126,10 +126,6 @@ export type SkillCreatedPayload = Static<typeof SkillCreatedPayload>;
 
 export const SkillUpdatedPayload = Type.Object({
   ...SkillEventCommonFields,
-  /** Set by move_scope to indicate the source-of-update; absent on regular updates. */
-  action: Type.Optional(Type.Literal("move_scope")),
-  /** Original scope when action="move_scope". */
-  from: Type.Optional(WritableSkillScope),
 });
 export type SkillUpdatedPayload = Static<typeof SkillUpdatedPayload>;
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -2987,14 +2987,13 @@ export class Runtime {
    * deduplicated by `manifest.name` with later scopes overriding earlier
    * ones (user > workspace > platform).
    *
-   * All three tiers are evaluated fresh per call so authoring or moving
-   * a skill takes effect mid-session without a process restart:
+   * All three tiers are evaluated fresh per call so authoring a skill
+   * takes effect mid-session without a process restart:
    *
    *   - bundled (core + builtin from the source tree) — from the boot-
    *     time `contextSkills` cache, since those files are immutable.
    *   - platform (`{workDir}/skills/`) — fresh disk read, so writes via
-   *     `skills__create` / `skills__update` / `move_scope → platform`
-   *     surface immediately.
+   *     `skills__create` / `skills__update` surface immediately.
    *   - workspace (`{workDir}/workspaces/{wsId}/skills/`) — fresh.
    *   - user (`{workDir}/users/{userId}/skills/`) — fresh.
    *

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1692,8 +1692,15 @@ export class Runtime {
     // Layer 3 selection — bundle workflow guidance still applies based on
     // the active tool set. No `appContextServerName` (tasks don't have
     // appContext).
+    //
+    // Workspace-tier skills follow the FOCUSED workspace, falling back
+    // to the session (personal) workspace only when the task has no
+    // focus. This mirrors `_chatInner` (line ~1259, fixed in PR #315);
+    // tasks scheduled against a shared workspace were silently dropping
+    // every `loading_strategy: always` skill in that workspace before
+    // this parity fix.
     const userId = requestIdentity.id;
-    const layer3Pool = this.loadConversationSkills(sessionWsId, userId);
+    const layer3Pool = this.loadConversationSkills(focusedWsId ?? sessionWsId, userId);
     const accessibleForSkills = await this._workspaceStore.getWorkspacesForUser(ownerId);
     const bundleSkills = (
       await Promise.all(accessibleForSkills.map((ws) => this.loadBundleSkills(ws.id, {})))

--- a/src/skills/core/skill-authoring.md
+++ b/src/skills/core/skill-authoring.md
@@ -26,8 +26,6 @@ customizations, use the `nb__skills` tool surface:
 - `skills__delete` — remove a skill (snapshots to `_versions/` first)
 - `skills__activate` / `skills__deactivate` — flip status without
   deleting the file
-- `skills__move_scope` — relocate a skill across tiers (e.g. workspace
-  → org to promote)
 - `skills__list` / `skills__read` — inspect what exists before changing
   anything
 

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -251,7 +251,12 @@ export function parseSkillContent(raw: string, sourcePath: string): Skill | null
   // existing files keep loading without a migration.
   let status: SkillStatus = "active";
   if (typeof data.status === "string") {
-    const aliased = STATUS_ALIASES[data.status];
+    // `Object.hasOwn` is the prototype-safe lookup; bare `obj[k]`
+    // would return `Object.prototype.toString` (truthy) for a value
+    // of `data.status === "toString"`. Same below for SCOPE_ALIASES.
+    const aliased = Object.hasOwn(STATUS_ALIASES, data.status)
+      ? STATUS_ALIASES[data.status]
+      : undefined;
     if (aliased) {
       status = aliased;
     } else if (VALID_STATUSES.has(data.status as SkillStatus)) {
@@ -269,7 +274,9 @@ export function parseSkillContent(raw: string, sourcePath: string): Skill | null
   // the field without losing it.
   let scope: SkillScope | undefined;
   if (typeof data.scope === "string") {
-    const aliased = SCOPE_ALIASES[data.scope];
+    const aliased = Object.hasOwn(SCOPE_ALIASES, data.scope)
+      ? SCOPE_ALIASES[data.scope]
+      : undefined;
     if (aliased) {
       scope = aliased;
     } else if (VALID_SCOPES.has(data.scope as SkillScope)) {

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -24,7 +24,16 @@ const VALID_LOADING_STRATEGIES = new Set<SkillLoadingStrategy>([
   "retrieval",
   "explicit",
 ]);
-const VALID_STATUSES = new Set<SkillStatus>(["active", "draft", "disabled", "archived"]);
+const VALID_STATUSES = new Set<SkillStatus>(["active", "disabled"]);
+/**
+ * Status rename — the legacy 4-value enum collapsed to a binary.
+ * `draft` and `archived` files keep loading; their value normalises
+ * to `disabled`. The writer never emits the legacy labels.
+ */
+const STATUS_ALIASES: Record<string, SkillStatus> = {
+  draft: "disabled",
+  archived: "disabled",
+};
 const VALID_SCOPES = new Set<SkillScope>(["org", "workspace", "user", "bundle"]);
 /**
  * Scope rename — `platform` was the original Phase-2 label for the
@@ -237,10 +246,15 @@ export function parseSkillContent(raw: string, sourcePath: string): Skill | null
     }
   }
 
-  // `status` defaults to "active" when missing or invalid.
+  // `status` defaults to "active" when missing or invalid. Legacy
+  // values (`draft`, `archived`) normalise to `disabled` silently so
+  // existing files keep loading without a migration.
   let status: SkillStatus = "active";
   if (typeof data.status === "string") {
-    if (VALID_STATUSES.has(data.status as SkillStatus)) {
+    const aliased = STATUS_ALIASES[data.status];
+    if (aliased) {
+      status = aliased;
+    } else if (VALID_STATUSES.has(data.status as SkillStatus)) {
       status = data.status as SkillStatus;
     } else {
       console.error(

--- a/src/skills/schemas/manifest.ts
+++ b/src/skills/schemas/manifest.ts
@@ -39,12 +39,7 @@ const SkillScope = Type.Union([
   Type.Literal("bundle"),
 ]);
 
-const SkillStatus = Type.Union([
-  Type.Literal("active"),
-  Type.Literal("draft"),
-  Type.Literal("disabled"),
-  Type.Literal("archived"),
-]);
+const SkillStatus = Type.Union([Type.Literal("active"), Type.Literal("disabled")]);
 
 const SkillLoadingStrategy = Type.Union([
   Type.Literal("always"),

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -15,7 +15,14 @@ export type SkillType = "context" | "skill";
  */
 export type SkillScope = "org" | "workspace" | "user" | "bundle";
 export type SkillLoadingStrategy = "always" | "tool_affined" | "retrieval" | "explicit";
-export type SkillStatus = "active" | "draft" | "disabled" | "archived";
+/**
+ * Skill enablement state. Collapsed from the legacy 4-value enum
+ * (`active | draft | disabled | archived`) to a binary that matches the
+ * UI's single On/Off toggle. The loader normalizes any legacy `draft`
+ * or `archived` value to `disabled` on read so existing files keep
+ * loading without a migration.
+ */
+export type SkillStatus = "active" | "disabled";
 
 export interface SkillOverride {
   bundle?: string;

--- a/src/tools/platform/schemas/catalog.ts
+++ b/src/tools/platform/schemas/catalog.ts
@@ -27,7 +27,6 @@ export const PlatformToolCatalog = {
     delete: { input: Skills.SkillsDeleteInput },
     activate: { input: Skills.SkillsActivateInput },
     deactivate: { input: Skills.SkillsDeactivateInput },
-    move_scope: { input: Skills.SkillsMoveScopeInput },
   },
   home: {
     activity: { input: Home.HomeActivityInput },

--- a/src/tools/platform/schemas/skills.ts
+++ b/src/tools/platform/schemas/skills.ts
@@ -15,8 +15,8 @@ const SkillType = StringEnum(["skill", "context"] as const, {
   description: "`skill` for procedural how-to content; `context` for declarative facts.",
 });
 
-const SkillStatus = StringEnum(["active", "draft", "disabled", "archived"] as const, {
-  description: "`active` to load. `draft` while authoring. Default `active`.",
+const SkillStatus = StringEnum(["active", "disabled"] as const, {
+  description: "`active` to load, `disabled` to suppress. Default `active`.",
 });
 
 const SkillManifestMetadata = Type.Object({
@@ -69,8 +69,8 @@ export const SkillsListInput = Type.Object({
     }),
   ),
   status: Type.Optional(
-    StringEnum(["active", "draft", "disabled", "archived"] as const, {
-      description: "Filter by lifecycle status. Defaults to all statuses when omitted.",
+    StringEnum(["active", "disabled"] as const, {
+      description: "Filter by enablement state. Defaults to all statuses when omitted.",
     }),
   ),
   modified_since: Type.Optional(
@@ -174,17 +174,6 @@ export type SkillsActivateInput = Static<typeof SkillsActivateInput>;
 export const SkillsDeactivateInput = IdOnlyInput;
 export type SkillsDeactivateInput = Static<typeof SkillsDeactivateInput>;
 
-export const SkillsMoveScopeInput = Type.Object(
-  {
-    id: Type.String({ description: "Filesystem path returned by `skills__list`." }),
-    target_scope: StringEnum(["org", "workspace", "user"] as const, {
-      description: "Tier to relocate the skill into.",
-    }),
-  },
-  { required: ["id", "target_scope"] },
-);
-export type SkillsMoveScopeInput = Static<typeof SkillsMoveScopeInput>;
-
 // ── Tool output types ────────────────────────────────────────────────────
 //
 // Same convention as `automations.ts` §2.1 in `tools/platform/AGENTS.md`:
@@ -202,8 +191,8 @@ export type SkillScope = "org" | "workspace" | "user" | "bundle";
 /** Skill layer per the loading-strategy spec. */
 export type SkillLayer = 1 | 3;
 
-/** Per-skill lifecycle status. */
-export type SkillStatus = "active" | "draft" | "disabled" | "archived";
+/** Per-skill enablement state. */
+export type SkillStatus = "active" | "disabled";
 
 /**
  * Source provenance for a skill — where it came from on disk or via

--- a/src/tools/platform/skills.ts
+++ b/src/tools/platform/skills.ts
@@ -51,7 +51,6 @@ import {
   SkillsDeleteInput,
   SkillsListInput,
   SkillsLoadingLogInput,
-  SkillsMoveScopeInput,
   SkillsReadInput,
   SkillsUpdateInput,
 } from "./schemas/skills.ts";
@@ -134,13 +133,6 @@ const SKILLS_ACTIVATE_DESCRIPTION =
 const SKILLS_DEACTIVATE_DESCRIPTION =
   "Deactivate a skill (set status=disabled). The skill stays on disk but is skipped during Layer 3 " +
   "selection. Reactivate with `activate`. Use to mute a skill mid-incident without deleting it.";
-
-const SKILLS_MOVE_SCOPE_DESCRIPTION =
-  "Relocate a Layer 3 skill across scope tiers (e.g. workspace → org to promote a " +
-  "workspace-local skill that should apply org-wide). The `id` is the filesystem path returned " +
-  "by `skills__list`. Snapshots the original to `_versions/` in the source scope, writes to " +
-  "the target scope, then deletes the source. Permissions: caller must satisfy both source " +
-  "and target scope rules.";
 
 // ── Source factory ───────────────────────────────────────────────────────
 
@@ -397,18 +389,6 @@ export function createSkillsSource(runtime: Runtime, eventSink: EventSink): McpS
         }
       },
     },
-    {
-      name: "move_scope",
-      description: SKILLS_MOVE_SCOPE_DESCRIPTION,
-      inputSchema: SkillsMoveScopeInput,
-      handler: async (input: Record<string, unknown>): Promise<ToolResult> => {
-        try {
-          return await moveScopeHandler(runtime, input, eventSink, authoringGuidePath);
-        } catch (err) {
-          return errorResult(err);
-        }
-      },
-    },
   ];
 
   // Layer 1 vendored authoring guide. Callback-form `text` so the file is
@@ -658,7 +638,7 @@ function realPathUnderAnyRootOrThrow(target: string, roots: string[]): string {
  *   3. realUserId === lexicalUserId for user scope — same for
  *      `{workDir}/users/`.
  *
- * Called from update / delete / move_scope (after existsSync, before
+ * Called from update / delete (after existsSync, before
  * any FS read or write that follows symlinks) and from skills__read.
  */
 function assertSymlinkBoundaryOrThrow(
@@ -1101,7 +1081,6 @@ function summarizeLog(events: LoadingLogEntry[]): string {
 // ── Mutation handlers ────────────────────────────────────────────────────
 
 type WritableScope = "org" | "workspace" | "user";
-const WRITABLE_SCOPES = new Set<WritableScope>(["org", "workspace", "user"]);
 
 interface PermissionDecision {
   allowed: boolean;
@@ -1672,88 +1651,6 @@ async function setStatusHandler(
     eventSink,
     authoringGuidePath,
   );
-}
-
-async function moveScopeHandler(
-  runtime: Runtime,
-  input: Record<string, unknown>,
-  eventSink: EventSink,
-  authoringGuidePath: string,
-): Promise<ToolResult> {
-  const { id, target_scope } = input as { id?: string; target_scope?: string };
-  if (!id) return errorResult(new Error("`id` is required"));
-  if (!target_scope || !WRITABLE_SCOPES.has(target_scope as WritableScope)) {
-    return errorResult(
-      new Error(`target_scope must be one of org | workspace | user (got "${target_scope}")`),
-    );
-  }
-  if (id.startsWith(SKILL_URI_PREFIX)) return bundleNotMutable();
-  const sourceScope = scopeOfPath(runtime, id, authoringGuidePath);
-  if (sourceScope === "bundle") return bundleNotMutable();
-  if (!sourceScope) {
-    return errorResult(new Error(unrecognizedIdMessage(id)));
-  }
-  const target = target_scope as WritableScope;
-  if (sourceScope === target) {
-    return errorResult(new Error(`Skill is already in ${target} scope`));
-  }
-
-  // Source permission — derived from the *source path's* workspace/user
-  // segment. A workspace admin in wsA cannot move a skill out of wsB.
-  const sourceCheck = await checkPathAccess(runtime, id, sourceScope, "write");
-  if (!sourceCheck.allowed) return permissionDenied(sourceCheck.reason ?? "Permission denied");
-
-  // Target permission — derived from the destination path. For
-  // workspace/user targets, scopeDir() picks the caller's own
-  // workspace/user dir, so this is naturally bound to the caller's
-  // identity (no cross-tenant promotion possible).
-  let targetDir: string;
-  try {
-    targetDir = scopeDir(runtime, target);
-  } catch (err) {
-    return errorResult(err);
-  }
-  const targetCheck = await checkPathAccess(runtime, targetDir, target, "write");
-  if (!targetCheck.allowed) return permissionDenied(targetCheck.reason ?? "Permission denied");
-
-  if (!existsSync(id)) return errorResult(new Error(`Skill not found: ${id}`));
-
-  // Symlink-boundary defense on the source path before reading +
-  // copying. parseSkillFile + snapshotVersion both follow symlinks, so
-  // a cross-tenant link would otherwise leak content into the target
-  // location and into _versions/. See updateSkillHandler for full
-  // rationale.
-  try {
-    assertSymlinkBoundaryOrThrow(runtime, id, sourceScope);
-  } catch (err) {
-    return errorResult(err);
-  }
-
-  const skill = parseSkillFile(id);
-  if (!skill) return errorResult(new Error(`Failed to parse skill at ${id}`));
-  const name = skill.manifest.name;
-  const targetPath = join(targetDir, `${name}.md`);
-  if (existsSync(targetPath)) {
-    return errorResult(new Error(`A skill named "${name}" already exists in ${target} scope`));
-  }
-
-  snapshotVersion(id);
-  // Strip the source scope from the manifest so the target dir's loader
-  // stamp wins without conflicting with a stale frontmatter value.
-  const { scope: _drop, ...manifestWithoutScope } = skill.manifest;
-  writeSkill(targetDir, name, manifestWithoutScope as typeof skill.manifest, skill.body);
-  deleteSkill(dirname(id), name);
-  await reloadBootSkills(runtime);
-
-  eventSink.emit({
-    type: "skill.updated",
-    data: { id: targetPath, name, scope: target, action: "move_scope", from: sourceScope },
-  });
-  return {
-    content: textContent(`Moved skill "${name}" from ${sourceScope} → ${target}`),
-    structuredContent: { id: targetPath, name, scope: target, fromScope: sourceScope },
-    isError: false,
-  };
 }
 
 function extractUserIdFromPath(path: string, workDir: string): string | null {

--- a/src/tools/platform/skills.ts
+++ b/src/tools/platform/skills.ts
@@ -71,7 +71,7 @@ const SKILLS_LIST_DESCRIPTION =
   "List Layer 3 skills (cross-bundle agent orchestration content) and Layer 1 vendored bundle skills. " +
   "Filter by `scope` (org | workspace | user | bundle), `layer` (1 | 3), `type` (context | skill), " +
   "`tool_affinity` (a tool name; returns skills whose `applies_to_tools` glob matches it), " +
-  "`status` (active | draft | disabled | archived), or `modified_since` (ISO 8601). " +
+  "`status` (active | disabled), or `modified_since` (ISO 8601). " +
   "Returns id, name, layer, scope, status, token count, and source metadata for each skill. " +
   "Use this to answer 'what skills do I have?' or 'what's available for the active tool set?'";
 

--- a/test/integration/execute-task.test.ts
+++ b/test/integration/execute-task.test.ts
@@ -27,7 +27,7 @@
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { textContent } from "../../src/engine/content-helpers.ts";
@@ -327,5 +327,51 @@ describe("runtime.executeTask", () => {
     expect(convo!.metadata?.source).toBe("task");
     // Caller's metadata passes through alongside the source tag.
     expect(convo!.metadata?.automationId).toBe("auto_test_123");
+  });
+
+  it("loads the focused workspace's `always` skill into Layer 3 (parity with chat path)", async () => {
+    // Regression guard for the executeTask analog of the chat-path bug
+    // PR #315 fixed in `_chatInner`. Before this fix,
+    // `loadConversationSkills(sessionWsId, ...)` at runtime.ts:1703
+    // pulled workspace-tier skills from the user's personal workspace,
+    // so any scheduled task focused on a shared workspace silently
+    // dropped that workspace's `loading_strategy: always` skills.
+    //
+    // Fix: `loadConversationSkills(focusedWsId ?? sessionWsId, ...)`.
+    // This test plants a workspace-tier skill in the SHARED workspace
+    // (different dir than the personal workspace), runs an
+    // executeTask focused on the shared workspace, and asserts the
+    // skill lands in the recorded `skills.loaded` event.
+    runtime = await bootRuntime(undefined);
+    const { personalWsId } = await provisionWorkspaces(runtime);
+    expect(personalWsId).not.toBe(SHARED_WS_ID);
+
+    const SKILL_NAME = "shared-task-voice";
+    const sharedSkillsDir = join(workDir, "workspaces", SHARED_WS_ID, "skills");
+    mkdirSync(sharedSkillsDir, { recursive: true });
+    writeFileSync(
+      join(sharedSkillsDir, `${SKILL_NAME}.md`),
+      `---\nname: ${SKILL_NAME}\ndescription: voice for the shared workspace\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n\nAlways answer in plain English.\n`,
+    );
+
+    const result = await runtime.executeTask({
+      prompt: "do a thing",
+      identity: { id: TEST_USER_ID, displayName: TEST_USER_DISPLAY },
+      workspaceId: SHARED_WS_ID,
+    });
+
+    const store = runtime.findConversationStore();
+    const events = await store.readEvents(result.conversationId);
+    const skillsLoaded = events.find((e) => e.type === "skills.loaded");
+    expect(skillsLoaded).toBeDefined();
+
+    const payload = skillsLoaded as unknown as {
+      skills: Array<{ id: string; scope: string; loadedBy: string }>;
+    };
+    const expectedPath = join(sharedSkillsDir, `${SKILL_NAME}.md`);
+    const entry = payload.skills.find((s) => s.id === expectedPath);
+    expect(entry).toBeDefined();
+    expect(entry?.scope).toBe("workspace");
+    expect(entry?.loadedBy).toBe("always");
   });
 });

--- a/test/unit/engine-event-schemas.test.ts
+++ b/test/unit/engine-event-schemas.test.ts
@@ -89,18 +89,6 @@ describe("event schemas — accept representative payloads", () => {
     ).toBe(true);
   });
 
-  test("skill.updated — move_scope variant", () => {
-    expect(
-      Value.Check(SkillUpdatedPayload, {
-        id: "/data/skills/foo.md",
-        name: "foo",
-        scope: "org",
-        action: "move_scope",
-        from: "workspace",
-      }),
-    ).toBe(true);
-  });
-
   test("skill.deleted — required fields", () => {
     expect(
       Value.Check(SkillDeletedPayload, {

--- a/test/unit/skills/manifest-extension.test.ts
+++ b/test/unit/skills/manifest-extension.test.ts
@@ -194,6 +194,57 @@ status: weird
     expect(skill.manifest.status).toBe("active");
   });
 
+  // Pre-Phase-3 SkillStatus was `active | draft | disabled | archived`.
+  // The redesign collapsed to `active | disabled`. Existing files on
+  // disk with `draft` / `archived` keep loading without a migration by
+  // normalising silently to `disabled`. This pair pins that contract —
+  // if the loader's STATUS_ALIASES path ever regresses, these break.
+  test("legacy status 'draft' normalises to 'disabled' on read", () => {
+    const skill = parse(`---
+name: legacy-draft
+description: x
+version: 1.0.0
+type: skill
+priority: 50
+status: draft
+---
+`);
+    expect(skill.manifest.status).toBe("disabled");
+  });
+
+  test("legacy status 'archived' normalises to 'disabled' on read", () => {
+    const skill = parse(`---
+name: legacy-archived
+description: x
+version: 1.0.0
+type: skill
+priority: 50
+status: archived
+---
+`);
+    expect(skill.manifest.status).toBe("disabled");
+  });
+
+  // Object.hasOwn guard — the alias map must not expose
+  // Object.prototype members like `toString` or `constructor`. A
+  // frontmatter value matching a prototype key used to return a
+  // truthy function under bare `obj[k]` lookup, which would coerce
+  // the status into garbage.
+  test("status matching Object.prototype keys does NOT alias", () => {
+    const skill = parse(`---
+name: proto-status
+description: x
+version: 1.0.0
+type: skill
+priority: 50
+status: toString
+---
+`);
+    // "toString" isn't a valid status, so the loader falls back to
+    // active and logs a warning — never sets status to a function.
+    expect(skill.manifest.status).toBe("active");
+  });
+
   test("invalid scope is ignored (left undefined for the multi-scope loader to stamp)", () => {
     const skill = parse(`---
 name: bad-scope

--- a/test/unit/skills/manifest-extension.test.ts
+++ b/test/unit/skills/manifest-extension.test.ts
@@ -52,7 +52,7 @@ loading-strategy: tool_affined
 applies-to-tools:
   - synapse-collateral__*
   - "*__patch_source"
-status: draft
+status: disabled
 derived-from: skill://platform/voice-rules
 ---
 Body.
@@ -63,7 +63,7 @@ Body.
       "synapse-collateral__*",
       "*__patch_source",
     ]);
-    expect(skill.manifest.status).toBe("draft");
+    expect(skill.manifest.status).toBe("disabled");
     expect(skill.manifest.derivedFrom).toBe("skill://platform/voice-rules");
   });
 
@@ -219,7 +219,7 @@ describe("Phase 2 manifest fields — round-trip", () => {
       scope: "user",
       loadingStrategy: "tool_affined",
       appliesToTools: ["synapse-collateral__*"],
-      status: "draft",
+      status: "disabled",
       overrides: [{ bundle: "x", skill: "y", reason: "because" }],
       derivedFrom: "skill://platform/parent",
       metadata: {
@@ -235,7 +235,7 @@ describe("Phase 2 manifest fields — round-trip", () => {
     expect(read?.manifest.scope).toBe("user");
     expect(read?.manifest.loadingStrategy).toBe("tool_affined");
     expect(read?.manifest.appliesToTools).toEqual(["synapse-collateral__*"]);
-    expect(read?.manifest.status).toBe("draft");
+    expect(read?.manifest.status).toBe("disabled");
     expect(read?.manifest.overrides).toEqual([
       { bundle: "x", skill: "y", reason: "because" },
     ]);

--- a/test/unit/skills/select.test.ts
+++ b/test/unit/skills/select.test.ts
@@ -84,31 +84,13 @@ describe("selectLayer3Skills — `always` strategy", () => {
     expect(result[0]?.skill).toBe(skill);
   });
 
-  test("draft status → not included", () => {
+  test("disabled status → not included", () => {
     const skill = makeSkill({
-      name: "voice-rules",
-      loadingStrategy: "always",
-      status: "draft",
-    });
-    const result = selectLayer3Skills({ skills: [skill], activeTools: [] });
-    expect(result).toHaveLength(0);
-  });
-
-  test("disabled and archived statuses → not included", () => {
-    const disabled = makeSkill({
       name: "disabled-skill",
       loadingStrategy: "always",
       status: "disabled",
     });
-    const archived = makeSkill({
-      name: "archived-skill",
-      loadingStrategy: "always",
-      status: "archived",
-    });
-    const result = selectLayer3Skills({
-      skills: [disabled, archived],
-      activeTools: [],
-    });
+    const result = selectLayer3Skills({ skills: [skill], activeTools: [] });
     expect(result).toHaveLength(0);
   });
 
@@ -263,11 +245,11 @@ describe("selectLayer3Skills — mixed input + ordering", () => {
         status: "active",
         priority: 30,
       }),
-      // excluded (always, draft)
+      // excluded (always, disabled)
       makeSkill({
-        name: "always-draft",
+        name: "always-disabled",
         loadingStrategy: "always",
-        status: "draft",
+        status: "disabled",
         priority: 20,
       }),
       // included (tool_affined, matches)

--- a/test/unit/tools/platform/skills-mutation.test.ts
+++ b/test/unit/tools/platform/skills-mutation.test.ts
@@ -3,7 +3,7 @@
  *
  * Per-tool: happy path + at least one error/permission edge. Versioning
  * (`_versions/{name}.{iso}.md` snapshots) is verified as a side-effect of
- * update / delete / move_scope. The fake runtime is intentionally close to
+ * update / delete. The fake runtime is intentionally close to
  * the read-tool tests' fixture so behavioral parity stays obvious.
  */
 
@@ -484,87 +484,6 @@ describe("skills__activate / skills__deactivate", () => {
   });
 });
 
-// ── move_scope ───────────────────────────────────────────────────────────
-
-describe("skills__move_scope", () => {
-  test("relocates from workspace → platform; original deleted, version snapshot kept", async () => {
-    runtime.wsId = "ws_demo";
-    const src = await buildSource();
-    const client = src.getClient()!;
-    const create = await client.callTool({
-      name: "create",
-      arguments: {
-        scope: "workspace",
-        manifest: { name: "promote-me", description: "test", type: "skill" },
-        body: "wide value",
-      },
-    });
-    expect(create.isError).toBeFalsy();
-    const sourcePath = join(workDir, "workspaces", "ws_demo", "skills", "promote-me.md");
-    expect(existsSync(sourcePath)).toBe(true);
-
-    const result = await client.callTool({
-      name: "move_scope",
-      arguments: { id: sourcePath, target_scope: "org" },
-    });
-    expect(result.isError).toBeFalsy();
-    expect(existsSync(sourcePath)).toBe(false);
-    const targetPath = join(workDir, "skills", "promote-me.md");
-    expect(existsSync(targetPath)).toBe(true);
-    expect(readFileSync(targetPath, "utf-8")).toContain("wide value");
-
-    const versions = readdirSync(join(workDir, "workspaces", "ws_demo", "skills", "_versions"));
-    expect(versions.length).toBe(1);
-  });
-
-  test("refuses no-op move", async () => {
-    const src = await buildSource();
-    const client = src.getClient()!;
-    await client.callTool({
-      name: "create",
-      arguments: {
-        scope: "org",
-        manifest: { name: "stay", description: "test", type: "skill" },
-        body: "x",
-      },
-    });
-    const id = join(workDir, "skills", "stay.md");
-    const result = await client.callTool({
-      name: "move_scope",
-      arguments: { id, target_scope: "org" },
-    });
-    expect(result.isError).toBe(true);
-  });
-
-  test("refuses to overwrite an existing skill at the target", async () => {
-    runtime.wsId = "ws_demo";
-    const src = await buildSource();
-    const client = src.getClient()!;
-    await client.callTool({
-      name: "create",
-      arguments: {
-        scope: "org",
-        manifest: { name: "collide", description: "test", type: "skill" },
-        body: "org",
-      },
-    });
-    await client.callTool({
-      name: "create",
-      arguments: {
-        scope: "workspace",
-        manifest: { name: "collide", description: "test", type: "skill" },
-        body: "workspace",
-      },
-    });
-    const wsPath = join(workDir, "workspaces", "ws_demo", "skills", "collide.md");
-    const result = await client.callTool({
-      name: "move_scope",
-      arguments: { id: wsPath, target_scope: "org" },
-    });
-    expect(result.isError).toBe(true);
-  });
-});
-
 // ── Cross-tenant access regressions ──────────────────────────────────────
 //
 // These exercise the strict access policy: workspace skills are scoped
@@ -646,18 +565,6 @@ describe("cross-workspace access — regression", () => {
     expect(off.isError).toBe(true);
     const on = await client.callTool({ name: "activate", arguments: { id: otherPath } });
     expect(on.isError).toBe(true);
-  });
-
-  test("move_scope from another workspace is permission_denied (source check)", async () => {
-    const otherPath = configureCrossWorkspaceFixture();
-    const src = await buildSource();
-    const client = src.getClient()!;
-    const result = await client.callTool({
-      name: "move_scope",
-      arguments: { id: otherPath, target_scope: "org" },
-    });
-    expect(result.isError).toBe(true);
-    expect(existsSync(otherPath)).toBe(true);
   });
 
   test("read against another workspace's path is permission_denied", async () => {

--- a/test/unit/tools/platform/skills-source.test.ts
+++ b/test/unit/tools/platform/skills-source.test.ts
@@ -96,7 +96,6 @@ describe("skills source — tools list", () => {
       "delete",
       "list",
       "loading_log",
-      "move_scope",
       "read",
       "update",
     ]);

--- a/test/unit/tools/platform/skills-tools.test.ts
+++ b/test/unit/tools/platform/skills-tools.test.ts
@@ -317,35 +317,35 @@ describe("skills__list", () => {
   test("status filter excludes other statuses", async () => {
     const wsDir = join(workDir, "workspaces", "ws_a", "skills");
     mkdirSync(wsDir, { recursive: true });
-    const draft = writeSkill(
-      join(wsDir, "drafty.md"),
+    const disabled = writeSkill(
+      join(wsDir, "off.md"),
       {
-        name: "drafty",
+        name: "off-skill",
         description: "x",
         version: "1.0.0",
         type: "skill",
         priority: 50,
-        status: "draft",
+        status: "disabled",
       },
       "body",
     );
-    draft.manifest.scope = "workspace";
+    disabled.manifest.scope = "workspace";
     const active = writeSkill(
       join(wsDir, "live.md"),
       { name: "live", description: "x", version: "1.0.0", type: "skill", priority: 50 },
       "body",
     );
     active.manifest.scope = "workspace";
-    runtime.conversationOverlay = [draft, active];
+    runtime.conversationOverlay = [disabled, active];
     runtime.wsId = "ws_a";
 
     const src = await buildSource();
     const client = src.getClient()!;
-    const result = await client.callTool({ name: "list", arguments: { status: "draft" } });
+    const result = await client.callTool({ name: "list", arguments: { status: "disabled" } });
     const skills = (result as { structuredContent?: { skills?: unknown[] } }).structuredContent
       ?.skills as Array<{ name: string; status: string }>;
-    expect(skills.every((s) => s.status === "draft")).toBe(true);
-    expect(skills.map((s) => s.name)).toContain("drafty");
+    expect(skills.every((s) => s.status === "disabled")).toBe(true);
+    expect(skills.map((s) => s.name)).toContain("off-skill");
     expect(skills.map((s) => s.name)).not.toContain("live");
   });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -411,9 +411,9 @@ function AuthenticatedAppContent({
             ))}
 
             {/* Profile — top-level, identity-bound. Tabbed surface
-                following the /org/* pattern. Phase 3 of SKILLS_SURFACE.md
-                added the Skills tab; future identity-level config
-                (custom instructions, model prefs) slots in alongside. */}
+                following the /org/* pattern. Future identity-level
+                config (custom instructions, model prefs) slots in
+                alongside the Skills tab. */}
             <Route path="/profile" element={<ProfilePage />}>
               <Route index element={<Navigate to="/profile/general" replace />} />
               <Route path="general" element={<ProfileTab />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,6 +43,8 @@ import { recoverFromWorkspaceError } from "./lib/workspace-recovery";
 import { toSlug } from "./lib/workspace-slug";
 import { GlobalHomePage } from "./pages/GlobalHomePage";
 import { ProfilePage } from "./pages/ProfilePage";
+import { ProfileSkillsTab } from "./pages/settings/ProfileSkillsTab";
+import { ProfileTab } from "./pages/settings/ProfileTab";
 import { ConnectorBrowsePage } from "./pages/settings/ConnectorBrowsePage";
 import { ConnectorDetailPage } from "./pages/settings/ConnectorDetailPage";
 import { ModelTab } from "./pages/settings/ModelTab";
@@ -408,8 +410,15 @@ function AuthenticatedAppContent({
               />
             ))}
 
-            {/* Profile — top-level, identity-bound. */}
-            <Route path="/profile" element={<ProfilePage />} />
+            {/* Profile — top-level, identity-bound. Tabbed surface
+                following the /org/* pattern. Phase 3 of SKILLS_SURFACE.md
+                added the Skills tab; future identity-level config
+                (custom instructions, model prefs) slots in alongside. */}
+            <Route path="/profile" element={<ProfilePage />}>
+              <Route index element={<Navigate to="/profile/general" replace />} />
+              <Route path="general" element={<ProfileTab />} />
+              <Route path="skills" element={<ProfileSkillsTab />} />
+            </Route>
 
             {/* Organization settings — dedicated top-level home, org-admin
                 scoped. Everything here affects the org as a whole (global

--- a/web/src/_generated/platform-schemas/catalog.d.ts
+++ b/web/src/_generated/platform-schemas/catalog.d.ts
@@ -19,7 +19,7 @@ export declare const PlatformToolCatalog: {
                 layer: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<3 | 1>>;
                 type: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
                 tool_affinity: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
-                status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "draft" | "disabled" | "archived">>;
+                status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "disabled">>;
                 modified_since: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
             }>;
         };
@@ -49,7 +49,7 @@ export declare const PlatformToolCatalog: {
                     description: import("@sinclair/typebox").TString;
                     type: import("@sinclair/typebox").TUnsafe<"skill" | "context">;
                     priority: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TNumber>;
-                    status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "draft" | "disabled" | "archived">>;
+                    status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "disabled">>;
                     version: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
                     metadata: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TObject<{
                         keywords: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TArray<import("@sinclair/typebox").TString>>;
@@ -68,7 +68,7 @@ export declare const PlatformToolCatalog: {
                     description: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
                     type: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"skill" | "context">>;
                     priority: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TNumber>;
-                    status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "draft" | "disabled" | "archived">>;
+                    status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "disabled">>;
                     version: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
                     metadata: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TObject<{
                         keywords: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TArray<import("@sinclair/typebox").TString>>;
@@ -93,12 +93,6 @@ export declare const PlatformToolCatalog: {
         readonly deactivate: {
             readonly input: import("@sinclair/typebox").TObject<{
                 id: import("@sinclair/typebox").TString;
-            }>;
-        };
-        readonly move_scope: {
-            readonly input: import("@sinclair/typebox").TObject<{
-                id: import("@sinclair/typebox").TString;
-                target_scope: import("@sinclair/typebox").TUnsafe<"user" | "org" | "workspace">;
             }>;
         };
     };

--- a/web/src/_generated/platform-schemas/skills.d.ts
+++ b/web/src/_generated/platform-schemas/skills.d.ts
@@ -8,7 +8,7 @@ export declare const SkillsListInput: import("@sinclair/typebox").TObject<{
     layer: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<3 | 1>>;
     type: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
     tool_affinity: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
-    status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "draft" | "disabled" | "archived">>;
+    status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "disabled">>;
     modified_since: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
 }>;
 export type SkillsListInput = Static<typeof SkillsListInput>;
@@ -34,7 +34,7 @@ export declare const SkillsCreateInput: import("@sinclair/typebox").TObject<{
         description: import("@sinclair/typebox").TString;
         type: import("@sinclair/typebox").TUnsafe<"skill" | "context">;
         priority: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TNumber>;
-        status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "draft" | "disabled" | "archived">>;
+        status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "disabled">>;
         version: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
         metadata: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TObject<{
             keywords: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TArray<import("@sinclair/typebox").TString>>;
@@ -52,7 +52,7 @@ export declare const SkillsUpdateInput: import("@sinclair/typebox").TObject<{
         description: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
         type: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"skill" | "context">>;
         priority: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TNumber>;
-        status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "draft" | "disabled" | "archived">>;
+        status: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"active" | "disabled">>;
         version: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
         metadata: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TObject<{
             keywords: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TArray<import("@sinclair/typebox").TString>>;
@@ -76,17 +76,12 @@ export declare const SkillsDeactivateInput: import("@sinclair/typebox").TObject<
     id: import("@sinclair/typebox").TString;
 }>;
 export type SkillsDeactivateInput = Static<typeof SkillsDeactivateInput>;
-export declare const SkillsMoveScopeInput: import("@sinclair/typebox").TObject<{
-    id: import("@sinclair/typebox").TString;
-    target_scope: import("@sinclair/typebox").TUnsafe<"user" | "org" | "workspace">;
-}>;
-export type SkillsMoveScopeInput = Static<typeof SkillsMoveScopeInput>;
 /** Tier a skill lives in. */
 export type SkillScope = "org" | "workspace" | "user" | "bundle";
 /** Skill layer per the loading-strategy spec. */
 export type SkillLayer = 1 | 3;
-/** Per-skill lifecycle status. */
-export type SkillStatus = "active" | "draft" | "disabled" | "archived";
+/** Per-skill enablement state. */
+export type SkillStatus = "active" | "disabled";
 /**
  * Source provenance for a skill — where it came from on disk or via
  * a bundle. Optional fields; at least one is populated.

--- a/web/src/pages/ProfilePage.tsx
+++ b/web/src/pages/ProfilePage.tsx
@@ -4,9 +4,8 @@ import { type SettingsNavItem, SettingsShell } from "./settings/SettingsShell";
 //
 // Profile is identity-level: it follows the user across every workspace
 // and isn't gated by workspace role. Items declare `minRole: "none"` so
-// any authenticated identity sees them. Phase 3 of SKILLS_SURFACE.md
-// adds the Skills tab; future identity-level config (custom
-// instructions, model preferences) slots in alongside.
+// any authenticated identity sees them. Future identity-level config
+// (custom instructions, model preferences) slots in alongside Skills.
 
 const PROFILE_ITEMS: SettingsNavItem[] = [
   { id: "profile-general", label: "General", to: "/profile/general", minRole: "none" },

--- a/web/src/pages/ProfilePage.tsx
+++ b/web/src/pages/ProfilePage.tsx
@@ -9,7 +9,7 @@ import { type SettingsNavItem, SettingsShell } from "./settings/SettingsShell";
 // instructions, model preferences) slots in alongside.
 
 const PROFILE_ITEMS: SettingsNavItem[] = [
-  { id: "profile-general", label: "Profile", to: "/profile/general", minRole: "none" },
+  { id: "profile-general", label: "General", to: "/profile/general", minRole: "none" },
   { id: "profile-skills", label: "Skills", to: "/profile/skills", minRole: "none" },
 ];
 

--- a/web/src/pages/ProfilePage.tsx
+++ b/web/src/pages/ProfilePage.tsx
@@ -1,18 +1,18 @@
-import { ProfileTab } from "./settings/ProfileTab";
+import { type SettingsNavItem, SettingsShell } from "./settings/SettingsShell";
 
-/**
- * Top-level Profile page — identity is not a setting, so it lives outside
- * the `/settings/*` tree and renders without the settings sub-nav.
- *
- * The page chrome matches the padding the settings outlet uses
- * (`p-4 md:p-6`) so visiting Profile feels visually congruent with
- * visiting any settings tab — just without the inner nav competing for
- * attention.
- */
+// ── Profile shell — `/profile/*` ─────────────────────────────────────
+//
+// Profile is identity-level: it follows the user across every workspace
+// and isn't gated by workspace role. Items declare `minRole: "none"` so
+// any authenticated identity sees them. Phase 3 of SKILLS_SURFACE.md
+// adds the Skills tab; future identity-level config (custom
+// instructions, model preferences) slots in alongside.
+
+const PROFILE_ITEMS: SettingsNavItem[] = [
+  { id: "profile-general", label: "Profile", to: "/profile/general", minRole: "none" },
+  { id: "profile-skills", label: "Skills", to: "/profile/skills", minRole: "none" },
+];
+
 export function ProfilePage() {
-  return (
-    <div className="h-full overflow-y-auto p-4 md:p-6">
-      <ProfileTab />
-    </div>
-  );
+  return <SettingsShell title="Profile" items={PROFILE_ITEMS} />;
 }

--- a/web/src/pages/settings/OrgSkillsTab.tsx
+++ b/web/src/pages/settings/OrgSkillsTab.tsx
@@ -4,12 +4,10 @@ import { SkillsBrowser } from "./SkillsTab";
  * Org-admin skills tab — `/org/skills`.
  *
  * Renders the shared `SkillsBrowser` locked to org-tier. The route guard
- * (RouteGuard role="org_admin" in App.tsx) is the access gate; this tab
+ * (`RouteGuard role="org_admin"` in App.tsx) is the access gate; this tab
  * assumes it has been passed before mount. Backend `checkPathAccess` is
  * the source of truth — UI gating is defense in depth, not the security
  * boundary.
- *
- * See `nimblebrain-ops/research/SKILLS_SURFACE.md` for the surface design.
  */
 export function OrgSkillsTab() {
   return <SkillsBrowser lockedScope="org" />;

--- a/web/src/pages/settings/ProfileSkillsTab.tsx
+++ b/web/src/pages/settings/ProfileSkillsTab.tsx
@@ -1,0 +1,16 @@
+import { SkillsBrowser } from "./SkillsTab";
+
+/**
+ * Personal-skills tab — `/profile/skills`.
+ *
+ * Renders the shared `SkillsBrowser` locked to user-tier. Personal skills
+ * follow the identity across every workspace; the load path reads from
+ * `users/<userId>/skills/` at runtime regardless of focused workspace
+ * (see runtime.loadConversationSkills) so the "follow me" invariant is
+ * delivered by the runtime, not the UI placement.
+ *
+ * See `nimblebrain-ops/research/SKILLS_SURFACE.md` for Phase 3 design.
+ */
+export function ProfileSkillsTab() {
+  return <SkillsBrowser lockedScope="user" />;
+}

--- a/web/src/pages/settings/ProfileSkillsTab.tsx
+++ b/web/src/pages/settings/ProfileSkillsTab.tsx
@@ -6,10 +6,8 @@ import { SkillsBrowser } from "./SkillsTab";
  * Renders the shared `SkillsBrowser` locked to user-tier. Personal skills
  * follow the identity across every workspace; the load path reads from
  * `users/<userId>/skills/` at runtime regardless of focused workspace
- * (see runtime.loadConversationSkills) so the "follow me" invariant is
+ * (see `runtime.loadConversationSkills`) so the "follow me" invariant is
  * delivered by the runtime, not the UI placement.
- *
- * See `nimblebrain-ops/research/SKILLS_SURFACE.md` for Phase 3 design.
  */
 export function ProfileSkillsTab() {
   return <SkillsBrowser lockedScope="user" />;

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -921,9 +921,7 @@ function EditView({
               ...(advancedOpen || existing?.metadata.loadingStrategy === "always"
                 ? { loadingStrategy }
                 : {}),
-              ...(advancedOpen || existing?.metadata.priority !== undefined
-                ? { priority }
-                : {}),
+              ...(advancedOpen || existing?.metadata.priority !== undefined ? { priority } : {}),
             })
           }
           disabled={!valid || pending}

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -4,12 +4,13 @@ import { Link } from "react-router-dom";
 import { Streamdown } from "streamdown";
 import type { ToolInput } from "../../_generated/platform-schemas/catalog";
 import { callTool } from "../../api/client";
+import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { Textarea } from "../../components/ui/textarea";
 import { parseToolResponse } from "../../lib/tool-response";
 import { cn } from "../../lib/utils";
-import { RequireActiveWorkspace } from "./components/RequireActiveWorkspace";
+import { RequireActiveWorkspace, Section, SettingsPageHeader } from "./components";
 
 import type {
   SkillDetail as ReadSkill,
@@ -250,20 +251,18 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
   }
 
   return (
-    <main className="max-w-[760px] mx-auto pt-2 sm:pt-6 px-1 sm:px-2">
-      <header className="mb-8 sm:mb-12">
-        <h2 className="flex items-center gap-2 text-[22px] tracking-tight text-foreground">
-          <Lightbulb className="h-4 w-4 text-muted-foreground" />
-          Skills
-        </h2>
-        <p className="text-sm text-muted-foreground mt-2 max-w-[52ch]">
-          {lockedScope === "org"
+    <div className="max-w-3xl mx-auto space-y-6">
+      <SettingsPageHeader
+        title="Skills"
+        description={
+          lockedScope === "org"
             ? "Organization-wide rules. These apply to every workspace."
             : isWorkspaceSurface
               ? "Rules that shape what your agent says and how it works in this workspace."
-              : "Rules that shape your agent's behavior."}
-        </p>
-      </header>
+              : "Rules that shape your agent's behavior."
+        }
+        icon={<Lightbulb className="h-5 w-5" />}
+      />
 
       {/* Loading message only when we have nothing to render yet — a
        * refetch triggered by a toggle/edit keeps the list mounted so the
@@ -290,88 +289,81 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
         </Card>
       )}
 
-      {skills.length > 0 && (
-        <div>
-          {grouped.map((group) => {
-            const inherited = isWorkspaceSurface && group.scope !== "workspace";
-            if (inherited) {
-              return (
-                <InheritedSection
-                  key={group.scope}
-                  title={
-                    group.scope === "org"
-                      ? "From your organization"
-                      : group.scope === "bundle"
-                        ? "From the system"
-                        : `From ${group.scope}`
-                  }
-                  rules={group.skills}
-                  deepLinkLabel={group.scope === "org" ? "Edit in org settings" : undefined}
-                  deepLinkTo={group.scope === "org" ? "/org/skills" : undefined}
-                  ambient={group.scope === "bundle"}
-                  expandedId={selectedId}
-                  onSelect={handleSelect}
-                  detail={detail}
-                  detailLoading={detailLoading}
-                />
-              );
-            }
-            // Own (editable) section — matches the inherited-section
-            // header shape so the hierarchy reads as "three peer
-            // sections under the page title" rather than "implicit
-            // primary content followed by labelled buckets". No
-            // chevron; this section is always open.
-            const ownTitle = isWorkspaceSurface
-              ? "From your workspace"
-              : group.scope === "org"
-                ? "Organization rules"
-                : group.scope === "user"
-                  ? "Your rules"
-                  : null;
-            const activeCount = group.skills.filter((s) => s.status === "active").length;
+      {skills.length > 0 &&
+        grouped.map((group, idx) => {
+          const inherited = isWorkspaceSurface && group.scope !== "workspace";
+          const activeCount = group.skills.filter((s) => s.status === "active").length;
+          if (inherited) {
             return (
-              <section key={group.scope} className="mt-0 first:mt-0">
-                {ownTitle && (
-                  <div className="flex items-center justify-between py-3">
-                    <span className="text-[13px] text-foreground">{ownTitle}</span>
-                    <span className="text-xs text-muted-foreground">{activeCount} active</span>
-                  </div>
-                )}
-                <div className="border-t border-border">
-                  {group.skills.map((s) => (
-                    <Rule
-                      key={s.id}
-                      skill={s}
-                      expanded={selectedId === s.id}
-                      detail={selectedId === s.id ? detail : null}
-                      detailLoading={selectedId === s.id && detailLoading}
-                      onSelect={() => handleSelect(s.id)}
-                      onToggle={() => handleToggle(s)}
-                      onEdit={() => startEdit(s.id)}
-                      onDelete={() => handleDelete(s.id)}
-                      pending={actionPending}
-                    />
-                  ))}
-                </div>
-              </section>
+              <InheritedSection
+                key={group.scope}
+                flush={idx === 0}
+                title={
+                  group.scope === "org"
+                    ? "From your organization"
+                    : group.scope === "bundle"
+                      ? "From the system"
+                      : `From ${group.scope}`
+                }
+                rules={group.skills}
+                deepLinkLabel={group.scope === "org" ? "Edit in org settings" : undefined}
+                deepLinkTo={group.scope === "org" ? "/org/skills" : undefined}
+                ambient={group.scope === "bundle"}
+                expandedId={selectedId}
+                onSelect={handleSelect}
+                detail={detail}
+                detailLoading={detailLoading}
+              />
             );
-          })}
-        </div>
-      )}
+          }
+          const ownTitle = isWorkspaceSurface
+            ? "From your workspace"
+            : group.scope === "org"
+              ? "Organization rules"
+              : group.scope === "user"
+                ? "Your rules"
+                : "Rules";
+          return (
+            <Section
+              key={group.scope}
+              flush={idx === 0}
+              title={ownTitle}
+              action={<span className="text-xs text-muted-foreground">{activeCount} active</span>}
+            >
+              <div className="border-t border-border">
+                {group.skills.map((s) => (
+                  <Rule
+                    key={s.id}
+                    skill={s}
+                    expanded={selectedId === s.id}
+                    detail={selectedId === s.id ? detail : null}
+                    detailLoading={selectedId === s.id && detailLoading}
+                    onSelect={() => handleSelect(s.id)}
+                    onToggle={() => handleToggle(s)}
+                    onEdit={() => startEdit(s.id)}
+                    onDelete={() => handleDelete(s.id)}
+                    pending={actionPending}
+                  />
+                ))}
+              </div>
+            </Section>
+          );
+        })}
 
       {!loading && (
-        <button
-          type="button"
+        <Button
+          variant="outline"
+          size="sm"
           onClick={startCreate}
           disabled={actionPending}
-          className="mt-6 py-2 text-[13px] text-foreground hover:opacity-70 underline-offset-4 hover:underline disabled:opacity-40"
+          className="self-start"
         >
           + Add a rule
-        </button>
+        </Button>
       )}
 
       {isWorkspaceSurface && <PersonalFooter count={personalCount} />}
-    </main>
+    </div>
   );
 }
 
@@ -454,19 +446,14 @@ function Rule({
   const labelIsName = label === skill.name;
 
   return (
-    <div className={cn("py-5 sm:py-6 border-b border-border", inherited && "opacity-80")}>
+    <div className={cn("py-4 border-b border-border", inherited && "opacity-80")}>
       <button
         type="button"
         onClick={onSelect}
-        className="w-full text-left grid items-center gap-[clamp(20px,6vw,56px)] grid-cols-[1fr_auto]"
+        className="w-full text-left grid items-center gap-4 sm:gap-6 grid-cols-[1fr_auto]"
       >
         <div className="min-w-0 pr-1">
-          <div
-            className={cn(
-              "text-[15.5px] sm:text-[16px] leading-[1.5] tracking-[-0.005em] text-foreground",
-              labelIsName && "font-mono text-[14px] sm:text-[14.5px]",
-            )}
-          >
+          <div className={cn("text-sm leading-snug text-foreground", labelIsName && "font-mono")}>
             {label}
           </div>
         </div>
@@ -485,44 +472,47 @@ function Rule({
         className="overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
         aria-hidden={!expanded}
       >
-        <div ref={bodyRef} className="pt-4">
+        <div ref={bodyRef} className="pt-3">
           {detailLoading && <p className="text-xs text-muted-foreground">Loading…</p>}
           {!detailLoading && detail && detail.id === skill.id && (
             <>
-              <div className="max-w-[60ch] text-[14.5px] text-foreground/80">
+              <div className="max-w-prose text-sm text-foreground/80">
                 <Streamdown className="streamdown-container presence-assistant-message">
                   {detail.content}
                 </Streamdown>
               </div>
               {!labelIsName && (
-                <div className="flex flex-wrap items-baseline gap-x-5 gap-y-1 mt-4 text-[11.5px] text-muted-foreground">
+                <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 mt-3 text-xs text-muted-foreground">
                   <span className="font-mono">{skill.name}</span>
                 </div>
               )}
               {!inherited && (
-                <div className="flex gap-6 mt-3">
-                  <button
+                <div className="flex gap-4 mt-3">
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="xs"
                     onClick={(e) => {
                       e.stopPropagation();
                       onEdit?.();
                     }}
                     disabled={pending}
-                    className="py-2 text-[12.5px] text-foreground hover:opacity-70 underline-offset-4 hover:underline disabled:opacity-40"
                   >
                     Edit
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="xs"
                     onClick={(e) => {
                       e.stopPropagation();
                       onDelete?.();
                     }}
                     disabled={pending}
-                    className="py-2 text-[12.5px] text-muted-foreground hover:text-destructive underline-offset-4 hover:underline disabled:opacity-40 inline-flex items-center gap-1.5"
+                    className="text-muted-foreground hover:text-destructive"
                   >
                     <Trash2 className="h-3 w-3" /> Delete
-                  </button>
+                  </Button>
                 </div>
               )}
             </>
@@ -556,7 +546,7 @@ function Toggle({
       disabled={disabled}
       aria-label={`${on ? "Turn off" : "Turn on"} ${label}`}
       className={cn(
-        "inline-flex items-center gap-2 px-2 py-1 rounded text-[12.5px] font-medium select-none",
+        "inline-flex items-center gap-2 px-2 py-1 rounded-md text-xs font-medium select-none",
         disabled ? "text-muted-foreground/70 cursor-not-allowed" : "text-foreground hover:bg-muted",
       )}
     >
@@ -570,7 +560,19 @@ function Toggle({
 
 // ── Inherited section ────────────────────────────────────────────────────
 
+/**
+ * Inherited (read-only) section — a quiet sibling of `Section` that
+ * collapses by default. Uses Section's chrome for consistency: same
+ * top-border separator, same `text-sm font-semibold` title vocabulary.
+ * The header acts as a button (click toggles open/closed); a chevron
+ * sits left of the title to telegraph "this expands".
+ *
+ * `ambient` shrinks the visual weight further (muted title, slightly
+ * dimmed rows) for sections the operator has zero editorial agency
+ * over (bundle / system).
+ */
 function InheritedSection({
+  flush,
   title,
   rules,
   deepLinkLabel,
@@ -581,13 +583,11 @@ function InheritedSection({
   detail,
   detailLoading,
 }: {
+  flush?: boolean;
   title: string;
   rules: ListedSkill[];
   deepLinkLabel?: string;
   deepLinkTo?: string;
-  /** Ambient sections (system / bundle) carry no editorial relationship
-   * to the operator. Render quieter — smaller header, tighter spacing,
-   * dimmed rows so the section sits below the conscious foreground. */
   ambient?: boolean;
   expandedId: string | null;
   onSelect: (id: string) => void;
@@ -597,43 +597,34 @@ function InheritedSection({
   const [open, setOpen] = useState(false);
   const activeCount = rules.filter((r) => r.status === "active").length;
   return (
-    <section className={cn(ambient ? "mt-6 first:mt-0" : "mt-10 first:mt-0")}>
+    <section className={cn("space-y-3", !flush && "pt-6 border-t border-border/60")}>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className={cn("w-full flex items-center justify-between group", ambient ? "py-2" : "py-3")}
+        className="w-full flex items-start justify-between gap-4 group"
       >
-        <div className="flex items-center gap-3">
+        <h3
+          className={cn(
+            "flex items-center gap-2 text-sm font-semibold transition-colors",
+            ambient
+              ? "text-muted-foreground/80 group-hover:text-foreground"
+              : "text-foreground/80 group-hover:text-foreground",
+          )}
+        >
           <span
             className={cn(
-              "text-xs transition-transform",
-              ambient ? "text-muted-foreground/60" : "text-muted-foreground",
+              "text-xs text-muted-foreground transition-transform",
               open && "rotate-90",
             )}
           >
             ▸
           </span>
-          <span
-            className={cn(
-              "group-hover:text-foreground",
-              ambient
-                ? "text-[12px] text-muted-foreground/70"
-                : "text-[13px] text-muted-foreground",
-            )}
-          >
-            {title}
-          </span>
-        </div>
-        <span
-          className={cn(
-            ambient ? "text-[11px] text-muted-foreground/60" : "text-xs text-muted-foreground",
-          )}
-        >
-          {activeCount} active
-        </span>
+          {title}
+        </h3>
+        <span className="text-xs text-muted-foreground shrink-0">{activeCount} active</span>
       </button>
       {open && (
-        <div className={cn("mt-1 border-t border-border", ambient && "opacity-90")}>
+        <div className={cn("border-t border-border", ambient && "opacity-90")}>
           {rules.map((r) => (
             <Rule
               key={r.id}
@@ -651,7 +642,7 @@ function InheritedSection({
             <div className="py-3">
               <Link
                 to={deepLinkTo}
-                className="text-[12.5px] text-foreground hover:opacity-70 underline-offset-4 hover:underline"
+                className="text-sm text-foreground hover:opacity-70 underline-offset-4 hover:underline"
               >
                 {deepLinkLabel} →
               </Link>
@@ -667,7 +658,7 @@ function InheritedSection({
 
 function PersonalFooter({ count }: { count: number }) {
   return (
-    <div className="mt-12 pt-6 border-t border-border flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+    <div className="pt-6 border-t border-border/60 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
       <div className="text-xs text-muted-foreground flex items-center gap-2">
         <User className="h-3.5 w-3.5" />
         {count === 0
@@ -676,7 +667,7 @@ function PersonalFooter({ count }: { count: number }) {
       </div>
       <Link
         to="/profile/skills"
-        className="text-[12.5px] text-foreground hover:opacity-70 underline-offset-4 hover:underline self-start sm:self-auto"
+        className="text-sm text-foreground hover:opacity-70 underline-offset-4 hover:underline self-start sm:self-auto"
       >
         Edit in your profile →
       </Link>
@@ -766,21 +757,14 @@ function EditView({
   const valid = slug.length > 0 && body.trim().length > 0;
 
   return (
-    <main className="max-w-[760px] mx-auto pt-2 sm:pt-6 px-1 sm:px-2">
-      <button
-        type="button"
-        onClick={onCancel}
-        className="py-2 text-[13px] text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
-      >
-        ← back to your rules
-      </button>
-
-      <h2 className="text-[22px] tracking-tight text-foreground mt-6 sm:mt-8">
-        {loading ? "Loading…" : isNew ? "A new rule for your agent" : "Edit this rule"}
-      </h2>
+    <div className="max-w-3xl mx-auto space-y-6">
+      <SettingsPageHeader
+        title={loading ? "Loading…" : isNew ? "A new rule for your agent" : "Edit this rule"}
+        back={{ to: "..", label: "Back to skills" }}
+      />
 
       {error && (
-        <Card className="mt-6">
+        <Card>
           <CardContent className="py-3 px-4">
             <p className="text-sm text-destructive">{error}</p>
           </CardContent>
@@ -788,9 +772,9 @@ function EditView({
       )}
 
       {!loading && (
-        <div className="mt-10 sm:mt-12 space-y-8 sm:space-y-10">
-          <div>
-            <label className="block text-[12.5px] text-muted-foreground mb-2" htmlFor="rule-name">
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium" htmlFor="rule-name">
               Name it
             </label>
             <Input
@@ -803,19 +787,19 @@ function EditView({
               className={isNew ? "" : "font-mono"}
             />
             {showSlugHint && (
-              <p className="text-[11.5px] text-muted-foreground mt-1.5">
+              <p className="text-xs text-muted-foreground">
                 Saved as <span className="font-mono">{slug}</span>
               </p>
             )}
             {!isNew && (
-              <p className="text-[11.5px] text-muted-foreground mt-1.5">
+              <p className="text-xs text-muted-foreground">
                 Names are immutable — they're the filename on disk.
               </p>
             )}
           </div>
 
-          <div>
-            <label className="block text-[12.5px] text-muted-foreground mb-2" htmlFor="rule-body">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium" htmlFor="rule-body">
               What should the agent do?
             </label>
             <Textarea
@@ -824,9 +808,8 @@ function EditView({
               onChange={(e) => setBody(e.target.value)}
               rows={8}
               placeholder="Match my writing voice. Avoid em-dashes."
-              className="text-[15px] leading-relaxed"
             />
-            <p className="text-xs text-muted-foreground mt-3">
+            <p className="text-xs text-muted-foreground">
               The agent reads this as a rule. Plain English works. Use line breaks for separate
               ideas.
             </p>
@@ -836,7 +819,7 @@ function EditView({
             <button
               type="button"
               onClick={() => setAdvancedOpen((v) => !v)}
-              className="text-[12.5px] text-muted-foreground hover:text-foreground inline-flex items-center gap-2"
+              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-2"
             >
               <span
                 className={cn(
@@ -850,46 +833,42 @@ function EditView({
             </button>
             {advancedOpen && (
               <div className="mt-4 pl-5 space-y-4 border-l border-border">
-                <div>
-                  <label
-                    className="block text-[12.5px] text-muted-foreground mb-1"
-                    htmlFor="loading-strategy"
-                  >
+                <div className="space-y-1">
+                  <label className="block text-sm font-medium" htmlFor="loading-strategy">
                     When to load
                   </label>
                   <select
                     id="loading-strategy"
                     value={loadingStrategy}
                     onChange={(e) => setLoadingStrategy(e.target.value as "auto" | "always")}
-                    className="text-[13px] bg-background border-b border-border pb-1 outline-none focus:border-foreground"
+                    className="text-sm bg-background border-b border-border pb-1 outline-none focus:border-foreground"
                   >
                     <option value="auto">Let the system decide</option>
                     <option value="always">Always</option>
                   </select>
-                  <p className="text-[11px] text-muted-foreground/70 mt-1.5 max-w-[48ch]">
+                  <p className="text-xs text-muted-foreground max-w-prose">
                     "Let the system decide" is the right default for short prose rules — the loader
                     picks "always" automatically.
                   </p>
                 </div>
-                <div>
-                  <label
-                    className="block text-[12.5px] text-muted-foreground mb-1"
-                    htmlFor="priority"
-                  >
+                <div className="space-y-1">
+                  <label className="block text-sm font-medium" htmlFor="priority">
                     Priority
                   </label>
-                  <input
-                    id="priority"
-                    type="number"
-                    min={1}
-                    max={100}
-                    value={priority}
-                    onChange={(e) => setPriority(parseInt(e.target.value, 10) || 50)}
-                    className="text-[13px] bg-background border-b border-border pb-1 w-20 outline-none focus:border-foreground"
-                  />
-                  <span className="text-[11.5px] text-muted-foreground ml-3">
-                    lower = read first (default 50)
-                  </span>
+                  <div className="flex items-baseline gap-3">
+                    <input
+                      id="priority"
+                      type="number"
+                      min={1}
+                      max={100}
+                      value={priority}
+                      onChange={(e) => setPriority(parseInt(e.target.value, 10) || 50)}
+                      className="text-sm bg-background border-b border-border pb-1 w-20 outline-none focus:border-foreground"
+                    />
+                    <span className="text-xs text-muted-foreground">
+                      lower = read first (default 50)
+                    </span>
+                  </div>
                 </div>
               </div>
             )}
@@ -897,16 +876,11 @@ function EditView({
         </div>
       )}
 
-      <div className="mt-12 sm:mt-16 flex items-center justify-between border-t border-border pt-6">
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={pending}
-          className="min-h-[44px] sm:min-h-0 py-2 text-[13px] text-muted-foreground hover:text-foreground underline-offset-4 hover:underline disabled:opacity-40"
-        >
+      <div className="flex items-center justify-between border-t border-border pt-6">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={pending}>
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
           onClick={() =>
             valid &&
@@ -925,16 +899,10 @@ function EditView({
             })
           }
           disabled={!valid || pending}
-          className={cn(
-            "min-h-[44px] sm:min-h-0 px-4 py-2 rounded-md text-[13px] transition-colors",
-            valid && !pending
-              ? "bg-foreground text-background hover:opacity-80"
-              : "bg-muted text-muted-foreground cursor-not-allowed",
-          )}
         >
           {pending ? "Saving…" : "Save"}
-        </button>
+        </Button>
       </div>
-    </main>
+    </div>
   );
 }

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -168,18 +168,16 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
   );
 
   const handleSubmit = useCallback(
-    async (patch: {
-      name: string;
-      body: string;
-      loadingStrategy: "auto" | "always";
-      priority: number;
-    }) => {
+    async (patch: { name: string; body: string }) => {
+      // type=context + no applies-to-tools → loader infers
+      // loading_strategy=always. Priority defaults to 50 server-side.
+      // No "Advanced" overrides are exposed: the prior toggle was a
+      // no-op (audit finding #2) and priority isn't a meaningful knob
+      // for the non-technical operator this surface is built for.
       const manifest: Record<string, unknown> = {
         name: patch.name,
         description: "",
         type: "context",
-        priority: patch.priority,
-        ...(patch.loadingStrategy === "always" ? { loadingStrategy: "always" } : {}),
       };
       if (editingId) {
         await runMutation("update", { id: editingId, manifest, body: patch.body }, () => {
@@ -687,21 +685,11 @@ function EditView({
   pending: boolean;
   error: string | null;
   onCancel: () => void;
-  onSubmit: (patch: {
-    name: string;
-    body: string;
-    loadingStrategy: "auto" | "always";
-    priority: number;
-  }) => void;
+  onSubmit: (patch: { name: string; body: string }) => void;
 }) {
   const isNew = existing === null && !loading;
   const [name, setName] = useState(existing?.metadata.name ?? "");
   const [body, setBody] = useState(existing?.content ?? "");
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [loadingStrategy, setLoadingStrategy] = useState<"auto" | "always">(
-    existing?.metadata.loadingStrategy === "always" ? "always" : "auto",
-  );
-  const [priority, setPriority] = useState<number>(existing?.metadata.priority ?? 50);
 
   const nameRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
@@ -714,8 +702,6 @@ function EditView({
     if (existing) {
       setName(existing.metadata.name);
       setBody(existing.content);
-      setLoadingStrategy(existing.metadata.loadingStrategy === "always" ? "always" : "auto");
-      setPriority(existing.metadata.priority ?? 50);
     }
   }, [existing]);
 
@@ -794,66 +780,6 @@ function EditView({
               ideas.
             </p>
           </div>
-
-          <div>
-            <button
-              type="button"
-              onClick={() => setAdvancedOpen((v) => !v)}
-              className="text-[12.5px] text-muted-foreground hover:text-foreground inline-flex items-center gap-2"
-            >
-              <span
-                className={cn(
-                  "text-muted-foreground/60 transition-transform inline-block",
-                  advancedOpen && "rotate-90",
-                )}
-              >
-                ▸
-              </span>
-              Advanced
-              <span className="text-muted-foreground/60">— when to load, priority</span>
-            </button>
-            {advancedOpen && (
-              <div className="mt-4 pl-5 space-y-4 border-l border-border">
-                <div>
-                  <label
-                    className="block text-[12.5px] text-muted-foreground mb-1"
-                    htmlFor="loading-strategy"
-                  >
-                    When to load
-                  </label>
-                  <select
-                    id="loading-strategy"
-                    value={loadingStrategy}
-                    onChange={(e) => setLoadingStrategy(e.target.value as "auto" | "always")}
-                    className="text-[13px] bg-background border-b border-border pb-1 outline-none focus:border-foreground"
-                  >
-                    <option value="auto">Let the system decide</option>
-                    <option value="always">Always</option>
-                  </select>
-                </div>
-                <div>
-                  <label
-                    className="block text-[12.5px] text-muted-foreground mb-1"
-                    htmlFor="priority"
-                  >
-                    Priority
-                  </label>
-                  <input
-                    id="priority"
-                    type="number"
-                    min={1}
-                    max={100}
-                    value={priority}
-                    onChange={(e) => setPriority(parseInt(e.target.value, 10) || 50)}
-                    className="text-[13px] bg-background border-b border-border pb-1 w-20 outline-none focus:border-foreground"
-                  />
-                  <span className="text-[11.5px] text-muted-foreground ml-3">
-                    lower = read first
-                  </span>
-                </div>
-              </div>
-            )}
-          </div>
         </div>
       )}
 
@@ -868,9 +794,7 @@ function EditView({
         </button>
         <button
           type="button"
-          onClick={() =>
-            valid && onSubmit({ name: slug, body: body.trim(), loadingStrategy, priority })
-          }
+          onClick={() => valid && onSubmit({ name: slug, body: body.trim() })}
           disabled={!valid || pending}
           className={cn(
             "min-h-[44px] sm:min-h-0 px-4 py-2 rounded-md text-[13px] transition-colors",

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -168,16 +168,25 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
   );
 
   const handleSubmit = useCallback(
-    async (patch: { name: string; body: string }) => {
-      // type=context + no applies-to-tools → loader infers
-      // loading_strategy=always. Priority defaults to 50 server-side.
-      // No "Advanced" overrides are exposed: the prior toggle was a
-      // no-op (audit finding #2) and priority isn't a meaningful knob
-      // for the non-technical operator this surface is built for.
+    async (patch: {
+      name: string;
+      body: string;
+      loadingStrategy?: "auto" | "always";
+      priority?: number;
+    }) => {
+      // For NEW rules: type=context + no applies-to-tools makes the
+      // loader auto-infer loading_strategy=always, so the default
+      // submission omits both overrides (audit finding #2 — they'd be
+      // a no-op for new rules). For EDITED rules: the user may have
+      // touched the Advanced expander to override an existing skill's
+      // priority or pin loadingStrategy=always explicitly; include
+      // those fields when set so the patch reaches disk.
       const manifest: Record<string, unknown> = {
         name: patch.name,
         description: "",
         type: "context",
+        ...(patch.loadingStrategy === "always" ? { loadingStrategy: "always" } : {}),
+        ...(patch.priority !== undefined ? { priority: patch.priority } : {}),
       };
       if (editingId) {
         await runMutation("update", { id: editingId, manifest, body: patch.body }, () => {
@@ -282,7 +291,7 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
       )}
 
       {skills.length > 0 && (
-        <div className="border-t border-border">
+        <div>
           {grouped.map((group) => {
             const inherited = isWorkspaceSurface && group.scope !== "workspace";
             if (inherited) {
@@ -307,20 +316,45 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
                 />
               );
             }
-            return group.skills.map((s) => (
-              <Rule
-                key={s.id}
-                skill={s}
-                expanded={selectedId === s.id}
-                detail={selectedId === s.id ? detail : null}
-                detailLoading={selectedId === s.id && detailLoading}
-                onSelect={() => handleSelect(s.id)}
-                onToggle={() => handleToggle(s)}
-                onEdit={() => startEdit(s.id)}
-                onDelete={() => handleDelete(s.id)}
-                pending={actionPending}
-              />
-            ));
+            // Own (editable) section — matches the inherited-section
+            // header shape so the hierarchy reads as "three peer
+            // sections under the page title" rather than "implicit
+            // primary content followed by labelled buckets". No
+            // chevron; this section is always open.
+            const ownTitle = isWorkspaceSurface
+              ? "From your workspace"
+              : group.scope === "org"
+                ? "Organization rules"
+                : group.scope === "user"
+                  ? "Your rules"
+                  : null;
+            const activeCount = group.skills.filter((s) => s.status === "active").length;
+            return (
+              <section key={group.scope} className="mt-0 first:mt-0">
+                {ownTitle && (
+                  <div className="flex items-center justify-between py-3">
+                    <span className="text-[13px] text-foreground">{ownTitle}</span>
+                    <span className="text-xs text-muted-foreground">{activeCount} active</span>
+                  </div>
+                )}
+                <div className="border-t border-border">
+                  {group.skills.map((s) => (
+                    <Rule
+                      key={s.id}
+                      skill={s}
+                      expanded={selectedId === s.id}
+                      detail={selectedId === s.id ? detail : null}
+                      detailLoading={selectedId === s.id && detailLoading}
+                      onSelect={() => handleSelect(s.id)}
+                      onToggle={() => handleToggle(s)}
+                      onEdit={() => startEdit(s.id)}
+                      onDelete={() => handleDelete(s.id)}
+                      pending={actionPending}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
           })}
         </div>
       )}
@@ -685,11 +719,26 @@ function EditView({
   pending: boolean;
   error: string | null;
   onCancel: () => void;
-  onSubmit: (patch: { name: string; body: string }) => void;
+  onSubmit: (patch: {
+    name: string;
+    body: string;
+    loadingStrategy?: "auto" | "always";
+    priority?: number;
+  }) => void;
 }) {
   const isNew = existing === null && !loading;
   const [name, setName] = useState(existing?.metadata.name ?? "");
   const [body, setBody] = useState(existing?.content ?? "");
+  // Advanced state — only consulted in the edit path, where the user
+  // may want to see/modify on-disk loading_strategy or priority that
+  // existed before the redesign or was authored outside the UI.
+  // For create, the loader's auto-inference is the right default, so
+  // we leave these absent unless the user explicitly opens Advanced.
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [loadingStrategy, setLoadingStrategy] = useState<"auto" | "always">(
+    existing?.metadata.loadingStrategy === "always" ? "always" : "auto",
+  );
+  const [priority, setPriority] = useState<number>(existing?.metadata.priority ?? 50);
 
   const nameRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
@@ -702,6 +751,8 @@ function EditView({
     if (existing) {
       setName(existing.metadata.name);
       setBody(existing.content);
+      setLoadingStrategy(existing.metadata.loadingStrategy === "always" ? "always" : "auto");
+      setPriority(existing.metadata.priority ?? 50);
     }
   }, [existing]);
 
@@ -780,6 +831,69 @@ function EditView({
               ideas.
             </p>
           </div>
+
+          <div>
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((v) => !v)}
+              className="text-[12.5px] text-muted-foreground hover:text-foreground inline-flex items-center gap-2"
+            >
+              <span
+                className={cn(
+                  "inline-block text-muted-foreground/60 transition-transform",
+                  advancedOpen && "rotate-90",
+                )}
+              >
+                ▸
+              </span>
+              Advanced
+            </button>
+            {advancedOpen && (
+              <div className="mt-4 pl-5 space-y-4 border-l border-border">
+                <div>
+                  <label
+                    className="block text-[12.5px] text-muted-foreground mb-1"
+                    htmlFor="loading-strategy"
+                  >
+                    When to load
+                  </label>
+                  <select
+                    id="loading-strategy"
+                    value={loadingStrategy}
+                    onChange={(e) => setLoadingStrategy(e.target.value as "auto" | "always")}
+                    className="text-[13px] bg-background border-b border-border pb-1 outline-none focus:border-foreground"
+                  >
+                    <option value="auto">Let the system decide</option>
+                    <option value="always">Always</option>
+                  </select>
+                  <p className="text-[11px] text-muted-foreground/70 mt-1.5 max-w-[48ch]">
+                    "Let the system decide" is the right default for short prose rules — the loader
+                    picks "always" automatically.
+                  </p>
+                </div>
+                <div>
+                  <label
+                    className="block text-[12.5px] text-muted-foreground mb-1"
+                    htmlFor="priority"
+                  >
+                    Priority
+                  </label>
+                  <input
+                    id="priority"
+                    type="number"
+                    min={1}
+                    max={100}
+                    value={priority}
+                    onChange={(e) => setPriority(parseInt(e.target.value, 10) || 50)}
+                    className="text-[13px] bg-background border-b border-border pb-1 w-20 outline-none focus:border-foreground"
+                  />
+                  <span className="text-[11.5px] text-muted-foreground ml-3">
+                    lower = read first (default 50)
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       )}
 
@@ -794,7 +908,24 @@ function EditView({
         </button>
         <button
           type="button"
-          onClick={() => valid && onSubmit({ name: slug, body: body.trim() })}
+          onClick={() =>
+            valid &&
+            onSubmit({
+              name: slug,
+              body: body.trim(),
+              // Only forward Advanced fields when the user actually
+              // touched them (or when editing a rule that already had
+              // them set on disk). For a fresh create with Advanced
+              // never opened, omit both so the loader's auto-default
+              // applies — the audit's no-op finding stays honoured.
+              ...(advancedOpen || existing?.metadata.loadingStrategy === "always"
+                ? { loadingStrategy }
+                : {}),
+              ...(advancedOpen || existing?.metadata.priority !== undefined
+                ? { priority }
+                : {}),
+            })
+          }
           disabled={!valid || pending}
           className={cn(
             "min-h-[44px] sm:min-h-0 px-4 py-2 rounded-md text-[13px] transition-colors",

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -175,29 +175,44 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
       loadingStrategy?: "auto" | "always";
       priority?: number;
     }) => {
-      // For NEW rules: type=context + no applies-to-tools makes the
-      // loader auto-infer loading_strategy=always, so the default
-      // submission omits both overrides (audit finding #2 — they'd be
-      // a no-op for new rules). For EDITED rules: the user may have
-      // touched the Advanced expander to override an existing skill's
-      // priority or pin loadingStrategy=always explicitly; include
-      // those fields when set so the patch reaches disk.
-      const manifest: Record<string, unknown> = {
-        name: patch.name,
-        description: "",
-        type: "context",
+      // CRITICAL: update is a partial patch — any field present in the
+      // manifest is written to disk and overwrites the prior value.
+      // So we MUST NOT include description, type, or name on update:
+      //   - description: "" would wipe an author-curated description
+      //     authored via CLI / markdown / OrgSkillsTab. Also breaks
+      //     this very PR's `rowLabel`, which uses description as the
+      //     row's display text — every edit would erase its own label.
+      //   - type would coerce a procedural skill into a context skill,
+      //     changing Layer-3 loading inference.
+      //   - name is immutable (it's the filename); sending it is at
+      //     best a no-op, at worst a silent rename attempt.
+      // For NEW rules, the create handler needs all three set because
+      // the file doesn't exist yet — and the loader's auto-inference
+      // (type=context + no applies-to-tools → always) is the right
+      // default for the prose rules this UI authors.
+      const advancedOverrides = {
         ...(patch.loadingStrategy === "always" ? { loadingStrategy: "always" } : {}),
         ...(patch.priority !== undefined ? { priority: patch.priority } : {}),
       };
       if (editingId) {
-        await runMutation("update", { id: editingId, manifest, body: patch.body }, () => {
-          setView("list");
-          setEditingId(null);
-        });
+        await runMutation(
+          "update",
+          { id: editingId, manifest: advancedOverrides, body: patch.body },
+          () => {
+            setView("list");
+            setEditingId(null);
+          },
+        );
       } else {
+        const createManifest = {
+          name: patch.name,
+          description: "",
+          type: "context",
+          ...advancedOverrides,
+        };
         await runMutation(
           "create",
-          { scope: createLockedScope ?? "workspace", manifest, body: patch.body },
+          { scope: createLockedScope ?? "workspace", manifest: createManifest, body: patch.body },
           (result) => {
             setView("list");
             setEditingId(null);
@@ -330,7 +345,7 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
               title={ownTitle}
               action={<span className="text-xs text-muted-foreground">{activeCount} active</span>}
             >
-              <div className="border-t border-border">
+              <div className="divide-y divide-border">
                 {group.skills.map((s) => (
                   <Rule
                     key={s.id}
@@ -446,7 +461,7 @@ function Rule({
   const labelIsName = label === skill.name;
 
   return (
-    <div className={cn("py-4 border-b border-border", inherited && "opacity-80")}>
+    <div className={cn("py-4", inherited && "opacity-80")}>
       <button
         type="button"
         onClick={onSelect}
@@ -624,7 +639,7 @@ function InheritedSection({
         <span className="text-xs text-muted-foreground shrink-0">{activeCount} active</span>
       </button>
       {open && (
-        <div className={cn("border-t border-border", ambient && "opacity-90")}>
+        <div className={cn("divide-y divide-border", ambient && "opacity-90")}>
           {rules.map((r) => (
             <Rule
               key={r.id}

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -1,6 +1,7 @@
 import { Lightbulb, Trash2, User } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { Streamdown } from "streamdown";
 import type { ToolInput } from "../../_generated/platform-schemas/catalog";
 import { callTool } from "../../api/client";
 import { Card, CardContent } from "../../components/ui/card";
@@ -257,7 +258,13 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
         </p>
       </header>
 
-      {loading && <div className="text-sm text-muted-foreground py-4">Loading rules…</div>}
+      {/* Loading message only when we have nothing to render yet — a
+       * refetch triggered by a toggle/edit keeps the list mounted so the
+       * accordion's per-row `shellH` state doesn't reset to 0 mid-flight
+       * (which manifested as a flicker collapse). */}
+      {loading && skills.length === 0 && (
+        <div className="text-sm text-muted-foreground py-4">Loading rules…</div>
+      )}
       {error && (
         <Card className="mb-4">
           <CardContent className="py-3 px-4">
@@ -276,7 +283,7 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
         </Card>
       )}
 
-      {!loading && skills.length > 0 && (
+      {skills.length > 0 && (
         <div className="border-t border-border">
           {grouped.map((group) => {
             const inherited = isWorkspaceSurface && group.scope !== "workspace";
@@ -288,12 +295,13 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
                     group.scope === "org"
                       ? "From your organization"
                       : group.scope === "bundle"
-                        ? "From installed apps"
+                        ? "From the system"
                         : `From ${group.scope}`
                   }
                   rules={group.skills}
                   deepLinkLabel={group.scope === "org" ? "Edit in org settings" : undefined}
                   deepLinkTo={group.scope === "org" ? "/org/skills" : undefined}
+                  ambient={group.scope === "bundle"}
                   expandedId={selectedId}
                   onSelect={handleSelect}
                   detail={detail}
@@ -359,9 +367,20 @@ function groupByScope(skills: ListedSkill[], opts?: { excludeUser?: boolean }): 
 
 // ── Rule row ─────────────────────────────────────────────────────────────
 
-function firstSentence(s: string): string {
-  const m = s.match(/^[^.\n]*[.!?]/);
-  return m ? m[0].trim() : s.trim();
+/**
+ * Resting-state label for a row.
+ *
+ * The body is rendered as full markdown in the expanded view, so using
+ * the body's first sentence as the label duplicates content the moment
+ * the row opens. Instead: prefer the (short) description if the author
+ * wrote one, otherwise fall back to the on-disk identifier (kebab-name).
+ * The author-controlled name is the closest thing to a meaningful label
+ * for rules without a description.
+ */
+function rowLabel(skill: ListedSkill): string {
+  const desc = skill.description?.trim();
+  if (desc && desc.length > 0 && desc.length <= 140) return desc;
+  return skill.name;
 }
 
 function Rule({
@@ -399,13 +418,8 @@ function Rule({
     });
   }, [expanded, detail]);
 
-  // Resting label = first sentence of the body when we have it; otherwise
-  // the summary description; otherwise the name. We don't fetch the body
-  // just for the label — only the expanded row has body content available.
-  const restingLabel =
-    detail && detail.id === skill.id
-      ? firstSentence(detail.content)
-      : firstSentence(skill.description ?? "") || skill.name;
+  const label = rowLabel(skill);
+  const labelIsName = label === skill.name;
 
   return (
     <div className={cn("py-5 sm:py-6 border-b border-border", inherited && "opacity-80")}>
@@ -415,15 +429,20 @@ function Rule({
         className="w-full text-left grid items-center gap-[clamp(20px,6vw,56px)] grid-cols-[1fr_auto]"
       >
         <div className="min-w-0 pr-1">
-          <div className="text-[15.5px] sm:text-[16px] leading-[1.5] tracking-[-0.005em] text-foreground">
-            {restingLabel}
+          <div
+            className={cn(
+              "text-[15.5px] sm:text-[16px] leading-[1.5] tracking-[-0.005em] text-foreground",
+              labelIsName && "font-mono text-[14px] sm:text-[14.5px]",
+            )}
+          >
+            {label}
           </div>
         </div>
         <div className="justify-self-end">
           <Toggle
             on={skill.status === "active"}
             onChange={onToggle}
-            locked={inherited || pending}
+            disabled={inherited}
             label={skill.name}
           />
         </div>
@@ -438,12 +457,16 @@ function Rule({
           {detailLoading && <p className="text-xs text-muted-foreground">Loading…</p>}
           {!detailLoading && detail && detail.id === skill.id && (
             <>
-              <p className="text-[14.5px] leading-relaxed text-foreground/80 max-w-[60ch] whitespace-pre-wrap">
-                {detail.content}
-              </p>
-              <div className="flex flex-wrap items-baseline gap-x-5 gap-y-1 mt-4 text-[11.5px] text-muted-foreground">
-                <span className="font-mono">{skill.name}</span>
+              <div className="max-w-[60ch] text-[14.5px] text-foreground/80">
+                <Streamdown className="streamdown-container presence-assistant-message">
+                  {detail.content}
+                </Streamdown>
               </div>
+              {!labelIsName && (
+                <div className="flex flex-wrap items-baseline gap-x-5 gap-y-1 mt-4 text-[11.5px] text-muted-foreground">
+                  <span className="font-mono">{skill.name}</span>
+                </div>
+              )}
               {!inherited && (
                 <div className="flex gap-6 mt-3">
                   <button
@@ -483,12 +506,12 @@ function Rule({
 function Toggle({
   on,
   onChange,
-  locked,
+  disabled,
   label,
 }: {
   on: boolean;
   onChange: () => void;
-  locked?: boolean;
+  disabled?: boolean;
   label: string;
 }) {
   return (
@@ -496,25 +519,19 @@ function Toggle({
       type="button"
       onClick={(e) => {
         e.stopPropagation();
-        if (!locked) onChange();
+        if (!disabled) onChange();
       }}
-      disabled={locked}
+      disabled={disabled}
       aria-label={`${on ? "Turn off" : "Turn on"} ${label}`}
       className={cn(
-        "inline-flex items-center gap-2 px-2 py-1.5 sm:py-1 rounded text-[12.5px] font-medium tabular-nums select-none transition-colors",
-        locked
-          ? "text-muted-foreground/70 cursor-not-allowed"
-          : "text-foreground hover:bg-muted active:bg-muted/80",
+        "inline-flex items-center gap-2 px-2 py-1 rounded text-[12.5px] font-medium select-none",
+        disabled ? "text-muted-foreground/70 cursor-not-allowed" : "text-foreground hover:bg-muted",
       )}
     >
       <span
-        className={cn(
-          "w-2 h-2 rounded-full transition-colors",
-          on ? "bg-emerald-500" : "bg-muted-foreground/60",
-        )}
+        className={cn("w-2 h-2 rounded-full", on ? "bg-emerald-500" : "bg-muted-foreground/60")}
       />
       {on ? "On" : "Off"}
-      {locked && <span className="ml-1 text-muted-foreground/60 text-[10.5px]">locked</span>}
     </button>
   );
 }
@@ -526,6 +543,7 @@ function InheritedSection({
   rules,
   deepLinkLabel,
   deepLinkTo,
+  ambient,
   expandedId,
   onSelect,
   detail,
@@ -535,6 +553,10 @@ function InheritedSection({
   rules: ListedSkill[];
   deepLinkLabel?: string;
   deepLinkTo?: string;
+  /** Ambient sections (system / bundle) carry no editorial relationship
+   * to the operator. Render quieter — smaller header, tighter spacing,
+   * dimmed rows so the section sits below the conscious foreground. */
+  ambient?: boolean;
   expandedId: string | null;
   onSelect: (id: string) => void;
   detail: ReadSkill | null;
@@ -543,29 +565,43 @@ function InheritedSection({
   const [open, setOpen] = useState(false);
   const activeCount = rules.filter((r) => r.status === "active").length;
   return (
-    <section className="mt-10 first:mt-0">
+    <section className={cn(ambient ? "mt-6 first:mt-0" : "mt-10 first:mt-0")}>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center justify-between py-3 group"
+        className={cn("w-full flex items-center justify-between group", ambient ? "py-2" : "py-3")}
       >
         <div className="flex items-center gap-3">
           <span
             className={cn(
-              "text-xs text-muted-foreground transition-transform",
+              "text-xs transition-transform",
+              ambient ? "text-muted-foreground/60" : "text-muted-foreground",
               open && "rotate-90",
             )}
           >
             ▸
           </span>
-          <span className="text-[13px] text-muted-foreground group-hover:text-foreground">
+          <span
+            className={cn(
+              "group-hover:text-foreground",
+              ambient
+                ? "text-[12px] text-muted-foreground/70"
+                : "text-[13px] text-muted-foreground",
+            )}
+          >
             {title}
           </span>
         </div>
-        <span className="text-xs text-muted-foreground">{activeCount} active</span>
+        <span
+          className={cn(
+            ambient ? "text-[11px] text-muted-foreground/60" : "text-xs text-muted-foreground",
+          )}
+        >
+          {activeCount} active
+        </span>
       </button>
       {open && (
-        <div className="mt-1 border-t border-border">
+        <div className={cn("mt-1 border-t border-border", ambient && "opacity-90")}>
           {rules.map((r) => (
             <Rule
               key={r.id}
@@ -607,7 +643,7 @@ function PersonalFooter({ count }: { count: number }) {
           : `${count} personal rule${count === 1 ? "" : "s"} active here · follow you across every workspace.`}
       </div>
       <Link
-        to="/profile"
+        to="/profile/skills"
         className="text-[12.5px] text-foreground hover:opacity-70 underline-offset-4 hover:underline self-start sm:self-auto"
       >
         Edit in your profile →
@@ -620,6 +656,23 @@ function PersonalFooter({ count }: { count: number }) {
 
 type CreateInput = ToolInput<"skills", "create">;
 export type { CreateInput };
+
+/**
+ * Slugify a user-typed name into the on-disk identifier shape the server
+ * accepts (`^[a-zA-Z0-9_-]+$`). Lowercases, replaces runs of disallowed
+ * characters with a single `-`, strips leading/trailing dashes.
+ *
+ *   "Test 123"          → "test-123"
+ *   "Voice / Tone"      → "voice-tone"
+ *   "  Already-Good_1"  → "already-good_1"
+ */
+function slugifyName(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "");
+}
 
 function EditView({
   existing,
@@ -666,7 +719,14 @@ function EditView({
     }
   }, [existing]);
 
-  const valid = name.trim().length > 0 && body.trim().length > 0;
+  // The user types anything they want ("Test 123") and we slugify before
+  // it reaches the server (which enforces `^[a-zA-Z0-9_-]+$` because the
+  // value becomes a filename). Show the slugified form as a hint when it
+  // differs from the typed value so the on-disk identity is honest.
+  const slug = slugifyName(name);
+  const showSlugHint = isNew && slug.length > 0 && slug !== name.trim();
+
+  const valid = slug.length > 0 && body.trim().length > 0;
 
   return (
     <main className="max-w-[760px] mx-auto pt-2 sm:pt-6 px-1 sm:px-2">
@@ -701,11 +761,15 @@ function EditView({
               ref={nameRef}
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="voice-rules"
-              pattern="[a-zA-Z0-9_-]+"
+              placeholder="Voice rules"
               disabled={!isNew}
-              className="font-mono"
+              className={isNew ? "" : "font-mono"}
             />
+            {showSlugHint && (
+              <p className="text-[11.5px] text-muted-foreground mt-1.5">
+                Saved as <span className="font-mono">{slug}</span>
+              </p>
+            )}
             {!isNew && (
               <p className="text-[11.5px] text-muted-foreground mt-1.5">
                 Names are immutable — they're the filename on disk.
@@ -805,7 +869,7 @@ function EditView({
         <button
           type="button"
           onClick={() =>
-            valid && onSubmit({ name: name.trim(), body: body.trim(), loadingStrategy, priority })
+            valid && onSubmit({ name: slug, body: body.trim(), loadingStrategy, priority })
           }
           disabled={!valid || pending}
           className={cn(

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -169,12 +169,7 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
   );
 
   const handleSubmit = useCallback(
-    async (patch: {
-      name: string;
-      body: string;
-      loadingStrategy?: "auto" | "always";
-      priority?: number;
-    }) => {
+    async (patch: { name: string; body: string; priority?: number }) => {
       // CRITICAL: update is a partial patch — any field present in the
       // manifest is written to disk and overwrites the prior value.
       // So we MUST NOT include description, type, or name on update:
@@ -190,8 +185,14 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
       // the file doesn't exist yet — and the loader's auto-inference
       // (type=context + no applies-to-tools → always) is the right
       // default for the prose rules this UI authors.
+      //
+      // `loadingStrategy` is NOT plumbed through either path. It's
+      // intentionally absent from the LLM-facing schema
+      // (schemas/skills.ts ManifestFields; cited rationale at
+      // skills.ts:116). Even if we sent it, the validator would
+      // strip it and the writer would never see it. The previous
+      // "When to load" dropdown was decorative — removed.
       const advancedOverrides = {
-        ...(patch.loadingStrategy === "always" ? { loadingStrategy: "always" } : {}),
         ...(patch.priority !== undefined ? { priority: patch.priority } : {}),
       };
       if (editingId) {
@@ -725,25 +726,16 @@ function EditView({
   pending: boolean;
   error: string | null;
   onCancel: () => void;
-  onSubmit: (patch: {
-    name: string;
-    body: string;
-    loadingStrategy?: "auto" | "always";
-    priority?: number;
-  }) => void;
+  onSubmit: (patch: { name: string; body: string; priority?: number }) => void;
 }) {
   const isNew = existing === null && !loading;
   const [name, setName] = useState(existing?.metadata.name ?? "");
   const [body, setBody] = useState(existing?.content ?? "");
-  // Advanced state — only consulted in the edit path, where the user
-  // may want to see/modify on-disk loading_strategy or priority that
-  // existed before the redesign or was authored outside the UI.
-  // For create, the loader's auto-inference is the right default, so
-  // we leave these absent unless the user explicitly opens Advanced.
+  // Priority is the only Advanced field that actually persists —
+  // `loadingStrategy` is intentionally absent from the LLM-facing
+  // schema (schemas/skills.ts) so any value sent here is dropped at
+  // the validator. Don't expose a decorative control.
   const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [loadingStrategy, setLoadingStrategy] = useState<"auto" | "always">(
-    existing?.metadata.loadingStrategy === "always" ? "always" : "auto",
-  );
   const [priority, setPriority] = useState<number>(existing?.metadata.priority ?? 50);
 
   const nameRef = useRef<HTMLInputElement | null>(null);
@@ -757,7 +749,6 @@ function EditView({
     if (existing) {
       setName(existing.metadata.name);
       setBody(existing.content);
-      setLoadingStrategy(existing.metadata.loadingStrategy === "always" ? "always" : "auto");
       setPriority(existing.metadata.priority ?? 50);
     }
   }, [existing]);
@@ -849,24 +840,6 @@ function EditView({
             {advancedOpen && (
               <div className="mt-4 pl-5 space-y-4 border-l border-border">
                 <div className="space-y-1">
-                  <label className="block text-sm font-medium" htmlFor="loading-strategy">
-                    When to load
-                  </label>
-                  <select
-                    id="loading-strategy"
-                    value={loadingStrategy}
-                    onChange={(e) => setLoadingStrategy(e.target.value as "auto" | "always")}
-                    className="text-sm bg-background border-b border-border pb-1 outline-none focus:border-foreground"
-                  >
-                    <option value="auto">Let the system decide</option>
-                    <option value="always">Always</option>
-                  </select>
-                  <p className="text-xs text-muted-foreground max-w-prose">
-                    "Let the system decide" is the right default for short prose rules — the loader
-                    picks "always" automatically.
-                  </p>
-                </div>
-                <div className="space-y-1">
                   <label className="block text-sm font-medium" htmlFor="priority">
                     Priority
                   </label>
@@ -902,14 +875,11 @@ function EditView({
             onSubmit({
               name: slug,
               body: body.trim(),
-              // Only forward Advanced fields when the user actually
-              // touched them (or when editing a rule that already had
-              // them set on disk). For a fresh create with Advanced
-              // never opened, omit both so the loader's auto-default
-              // applies — the audit's no-op finding stays honoured.
-              ...(advancedOpen || existing?.metadata.loadingStrategy === "always"
-                ? { loadingStrategy }
-                : {}),
+              // Only forward priority when the user explicitly opened
+              // Advanced (or when editing a rule that already had a
+              // priority set on disk). For fresh creates with Advanced
+              // never opened, omit so the server's default (50) lands —
+              // sending `priority: 50` ourselves would be redundant.
               ...(advancedOpen || existing?.metadata.priority !== undefined ? { priority } : {}),
             })
           }

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -1,9 +1,8 @@
-import { Lightbulb, Plus, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Lightbulb, Trash2, User } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import type { ToolInput } from "../../_generated/platform-schemas/catalog";
 import { callTool } from "../../api/client";
-import { Badge } from "../../components/ui/badge";
-import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { Textarea } from "../../components/ui/textarea";
@@ -11,119 +10,94 @@ import { parseToolResponse } from "../../lib/tool-response";
 import { cn } from "../../lib/utils";
 import { RequireActiveWorkspace } from "./components/RequireActiveWorkspace";
 
-// ── Types ────────────────────────────────────────────────────────────────
-//
-// Canonical shapes from `src/tools/platform/schemas/skills.ts`, mirrored
-// here via codegen at `web/src/_generated/platform-schemas/`. Server and
-// web both import from the same declarations so a shape change in one
-// place can't silently drift from the other (the pattern §2.1 in
-// `src/tools/platform/AGENTS.md` exists to enforce). Local aliases keep
-// the diff small for historical readers.
 import type {
   SkillDetail as ReadSkill,
   SkillScope as Scope,
   SkillsListOutput,
-  SkillStatus as Status,
   SkillSummary as ListedSkill,
 } from "../../_generated/platform-schemas/skills";
 
-// ── Helpers ──────────────────────────────────────────────────────────────
+// ── Wrappers ─────────────────────────────────────────────────────────────
 
-function formatTokens(n: number): string {
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
-  return String(n);
-}
-
-const SCOPE_BADGE: Record<Scope, string> = {
-  org: "border-blue-300/30 text-blue-400",
-  workspace: "border-emerald-300/30 text-emerald-400",
-  user: "border-violet-300/30 text-violet-400",
-  bundle: "border-amber-300/30 text-amber-400",
-};
-
-const STATUS_BADGE: Record<Status, string> = {
-  active: "border-emerald-300/30 text-emerald-500",
-  draft: "border-amber-300/30 text-amber-500",
-  disabled: "border-muted text-muted-foreground",
-  archived: "border-muted text-muted-foreground",
-};
-
-// ── Component ────────────────────────────────────────────────────────────
-
+/** Workspace settings tab — `/w/:slug/settings/skills`. */
 export function SkillsTab() {
   return (
     <RequireActiveWorkspace>
-      <SkillsBrowser />
+      <SkillsBrowser surface="workspace" />
     </RequireActiveWorkspace>
   );
 }
 
 /**
- * Shared skills browser. The workspace tab renders it with no lock so users
- * can see/filter every scope they have access to; the org-admin tab renders
- * it with `lockedScope="org"` so only org-tier skills are listed, the scope
- * filter UI is suppressed, and the create form has no scope picker (org is
- * the only writable target on that surface).
+ * Shared skills browser.
  *
- * Per SKILLS_SURFACE.md, Phase 2 will refactor the workspace tab to grouped
- * sections (workspace + inherited-org + inherited-bundles + personal-footer).
- * That work touches this same component; the `lockedScope` param is the
- * minimal Phase 1 hook so we don't ship duplicated state machines.
+ *   - `surface="workspace"` — grouped sections (workspace editable +
+ *     inherited org disabled + inherited bundles disabled) + personal
+ *     footer + create locked to workspace.
+ *   - `lockedScope="org"` — single-scope org-tier view + create locked
+ *     to org. (Org-admin tab calls this directly via OrgSkillsTab.)
+ *
+ * The two props are independent. No-prop callers fall through to the
+ * legacy "show every scope" view, kept only for the test seam — no
+ * production route uses it.
  */
-type DetailMode = "view" | "edit";
+interface SkillsBrowserProps {
+  lockedScope?: Scope;
+  surface?: "workspace";
+}
 
-export function SkillsBrowser({ lockedScope }: { lockedScope?: Scope } = {}) {
+type WritableScope = "org" | "workspace" | "user";
+
+export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {}) {
+  const isWorkspaceSurface = surface === "workspace";
+  const initialScopeFilter: Scope | "all" = isWorkspaceSurface ? "all" : (lockedScope ?? "all");
+  const createLockedScope: WritableScope | undefined = isWorkspaceSurface
+    ? "workspace"
+    : lockedScope === "org" || lockedScope === "workspace" || lockedScope === "user"
+      ? lockedScope
+      : undefined;
+
   const [skills, setSkills] = useState<ListedSkill[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<ReadSkill | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  // When the surface is scope-locked, the filter UI is hidden and the lock
-  // value is the effective filter — `setScopeFilter` becomes a no-op via the
-  // hidden control. Default the state to the lock so the first fetch is
-  // already scoped (no flash of "all").
-  const [scopeFilter, setScopeFilter] = useState<Scope | "all">(lockedScope ?? "all");
-  const [statusFilter, setStatusFilter] = useState<Status | "all">("active");
-  const [mode, setMode] = useState<DetailMode>("view");
-  const [creating, setCreating] = useState(false);
   const [actionPending, setActionPending] = useState(false);
+  const [view, setView] = useState<"list" | "edit">("list");
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   const fetchSkills = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const args: Record<string, unknown> = {};
-      if (scopeFilter !== "all") args.scope = scopeFilter;
-      if (statusFilter !== "all") args.status = statusFilter;
+      if (initialScopeFilter !== "all") args.scope = initialScopeFilter;
+      // List both active and disabled so the user can see Off rules and
+      // turn them back on. The per-row toggle reflects the current state.
       const res = await callTool("skills", "list", args);
       const data = parseToolResponse<SkillsListOutput>(res);
       setSkills(data.skills);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Failed to load skills.";
-      setError(msg);
+      setError(err instanceof Error ? err.message : "Failed to load skills.");
       setSkills([]);
     } finally {
       setLoading(false);
     }
-  }, [scopeFilter, statusFilter]);
+  }, [initialScopeFilter]);
 
   useEffect(() => {
     void fetchSkills();
   }, [fetchSkills]);
 
-  // When the catalog reloads, refresh the open detail panel if its skill is
-  // still in view; otherwise drop the selection.
   useEffect(() => {
     if (!selectedId) return;
     if (!skills.some((s) => s.id === selectedId)) {
       setSelectedId(null);
       setDetail(null);
-      setMode("view");
     }
   }, [skills, selectedId]);
 
-  // Fetch the detail body whenever selection changes.
   const fetchDetail = useCallback(async (id: string) => {
     setDetailLoading(true);
     try {
@@ -131,8 +105,7 @@ export function SkillsBrowser({ lockedScope }: { lockedScope?: Scope } = {}) {
       const data = parseToolResponse<ReadSkill>(res);
       setDetail(data);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Failed to read skill.";
-      setError(msg);
+      setError(err instanceof Error ? err.message : "Failed to read skill.");
       setDetail(null);
     } finally {
       setDetailLoading(false);
@@ -142,25 +115,14 @@ export function SkillsBrowser({ lockedScope }: { lockedScope?: Scope } = {}) {
   useEffect(() => {
     if (!selectedId) {
       setDetail(null);
-      setMode("view");
       return;
     }
     void fetchDetail(selectedId);
   }, [selectedId, fetchDetail]);
 
   const handleSelect = useCallback((id: string) => {
-    setMode("view");
-    setCreating(false);
     setError(null);
-    setSelectedId(id);
-  }, []);
-
-  const handleStartCreate = useCallback(() => {
-    setSelectedId(null);
-    setDetail(null);
-    setMode("view");
-    setCreating(true);
-    setError(null);
+    setSelectedId((prev) => (prev === id ? null : id));
   }, []);
 
   const runMutation = useCallback(
@@ -177,8 +139,7 @@ export function SkillsBrowser({ lockedScope }: { lockedScope?: Scope } = {}) {
         await fetchSkills();
         onSuccess?.(data);
       } catch (err) {
-        const msg = err instanceof Error ? err.message : `Failed to ${tool} skill.`;
-        setError(msg);
+        setError(err instanceof Error ? err.message : `Failed to ${tool} skill.`);
       } finally {
         setActionPending(false);
       }
@@ -186,817 +147,677 @@ export function SkillsBrowser({ lockedScope }: { lockedScope?: Scope } = {}) {
     [fetchSkills],
   );
 
-  const handleCreate = useCallback(
-    async (input: CreateInput) => {
-      await runMutation("create", input, (result) => {
-        setCreating(false);
-        if (result.id) setSelectedId(result.id);
-      });
+  const handleToggle = useCallback(
+    async (skill: ListedSkill) => {
+      const tool = skill.status === "active" ? "deactivate" : "activate";
+      await runMutation(tool, { id: skill.id });
     },
     [runMutation],
-  );
-
-  const handleSaveEdit = useCallback(
-    async (id: string, patch: { manifest: Record<string, unknown>; body: string }) => {
-      await runMutation("update", { id, manifest: patch.manifest, body: patch.body }, async () => {
-        setMode("view");
-        await fetchDetail(id);
-      });
-    },
-    [runMutation, fetchDetail],
   );
 
   const handleDelete = useCallback(
     async (id: string) => {
-      if (!window.confirm("Delete this skill? It will be snapshotted to _versions/ first.")) {
-        return;
-      }
+      if (!window.confirm("Delete this rule? It will be snapshotted to _versions/ first.")) return;
       await runMutation("delete", { id }, () => {
         setSelectedId(null);
         setDetail(null);
-        setMode("view");
       });
     },
     [runMutation],
   );
 
-  const handleToggleStatus = useCallback(
-    async (id: string, currentStatus: string | undefined) => {
-      const tool = currentStatus === "active" ? "deactivate" : "activate";
-      await runMutation(tool, { id }, () => {
-        void fetchDetail(id);
-      });
-    },
-    [runMutation, fetchDetail],
-  );
-
-  const handleMoveScope = useCallback(
-    async (id: string, targetScope: WritableScope) => {
-      if (
-        !window.confirm(
-          `Move skill to ${targetScope} scope? The original location is removed (snapshotted first).`,
-        )
-      ) {
-        return;
+  const handleSubmit = useCallback(
+    async (patch: {
+      name: string;
+      body: string;
+      loadingStrategy: "auto" | "always";
+      priority: number;
+    }) => {
+      const manifest: Record<string, unknown> = {
+        name: patch.name,
+        description: "",
+        type: "context",
+        priority: patch.priority,
+        ...(patch.loadingStrategy === "always" ? { loadingStrategy: "always" } : {}),
+      };
+      if (editingId) {
+        await runMutation("update", { id: editingId, manifest, body: patch.body }, () => {
+          setView("list");
+          setEditingId(null);
+        });
+      } else {
+        await runMutation(
+          "create",
+          { scope: createLockedScope ?? "workspace", manifest, body: patch.body },
+          (result) => {
+            setView("list");
+            setEditingId(null);
+            if (result.id) setSelectedId(result.id);
+          },
+        );
       }
-      await runMutation("move_scope", { id, target_scope: targetScope }, (result) => {
-        if (result.id) setSelectedId(result.id);
-      });
     },
-    [runMutation],
+    [editingId, createLockedScope, runMutation],
   );
 
-  const grouped = useMemo(() => groupByScope(skills), [skills]);
+  const startCreate = useCallback(() => {
+    setEditingId(null);
+    setView("edit");
+    setError(null);
+  }, []);
+
+  const startEdit = useCallback((id: string) => {
+    setEditingId(id);
+    setView("edit");
+    setError(null);
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditingId(null);
+    setView("list");
+    setError(null);
+  }, []);
+
+  const grouped = useMemo(
+    () => groupByScope(skills, { excludeUser: isWorkspaceSurface }),
+    [skills, isWorkspaceSurface],
+  );
+  const personalCount = useMemo(
+    () => (isWorkspaceSurface ? skills.filter((s) => s.scope === "user").length : 0),
+    [skills, isWorkspaceSurface],
+  );
+
+  if (view === "edit") {
+    const existing = editingId && detail?.id === editingId ? detail : null;
+    return (
+      <EditView
+        existing={existing}
+        loading={editingId !== null && (!detail || detail.id !== editingId)}
+        pending={actionPending}
+        error={error}
+        onCancel={cancelEdit}
+        onSubmit={handleSubmit}
+      />
+    );
+  }
 
   return (
-    <div className="space-y-4">
-      <header className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
+    <main className="max-w-[760px] mx-auto pt-2 sm:pt-6 px-1 sm:px-2">
+      <header className="mb-8 sm:mb-12">
+        <h2 className="flex items-center gap-2 text-[22px] tracking-tight text-foreground">
           <Lightbulb className="h-4 w-4 text-muted-foreground" />
-          <h2 className="text-base font-semibold">Skills</h2>
-        </div>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={handleStartCreate}
-          disabled={creating || actionPending}
-        >
-          <Plus className="h-3.5 w-3.5 mr-1" />
-          New skill
-        </Button>
+          Skills
+        </h2>
+        <p className="text-sm text-muted-foreground mt-2 max-w-[52ch]">
+          {lockedScope === "org"
+            ? "Organization-wide rules. These apply to every workspace."
+            : isWorkspaceSurface
+              ? "Rules that shape what your agent says and how it works in this workspace."
+              : "Rules that shape your agent's behavior."}
+        </p>
       </header>
-      <p className="text-xs text-muted-foreground">
-        {lockedScope === "org" ? (
-          <>
-            Organization-wide skills. These load into every workspace's agent context and apply to
-            every member. Authored here or as markdown files under{" "}
-            <code>~/.nimblebrain/skills/</code>.
-          </>
-        ) : (
-          <>
-            Layer 3 cross-bundle agent orchestration content (voice, workflow, personal, tool
-            routing) plus Layer 1 vendored bundle skills. The agent uses these to shape its
-            behavior; you can also author them as markdown files under{" "}
-            <code>~/.nimblebrain/skills/</code> (org), <code>workspaces/&lt;wsId&gt;/skills/</code>,
-            or <code>users/&lt;userId&gt;/skills/</code>.
-          </>
-        )}
-      </p>
 
-      <Filters
-        scope={scopeFilter}
-        status={statusFilter}
-        onScopeChange={setScopeFilter}
-        onStatusChange={setStatusFilter}
-        lockedScope={lockedScope}
-      />
-
-      {loading && <div className="text-sm text-muted-foreground">Loading skills…</div>}
+      {loading && <div className="text-sm text-muted-foreground py-4">Loading rules…</div>}
       {error && (
-        <Card>
+        <Card className="mb-4">
           <CardContent className="py-3 px-4">
             <p className="text-sm text-destructive">{error}</p>
           </CardContent>
         </Card>
       )}
 
-      {!loading && !creating && skills.length === 0 && (
+      {!loading && skills.length === 0 && (
         <Card>
           <CardContent className="py-8 text-center">
             <p className="text-sm text-muted-foreground">
-              No skills match the current filters. Click <strong>New skill</strong> to create one,
-              or drop a markdown file under any of the skills directories above.
+              No rules here yet. Click <strong>+ Add a rule</strong> below to write one.
             </p>
           </CardContent>
         </Card>
       )}
 
-      {!loading && (creating || skills.length > 0) && (
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
-          <SkillList grouped={grouped} selectedId={selectedId} onSelect={handleSelect} />
-          {creating ? (
-            <CreateForm
-              pending={actionPending}
-              // Only "org" is a live caller today (Phase 1). Phase 2 will
-              // add "workspace" / "user" callers and broaden this narrowing
-              // when those branches actually ship.
-              lockedScope={lockedScope === "org" ? "org" : undefined}
-              onCancel={() => {
-                setCreating(false);
-                setError(null);
-              }}
-              onSubmit={handleCreate}
-            />
-          ) : (
-            <SkillDetail
-              selectedId={selectedId}
-              detail={detail}
-              loading={detailLoading}
-              mode={mode}
-              actionPending={actionPending}
-              onEdit={() => {
-                setError(null);
-                setMode("edit");
-              }}
-              onCancelEdit={() => {
-                setMode("view");
-                setError(null);
-              }}
-              onSave={(patch) => selectedId && handleSaveEdit(selectedId, patch)}
-              onDelete={() => selectedId && handleDelete(selectedId)}
-              onToggleStatus={() =>
-                selectedId && handleToggleStatus(selectedId, detail?.metadata.status)
-              }
-              onMoveScope={(target) => selectedId && handleMoveScope(selectedId, target)}
-              placeholder={skills.length > 0}
-            />
-          )}
+      {!loading && skills.length > 0 && (
+        <div className="border-t border-border">
+          {grouped.map((group) => {
+            const inherited = isWorkspaceSurface && group.scope !== "workspace";
+            if (inherited) {
+              return (
+                <InheritedSection
+                  key={group.scope}
+                  title={
+                    group.scope === "org"
+                      ? "From your organization"
+                      : group.scope === "bundle"
+                        ? "From installed apps"
+                        : `From ${group.scope}`
+                  }
+                  rules={group.skills}
+                  deepLinkLabel={group.scope === "org" ? "Edit in org settings" : undefined}
+                  deepLinkTo={group.scope === "org" ? "/org/skills" : undefined}
+                  expandedId={selectedId}
+                  onSelect={handleSelect}
+                  detail={detail}
+                  detailLoading={detailLoading}
+                />
+              );
+            }
+            return group.skills.map((s) => (
+              <Rule
+                key={s.id}
+                skill={s}
+                expanded={selectedId === s.id}
+                detail={selectedId === s.id ? detail : null}
+                detailLoading={selectedId === s.id && detailLoading}
+                onSelect={() => handleSelect(s.id)}
+                onToggle={() => handleToggle(s)}
+                onEdit={() => startEdit(s.id)}
+                onDelete={() => handleDelete(s.id)}
+                pending={actionPending}
+              />
+            ));
+          })}
         </div>
       )}
-    </div>
+
+      {!loading && (
+        <button
+          type="button"
+          onClick={startCreate}
+          disabled={actionPending}
+          className="mt-6 py-2 text-[13px] text-foreground hover:opacity-70 underline-offset-4 hover:underline disabled:opacity-40"
+        >
+          + Add a rule
+        </button>
+      )}
+
+      {isWorkspaceSurface && <PersonalFooter count={personalCount} />}
+    </main>
   );
 }
 
-type WritableScope = "org" | "workspace" | "user";
-
-// Args shape derived from the schema catalog. `name` lives inside `manifest`
-// because that's where the on-disk frontmatter has it — see the original
-// SkillsTab incident where the form was sending name at the root and the
-// validator rejected it.
-type CreateInput = ToolInput<"skills", "create">;
-
-// ── List view ────────────────────────────────────────────────────────────
+// ── Group / partition ────────────────────────────────────────────────────
 
 interface GroupedSkills {
   scope: Scope;
   skills: ListedSkill[];
 }
 
-function groupByScope(skills: ListedSkill[]): GroupedSkills[] {
-  const order: Scope[] = ["user", "workspace", "org", "bundle"];
+function groupByScope(skills: ListedSkill[], opts?: { excludeUser?: boolean }): GroupedSkills[] {
+  const order: Scope[] = opts?.excludeUser
+    ? ["workspace", "org", "bundle"]
+    : ["user", "workspace", "org", "bundle"];
   const map = new Map<Scope, ListedSkill[]>();
   for (const s of skills) {
+    if (opts?.excludeUser && s.scope === "user") continue;
     const list = map.get(s.scope) ?? [];
     list.push(s);
     map.set(s.scope, list);
   }
-  for (const list of map.values()) {
-    list.sort((a, b) => a.name.localeCompare(b.name));
-  }
+  for (const list of map.values()) list.sort((a, b) => a.name.localeCompare(b.name));
   return order.filter((s) => map.has(s)).map((scope) => ({ scope, skills: map.get(scope)! }));
 }
 
-const SCOPE_LABEL: Record<Scope, string> = {
-  user: "User",
-  workspace: "Workspace",
-  org: "Org",
-  bundle: "Bundle (Layer 1)",
-};
+// ── Rule row ─────────────────────────────────────────────────────────────
 
-function SkillList({
-  grouped,
-  selectedId,
+function firstSentence(s: string): string {
+  const m = s.match(/^[^.\n]*[.!?]/);
+  return m ? m[0].trim() : s.trim();
+}
+
+function Rule({
+  skill,
+  expanded,
+  detail,
+  detailLoading,
+  inherited,
   onSelect,
+  onToggle,
+  onEdit,
+  onDelete,
+  pending,
 }: {
-  grouped: GroupedSkills[];
-  selectedId: string | null;
-  onSelect: (id: string) => void;
+  skill: ListedSkill;
+  expanded: boolean;
+  detail: ReadSkill | null;
+  detailLoading: boolean;
+  inherited?: boolean;
+  onSelect: () => void;
+  onToggle: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  pending: boolean;
 }) {
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const [shellH, setShellH] = useState(0);
+  useEffect(() => {
+    if (!expanded) {
+      setShellH(0);
+      return;
+    }
+    requestAnimationFrame(() => {
+      if (bodyRef.current) setShellH(bodyRef.current.scrollHeight);
+    });
+  }, [expanded, detail]);
+
+  // Resting label = first sentence of the body when we have it; otherwise
+  // the summary description; otherwise the name. We don't fetch the body
+  // just for the label — only the expanded row has body content available.
+  const restingLabel =
+    detail && detail.id === skill.id
+      ? firstSentence(detail.content)
+      : firstSentence(skill.description ?? "") || skill.name;
+
   return (
-    <div className="space-y-4">
-      {grouped.map((group) => (
-        <section key={group.scope} className="space-y-1.5">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground px-1">
-            {SCOPE_LABEL[group.scope]}{" "}
-            <span className="text-muted-foreground/60 font-normal">({group.skills.length})</span>
-          </h3>
-          <div className="grid gap-1">
-            {group.skills.map((s) => (
-              <SkillRow
-                key={s.id}
-                skill={s}
-                selected={s.id === selectedId}
-                onSelect={() => onSelect(s.id)}
-              />
-            ))}
+    <div className={cn("py-5 sm:py-6 border-b border-border", inherited && "opacity-80")}>
+      <button
+        type="button"
+        onClick={onSelect}
+        className="w-full text-left grid items-center gap-[clamp(20px,6vw,56px)] grid-cols-[1fr_auto]"
+      >
+        <div className="min-w-0 pr-1">
+          <div className="text-[15.5px] sm:text-[16px] leading-[1.5] tracking-[-0.005em] text-foreground">
+            {restingLabel}
           </div>
-        </section>
-      ))}
+        </div>
+        <div className="justify-self-end">
+          <Toggle
+            on={skill.status === "active"}
+            onChange={onToggle}
+            locked={inherited || pending}
+            label={skill.name}
+          />
+        </div>
+      </button>
+
+      <div
+        style={{ maxHeight: shellH, opacity: expanded ? 1 : 0 }}
+        className="overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
+        aria-hidden={!expanded}
+      >
+        <div ref={bodyRef} className="pt-4">
+          {detailLoading && <p className="text-xs text-muted-foreground">Loading…</p>}
+          {!detailLoading && detail && detail.id === skill.id && (
+            <>
+              <p className="text-[14.5px] leading-relaxed text-foreground/80 max-w-[60ch] whitespace-pre-wrap">
+                {detail.content}
+              </p>
+              <div className="flex flex-wrap items-baseline gap-x-5 gap-y-1 mt-4 text-[11.5px] text-muted-foreground">
+                <span className="font-mono">{skill.name}</span>
+              </div>
+              {!inherited && (
+                <div className="flex gap-6 mt-3">
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onEdit?.();
+                    }}
+                    disabled={pending}
+                    className="py-2 text-[12.5px] text-foreground hover:opacity-70 underline-offset-4 hover:underline disabled:opacity-40"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDelete?.();
+                    }}
+                    disabled={pending}
+                    className="py-2 text-[12.5px] text-muted-foreground hover:text-destructive underline-offset-4 hover:underline disabled:opacity-40 inline-flex items-center gap-1.5"
+                  >
+                    <Trash2 className="h-3 w-3" /> Delete
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
     </div>
   );
 }
 
-function SkillRow({
-  skill,
-  selected,
-  onSelect,
+// ── Toggle ───────────────────────────────────────────────────────────────
+
+function Toggle({
+  on,
+  onChange,
+  locked,
+  label,
 }: {
-  skill: ListedSkill;
-  selected: boolean;
-  onSelect: () => void;
+  on: boolean;
+  onChange: () => void;
+  locked?: boolean;
+  label: string;
 }) {
   return (
-    <Card
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!locked) onChange();
+      }}
+      disabled={locked}
+      aria-label={`${on ? "Turn off" : "Turn on"} ${label}`}
       className={cn(
-        "cursor-pointer transition-colors",
-        selected ? "ring-1 ring-primary border-primary/40" : "hover:bg-muted/40",
+        "inline-flex items-center gap-2 px-2 py-1.5 sm:py-1 rounded text-[12.5px] font-medium tabular-nums select-none transition-colors",
+        locked
+          ? "text-muted-foreground/70 cursor-not-allowed"
+          : "text-foreground hover:bg-muted active:bg-muted/80",
       )}
     >
-      <CardContent className="py-2.5 px-3">
-        <button
-          type="button"
-          onClick={onSelect}
-          className="w-full flex items-center gap-3 text-left"
-        >
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium truncate">{skill.name}</span>
-              {skill.status !== "active" && (
-                <Badge variant="outline" className={cn("text-[10px]", STATUS_BADGE[skill.status])}>
-                  {skill.status}
-                </Badge>
-              )}
-            </div>
-            {skill.description && (
-              <div className="text-xs text-muted-foreground truncate mt-0.5">
-                {skill.description}
-              </div>
-            )}
-          </div>
-          <div className="flex flex-col items-end gap-1 shrink-0">
-            <Badge variant="outline" className={cn("text-[10px]", SCOPE_BADGE[skill.scope])}>
-              L{skill.layer} · {skill.scope}
-            </Badge>
-            <span className="text-[10px] text-muted-foreground tabular-nums">
-              {formatTokens(skill.tokens)} tok
-            </span>
-          </div>
-        </button>
-      </CardContent>
-    </Card>
-  );
-}
-
-// ── Detail panel ─────────────────────────────────────────────────────────
-
-interface SkillDetailProps {
-  selectedId: string | null;
-  detail: ReadSkill | null;
-  loading: boolean;
-  mode: DetailMode;
-  actionPending: boolean;
-  onEdit: () => void;
-  onCancelEdit: () => void;
-  onSave: (patch: { manifest: Record<string, unknown>; body: string }) => void;
-  onDelete: () => void;
-  onToggleStatus: () => void;
-  onMoveScope: (target: WritableScope) => void;
-  placeholder: boolean;
-}
-
-function SkillDetail(props: SkillDetailProps) {
-  const { selectedId, detail, loading, mode, placeholder } = props;
-  if (!selectedId) {
-    return (
-      <Card className="lg:sticky lg:top-4 self-start">
-        <CardContent className="py-12 text-center text-sm text-muted-foreground">
-          {placeholder ? "Select a skill to see its body and metadata." : null}
-        </CardContent>
-      </Card>
-    );
-  }
-  if (loading || !detail) {
-    return (
-      <Card className="lg:sticky lg:top-4 self-start">
-        <CardContent className="py-8 text-sm text-muted-foreground">Loading…</CardContent>
-      </Card>
-    );
-  }
-  if (mode === "edit") {
-    return (
-      <SkillEditor
-        detail={detail}
-        actionPending={props.actionPending}
-        onCancelEdit={props.onCancelEdit}
-        onSave={props.onSave}
-      />
-    );
-  }
-  return (
-    <SkillDetailView
-      detail={detail}
-      actionPending={props.actionPending}
-      onEdit={props.onEdit}
-      onDelete={props.onDelete}
-      onToggleStatus={props.onToggleStatus}
-      onMoveScope={props.onMoveScope}
-    />
-  );
-}
-
-function SkillDetailView({
-  detail,
-  actionPending,
-  onEdit,
-  onDelete,
-  onToggleStatus,
-  onMoveScope,
-}: { detail: ReadSkill } & Pick<
-  SkillDetailProps,
-  "actionPending" | "onEdit" | "onDelete" | "onToggleStatus" | "onMoveScope"
->) {
-  const m = detail.metadata;
-  const isBundle = detail.scope === "bundle";
-  const currentStatus = (m.status ?? "active") as Status;
-  return (
-    <Card className="lg:sticky lg:top-4 self-start">
-      <CardContent className="py-4 px-4 space-y-4">
-        <header className="space-y-2">
-          <div className="flex items-center justify-between gap-2 flex-wrap">
-            <div className="flex items-center gap-2 flex-wrap">
-              <h3 className="text-sm font-semibold">{m.name}</h3>
-              <Badge variant="outline" className={cn("text-[10px]", SCOPE_BADGE[detail.scope])}>
-                L{detail.layer} · {detail.scope}
-              </Badge>
-              <Badge variant="outline" className={cn("text-[10px]", STATUS_BADGE[currentStatus])}>
-                {currentStatus}
-              </Badge>
-            </div>
-            {!isBundle && (
-              <div className="flex items-center gap-1">
-                <Button size="sm" variant="outline" onClick={onEdit} disabled={actionPending}>
-                  Edit
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={onToggleStatus}
-                  disabled={actionPending}
-                >
-                  {currentStatus === "active" ? "Deactivate" : "Activate"}
-                </Button>
-                <ScopeMover
-                  current={detail.scope as WritableScope}
-                  pending={actionPending}
-                  onMove={onMoveScope}
-                />
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={onDelete}
-                  disabled={actionPending}
-                  aria-label="Delete skill"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            )}
-          </div>
-          {m.description && <p className="text-xs text-muted-foreground">{m.description}</p>}
-          {isBundle && (
-            <p className="text-[11px] text-muted-foreground italic">
-              Bundle (Layer 1) skills are vendored — edit them through the bundle's own settings.
-            </p>
-          )}
-        </header>
-
-        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
-          {m.type && <Row label="Type" value={m.type} />}
-          {m.priority !== undefined && <Row label="Priority" value={String(m.priority)} />}
-          {m.loadingStrategy && <Row label="Loads" value={m.loadingStrategy} />}
-          {m.appliesToTools && m.appliesToTools.length > 0 && (
-            <Row label="Tool affinity" value={m.appliesToTools.join(", ")} mono />
-          )}
-          {detail.modifiedAt && <Row label="Modified" value={formatTime(detail.modifiedAt)} />}
-          {detail.source.path && <Row label="Path" value={detail.source.path} mono />}
-          {detail.source.uri && <Row label="URI" value={detail.source.uri} mono />}
-          {m.derivedFrom && <Row label="Derived from" value={m.derivedFrom} mono />}
-        </dl>
-
-        {m.overrides && m.overrides.length > 0 && (
-          <div className="space-y-1">
-            <div className="text-xs font-medium text-muted-foreground">Overrides</div>
-            <ul className="text-xs space-y-1 list-disc list-inside">
-              {m.overrides.map((o) => (
-                <li key={`${o.bundle ?? ""}-${o.skill ?? ""}-${o.reason}`}>
-                  {o.bundle && <code className="text-[11px]">{o.bundle}</code>}
-                  {o.bundle && o.skill && " / "}
-                  {o.skill && <code className="text-[11px]">{o.skill}</code>}
-                  {(o.bundle || o.skill) && " — "}
-                  <span className="text-muted-foreground">{o.reason}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+      <span
+        className={cn(
+          "w-2 h-2 rounded-full transition-colors",
+          on ? "bg-emerald-500" : "bg-muted-foreground/60",
         )}
-
-        <div className="space-y-1">
-          <div className="text-xs font-medium text-muted-foreground">Body</div>
-          <pre className="rounded border bg-muted/30 p-3 text-[11px] leading-relaxed whitespace-pre-wrap break-words font-mono max-h-[500px] overflow-auto">
-            {detail.content}
-          </pre>
-        </div>
-      </CardContent>
-    </Card>
+      />
+      {on ? "On" : "Off"}
+      {locked && <span className="ml-1 text-muted-foreground/60 text-[10.5px]">locked</span>}
+    </button>
   );
 }
 
-// ── Editor (shared by edit + create) ─────────────────────────────────────
+// ── Inherited section ────────────────────────────────────────────────────
 
-interface EditorFormState {
-  description: string;
-  type: "context" | "skill";
-  priority: string; // string for input; parsed on save
-  status: Status;
-  body: string;
-}
-
-function SkillEditor({
+function InheritedSection({
+  title,
+  rules,
+  deepLinkLabel,
+  deepLinkTo,
+  expandedId,
+  onSelect,
   detail,
-  actionPending,
-  onCancelEdit,
-  onSave,
-}: { detail: ReadSkill } & Pick<SkillDetailProps, "actionPending" | "onCancelEdit" | "onSave">) {
-  const m = detail.metadata;
-  const [form, setForm] = useState<EditorFormState>({
-    description: m.description ?? "",
-    type: (m.type as "context" | "skill") ?? "skill",
-    priority: m.priority !== undefined ? String(m.priority) : "50",
-    status: (m.status as Status) ?? "active",
-    body: detail.content,
-  });
-
-  const handleSave = () => {
-    const priorityNum = Number.parseInt(form.priority, 10);
-    const patch: NonNullable<ToolInput<"skills", "update">["manifest"]> = {
-      description: form.description,
-      type: form.type,
-      status: form.status,
-      ...(Number.isFinite(priorityNum) ? { priority: priorityNum } : {}),
-    };
-    onSave({ manifest: patch, body: form.body });
-  };
-
+  detailLoading,
+}: {
+  title: string;
+  rules: ListedSkill[];
+  deepLinkLabel?: string;
+  deepLinkTo?: string;
+  expandedId: string | null;
+  onSelect: (id: string) => void;
+  detail: ReadSkill | null;
+  detailLoading: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const activeCount = rules.filter((r) => r.status === "active").length;
   return (
-    <Card className="lg:sticky lg:top-4 self-start">
-      <CardContent className="py-4 px-4 space-y-4">
-        <header className="flex items-center justify-between gap-2">
-          <h3 className="text-sm font-semibold">Edit {m.name}</h3>
-          <div className="flex gap-1">
-            <Button size="sm" variant="outline" onClick={onCancelEdit} disabled={actionPending}>
-              Cancel
-            </Button>
-            <Button size="sm" onClick={handleSave} disabled={actionPending}>
-              {actionPending ? "Saving…" : "Save"}
-            </Button>
-          </div>
-        </header>
-
-        <ManifestForm form={form} setForm={setForm} />
-
-        <div className="space-y-1">
-          <label className="text-xs font-medium" htmlFor="skill-body-edit">
-            Body
-          </label>
-          <Textarea
-            id="skill-body-edit"
-            value={form.body}
-            onChange={(e) => setForm({ ...form, body: e.target.value })}
-            className="font-mono text-[11px] min-h-[300px]"
-          />
+    <section className="mt-10 first:mt-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between py-3 group"
+      >
+        <div className="flex items-center gap-3">
+          <span
+            className={cn(
+              "text-xs text-muted-foreground transition-transform",
+              open && "rotate-90",
+            )}
+          >
+            ▸
+          </span>
+          <span className="text-[13px] text-muted-foreground group-hover:text-foreground">
+            {title}
+          </span>
         </div>
-      </CardContent>
-    </Card>
+        <span className="text-xs text-muted-foreground">{activeCount} active</span>
+      </button>
+      {open && (
+        <div className="mt-1 border-t border-border">
+          {rules.map((r) => (
+            <Rule
+              key={r.id}
+              skill={r}
+              expanded={expandedId === r.id}
+              detail={expandedId === r.id ? detail : null}
+              detailLoading={expandedId === r.id && detailLoading}
+              onSelect={() => onSelect(r.id)}
+              onToggle={() => {}}
+              inherited
+              pending={false}
+            />
+          ))}
+          {deepLinkLabel && deepLinkTo && (
+            <div className="py-3">
+              <Link
+                to={deepLinkTo}
+                className="text-[12.5px] text-foreground hover:opacity-70 underline-offset-4 hover:underline"
+              >
+                {deepLinkLabel} →
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
   );
 }
 
-function CreateForm({
+// ── Personal footer ──────────────────────────────────────────────────────
+
+function PersonalFooter({ count }: { count: number }) {
+  return (
+    <div className="mt-12 pt-6 border-t border-border flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <div className="text-xs text-muted-foreground flex items-center gap-2">
+        <User className="h-3.5 w-3.5" />
+        {count === 0
+          ? "No personal rules active here."
+          : `${count} personal rule${count === 1 ? "" : "s"} active here · follow you across every workspace.`}
+      </div>
+      <Link
+        to="/profile"
+        className="text-[12.5px] text-foreground hover:opacity-70 underline-offset-4 hover:underline self-start sm:self-auto"
+      >
+        Edit in your profile →
+      </Link>
+    </div>
+  );
+}
+
+// ── Edit view ────────────────────────────────────────────────────────────
+
+type CreateInput = ToolInput<"skills", "create">;
+export type { CreateInput };
+
+function EditView({
+  existing,
+  loading,
   pending,
-  lockedScope,
+  error,
   onCancel,
   onSubmit,
 }: {
+  existing: ReadSkill | null;
+  loading: boolean;
   pending: boolean;
-  /** When set, force the create scope and hide the picker. Org-tier-only
-   * surfaces pass `"org"` so the form can't author into another scope. */
-  lockedScope?: WritableScope;
+  error: string | null;
   onCancel: () => void;
-  onSubmit: (input: CreateInput) => void;
+  onSubmit: (patch: {
+    name: string;
+    body: string;
+    loadingStrategy: "auto" | "always";
+    priority: number;
+  }) => void;
 }) {
-  const [scope, setScope] = useState<WritableScope>(lockedScope ?? "workspace");
-  const [name, setName] = useState("");
-  const [form, setForm] = useState<EditorFormState>({
-    description: "",
-    type: "skill",
-    priority: "50",
-    status: "active",
-    body: "",
-  });
+  const isNew = existing === null && !loading;
+  const [name, setName] = useState(existing?.metadata.name ?? "");
+  const [body, setBody] = useState(existing?.content ?? "");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [loadingStrategy, setLoadingStrategy] = useState<"auto" | "always">(
+    existing?.metadata.loadingStrategy === "always" ? "always" : "auto",
+  );
+  const [priority, setPriority] = useState<number>(existing?.metadata.priority ?? 50);
 
-  const handleSubmit = () => {
-    if (!name.trim()) return;
-    const priorityNum = Number.parseInt(form.priority, 10);
-    const manifest: CreateInput["manifest"] = {
-      name: name.trim(),
-      description: form.description,
-      type: form.type,
-      status: form.status,
-      ...(Number.isFinite(priorityNum) ? { priority: priorityNum } : {}),
-    };
-    onSubmit({ scope, manifest, body: form.body });
-  };
+  const nameRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    if (isNew) nameRef.current?.focus();
+  }, [isNew]);
+
+  // Sync form to a freshly-loaded detail (e.g. user clicked Edit on a
+  // different rule before the prior read resolved).
+  useEffect(() => {
+    if (existing) {
+      setName(existing.metadata.name);
+      setBody(existing.content);
+      setLoadingStrategy(existing.metadata.loadingStrategy === "always" ? "always" : "auto");
+      setPriority(existing.metadata.priority ?? 50);
+    }
+  }, [existing]);
+
+  const valid = name.trim().length > 0 && body.trim().length > 0;
 
   return (
-    <Card className="lg:sticky lg:top-4 self-start">
-      <CardContent className="py-4 px-4 space-y-4">
-        <header className="flex items-center justify-between gap-2">
-          <h3 className="text-sm font-semibold">New skill</h3>
-          <div className="flex gap-1">
-            <Button size="sm" variant="outline" onClick={onCancel} disabled={pending}>
-              Cancel
-            </Button>
-            <Button size="sm" onClick={handleSubmit} disabled={pending || !name.trim()}>
-              {pending ? "Creating…" : "Create"}
-            </Button>
-          </div>
-        </header>
+    <main className="max-w-[760px] mx-auto pt-2 sm:pt-6 px-1 sm:px-2">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="py-2 text-[13px] text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
+      >
+        ← back to your rules
+      </button>
 
-        <div className={cn("grid gap-3", lockedScope ? "grid-cols-1" : "grid-cols-2")}>
-          {lockedScope === undefined && (
-            <div className="space-y-1">
-              <label className="text-xs font-medium" htmlFor="skill-scope">
-                Scope
-              </label>
-              <select
-                id="skill-scope"
-                value={scope}
-                onChange={(e) => setScope(e.target.value as WritableScope)}
-                className="rounded-md border bg-background px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-ring"
-              >
-                <option value="user">User</option>
-                <option value="workspace">Workspace</option>
-                <option value="org">Org</option>
-              </select>
-            </div>
-          )}
-          <div className="space-y-1">
-            <label className="text-xs font-medium" htmlFor="skill-name">
-              Name
+      <h2 className="text-[22px] tracking-tight text-foreground mt-6 sm:mt-8">
+        {loading ? "Loading…" : isNew ? "A new rule for your agent" : "Edit this rule"}
+      </h2>
+
+      {error && (
+        <Card className="mt-6">
+          <CardContent className="py-3 px-4">
+            <p className="text-sm text-destructive">{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {!loading && (
+        <div className="mt-10 sm:mt-12 space-y-8 sm:space-y-10">
+          <div>
+            <label className="block text-[12.5px] text-muted-foreground mb-2" htmlFor="rule-name">
+              Name it
             </label>
             <Input
-              id="skill-name"
+              id="rule-name"
+              ref={nameRef}
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="voice-rules"
               pattern="[a-zA-Z0-9_-]+"
+              disabled={!isNew}
+              className="font-mono"
             />
+            {!isNew && (
+              <p className="text-[11.5px] text-muted-foreground mt-1.5">
+                Names are immutable — they're the filename on disk.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-[12.5px] text-muted-foreground mb-2" htmlFor="rule-body">
+              What should the agent do?
+            </label>
+            <Textarea
+              id="rule-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={8}
+              placeholder="Match my writing voice. Avoid em-dashes."
+              className="text-[15px] leading-relaxed"
+            />
+            <p className="text-xs text-muted-foreground mt-3">
+              The agent reads this as a rule. Plain English works. Use line breaks for separate
+              ideas.
+            </p>
+          </div>
+
+          <div>
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((v) => !v)}
+              className="text-[12.5px] text-muted-foreground hover:text-foreground inline-flex items-center gap-2"
+            >
+              <span
+                className={cn(
+                  "text-muted-foreground/60 transition-transform inline-block",
+                  advancedOpen && "rotate-90",
+                )}
+              >
+                ▸
+              </span>
+              Advanced
+              <span className="text-muted-foreground/60">— when to load, priority</span>
+            </button>
+            {advancedOpen && (
+              <div className="mt-4 pl-5 space-y-4 border-l border-border">
+                <div>
+                  <label
+                    className="block text-[12.5px] text-muted-foreground mb-1"
+                    htmlFor="loading-strategy"
+                  >
+                    When to load
+                  </label>
+                  <select
+                    id="loading-strategy"
+                    value={loadingStrategy}
+                    onChange={(e) => setLoadingStrategy(e.target.value as "auto" | "always")}
+                    className="text-[13px] bg-background border-b border-border pb-1 outline-none focus:border-foreground"
+                  >
+                    <option value="auto">Let the system decide</option>
+                    <option value="always">Always</option>
+                  </select>
+                </div>
+                <div>
+                  <label
+                    className="block text-[12.5px] text-muted-foreground mb-1"
+                    htmlFor="priority"
+                  >
+                    Priority
+                  </label>
+                  <input
+                    id="priority"
+                    type="number"
+                    min={1}
+                    max={100}
+                    value={priority}
+                    onChange={(e) => setPriority(parseInt(e.target.value, 10) || 50)}
+                    className="text-[13px] bg-background border-b border-border pb-1 w-20 outline-none focus:border-foreground"
+                  />
+                  <span className="text-[11.5px] text-muted-foreground ml-3">
+                    lower = read first
+                  </span>
+                </div>
+              </div>
+            )}
           </div>
         </div>
-
-        <ManifestForm form={form} setForm={setForm} />
-
-        <div className="space-y-1">
-          <label className="text-xs font-medium" htmlFor="skill-body-new">
-            Body
-          </label>
-          <Textarea
-            id="skill-body-new"
-            value={form.body}
-            onChange={(e) => setForm({ ...form, body: e.target.value })}
-            className="font-mono text-[11px] min-h-[200px]"
-            placeholder="Markdown content of the skill…"
-          />
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function ManifestForm({
-  form,
-  setForm,
-}: {
-  form: EditorFormState;
-  setForm: (f: EditorFormState) => void;
-}) {
-  const selectClass =
-    "rounded-md border bg-background px-2 py-1 text-xs w-full focus:outline-none focus:ring-1 focus:ring-ring";
-  return (
-    <div className="space-y-3">
-      <div className="space-y-1">
-        <label className="text-xs font-medium" htmlFor="skill-description">
-          Description
-        </label>
-        <Input
-          id="skill-description"
-          value={form.description}
-          onChange={(e) => setForm({ ...form, description: e.target.value })}
-          placeholder="One-line summary of what this skill does"
-        />
-      </div>
-      <div className="grid grid-cols-3 gap-3">
-        <div className="space-y-1">
-          <label className="text-xs font-medium" htmlFor="skill-type">
-            Type
-          </label>
-          <select
-            id="skill-type"
-            value={form.type}
-            onChange={(e) => setForm({ ...form, type: e.target.value as EditorFormState["type"] })}
-            className={selectClass}
-          >
-            <option value="skill">skill (triggered)</option>
-            <option value="context">context (always-on)</option>
-          </select>
-        </div>
-        <div className="space-y-1">
-          <label className="text-xs font-medium" htmlFor="skill-priority">
-            Priority
-          </label>
-          <Input
-            id="skill-priority"
-            type="number"
-            min="11"
-            max="99"
-            value={form.priority}
-            onChange={(e) => setForm({ ...form, priority: e.target.value })}
-          />
-        </div>
-        <div className="space-y-1">
-          <label className="text-xs font-medium" htmlFor="skill-status">
-            Status
-          </label>
-          <select
-            id="skill-status"
-            value={form.status}
-            onChange={(e) => setForm({ ...form, status: e.target.value as Status })}
-            className={selectClass}
-          >
-            <option value="active">active</option>
-            <option value="draft">draft</option>
-            <option value="disabled">disabled</option>
-            <option value="archived">archived</option>
-          </select>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ScopeMover({
-  current,
-  pending,
-  onMove,
-}: {
-  current: WritableScope;
-  pending: boolean;
-  onMove: (target: WritableScope) => void;
-}) {
-  const targets: WritableScope[] = (["org", "workspace", "user"] as WritableScope[]).filter(
-    (s) => s !== current,
-  );
-  return (
-    <select
-      onChange={(e) => {
-        const v = e.target.value as WritableScope | "";
-        if (v) onMove(v);
-        e.target.value = "";
-      }}
-      defaultValue=""
-      disabled={pending}
-      aria-label="Move skill to a different scope"
-      className="rounded-md border bg-background px-2 py-1 text-xs h-8 disabled:opacity-50"
-    >
-      <option value="">Move to…</option>
-      {targets.map((t) => (
-        <option key={t} value={t}>
-          {t}
-        </option>
-      ))}
-    </select>
-  );
-}
-
-function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
-  return (
-    <>
-      <dt className="text-muted-foreground">{label}</dt>
-      <dd className={cn("break-all", mono && "font-mono text-[11px]")}>{value}</dd>
-    </>
-  );
-}
-
-function formatTime(iso: string): string {
-  try {
-    const d = new Date(iso);
-    return d.toLocaleString();
-  } catch {
-    return iso;
-  }
-}
-
-// ── Filters ──────────────────────────────────────────────────────────────
-
-const SCOPE_OPTIONS: Array<{ value: Scope | "all"; label: string }> = [
-  { value: "all", label: "All scopes" },
-  { value: "user", label: "User" },
-  { value: "workspace", label: "Workspace" },
-  { value: "org", label: "Org" },
-  { value: "bundle", label: "Bundle (L1)" },
-];
-
-const STATUS_OPTIONS: Array<{ value: Status | "all"; label: string }> = [
-  { value: "active", label: "Active" },
-  { value: "draft", label: "Draft" },
-  { value: "disabled", label: "Disabled" },
-  { value: "archived", label: "Archived" },
-  { value: "all", label: "All statuses" },
-];
-
-function Filters({
-  scope,
-  status,
-  onScopeChange,
-  onStatusChange,
-  lockedScope,
-}: {
-  scope: Scope | "all";
-  status: Status | "all";
-  onScopeChange: (s: Scope | "all") => void;
-  onStatusChange: (s: Status | "all") => void;
-  /** When set, suppress the scope selector — the surface is scope-locked. */
-  lockedScope?: Scope;
-}) {
-  const selectClass =
-    "rounded-md border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring";
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      {lockedScope === undefined && (
-        <select
-          value={scope}
-          onChange={(e) => onScopeChange(e.target.value as Scope | "all")}
-          className={selectClass}
-          aria-label="Filter by scope"
-        >
-          {SCOPE_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
       )}
-      <select
-        value={status}
-        onChange={(e) => onStatusChange(e.target.value as Status | "all")}
-        className={selectClass}
-        aria-label="Filter by status"
-      >
-        {STATUS_OPTIONS.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-    </div>
+
+      <div className="mt-12 sm:mt-16 flex items-center justify-between border-t border-border pt-6">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={pending}
+          className="min-h-[44px] sm:min-h-0 py-2 text-[13px] text-muted-foreground hover:text-foreground underline-offset-4 hover:underline disabled:opacity-40"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            valid && onSubmit({ name: name.trim(), body: body.trim(), loadingStrategy, priority })
+          }
+          disabled={!valid || pending}
+          className={cn(
+            "min-h-[44px] sm:min-h-0 px-4 py-2 rounded-md text-[13px] transition-colors",
+            valid && !pending
+              ? "bg-foreground text-background hover:opacity-80"
+              : "bg-muted text-muted-foreground cursor-not-allowed",
+          )}
+        >
+          {pending ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </main>
   );
 }

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -31,33 +31,30 @@ export function SkillsTab() {
 }
 
 /**
- * Shared skills browser.
+ * Shared skills browser. Each surface picks exactly one prop:
  *
  *   - `surface="workspace"` — grouped sections (workspace editable +
  *     inherited org disabled + inherited bundles disabled) + personal
  *     footer + create locked to workspace.
  *   - `lockedScope="org"` — single-scope org-tier view + create locked
- *     to org. (Org-admin tab calls this directly via OrgSkillsTab.)
+ *     to org. (OrgSkillsTab.)
+ *   - `lockedScope="user"` — single-scope user-tier view + create locked
+ *     to user. (ProfileSkillsTab.)
  *
- * The two props are independent. No-prop callers fall through to the
- * legacy "show every scope" view, kept only for the test seam — no
- * production route uses it.
+ * The discriminated union prevents a caller from passing neither — the
+ * "show every scope" fallback isn't reachable from any route.
  */
-interface SkillsBrowserProps {
-  lockedScope?: Scope;
-  surface?: "workspace";
-}
+type SkillsBrowserProps =
+  | { surface: "workspace"; lockedScope?: never }
+  | { lockedScope: "org" | "user"; surface?: never };
 
 type WritableScope = "org" | "workspace" | "user";
 
-export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {}) {
-  const isWorkspaceSurface = surface === "workspace";
-  const initialScopeFilter: Scope | "all" = isWorkspaceSurface ? "all" : (lockedScope ?? "all");
-  const createLockedScope: WritableScope | undefined = isWorkspaceSurface
-    ? "workspace"
-    : lockedScope === "org" || lockedScope === "workspace" || lockedScope === "user"
-      ? lockedScope
-      : undefined;
+export function SkillsBrowser(props: SkillsBrowserProps) {
+  const isWorkspaceSurface = props.surface === "workspace";
+  const lockedScope = isWorkspaceSurface ? undefined : props.lockedScope;
+  const initialScopeFilter: Scope | "all" = isWorkspaceSurface ? "all" : lockedScope!;
+  const createLockedScope: WritableScope = isWorkspaceSurface ? "workspace" : lockedScope!;
 
   const [skills, setSkills] = useState<ListedSkill[]>([]);
   const [loading, setLoading] = useState(true);
@@ -213,7 +210,7 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
         };
         await runMutation(
           "create",
-          { scope: createLockedScope ?? "workspace", manifest: createManifest, body: patch.body },
+          { scope: createLockedScope, manifest: createManifest, body: patch.body },
           (result) => {
             setView("list");
             setEditingId(null);
@@ -332,13 +329,13 @@ export function SkillsBrowser({ lockedScope, surface }: SkillsBrowserProps = {})
               />
             );
           }
+          // Own (editable) section title — `group.scope` always matches
+          // one of these three because the list fetch is pre-scoped.
           const ownTitle = isWorkspaceSurface
             ? "From your workspace"
             : group.scope === "org"
               ? "Organization rules"
-              : group.scope === "user"
-                ? "Your rules"
-                : "Rules";
+              : "Your rules";
           return (
             <Section
               key={group.scope}
@@ -766,7 +763,11 @@ function EditView({
     <div className="max-w-3xl mx-auto space-y-6">
       <SettingsPageHeader
         title={loading ? "Loading…" : isNew ? "A new rule for your agent" : "Edit this rule"}
-        back={{ to: "..", label: "Back to skills" }}
+        // `onBack` (not `back`) because EditView is component state on
+        // SkillsBrowser, not a routed sub-page — the URL stays on
+        // .../skills while editing. A router Link would navigate UP the
+        // tree (out of skills) and silently drop the form state.
+        onBack={{ onClick: onCancel, label: "Back to skills" }}
       />
 
       {error && (

--- a/web/src/pages/settings/components/SettingsPageHeader.tsx
+++ b/web/src/pages/settings/components/SettingsPageHeader.tsx
@@ -28,8 +28,22 @@ export interface SettingsPageHeaderProps {
   icon?: ReactNode;
   /** Right-aligned action — typically a primary button (Create, Save, etc). */
   action?: ReactNode;
-  /** Optional back-nav rendered as an arrow button to the left of the title. */
+  /**
+   * Optional back-nav rendered as an arrow button to the left of the
+   * title.
+   *
+   * Use `back` (a router Link) for pages that are real routed sub-pages
+   * — the back arrow navigates UP one route segment.
+   *
+   * Use `onBack` for pages that are component state inside a parent
+   * surface (e.g. an inline edit view rendered when local state flips,
+   * NOT a /:id child route). A router Link can't flip parent component
+   * state, so the click would silently leave the page entirely — at
+   * best surprising, at worst data-loss (unsaved edits dropped).
+   * `onBack` renders a button that calls the supplied handler instead.
+   */
   back?: { to: string; label?: string };
+  onBack?: { onClick: () => void; label?: string };
 }
 
 export function SettingsPageHeader({
@@ -38,18 +52,27 @@ export function SettingsPageHeader({
   icon,
   action,
   back,
+  onBack,
 }: SettingsPageHeaderProps) {
+  const backButtonClass =
+    "-ml-1 shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50";
   return (
     <header className="flex items-start justify-between gap-4">
       <div className="flex items-start gap-2 min-w-0">
         {back ? (
-          <Link
-            to={back.to}
-            aria-label={back.label ?? "Back"}
-            className="-ml-1 shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
-          >
+          <Link to={back.to} aria-label={back.label ?? "Back"} className={backButtonClass}>
             <ArrowLeft className="h-4 w-4" />
           </Link>
+        ) : null}
+        {onBack ? (
+          <button
+            type="button"
+            onClick={onBack.onClick}
+            aria-label={onBack.label ?? "Back"}
+            className={backButtonClass}
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
         ) : null}
         {icon ? (
           <span

--- a/web/test/ProfileSkillsTab.test.tsx
+++ b/web/test/ProfileSkillsTab.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Pinpoint test for `ProfileSkillsTab` — the /profile/skills surface.
+ *
+ * The whole component is one line wrapping `SkillsBrowser` with
+ * `lockedScope="user"`. The pin: the initial skills__list fetch is
+ * pre-scoped to user-tier, and a created rule sends `scope: "user"`
+ * regardless of internal state. The full behavioral surface (toggle,
+ * inline expand, edit form) is exercised by the workspace + org
+ * surface tests; this only verifies the wrapper actually wires the
+ * user-tier lock.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "./setup";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+{
+  const win = (globalThis as unknown as { window: Record<string, unknown> }).window;
+  if (win) {
+    win.SyntaxError ??= SyntaxError;
+    win.TypeError ??= TypeError;
+  }
+}
+
+type CallToolArgs = { server: string; tool: string; args: Record<string, unknown> };
+const callToolCalls: CallToolArgs[] = [];
+
+mock.module("../src/api/client", () => ({
+  ...realClient,
+  callTool: async (server: string, tool: string, args: Record<string, unknown>) => {
+    callToolCalls.push({ server, tool, args });
+    if (server === "skills" && tool === "list") {
+      return { structuredContent: { skills: [] }, isError: false };
+    }
+    if (server === "skills" && tool === "create") {
+      return { structuredContent: { id: "/tmp/user/test.md" }, isError: false };
+    }
+    return { structuredContent: {}, isError: false };
+  },
+}));
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { MemoryRouter } = await import("react-router-dom");
+const { ProfileSkillsTab } = await import("../src/pages/settings/ProfileSkillsTab");
+
+interface Mounted {
+  container: HTMLDivElement;
+  unmount(): void;
+}
+
+let mounted: Mounted | null = null;
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+  callToolCalls.length = 0;
+});
+
+async function mount(element: React.ReactElement): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(MemoryRouter, null, element));
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return {
+    container,
+    unmount() {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+function clickByText(container: HTMLElement, text: string): boolean {
+  for (const el of Array.from(container.querySelectorAll("button"))) {
+    if (el.textContent?.includes(text)) {
+      el.click();
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("ProfileSkillsTab (the /profile/skills surface)", () => {
+  test("initial skills.list fetch is pre-scoped to user-tier", async () => {
+    mounted = await mount(React.createElement(ProfileSkillsTab));
+    const listCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "list");
+    expect(listCall).toBeDefined();
+    expect(listCall!.args.scope).toBe("user");
+  });
+
+  test("create form sends scope='user' regardless of internal state", async () => {
+    mounted = await mount(React.createElement(ProfileSkillsTab));
+    await act(async () => {
+      clickByText(mounted!.container, "+ Add a rule");
+    });
+
+    const nameInput = mounted.container.querySelector("#rule-name") as HTMLInputElement | null;
+    const bodyInput = mounted.container.querySelector("#rule-body") as HTMLTextAreaElement | null;
+    expect(nameInput).not.toBeNull();
+    expect(bodyInput).not.toBeNull();
+
+    const WindowEvent = (globalThis as unknown as { window: { Event: typeof Event } }).window
+      .Event;
+    await act(async () => {
+      const setVal = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setVal?.call(nameInput, "personal-voice");
+      nameInput!.dispatchEvent(new WindowEvent("input", { bubbles: true }));
+      const setTa = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setTa?.call(bodyInput, "Match my writing voice.");
+      bodyInput!.dispatchEvent(new WindowEvent("input", { bubbles: true }));
+    });
+    await act(async () => {
+      clickByText(mounted!.container, "Save");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const createCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "create");
+    expect(createCall).toBeDefined();
+    expect(createCall!.args.scope).toBe("user");
+    expect((createCall!.args.manifest as { name?: string }).name).toBe("personal-voice");
+    expect((createCall!.args.manifest as { type?: string }).type).toBe("context");
+  });
+});

--- a/web/test/SkillsBrowser.org.test.tsx
+++ b/web/test/SkillsBrowser.org.test.tsx
@@ -1,24 +1,12 @@
 /**
- * Behavioral tests for `<SkillsBrowser lockedScope="org" />` — the
- * shared component the org-admin /org/skills surface renders.
+ * Behavioral tests for `<SkillsBrowser lockedScope="org" />` after the
+ * skills-redesign rewrite. The org-admin tab uses this surface.
  *
- * The role-gate test (orgRoleGate.test.ts) covers WHO can reach this
- * surface. This file covers WHAT the surface does once reached:
- *
- *   1. The scope filter is suppressed (only one scope is in view).
- *   2. The create form has no scope picker.
- *   3. Submitting the create form sends `scope: "org"` to the tool,
- *      regardless of what the user did inside the form. This is the
- *      load-bearing assertion: if a future edit drops the
- *      `useState<WritableScope>(lockedScope ?? "workspace")` default,
- *      the org surface would silently author into workspace scope.
- *      Nothing else catches that — the server's checkPathAccess gate
- *      rejects MEMBERS writing org skills, but cannot catch an ADMIN
- *      writing to the wrong scope through a regressed UI.
- *
- * The workspace surface (no lock) is covered structurally by the absence
- * of changes in the unmounted path — both selects render, scope defaults
- * to "workspace" — see SkillsTab.tsx::SkillsTab.
+ *   1. No scope filter (single-scope view).
+ *   2. The create form's "Name it" + "What should the agent do?" submit
+ *      sends `scope: "org"` regardless of internal state — the load-
+ *      bearing assertion the server's checkPathAccess can't catch.
+ *   3. Initial skills__list fetch is pre-scoped to org-tier.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -26,13 +14,6 @@ import { realClient } from "./setup";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-// Patch globals happy-dom forgets to expose on its Window stub. Without
-// these, mounting any `<select>` inside the component graph throws on
-// `HTMLOptionElement[updateSelectedness]` → `new this.window.SyntaxError(...)`,
-// and dispatching events throws on `new this.window.TypeError(...)`. The
-// status filter select alone is enough to trip the first failure on initial
-// render. Setting these on the happy-dom window once at module load avoids
-// per-test scaffolding.
 {
   const win = (globalThis as unknown as { window: Record<string, unknown> }).window;
   if (win) {
@@ -41,16 +22,7 @@ import { realClient } from "./setup";
   }
 }
 
-// Capture every callTool invocation so we can assert against the create
-// payload at the end of the flow. The list call returns an empty catalog so
-// the UI lands on "no skills, click New skill" — the create form is the
-// surface we want to exercise. Spread the preload snapshot so other exports
-// (getAuthToken, getActiveWorkspaceId, …) stay intact for cross-suite safety.
-type CallToolArgs = {
-  server: string;
-  tool: string;
-  args: Record<string, unknown>;
-};
+type CallToolArgs = { server: string; tool: string; args: Record<string, unknown> };
 const callToolCalls: CallToolArgs[] = [];
 
 mock.module("../src/api/client", () => ({
@@ -61,7 +33,7 @@ mock.module("../src/api/client", () => ({
       return { structuredContent: { skills: [] }, isError: false };
     }
     if (server === "skills" && tool === "create") {
-      return { structuredContent: { id: "/tmp/test-skill.md" }, isError: false };
+      return { structuredContent: { id: "/tmp/org/test.md" }, isError: false };
     }
     return { structuredContent: {}, isError: false };
   },
@@ -70,6 +42,7 @@ mock.module("../src/api/client", () => ({
 const React = await import("react");
 const ReactDOMClient = await import("react-dom/client");
 const { act } = await import("react");
+const { MemoryRouter } = await import("react-router-dom");
 const { SkillsBrowser } = await import("../src/pages/settings/SkillsTab");
 
 interface Mounted {
@@ -89,9 +62,8 @@ async function mount(element: React.ReactElement): Promise<Mounted> {
   document.body.appendChild(container);
   const root = ReactDOMClient.createRoot(container);
   await act(async () => {
-    root.render(element);
+    root.render(React.createElement(MemoryRouter, null, element));
   });
-  // Drain the initial fetch + state updates.
   await act(async () => {
     await Promise.resolve();
   });
@@ -107,7 +79,7 @@ async function mount(element: React.ReactElement): Promise<Mounted> {
   };
 }
 
-function clickButtonByText(container: HTMLElement, text: string): boolean {
+function clickByText(container: HTMLElement, text: string): boolean {
   for (const el of Array.from(container.querySelectorAll("button"))) {
     if (el.textContent?.includes(text)) {
       el.click();
@@ -117,56 +89,35 @@ function clickButtonByText(container: HTMLElement, text: string): boolean {
   return false;
 }
 
-describe("SkillsBrowser with lockedScope='org' (the /org/skills surface)", () => {
-  test("does not render the scope filter selector", async () => {
+describe("SkillsBrowser with lockedScope='org' (org-admin /org/skills surface)", () => {
+  test("does not render a scope filter", async () => {
     mounted = await mount(React.createElement(SkillsBrowser, { lockedScope: "org" }));
-    const filterSelect = mounted.container.querySelector('select[aria-label="Filter by scope"]');
-    expect(filterSelect).toBeNull();
-    // Status filter still renders — it's an orthogonal axis.
-    const statusSelect = mounted.container.querySelector('select[aria-label="Filter by status"]');
-    expect(statusSelect).not.toBeNull();
+    expect(mounted.container.querySelector('select[aria-label="Filter by scope"]')).toBeNull();
   });
 
-  test("does not render the scope picker inside the create form", async () => {
+  test("submitting + Add a rule sends scope='org' regardless of internal state", async () => {
     mounted = await mount(React.createElement(SkillsBrowser, { lockedScope: "org" }));
     await act(async () => {
-      clickButtonByText(mounted!.container, "New skill");
-    });
-    const scopePicker = mounted.container.querySelector("#skill-scope");
-    expect(scopePicker).toBeNull();
-    // Name input does render — confirms the form mounted, not just the
-    // entire form was suppressed.
-    const nameInput = mounted.container.querySelector("#skill-name");
-    expect(nameInput).not.toBeNull();
-  });
-
-  test("submitting the create form sends scope='org' regardless of internal state", async () => {
-    mounted = await mount(React.createElement(SkillsBrowser, { lockedScope: "org" }));
-    await act(async () => {
-      clickButtonByText(mounted!.container, "New skill");
+      clickByText(mounted!.container, "+ Add a rule");
     });
 
-    // Fill in the name — required to enable the Create button.
-    const nameInput = mounted.container.querySelector("#skill-name") as HTMLInputElement | null;
+    const nameInput = mounted.container.querySelector("#rule-name") as HTMLInputElement | null;
+    const bodyInput = mounted.container.querySelector("#rule-body") as HTMLTextAreaElement | null;
     expect(nameInput).not.toBeNull();
+    expect(bodyInput).not.toBeNull();
+
+    const WindowEvent = (globalThis as unknown as { window: { Event: typeof Event } }).window
+      .Event;
     await act(async () => {
-      // React uses a synthetic event system; fire a native input event and
-      // set the value through the descriptor so React's onChange fires.
-      // Use the happy-dom window's Event constructor — a globalThis.Event
-      // instance fails happy-dom's `instanceof Event` check (it has its
-      // own per-Window Event class).
-      const setter = Object.getOwnPropertyDescriptor(
-        HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      setter?.call(nameInput, "voice-rule");
-      const WindowEvent = (globalThis as unknown as { window: { Event: typeof Event } }).window
-        .Event;
+      const setVal = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setVal?.call(nameInput, "voice-rule");
       nameInput!.dispatchEvent(new WindowEvent("input", { bubbles: true }));
+      const setTa = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setTa?.call(bodyInput, "Match editorial voice.");
+      bodyInput!.dispatchEvent(new WindowEvent("input", { bubbles: true }));
     });
-
     await act(async () => {
-      clickButtonByText(mounted!.container, "Create");
+      clickByText(mounted!.container, "Save");
     });
     await act(async () => {
       await Promise.resolve();
@@ -174,20 +125,16 @@ describe("SkillsBrowser with lockedScope='org' (the /org/skills surface)", () =>
 
     const createCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "create");
     expect(createCall).toBeDefined();
-    // This is THE assertion the gate can't catch — if the form's
-    // `useState<WritableScope>(lockedScope ?? "workspace")` default ever
-    // drops the lock, scope here goes to "workspace" and the org surface
-    // silently authors into the wrong tier. Pin it.
     expect(createCall!.args.scope).toBe("org");
     expect((createCall!.args.manifest as { name?: string }).name).toBe("voice-rule");
+    expect((createCall!.args.manifest as { description?: string }).description).toBe("");
+    expect((createCall!.args.manifest as { type?: string }).type).toBe("context");
   });
 
-  test("initial skills.list fetch is scoped to org-tier", async () => {
+  test("initial skills.list fetch is pre-scoped to org", async () => {
     mounted = await mount(React.createElement(SkillsBrowser, { lockedScope: "org" }));
     const listCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "list");
     expect(listCall).toBeDefined();
-    // The scope filter starts at the locked value, so the first network
-    // call must already be scoped — no flash of cross-tier skills.
     expect(listCall!.args.scope).toBe("org");
   });
 });

--- a/web/test/SkillsBrowser.workspace.test.tsx
+++ b/web/test/SkillsBrowser.workspace.test.tsx
@@ -107,18 +107,27 @@ mock.module("../src/api/client", () => ({
     if (server === "skills" && tool === "create") {
       return { structuredContent: { id: "/tmp/skills/ws/test-skill.md" }, isError: false };
     }
+    if (server === "skills" && tool === "update") {
+      return { structuredContent: { id: args.id }, isError: false };
+    }
     if (server === "skills" && tool === "read") {
+      // The fixture's editable rule is "workflow" (a `type: skill` with
+      // a curated description). The update-path test below relies on
+      // this: a hardcoded description: "" or type: "context" on update
+      // would silently wipe these values, which is the regression PR
+      // QA caught.
       return {
         structuredContent: {
           id: args.id,
-          content: "Test body.",
+          content: "Original body content.",
           layer: 3,
           scope: "workspace",
           source: { path: args.id },
           metadata: {
-            name: "x",
-            type: "context",
-            priority: 50,
+            name: "workflow",
+            description: "Workspace-tier rule.",
+            type: "skill",
+            priority: 75,
             status: "active",
           },
         },
@@ -253,5 +262,65 @@ describe("SkillsBrowser with surface='workspace' (workspace settings tab)", () =
     const listCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "list");
     expect(listCall).toBeDefined();
     expect(listCall!.args.scope).toBeUndefined();
+  });
+
+  test("editing an existing rule does NOT send description or type (would wipe on-disk values)", async () => {
+    // CRITICAL regression guard. skills__update is a partial-patch
+    // merge: any field present in the manifest is written to disk and
+    // overwrites the prior value. Earlier in this PR the UI was sending
+    // `{ description: "", type: "context", ... }` identically on create
+    // and update — which silently wiped author-curated descriptions and
+    // coerced `type: skill` rules into `type: context`, changing
+    // Layer-3 loading inference. (It was also self-defeating because
+    // the redesigned row's display label IS the description.)
+    //
+    // The fix at SkillsTab.tsx::handleSubmit splits the manifest by
+    // branch: update only carries fields the user explicitly touched
+    // via the Advanced expander; create carries the full set.
+    mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
+
+    // Expand the workspace rule (the "workflow" fixture), wait for the
+    // read, then click Edit.
+    await act(async () => {
+      clickByText(mounted!.container, "Workspace-tier rule.");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      clickByText(mounted!.container, "Edit");
+    });
+
+    // Modify the body so there's a real edit to ship.
+    const bodyInput = mounted.container.querySelector("#rule-body") as HTMLTextAreaElement | null;
+    expect(bodyInput).not.toBeNull();
+    const WindowEvent = (globalThis as unknown as { window: { Event: typeof Event } }).window
+      .Event;
+    await act(async () => {
+      const setTa = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setTa?.call(bodyInput, "Edited body content.");
+      bodyInput!.dispatchEvent(new WindowEvent("input", { bubbles: true }));
+    });
+    await act(async () => {
+      clickByText(mounted!.container, "Save");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const updateCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "update");
+    expect(updateCall).toBeDefined();
+    // The body change goes through.
+    expect(updateCall!.args.body).toBe("Edited body content.");
+    // THE load-bearing assertions — the manifest patch MUST NOT carry
+    // description, type, or name. If any of these appear, the partial
+    // patch silently overwrites disk and we're back in the bug.
+    const manifest = updateCall!.args.manifest as Record<string, unknown>;
+    expect(manifest.description).toBeUndefined();
+    expect(manifest.type).toBeUndefined();
+    expect(manifest.name).toBeUndefined();
   });
 });

--- a/web/test/SkillsBrowser.workspace.test.tsx
+++ b/web/test/SkillsBrowser.workspace.test.tsx
@@ -189,13 +189,13 @@ describe("SkillsBrowser with surface='workspace' (workspace settings tab)", () =
     mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
     const text = mounted.container.textContent ?? "";
     expect(text).toContain("From your organization");
-    expect(text).toContain("From installed apps");
+    expect(text).toContain("From the system");
     // User-tier skills never appear as a section — only as the
     // personal-footer count.
     expect(text).not.toMatch(/From user/);
   });
 
-  test("personal-skills footer shows the correct count and links to /profile", async () => {
+  test("personal-skills footer shows the correct count and links to /profile/skills", async () => {
     mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
     const text = mounted.container.textContent ?? "";
     expect(text).toContain("2 personal rules active here");
@@ -203,7 +203,7 @@ describe("SkillsBrowser with surface='workspace' (workspace settings tab)", () =
       a.textContent?.includes("Edit in your profile"),
     );
     expect(link).toBeDefined();
-    expect(link?.getAttribute("href")).toBe("/profile");
+    expect(link?.getAttribute("href")).toBe("/profile/skills");
   });
 
   test("submitting + Add a rule sends scope='workspace' regardless of internal state", async () => {

--- a/web/test/SkillsBrowser.workspace.test.tsx
+++ b/web/test/SkillsBrowser.workspace.test.tsx
@@ -328,4 +328,63 @@ describe("SkillsBrowser with surface='workspace' (workspace settings tab)", () =
     // UI as a "When to load" override. The dropdown is gone.
     expect(manifest.loadingStrategy).toBeUndefined();
   });
+
+  test("edit-view back arrow returns to the list (not up the route tree)", async () => {
+    // CRITICAL regression guard. EditView is component state on
+    // SkillsBrowser — when `view === "edit"` the parent returns
+    // <EditView /> instead of the list. The URL stays the same.
+    //
+    // An earlier version of EditView passed
+    // `back={{ to: "..", ... }}` to SettingsPageHeader, which renders
+    // a <Link to=".."> — a router link that navigates UP one route
+    // segment. From /w/:slug/settings/skills that goes to
+    // /w/:slug/settings (out of skills); from /profile/skills that
+    // goes to /profile/general; from /org/skills it leaves
+    // entirely. Each navigation silently discards the form state.
+    //
+    // The fix routes through SettingsPageHeader's `onBack` prop,
+    // which renders a <button> that calls a handler the parent
+    // controls (onCancel, which flips view back to "list").
+    //
+    // This test pins it: open the edit view, click the back arrow,
+    // assert the URL is unchanged AND the list view is back.
+    mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
+
+    await act(async () => {
+      clickByText(mounted!.container, "Workspace-tier rule.");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      clickByText(mounted!.container, "Edit");
+    });
+
+    // We're in the edit view now.
+    expect(mounted.container.querySelector("#rule-name")).not.toBeNull();
+
+    // Click the back-arrow button (aria-label="Back to skills").
+    const backButton = mounted.container.querySelector(
+      'button[aria-label="Back to skills"]',
+    ) as HTMLButtonElement | null;
+    expect(backButton).not.toBeNull();
+    await act(async () => {
+      backButton!.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // List view is back — the "+ Add a rule" affordance only renders
+    // on the list, not the edit view.
+    const hasAddRule = Array.from(mounted.container.querySelectorAll("button")).some((b) =>
+      b.textContent?.includes("+ Add a rule"),
+    );
+    expect(hasAddRule).toBe(true);
+    // And we're NOT still in edit mode — the rule-name input is gone.
+    expect(mounted.container.querySelector("#rule-name")).toBeNull();
+  });
 });

--- a/web/test/SkillsBrowser.workspace.test.tsx
+++ b/web/test/SkillsBrowser.workspace.test.tsx
@@ -322,5 +322,10 @@ describe("SkillsBrowser with surface='workspace' (workspace settings tab)", () =
     expect(manifest.description).toBeUndefined();
     expect(manifest.type).toBeUndefined();
     expect(manifest.name).toBeUndefined();
+    // `loadingStrategy` is intentionally absent from the LLM-facing
+    // schema (schemas/skills.ts ManifestFields). Sending it would be
+    // a silent no-op (validator strips it) and was misleading in the
+    // UI as a "When to load" override. The dropdown is gone.
+    expect(manifest.loadingStrategy).toBeUndefined();
   });
 });

--- a/web/test/SkillsBrowser.workspace.test.tsx
+++ b/web/test/SkillsBrowser.workspace.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Behavioral tests for `<SkillsBrowser surface="workspace" />` after the
+ * skills-redesign rewrite.
+ *
+ * The workspace surface owes its user:
+ *
+ *   1. No scope filter — sections are the partition.
+ *   2. No status filter either — the per-row On/Off toggle is the
+ *      enablement control.
+ *   3. Sections render: workspace, inherited from organization,
+ *      inherited from installed apps. User-tier skills surface only
+ *      as the personal-footer count, not as a section.
+ *   4. The create form ("+ Add a rule") sends `scope: "workspace"`
+ *      regardless of internal state. This is the load-bearing assertion
+ *      the server's checkPathAccess can't catch.
+ *   5. Initial skills__list fetch is unfiltered by scope.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "./setup";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// happy-dom doesn't expose SyntaxError/TypeError on its Window stub;
+// any <select> render trips this. Same patch as the org-surface test.
+{
+  const win = (globalThis as unknown as { window: Record<string, unknown> }).window;
+  if (win) {
+    win.SyntaxError ??= SyntaxError;
+    win.TypeError ??= TypeError;
+  }
+}
+
+type CallToolArgs = { server: string; tool: string; args: Record<string, unknown> };
+const callToolCalls: CallToolArgs[] = [];
+
+const SKILLS_FIXTURE = [
+  {
+    id: "/tmp/skills/ws/workflow.md",
+    name: "workflow",
+    description: "Workspace-tier rule.",
+    scope: "workspace",
+    layer: 3,
+    status: "active",
+    type: "skill",
+    priority: 50,
+    tokens: 100,
+    source: { path: "/tmp/skills/ws/workflow.md" },
+  },
+  {
+    id: "/tmp/skills/org/voice.md",
+    name: "voice",
+    description: "Org-tier voice rules.",
+    scope: "org",
+    layer: 3,
+    status: "active",
+    type: "context",
+    priority: 30,
+    tokens: 50,
+    source: { path: "/tmp/skills/org/voice.md" },
+  },
+  {
+    id: "skill://bundle/usage",
+    name: "bundle-skill",
+    description: "Bundle (Layer 1).",
+    scope: "bundle",
+    layer: 1,
+    status: "active",
+    type: "skill",
+    priority: 50,
+    tokens: 80,
+    source: { uri: "skill://bundle/usage" },
+  },
+  {
+    id: "/tmp/skills/user/personal-1.md",
+    name: "personal-1",
+    description: "Personal skill A.",
+    scope: "user",
+    layer: 3,
+    status: "active",
+    type: "skill",
+    priority: 50,
+    tokens: 25,
+    source: { path: "/tmp/skills/user/personal-1.md" },
+  },
+  {
+    id: "/tmp/skills/user/personal-2.md",
+    name: "personal-2",
+    description: "Personal skill B.",
+    scope: "user",
+    layer: 3,
+    status: "active",
+    type: "skill",
+    priority: 50,
+    tokens: 35,
+    source: { path: "/tmp/skills/user/personal-2.md" },
+  },
+];
+
+mock.module("../src/api/client", () => ({
+  ...realClient,
+  callTool: async (server: string, tool: string, args: Record<string, unknown>) => {
+    callToolCalls.push({ server, tool, args });
+    if (server === "skills" && tool === "list") {
+      return { structuredContent: { skills: SKILLS_FIXTURE }, isError: false };
+    }
+    if (server === "skills" && tool === "create") {
+      return { structuredContent: { id: "/tmp/skills/ws/test-skill.md" }, isError: false };
+    }
+    if (server === "skills" && tool === "read") {
+      return {
+        structuredContent: {
+          id: args.id,
+          content: "Test body.",
+          layer: 3,
+          scope: "workspace",
+          source: { path: args.id },
+          metadata: {
+            name: "x",
+            type: "context",
+            priority: 50,
+            status: "active",
+          },
+        },
+        isError: false,
+      };
+    }
+    return { structuredContent: {}, isError: false };
+  },
+}));
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { MemoryRouter } = await import("react-router-dom");
+const { SkillsBrowser } = await import("../src/pages/settings/SkillsTab");
+
+interface Mounted {
+  container: HTMLDivElement;
+  unmount(): void;
+}
+
+let mounted: Mounted | null = null;
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+  callToolCalls.length = 0;
+});
+
+async function mount(element: React.ReactElement): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(MemoryRouter, null, element));
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return {
+    container,
+    unmount() {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+function clickByText(container: HTMLElement, text: string): boolean {
+  for (const el of Array.from(container.querySelectorAll("button"))) {
+    if (el.textContent?.includes(text)) {
+      el.click();
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("SkillsBrowser with surface='workspace' (workspace settings tab)", () => {
+  test("does not render a scope filter", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
+    expect(mounted.container.querySelector('select[aria-label="Filter by scope"]')).toBeNull();
+  });
+
+  test("renders inherited-org, inherited-bundles sections (no user section)", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
+    const text = mounted.container.textContent ?? "";
+    expect(text).toContain("From your organization");
+    expect(text).toContain("From installed apps");
+    // User-tier skills never appear as a section — only as the
+    // personal-footer count.
+    expect(text).not.toMatch(/From user/);
+  });
+
+  test("personal-skills footer shows the correct count and links to /profile", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
+    const text = mounted.container.textContent ?? "";
+    expect(text).toContain("2 personal rules active here");
+    const link = Array.from(mounted.container.querySelectorAll("a")).find((a) =>
+      a.textContent?.includes("Edit in your profile"),
+    );
+    expect(link).toBeDefined();
+    expect(link?.getAttribute("href")).toBe("/profile");
+  });
+
+  test("submitting + Add a rule sends scope='workspace' regardless of internal state", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
+    await act(async () => {
+      clickByText(mounted!.container, "+ Add a rule");
+    });
+
+    const nameInput = mounted.container.querySelector("#rule-name") as HTMLInputElement | null;
+    const bodyInput = mounted.container.querySelector("#rule-body") as HTMLTextAreaElement | null;
+    expect(nameInput).not.toBeNull();
+    expect(bodyInput).not.toBeNull();
+
+    const WindowEvent = (globalThis as unknown as { window: { Event: typeof Event } }).window
+      .Event;
+    await act(async () => {
+      const setVal = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setVal?.call(nameInput, "new-ws-rule");
+      nameInput!.dispatchEvent(new WindowEvent("input", { bubbles: true }));
+      const setTa = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setTa?.call(bodyInput, "Match the workspace voice.");
+      bodyInput!.dispatchEvent(new WindowEvent("input", { bubbles: true }));
+    });
+    await act(async () => {
+      clickByText(mounted!.container, "Save");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const createCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "create");
+    expect(createCall).toBeDefined();
+    // THE load-bearing assertion. If a future refactor drops the
+    // workspace-surface lock, the server's checkPathAccess won't catch
+    // an admin authoring into the wrong scope.
+    expect(createCall!.args.scope).toBe("workspace");
+    expect((createCall!.args.manifest as { name?: string }).name).toBe("new-ws-rule");
+    // Description field is never authored from the UI.
+    expect((createCall!.args.manifest as { description?: string }).description).toBe("");
+    // Type defaults to "context" so the loader picks `loading_strategy:
+    // always` for short prose rules.
+    expect((createCall!.args.manifest as { type?: string }).type).toBe("context");
+  });
+
+  test("initial skills.list fetch is unfiltered by scope", async () => {
+    mounted = await mount(React.createElement(SkillsBrowser, { surface: "workspace" }));
+    const listCall = callToolCalls.find((c) => c.server === "skills" && c.tool === "list");
+    expect(listCall).toBeDefined();
+    expect(listCall!.args.scope).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces a 12-frontmatter-field config panel with a sentence-first On/Off rule surface. Bundles in two server-side simplifications (`SkillStatus` 4→2 values, `skills__move_scope` removal) and an `executeTask` Layer 3 parity fix. Profile tab promoted to a tabbed surface with Skills. Net `+1395 / −1209`, 28 files.

## Major changes

**UI rewrite** — `SkillsTab.tsx`:
- One row per rule, sentence-first label, single On/Off pill at the far right (`skills__activate` / `skills__deactivate`).
- Inline click-to-expand (no two-pane).
- Full-page edit view: Name + Body, Advanced expander with Priority.
- Inherited sections ("From your organization", "From the system") collapse by default, render quieter when ambient.
- Personal-skills footer with `/profile/skills` deep link.
- Skill bodies rendered as markdown via `<Streamdown>` (matches chat surface).
- Aligned to the settings design system: `<SettingsPageHeader>`, `<Section>`, `<Button>`, `max-w-3xl`, `text-sm` / `text-xs` instead of arbitrary `text-[Npx]`.

**Server-side simplifications**:
- `SkillStatus` narrowed: `active | draft | disabled | archived` → `active | disabled`. Legacy values normalise to `disabled` on read (no migration needed).
- `skills__move_scope` removed entirely — tool, handler, schema, privilege gate, feature flag, event-payload action field. Rare power-user op; markdown edit remains.

**Runtime fix** — `runtime.ts:1703`:
- `loadConversationSkills(sessionWsId, ...)` → `loadConversationSkills(focusedWsId ?? sessionWsId, ...)` in `executeTask`, mirroring the `_chatInner` fix. Scheduled tasks focused on a shared workspace were silently dropping every workspace-tier `always` skill.

**Profile / Skills tab**:
- `/profile` promoted to `SettingsShell` with General + Skills tabs.
- `ProfileSkillsTab` wraps `<SkillsBrowser lockedScope="user" />`.
- Workspace footer's "Edit in your profile" links to `/profile/skills`.

## Test plan

- [x] **Server-side coverage**:
  - `test/unit/skills/manifest-extension.test.ts` — three cases pinning the legacy-status normalisation contract: `draft → disabled`, `archived → disabled`, `status: toString` does NOT alias (the `Object.hasOwn` prototype-safety guard).
  - `test/unit/skills/select.test.ts` — stale `draft`/`archived` fixtures replaced with `disabled`.
  - `test/integration/execute-task.test.ts` — regression test plants a workspace skill in a shared workspace, runs `executeTask` focused on that workspace, asserts the skill lands in `skills.loaded`.
- [x] **Web coverage**:
  - `web/test/SkillsBrowser.workspace.test.tsx` — 6 cases incl. update-path regression test (manifest must NOT carry `description`, `type`, `name`, or `loadingStrategy`).
  - `web/test/SkillsBrowser.org.test.tsx` — 3 cases for the org-tier surface.
  - `web/test/ProfileSkillsTab.test.tsx` — 2 cases for the user-tier surface.
  - `web/test/orgRoleGate.test.ts` — unchanged role-gate contract.
- [x] `bun run verify:static` clean
- [x] `bun run test:web` — 469 pass / 0 fail
- [x] Skills slice server tests — 215 pass / 0 fail (`test/unit/skills`, `test/unit/tools/platform`, `test/integration/execute-task.test.ts`, `test/integration/workspace-tier-skills.test.ts`)
- [x] `cd web && bun run build` clean

## Closed in this PR

- PR #347 (`feat/workspace-skills-grouped`) — closed without merge, superseded by this PR.