### PR TITLE
refactor(identity): consolidate org-admin role set to single source (#390)

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,3 +1,5 @@
+import { ORG_ADMIN_ROLES, type OrgRole } from "../identity/types.ts";
+
 /**
  * Feature flags for controlling which capabilities are available.
  * Most flags default to true for backward compatibility.
@@ -107,5 +109,7 @@ const ADMIN_ONLY_TOOLS = new Set([
  */
 export function isToolVisibleToRole(toolName: string, orgRole: string | null | undefined): boolean {
   if (!ADMIN_ONLY_TOOLS.has(toolName)) return true;
-  return orgRole === "admin" || orgRole === "owner";
+  // orgRole arrives as a free string from web/API callers; the OrgRole-typed
+  // set needs the narrowing. A non-OrgRole string just misses and returns false.
+  return orgRole != null && ORG_ADMIN_ROLES.has(orgRole as OrgRole);
 }

--- a/src/tools/connector-tools.ts
+++ b/src/tools/connector-tools.ts
@@ -12,6 +12,7 @@ import type { UserConfigFieldDef } from "../config/workspace-credentials.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
 import type { UserIdentity } from "../identity/provider.ts";
+import { ORG_ADMIN_ROLES } from "../identity/types.ts";
 import type { ConnectorCatalogEntry } from "../registries/projection.ts";
 import type { DirectoryEntry } from "../registries/types.ts";
 import type { Runtime } from "../runtime/runtime.ts";
@@ -2197,7 +2198,7 @@ function isWorkspaceAdmin(
   ws: { members?: Array<{ userId: string; role: string }> },
   identity: UserIdentity,
 ): boolean {
-  if (identity.orgRole === "admin" || identity.orgRole === "owner") return true;
+  if (ORG_ADMIN_ROLES.has(identity.orgRole)) return true;
   const members = Array.isArray(ws.members) ? ws.members : [];
   const member = members.find((m) => m.userId === identity.id);
   return member?.role === "admin";

--- a/src/tools/platform/skills.ts
+++ b/src/tools/platform/skills.ts
@@ -25,6 +25,7 @@ import { EventSourcedConversationStore } from "../../conversation/event-sourced-
 import type { ConversationEvent, SkillsLoadedEvent } from "../../conversation/types.ts";
 import { textContent } from "../../engine/content-helpers.ts";
 import type { EventSink, ToolResult } from "../../engine/types.ts";
+import { ORG_ADMIN_ROLES } from "../../identity/types.ts";
 import { getRequestContext } from "../../runtime/request-context.ts";
 import type { Runtime } from "../../runtime/runtime.ts";
 import { parseSkillFile, readSkillMtime } from "../../skills/loader.ts";
@@ -1086,8 +1087,6 @@ interface PermissionDecision {
   allowed: boolean;
   reason?: string;
 }
-
-const ORG_ADMIN_ROLES = new Set(["admin", "owner"]);
 
 type AccessMode = "read" | "write";
 

--- a/src/tools/registry-tools.ts
+++ b/src/tools/registry-tools.ts
@@ -1,6 +1,7 @@
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
 import type { UserIdentity } from "../identity/provider.ts";
+import { ORG_ADMIN_ROLES } from "../identity/types.ts";
 import type { Runtime } from "../runtime/runtime.ts";
 import type { InProcessTool } from "./in-process-app.ts";
 
@@ -60,7 +61,7 @@ export function createManageRegistriesTool(ctx: ManageRegistriesContext): InProc
       // All write actions require an admin caller. Reads above already
       // returned by this point, so the gate is correctly scoped.
       const identity = ctx.getIdentity();
-      if (!identity || (identity.orgRole !== "admin" && identity.orgRole !== "owner")) {
+      if (!identity || !ORG_ADMIN_ROLES.has(identity.orgRole)) {
         return {
           content: textContent("Org admin or owner role required to modify registries."),
           isError: true,

--- a/src/tools/user-tools.ts
+++ b/src/tools/user-tools.ts
@@ -1,6 +1,7 @@
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
 import type { CreateUserResult, IdentityProvider, UserIdentity } from "../identity/provider.ts";
+import { ORG_ADMIN_ROLES } from "../identity/types.ts";
 import type { User, UserStore } from "../identity/user.ts";
 import type { InProcessTool } from "./in-process-app.ts";
 
@@ -15,10 +16,8 @@ export interface ManageUsersContext {
 
 // ── Permission check ──────────────────────────────────────────────
 
-const ADMIN_ROLES = new Set(["admin", "owner"]);
-
 function isAdmin(identity: UserIdentity | null): boolean {
-  return identity !== null && ADMIN_ROLES.has(identity.orgRole);
+  return identity !== null && ORG_ADMIN_ROLES.has(identity.orgRole);
 }
 
 function permissionDenied(): ToolResult {

--- a/src/tools/workspace-mgmt-tools.ts
+++ b/src/tools/workspace-mgmt-tools.ts
@@ -23,10 +23,8 @@ export type ManageMembersContext = ManageWorkspacesContext & { userStore: UserSt
 
 // ── Permission check ──────────────────────────────────────────────
 
-const ADMIN_ROLES = new Set(["admin", "owner"]);
-
 function isAdmin(identity: UserIdentity | null): boolean {
-  return identity !== null && ADMIN_ROLES.has(identity.orgRole);
+  return identity !== null && ORG_ADMIN_ROLES.has(identity.orgRole);
 }
 
 function permissionDenied(): ToolResult {

--- a/test/unit/features.test.ts
+++ b/test/unit/features.test.ts
@@ -63,4 +63,14 @@ describe("isToolVisibleToRole", () => {
 		expect(isToolVisibleToRole("nb__set_model_config", null)).toBe(false);
 		expect(isToolVisibleToRole("nb__search", null)).toBe(true);
 	});
+
+	it("hides admin tools when role is undefined", () => {
+		expect(isToolVisibleToRole("nb__set_model_config", undefined)).toBe(false);
+		expect(isToolVisibleToRole("nb__search", undefined)).toBe(true);
+	});
+
+	it("treats an unrecognized role string as non-admin", () => {
+		expect(isToolVisibleToRole("nb__set_model_config", "superuser")).toBe(false);
+		expect(isToolVisibleToRole("nb__search", "superuser")).toBe(true);
+	});
 });


### PR DESCRIPTION
Closes #390.

## What

The `{admin, owner}` org-admin role set was defined in **six** places using **three** patterns. Every site now references the single canonical `ORG_ADMIN_ROLES` from `src/identity/types.ts`.

### Local redefinitions deleted (used the copy, not the import)
- `src/tools/user-tools.ts` — added import, removed local `ADMIN_ROLES`
- `src/tools/workspace-mgmt-tools.ts` — removed local `ADMIN_ROLES` (this file **already imported** `ORG_ADMIN_ROLES` and used it elsewhere — a half-migration)
- `src/tools/platform/skills.ts` — added import, removed local `ORG_ADMIN_ROLES`

### String-literal comparisons replaced with `.has()`
- `src/config/features.ts` `isToolVisibleToRole` — the highest-leverage site (~21 call sites)
- `src/tools/registry-tools.ts`
- `src/tools/connector-tools.ts` `isWorkspaceAdmin` (org-level check only; the workspace-member fallback is untouched)

## Notes
- `src/identity/types.ts` is unchanged — it was already correct.
- `isToolVisibleToRole` keeps its `(string | null | undefined)` signature (21 call sites). It now null-guards and narrows to `OrgRole` before `.has()`; a non-`OrgRole` string simply misses and returns `false`. A comment names the narrowing per the repo's cast-comment rule.
- Single-role `"owner"` checks (last-owner protection, owner-preservation across login) are intentionally **not** touched — they are not the admin set.

## Behavior

Pure refactor. Every set is `{admin, owner}` today, so results are byte-for-byte identical. Adds `undefined` and unrecognized-role cases to the `features` test to lock the contract the refactor now leans on.

## Verification
- `bun run verify:static` — clean (tsc strict, biome lint + format, cycles, all path/codegen checks)
- Role-gate unit suites pass (features, connector-tools, registry-permission-enforcement, workspace-mgmt-tools, user-tools, skills-mutation, features-identity)
- Natural follow-up to #388.