### PR TITLE
fix(identity): configurable WorkOS admin-role slug mapping; preserve app owner across login

### DIFF
--- a/src/identity/instance.ts
+++ b/src/identity/instance.ts
@@ -30,6 +30,16 @@ export interface WorkosAuth {
    * exposes /.well-known/oauth-protected-resource for MCP client discovery.
    */
   authkitDomain?: string;
+  /**
+   * WorkOS organization-membership role slugs that map to the app `admin`
+   * role, matched case-insensitively. Defaults to `["admin", "owner"]` when
+   * omitted. Set this when your WorkOS org's admin role carries a custom slug
+   * (e.g. `org-admin`) — otherwise it silently maps to `member`. Any slug not
+   * listed maps to `member` (and is logged). Note: `owner` is an app-internal
+   * elevation assigned via `manage_users`, not a WorkOS-derived role; listing
+   * an `owner` slug here grants app `admin`, not app `owner`.
+   */
+  adminRoleSlugs?: string[];
 }
 
 export type AuthConfig = OidcAuth | WorkosAuth;
@@ -106,6 +116,16 @@ function validateAuthConfig(raw: unknown): AuthConfig {
         if (typeof auth.authkitDomain !== "string")
           throw new Error("instance.json: workos auth 'authkitDomain' must be a string");
         workos.authkitDomain = auth.authkitDomain as string;
+      }
+      if (auth.adminRoleSlugs !== undefined) {
+        if (
+          !Array.isArray(auth.adminRoleSlugs) ||
+          auth.adminRoleSlugs.some((s) => typeof s !== "string")
+        )
+          throw new Error(
+            "instance.json: workos auth 'adminRoleSlugs' must be an array of strings",
+          );
+        workos.adminRoleSlugs = auth.adminRoleSlugs as string[];
       }
       return workos;
     }

--- a/src/identity/instance.ts
+++ b/src/identity/instance.ts
@@ -32,12 +32,14 @@ export interface WorkosAuth {
   authkitDomain?: string;
   /**
    * WorkOS organization-membership role slugs that map to the app `admin`
-   * role, matched case-insensitively. Defaults to `["admin", "owner"]` when
-   * omitted. Set this when your WorkOS org's admin role carries a custom slug
-   * (e.g. `org-admin`) — otherwise it silently maps to `member`. Any slug not
-   * listed maps to `member` (and is logged). Note: `owner` is an app-internal
-   * elevation assigned via `manage_users`, not a WorkOS-derived role; listing
-   * an `owner` slug here grants app `admin`, not app `owner`.
+   * role, matched case-insensitively. Omit to use the default
+   * `["admin", "owner"]`; an explicit list REPLACES the defaults and must
+   * contain at least one non-empty slug. Set this when your WorkOS org's admin
+   * role carries a custom slug (e.g. `org-admin`) — otherwise it silently maps
+   * to `member`. Any slug not listed maps to `member` (and is logged). Note:
+   * `owner` is an app-internal elevation assigned via `manage_users`, not a
+   * WorkOS-derived role; listing an `owner` slug here grants app `admin`, not
+   * app `owner`.
    */
   adminRoleSlugs?: string[];
 }
@@ -124,6 +126,15 @@ function validateAuthConfig(raw: unknown): AuthConfig {
         )
           throw new Error(
             "instance.json: workos auth 'adminRoleSlugs' must be an array of strings",
+          );
+        // An explicit list replaces the defaults, so an empty or blank-only list
+        // would mean "no slug grants admin" — almost always a mistake (it locks
+        // out every WorkOS admin). Reject it loudly instead of silently falling
+        // back to the defaults; omit the field to use ["admin", "owner"].
+        if ((auth.adminRoleSlugs as string[]).every((s) => s.trim() === ""))
+          throw new Error(
+            "instance.json: workos auth 'adminRoleSlugs' must contain at least one " +
+              'non-empty slug (omit the field to use the default ["admin", "owner"])',
           );
         workos.adminRoleSlugs = auth.adminRoleSlugs as string[];
       }

