### PR TITLE
test(oauth): make authorize-probe test hermetic (fix CI flake)

### DIFF
--- a/test/integration/workspace-oauth-provider.test.ts
+++ b/test/integration/workspace-oauth-provider.test.ts
@@ -156,12 +156,29 @@ describe("WorkspaceOAuthProvider — authorize redirect probe (interactive)", ()
   });
 
   it("302 to a non-self-target login page registers flow + fires callback + throws UnauthorizedError", async () => {
+    // The login page is a SECOND loopback mock on its own port — a genuinely
+    // non-self target (the callback lives on :27247) that the probe will
+    // actually fetch. Must stay on loopback: redirecting to a public domain
+    // (e.g. login.example.com) makes the headless probe's hop-1 fetch escape
+    // to the internet, and with no abortSignal in this test it hangs until the
+    // 5s test timeout wherever egress is dropped (CI firewalls DROP, so the
+    // connection never rejects). The 200 login page ends the probe loop
+    // (non-redirect) and the provider falls through to the interactive branch.
+    const loginPage = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("<html>login form</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      },
+    });
     const mockAuthServer = Bun.serve({
       port: 0,
       fetch(_req: Request) {
         return new Response(null, {
           status: 302,
-          headers: { location: "https://login.example.com/authenticate" },
+          headers: { location: `http://localhost:${loginPage.port}/authenticate` },
         });
       },
     });
@@ -196,6 +213,7 @@ describe("WorkspaceOAuthProvider — authorize redirect probe (interactive)", ()
       expect(await pending).toBe("the-code-123");
     } finally {
       mockAuthServer.stop(true);
+      loginPage.stop(true);
     }
   });
 


### PR DESCRIPTION
## Problem

CI intermittently fails on an OAuth integration test timing out — most recently on an unrelated skills-UI PR:

\`\`\`
(fail) WorkspaceOAuthProvider — authorize redirect probe (interactive) >
  302 to a non-self-target login page ... ^ this test timed out after 5000ms.
\`\`\`

It's not a regression in whatever PR happens to trip it — it's a latent flake in the test itself.

## Root cause

The test's mock auth server returns \`302 → https://login.example.com/authenticate\`, a **real public domain**. With \`headlessAuthProbe: true\`, \`redirectToAuthorization\` (\`src/tools/workspace-oauth-provider.ts\`) follows that 302 and does a real \`fetch()\` to the public internet. The test passes **no \`abortSignal\`**, so the fetch has no timeout of its own.

- **Locally it passes** because \`login.example.com\` returns DNS NXDOMAIN in ~26ms.
- **In CI it hangs** because egress is dropped (firewall DROP, not REJECT), so the connection never returns — it sits until the test's own 5000ms timeout fires.

Production is unaffected: the lifecycle always threads a 15s \`abortSignal\` into the probe; only this test left the fetch unbounded.

## Fix

Redirect the probe to a second loopback \`Bun.serve\` mock returning a 200 login page instead of a public domain. It's still a genuinely non-self target (the callback lives on \`:27247\`), so the test's intent is preserved — the probe follows the hop, hits a non-redirect login page, and falls through to the interactive branch — but it never leaves loopback.

## Verification

- \`bun test test/integration/workspace-oauth-provider.test.ts\` → 8 pass, ~56ms (was network-dependent)
- \`bun run test:integration\` → 561 pass, 0 fail
- \`bun run check\` clean