--- a/src/identity/providers/workos.ts
+++ b/src/identity/providers/workos.ts
@@ -97,6 +97,24 @@ function extractToken(req: Request): string | null {
   return null;
 }
 
+/**
+ * WorkOS role slugs that map to the app `admin` role when the operator hasn't
+ * configured `adminRoleSlugs`. Includes `owner` so a WorkOS org-owner role
+ * lands as app `admin` (the app's `owner` tier is internal — see
+ * `syncLocalProfile`), and so the common case works without configuration.
+ */
+const DEFAULT_ADMIN_ROLE_SLUGS = ["admin", "owner"];
+
+/**
+ * Normalize the configured (or default) admin role slugs into a lowercased
+ * Set for case-insensitive membership tests. Empty/whitespace entries are
+ * dropped; an empty or omitted config falls back to the defaults.
+ */
+function normalizeAdminRoleSlugs(slugs: string[] | undefined): Set<string> {
+  const source = slugs && slugs.length > 0 ? slugs : DEFAULT_ADMIN_ROLE_SLUGS;
+  return new Set(source.map((s) => s.trim().toLowerCase()).filter((s) => s.length > 0));
+}
+
 // ── WorkosIdentityProvider ────────────────────────────────────────
 
 /**
@@ -120,6 +138,7 @@ export class WorkosIdentityProvider implements IdentityProvider {
   private redirectUri: string;
   private organizationId: string | undefined;
   private authkitDomain: string | undefined;
+  private adminRoleSlugs: Set<string>;
   private userStore: UserStore | null;
   private workspaceStore: WorkspaceStore;
 
@@ -150,6 +169,7 @@ export class WorkosIdentityProvider implements IdentityProvider {
     this.redirectUri = config.redirectUri;
     this.organizationId = config.organizationId;
     this.authkitDomain = config.authkitDomain;
+    this.adminRoleSlugs = normalizeAdminRoleSlugs(config.adminRoleSlugs);
     this.userStore = userStore ?? null;
     this.workspaceStore = workspaceStore;
   }
@@ -419,16 +439,24 @@ export class WorkosIdentityProvider implements IdentityProvider {
 
     const existing = await this.userStore.get(workosUserId);
     if (existing) {
+      // `owner` is an app-internal elevation, not a WorkOS-derived role:
+      // `resolveOrgRole` only ever yields "admin"/"member", and only the
+      // guarded `manage_users` path may create or remove an owner. So a
+      // login-time sync must never DOWNGRADE a local owner to a lesser
+      // WorkOS-derived role — otherwise a WorkOS membership change would
+      // silently strip owners and defeat the last-owner invariant (the
+      // sync path bypasses that guard). admin/member still track WorkOS.
+      const effectiveRole: OrgRole = existing.orgRole === "owner" ? "owner" : data.orgRole;
       // Update identity fields from WorkOS, preserve preferences
       if (
         existing.email !== data.email ||
         existing.displayName !== data.displayName ||
-        existing.orgRole !== data.orgRole
+        existing.orgRole !== effectiveRole
       ) {
         await this.userStore.update(workosUserId, {
           email: data.email,
           displayName: data.displayName,
-          orgRole: data.orgRole,
+          orgRole: effectiveRole,
         });
       }
       return existing.preferences;
@@ -453,13 +481,19 @@ export class WorkosIdentityProvider implements IdentityProvider {
   /**
    * Resolve the NimbleBrain OrgRole from WorkOS organization membership.
    *
-   * Queries the WorkOS Organization Membership API for the user's role
-   * in the configured organization. Maps WorkOS role slugs to OrgRole:
-   *   - "admin" → "admin"
-   *   - "member" → "member"
+   * Queries the WorkOS Organization Membership API for the user's role in the
+   * configured organization and maps the role slug to an app OrgRole:
+   *   - slug ∈ `adminRoleSlugs` (default `["admin", "owner"]`, case-insensitive)
+   *     → "admin"
+   *   - any other slug → "member" (logged, so a custom admin slug that should
+   *     have matched is diagnosable instead of silently downgraded)
    *
-   * Returns null if the user has no org membership — this is a security
-   * signal that the user should be denied access.
+   * This NEVER returns "owner": `owner` is an app-internal elevation managed
+   * via `manage_users` and preserved across login by `syncLocalProfile`, not a
+   * WorkOS-derived role. A WorkOS owner-slug role therefore grants app `admin`.
+   *
+   * Returns null if the user has no org membership — a security signal that the
+   * user should be denied access.
    */
   private async resolveOrgRole(workosUserId: string): Promise<OrgRole | null> {
     if (!this.organizationId) return "member";
@@ -479,7 +513,21 @@ export class WorkosIdentityProvider implements IdentityProvider {
       }
 
       const roleSlug = (membership.role as { slug?: string })?.slug;
-      if (roleSlug === "admin") return "admin";
+      const normalized = roleSlug?.trim().toLowerCase();
+      if (normalized && this.adminRoleSlugs.has(normalized)) return "admin";
+      if (normalized && normalized !== "member") {
+        // An unexpected slug that isn't a recognized admin slug and isn't the
+        // ordinary "member" — this is the silent-downgrade trap. Log the actual
+        // slug and the configured set so a misconfigured admin role surfaces in
+        // the logs instead of an invisible "everyone is a member" outcome. The
+        // plain "member" slug is the normal case and is intentionally quiet.
+        // Add the slug to `auth.adminRoleSlugs` to grant admin.
+        console.warn(
+          `[workos] role slug "${roleSlug}" for user=${workosUserId} is not in ` +
+            `adminRoleSlugs [${[...this.adminRoleSlugs].join(", ")}] — mapping to "member". ` +
+            "If this role should be an org admin, add its slug to auth.adminRoleSlugs.",
+        );
+      }
       return "member";
     } catch (err) {
       console.error(

--- a/src/identity/providers/workos.ts
+++ b/src/identity/providers/workos.ts
@@ -390,7 +390,12 @@ export class WorkosIdentityProvider implements IdentityProvider {
       const displayName =
         [workosUser.firstName, workosUser.lastName].filter(Boolean).join(" ") || workosUser.email;
 
-      const preferences = await this.syncLocalProfile(workosUserId, {
+      // The effective role (not the raw `orgRole`) is what gates the live
+      // session: `syncLocalProfile` may preserve a local `owner` that
+      // `resolveOrgRole` can't produce. Building the identity from the raw
+      // value would leave a preserved owner inert (store says owner, session
+      // says member) — see syncLocalProfile's contract.
+      const { preferences, orgRole: effectiveRole } = await this.syncLocalProfile(workosUserId, {
         email: workosUser.email,
         displayName,
         orgRole,
@@ -400,7 +405,7 @@ export class WorkosIdentityProvider implements IdentityProvider {
         id: workosUser.id,
         email: workosUser.email,
         displayName,
-        orgRole,
+        orgRole: effectiveRole,
         preferences,
       };
       this.userCache.set(workosUserId, { identity, fetchedAt: nowMs });
@@ -429,13 +434,18 @@ export class WorkosIdentityProvider implements IdentityProvider {
    * (email, displayName, orgRole) on each login while preserving
    * user-owned data (preferences).
    *
-   * Returns the user's current preferences.
+   * Returns both the user's preferences AND the **effective** org role — the
+   * post-preservation value, which may be `owner` even though `resolveOrgRole`
+   * never yields `owner`. The caller MUST build the live session identity from
+   * this returned role, not from the raw `data.orgRole`; otherwise a preserved
+   * owner exists only in the store and the live session is gated as a lesser
+   * role (store and session disagree).
    */
   private async syncLocalProfile(
     workosUserId: string,
     data: { email: string; displayName: string; orgRole: OrgRole },
-  ): Promise<UserPreferences> {
-    if (!this.userStore) return {};
+  ): Promise<{ preferences: UserPreferences; orgRole: OrgRole }> {
+    if (!this.userStore) return { preferences: {}, orgRole: data.orgRole };
 
     const existing = await this.userStore.get(workosUserId);
     if (existing) {
@@ -459,10 +469,11 @@ export class WorkosIdentityProvider implements IdentityProvider {
           orgRole: effectiveRole,
         });
       }
-      return existing.preferences;
+      return { preferences: existing.preferences, orgRole: effectiveRole };
     }
 
-    // First login — create local profile
+    // First login — create local profile. No existing record means no owner to
+    // preserve, so the effective role is the WorkOS-derived one.
     try {
       const user = await this.userStore.create({
         id: workosUserId,
@@ -470,11 +481,14 @@ export class WorkosIdentityProvider implements IdentityProvider {
         displayName: data.displayName,
         orgRole: data.orgRole,
       });
-      return user.preferences;
+      return { preferences: user.preferences, orgRole: user.orgRole };
     } catch {
-      // UserConflictError — race condition, profile was created between get and create
+      // UserConflictError — race condition, profile was created between get and
+      // create. Preserve the raced record's owner the same way the existing
+      // branch does, so a concurrent login can't strip it either.
       const raced = await this.userStore.get(workosUserId);
-      return raced?.preferences ?? {};
+      const racedRole: OrgRole = raced?.orgRole === "owner" ? "owner" : data.orgRole;
+      return { preferences: raced?.preferences ?? {}, orgRole: racedRole };
     }
   }
 

--- a/src/identity/providers/workos.ts
+++ b/src/identity/providers/workos.ts
@@ -107,12 +107,16 @@ const DEFAULT_ADMIN_ROLE_SLUGS = ["admin", "owner"];
 
 /**
  * Normalize the configured (or default) admin role slugs into a lowercased
- * Set for case-insensitive membership tests. Empty/whitespace entries are
- * dropped; an empty or omitted config falls back to the defaults.
+ * Set for case-insensitive membership tests. Whitespace entries are dropped.
+ * An omitted, empty, or blank-only config falls back to the defaults — the
+ * result is never an empty set, which would mean "no slug grants admin" and
+ * lock out every WorkOS admin. (Config-level empties are already rejected in
+ * `instance.ts`; this is the defense-in-depth invariant for direct callers.)
  */
 function normalizeAdminRoleSlugs(slugs: string[] | undefined): Set<string> {
   const source = slugs && slugs.length > 0 ? slugs : DEFAULT_ADMIN_ROLE_SLUGS;
-  return new Set(source.map((s) => s.trim().toLowerCase()).filter((s) => s.length > 0));
+  const normalized = source.map((s) => s.trim().toLowerCase()).filter((s) => s.length > 0);
+  return new Set(normalized.length > 0 ? normalized : DEFAULT_ADMIN_ROLE_SLUGS);
 }
 
 // ── WorkosIdentityProvider ────────────────────────────────────────
@@ -146,6 +150,13 @@ export class WorkosIdentityProvider implements IdentityProvider {
   private authkitJwksCache: CachedJwks | null = null;
   private userCache = new Map<string, { identity: UserIdentity; fetchedAt: number }>();
   private static USER_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+  /**
+   * Normalized slugs already warned about in `resolveOrgRole`, so an
+   * unrecognized-but-legitimate non-admin slug (e.g. `viewer`) logs once per
+   * process instead of on every login. The diagnostic is the first occurrence;
+   * recurring volume on a busy tenant is not.
+   */
+  private warnedUnmatchedSlugs = new Set<string>();
 
   /** Overridable for testing. */
   fetcher: typeof globalThis.fetch = globalThis.fetch.bind(globalThis);
@@ -529,13 +540,16 @@ export class WorkosIdentityProvider implements IdentityProvider {
       const roleSlug = (membership.role as { slug?: string })?.slug;
       const normalized = roleSlug?.trim().toLowerCase();
       if (normalized && this.adminRoleSlugs.has(normalized)) return "admin";
-      if (normalized && normalized !== "member") {
+      if (normalized && normalized !== "member" && !this.warnedUnmatchedSlugs.has(normalized)) {
         // An unexpected slug that isn't a recognized admin slug and isn't the
         // ordinary "member" — this is the silent-downgrade trap. Log the actual
         // slug and the configured set so a misconfigured admin role surfaces in
         // the logs instead of an invisible "everyone is a member" outcome. The
-        // plain "member" slug is the normal case and is intentionally quiet.
+        // plain "member" slug is the normal case and is intentionally quiet, and
+        // each unmatched slug warns once per process (not per login) so a tenant
+        // with legitimate non-admin slugs (e.g. `viewer`) isn't spammed.
         // Add the slug to `auth.adminRoleSlugs` to grant admin.
+        this.warnedUnmatchedSlugs.add(normalized);
         console.warn(
           `[workos] role slug "${roleSlug}" for user=${workosUserId} is not in ` +
             `adminRoleSlugs [${[...this.adminRoleSlugs].join(", ")}] — mapping to "member". ` +

--- a/test/unit/identity/instance.test.ts
+++ b/test/unit/identity/instance.test.ts
@@ -57,6 +57,39 @@ describe("loadInstanceConfig", () => {
     expect(result).toEqual(config);
   });
 
+  test("loads workos auth with custom adminRoleSlugs", async () => {
+    const config: InstanceConfig = {
+      auth: {
+        adapter: "workos",
+        clientId: "client_123",
+        redirectUri: "http://localhost:3000/v1/auth/callback",
+        organizationId: "org_789",
+        adminRoleSlugs: ["org-admin", "owner"],
+      },
+    };
+    await writeFile(join(workDir, "instance.json"), JSON.stringify(config));
+
+    const result = await loadInstanceConfig(workDir);
+    expect(result).toEqual(config);
+  });
+
+  test("rejects an empty adminRoleSlugs (would lock out every admin)", async () => {
+    await writeFile(
+      join(workDir, "instance.json"),
+      JSON.stringify({
+        auth: {
+          adapter: "workos",
+          clientId: "client_123",
+          redirectUri: "http://localhost:3000/v1/auth/callback",
+          adminRoleSlugs: [],
+        },
+      }),
+    );
+    await expect(loadInstanceConfig(workDir)).rejects.toThrow(
+      "'adminRoleSlugs' must contain at least one",
+    );
+  });
+
   test("returns null when instance.json is missing", async () => {
     const result = await loadInstanceConfig(workDir);
     expect(result).toBeNull();

--- a/test/unit/identity/workos-org-role.test.ts
+++ b/test/unit/identity/workos-org-role.test.ts
@@ -1,0 +1,190 @@
+/**
+ * WorkOS org-role mapping + owner preservation.
+ *
+ * Covers `resolveOrgRole`'s configurable, case-insensitive admin-slug mapping
+ * (the fix for a custom WorkOS admin role slug silently mapping to `member`)
+ * and the rule that a login-time `syncLocalProfile` never downgrades a local
+ * `owner` (so `owner` is a stable app-internal elevation, not clobbered by a
+ * WorkOS membership change).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { WorkosAuth } from "../../../src/identity/instance.ts";
+import { WorkosIdentityProvider } from "../../../src/identity/providers/workos.ts";
+import type { OrgRole } from "../../../src/identity/types.ts";
+import { UserStore } from "../../../src/identity/user.ts";
+import { WorkspaceStore } from "../../../src/workspace/workspace-store.ts";
+
+let workDir: string;
+let userStore: UserStore;
+let workspaceStore: WorkspaceStore;
+
+const BASE_CONFIG: WorkosAuth = {
+  adapter: "workos",
+  clientId: "client_test",
+  redirectUri: "http://localhost/callback",
+  organizationId: "org_test123",
+  apiKey: "sk_test_fake",
+};
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "nb-workos-role-"));
+  userStore = new UserStore(workDir);
+  workspaceStore = new WorkspaceStore(workDir);
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+/**
+ * Build a provider with the WorkOS SDK's org-membership lookup mocked.
+ * `memberships` maps userId → role slug; absence means "no membership".
+ */
+function makeProvider(memberships: Map<string, string>, configOverride?: Partial<WorkosAuth>) {
+  const provider = new WorkosIdentityProvider(
+    { ...BASE_CONFIG, ...configOverride },
+    userStore,
+    workspaceStore,
+  );
+  const workos = (provider as unknown as { workos: Record<string, unknown> }).workos;
+  workos.userManagement = {
+    getUser: async (userId: string) => ({
+      id: userId,
+      email: `${userId}@test.com`,
+      firstName: "Test",
+      lastName: "User",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }),
+    listOrganizationMemberships: async (opts: { userId: string; organizationId: string }) => {
+      const slug = memberships.get(opts.userId);
+      if (!slug) return { data: [] };
+      return {
+        data: [
+          {
+            id: "om_test",
+            userId: opts.userId,
+            organizationId: opts.organizationId,
+            role: { slug },
+            status: "active",
+          },
+        ],
+      };
+    },
+  };
+  return provider;
+}
+
+/** Invoke the private `resolveOrgRole` (mirrors the cast in workos-provisioning.test.ts). */
+function resolveOrgRole(provider: WorkosIdentityProvider, userId: string): Promise<OrgRole | null> {
+  return (
+    provider as unknown as { resolveOrgRole: (id: string) => Promise<OrgRole | null> }
+  ).resolveOrgRole.call(provider, userId);
+}
+
+describe("WorkOS resolveOrgRole slug mapping", () => {
+  it("maps the default 'admin' slug to admin", async () => {
+    const p = makeProvider(new Map([["u", "admin"]]));
+    expect(await resolveOrgRole(p, "u")).toBe("admin");
+  });
+
+  it("maps the default 'owner' slug to admin (owner is app-internal, never WorkOS-derived)", async () => {
+    const p = makeProvider(new Map([["u", "owner"]]));
+    expect(await resolveOrgRole(p, "u")).toBe("admin");
+  });
+
+  it("matches admin slugs case-insensitively", async () => {
+    const p = makeProvider(new Map([["u", "Admin"]]));
+    expect(await resolveOrgRole(p, "u")).toBe("admin");
+  });
+
+  it("maps an unrecognized slug to member and logs the downgrade", async () => {
+    const p = makeProvider(new Map([["u", "org-admin"]]));
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      expect(await resolveOrgRole(p, "u")).toBe("member");
+    } finally {
+      console.warn = original;
+    }
+    // The silent-downgrade trap must be observable: log names the actual slug
+    // and points at the config knob.
+    expect(warnings.some((w) => w.includes("org-admin") && w.includes("adminRoleSlugs"))).toBe(true);
+  });
+
+  it("honors a custom admin slug via adminRoleSlugs config", async () => {
+    const p = makeProvider(new Map([["u", "org-admin"]]), { adminRoleSlugs: ["org-admin"] });
+    expect(await resolveOrgRole(p, "u")).toBe("admin");
+  });
+
+  it("treats an explicit adminRoleSlugs list as the full set (replaces defaults)", async () => {
+    // With a custom list, the built-in 'admin' slug is no longer special — and
+    // the unmatched-slug warning makes that visible in logs.
+    const p = makeProvider(new Map([["u", "admin"]]), { adminRoleSlugs: ["org-admin"] });
+    expect(await resolveOrgRole(p, "u")).toBe("member");
+  });
+
+  it("returns member when no organizationId is configured", async () => {
+    const p = makeProvider(new Map(), { organizationId: undefined });
+    expect(await resolveOrgRole(p, "u")).toBe("member");
+  });
+
+  it("returns null (deny) when the user has no org membership", async () => {
+    const p = makeProvider(new Map());
+    expect(await resolveOrgRole(p, "u")).toBeNull();
+  });
+});
+
+describe("WorkOS syncLocalProfile owner preservation", () => {
+  it("does not downgrade a local owner when WorkOS resolves a lesser role", async () => {
+    await userStore.create({
+      id: "user_owner",
+      email: "owner@test.com",
+      displayName: "Owner",
+      orgRole: "owner",
+    });
+
+    const provider = makeProvider(new Map([["user_owner", "member"]]));
+    const workos = (provider as unknown as { workos: Record<string, unknown> }).workos;
+    (workos.userManagement as Record<string, unknown>).authenticateWithCode = async () => ({
+      accessToken: "tok",
+      refreshToken: "ref",
+      user: { id: "user_owner", email: "owner@test.com", firstName: "Owner", lastName: "" },
+    });
+
+    await provider.exchangeCode("code");
+
+    const profile = await userStore.get("user_owner");
+    expect(profile?.orgRole).toBe("owner");
+  });
+
+  it("still syncs the WorkOS-derived role for a non-owner on login", async () => {
+    await userStore.create({
+      id: "user_member",
+      email: "member@test.com",
+      displayName: "Member",
+      orgRole: "member",
+    });
+
+    const provider = makeProvider(new Map([["user_member", "admin"]]));
+    const workos = (provider as unknown as { workos: Record<string, unknown> }).workos;
+    (workos.userManagement as Record<string, unknown>).authenticateWithCode = async () => ({
+      accessToken: "tok",
+      refreshToken: "ref",
+      user: { id: "user_member", email: "member@test.com", firstName: "Member", lastName: "" },
+    });
+
+    await provider.exchangeCode("code");
+
+    const profile = await userStore.get("user_member");
+    expect(profile?.orgRole).toBe("admin");
+  });
+});

--- a/test/unit/identity/workos-org-role.test.ts
+++ b/test/unit/identity/workos-org-role.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WorkosAuth } from "../../../src/identity/instance.ts";
 import { WorkosIdentityProvider } from "../../../src/identity/providers/workos.ts";
+import type { UserIdentity } from "../../../src/identity/provider.ts";
 import type { OrgRole } from "../../../src/identity/types.ts";
 import { UserStore } from "../../../src/identity/user.ts";
 import { WorkspaceStore } from "../../../src/workspace/workspace-store.ts";
@@ -85,6 +86,16 @@ function resolveOrgRole(provider: WorkosIdentityProvider, userId: string): Promi
   return (
     provider as unknown as { resolveOrgRole: (id: string) => Promise<OrgRole | null> }
   ).resolveOrgRole.call(provider, userId);
+}
+
+/** Invoke the private `resolveUser` to inspect the live session identity it builds. */
+function resolveUser(
+  provider: WorkosIdentityProvider,
+  userId: string,
+): Promise<UserIdentity | null> {
+  return (
+    provider as unknown as { resolveUser: (id: string) => Promise<UserIdentity | null> }
+  ).resolveUser.call(provider, userId);
 }
 
 describe("WorkOS resolveOrgRole slug mapping", () => {
@@ -164,6 +175,23 @@ describe("WorkOS syncLocalProfile owner preservation", () => {
 
     const profile = await userStore.get("user_owner");
     expect(profile?.orgRole).toBe("owner");
+  });
+
+  it("surfaces a preserved owner into the live session identity, not just the store", async () => {
+    // The store record is necessary but not sufficient: authz gates read the
+    // live session `identity.orgRole`. If resolveUser built it from the raw
+    // resolveOrgRole value (member), the preserved owner would be inert.
+    await userStore.create({
+      id: "user_owner",
+      email: "user_owner@test.com",
+      displayName: "Owner",
+      orgRole: "owner",
+    });
+
+    const provider = makeProvider(new Map([["user_owner", "member"]]));
+    const identity = await resolveUser(provider, "user_owner");
+
+    expect(identity?.orgRole).toBe("owner");
   });
 
   it("still syncs the WorkOS-derived role for a non-owner on login", async () => {

--- a/test/unit/identity/workos-org-role.test.ts
+++ b/test/unit/identity/workos-org-role.test.ts
@@ -131,6 +131,30 @@ describe("WorkOS resolveOrgRole slug mapping", () => {
     expect(warnings.some((w) => w.includes("org-admin") && w.includes("adminRoleSlugs"))).toBe(true);
   });
 
+  it("warns at most once per unmatched slug per process", async () => {
+    const p = makeProvider(new Map([["a", "viewer"], ["b", "viewer"]]));
+    let warnCount = 0;
+    const original = console.warn;
+    console.warn = () => {
+      warnCount++;
+    };
+    try {
+      // Two logins carrying the same non-admin slug — only the first should warn.
+      expect(await resolveOrgRole(p, "a")).toBe("member");
+      expect(await resolveOrgRole(p, "b")).toBe("member");
+    } finally {
+      console.warn = original;
+    }
+    expect(warnCount).toBe(1);
+  });
+
+  it("falls back to the defaults when adminRoleSlugs is blank-only (never an empty set)", async () => {
+    // Unreachable via config (instance.ts rejects it) but a latent footgun for
+    // direct construction — the normalized set must never be empty.
+    const p = makeProvider(new Map([["u", "admin"]]), { adminRoleSlugs: ["  "] });
+    expect(await resolveOrgRole(p, "u")).toBe("admin");
+  });
+
   it("honors a custom admin slug via adminRoleSlugs config", async () => {
     const p = makeProvider(new Map([["u", "org-admin"]]), { adminRoleSlugs: ["org-admin"] });
     expect(await resolveOrgRole(p, "u")).toBe("admin");


### PR DESCRIPTION
## Problem

`resolveOrgRole` (the WorkOS provider's external→app role mapping) matched only the **exact** slug `"admin"` → app `admin`, and collapsed everything else to `member`:

```ts
const roleSlug = (membership.role as { slug?: string })?.slug;
if (roleSlug === "admin") return "admin";
return "member";
```

Consequences:

- A WorkOS org whose admin role carries a **custom slug** (e.g. `org-admin`), or differs in case, silently maps every such user to `member` — so the tenant has **no working org admins**, and there is **no log line** explaining the downgrade.
- `owner` is **unreachable** from WorkOS — yet the rest of the platform treats it as first-class (`ORG_ADMIN_ROLES`, the last-owner guards, the `manage_users` enum).
- `syncLocalProfile` overwrites `orgRole` on **every** login, so a `manage_users`-set `owner` is durable on OIDC/dev but **silently reverted** on WorkOS — and the login-sync path bypasses the last-owner guard entirely, so a WorkOS tenant can decay to zero owners.

## Fix

- **`resolveOrgRole`** — match a **configurable, case-insensitive** set of admin slugs (default `["admin", "owner"]`). Any unrecognized non-`member` slug that falls through is **logged** (with the actual slug + the configured set), turning a silent privilege downgrade into a diagnosable one. The normal `member` slug stays quiet.
- **`WorkosAuth.adminRoleSlugs`** — new optional `instance.json` config so operators with custom WorkOS admin slugs map them without a code change. An explicit list replaces the defaults; the unmatched-slug warning makes a forgotten `admin` visible in logs.
- **`syncLocalProfile`** — never **downgrade** a local `owner` on login. `owner` becomes a coherent **app-internal elevation**: created/removed only via the guarded `manage_users` path (which enforces the last-owner invariant), never stripped by a WorkOS membership change. `admin`/`member` continue to track WorkOS.

### Design note

This deliberately keeps `owner` out of the WorkOS-derived set: WorkOS grants `admin`/`member`; `owner` is the app's break-glass tier layered above. A WorkOS owner-slug role therefore grants app `admin` (sane default), and app `owner` is managed in-app. This makes the last-owner guard actually hold on WorkOS tenants.

## Test plan

New `test/unit/identity/workos-org-role.test.ts`:
- default `admin`/`owner` slugs → `admin`; case-insensitive match
- unrecognized slug → `member` **and** logs the downgrade
- custom `adminRoleSlugs` honored; explicit list replaces defaults
- no `organizationId` → `member`; no membership → `null` (deny)
- `syncLocalProfile` preserves a local `owner` when WorkOS reports a lesser role; still syncs `admin`/`member` for non-owners

Existing `workos-provisioning.test.ts` unchanged and green. `bun run verify:static` + `bun run test:unit` pass.