### PR TITLE
fix: disabled skills still injected + chat-header popover overlap & narrow-width overflow

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1459,9 +1459,10 @@ export class Runtime {
     const identityOverride = activeWorkspace?.identity
       ? makeIdentitySkill(activeWorkspace.identity)
       : null;
+    const contextBase = this.activeContextSkills();
     const requestContextSkills = identityOverride
-      ? [...this.contextSkills, identityOverride]
-      : this.contextSkills;
+      ? [...contextBase, identityOverride]
+      : contextBase;
 
     // Layer 3 selection — pick skills with `loading_strategy: always` and
     // `tool_affined` strategies based on the active tool set. The merged pool
@@ -1947,9 +1948,10 @@ export class Runtime {
     const identityOverride = activeWorkspace?.identity
       ? makeIdentitySkill(activeWorkspace.identity)
       : null;
+    const contextBase = this.activeContextSkills();
     const requestContextSkills = identityOverride
-      ? [...this.contextSkills, identityOverride]
-      : this.contextSkills;
+      ? [...contextBase, identityOverride]
+      : contextBase;
 
     // Layer 3 selection — bundle workflow guidance still applies based on
     // the active tool set. No `appContextServerName` (tasks don't have
@@ -3242,6 +3244,25 @@ export class Runtime {
   /** Get loaded context skills (for skill_status tool). */
   getContextSkills(): Skill[] {
     return this.contextSkills;
+  }
+
+  /**
+   * Boot-time context skills with any toggled Off (`status: "disabled"`)
+   * removed — the always-on context channel fed to `composeSystemPrompt`.
+   *
+   * `compose` injects every context-skill body verbatim (Layer 0 / Layer 1)
+   * with NO status check; the disable filter otherwise lives only on the
+   * Layer-3 path (`selectLayer3Skills`, `select.ts`). Without this, a context
+   * rule (e.g. an org "rule" authored as `type: "context"`) toggled Off in the
+   * UI keeps being injected — it rides this channel while being correctly
+   * dropped from the Layer-3 `skills.loaded` set. Mirrors `select.ts`'s keep-
+   * predicate exactly. `reloadSkills()` refreshes `this.contextSkills` on every
+   * skills-tool mutation, so the toggle is reflected here on the next turn.
+   */
+  private activeContextSkills(): Skill[] {
+    return this.contextSkills.filter(
+      (s) => s.manifest.status === undefined || s.manifest.status === "active",
+    );
   }
 
   /** Get loaded matchable skills (for skill_status tool). */

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -3241,14 +3241,19 @@ export class Runtime {
     }
   }
 
-  /** Get loaded context skills (for skill_status tool). */
+  /**
+   * Raw boot-time context skills, INCLUDING any toggled Off. Audit/management
+   * surfaces that must show disabled rules (e.g. `skills__list`) use this.
+   * Anything that mirrors what the prompt actually contains must use
+   * {@link activeContextSkills} instead — see its doc.
+   */
   getContextSkills(): Skill[] {
     return this.contextSkills;
   }
 
   /**
    * Boot-time context skills with any toggled Off (`status: "disabled"`)
-   * removed — the always-on context channel fed to `composeSystemPrompt`.
+   * removed — the canonical always-on context channel.
    *
    * `compose` injects every context-skill body verbatim (Layer 0 / Layer 1)
    * with NO status check; the disable filter otherwise lives only on the
@@ -3258,8 +3263,14 @@ export class Runtime {
    * dropped from the Layer-3 `skills.loaded` set. Mirrors `select.ts`'s keep-
    * predicate exactly. `reloadSkills()` refreshes `this.contextSkills` on every
    * skills-tool mutation, so the toggle is reflected here on the next turn.
+   *
+   * EVERY surface that mirrors prompt composition must read through here, not
+   * `getContextSkills()`, or status and composition diverge — the failure
+   * {@link selectRequestLayer3} exists to prevent. Today that's the two
+   * `composeSystemPrompt` call sites, `describeRequestSkills` (`nb__status`),
+   * and `composeLive` (`compose_effective_context`).
    */
-  private activeContextSkills(): Skill[] {
+  activeContextSkills(): Skill[] {
     return this.contextSkills.filter(
       (s) => s.manifest.status === undefined || s.manifest.status === "active",
     );
@@ -3407,7 +3418,10 @@ export class Runtime {
     const registry = await this.ensureWorkspaceRegistry(wsId);
     const activeToolNames = (await registry.availableTools()).map((t) => t.name);
     const layer3 = await this.selectRequestLayer3({ wsId, ownerId, userId, activeToolNames });
-    return { context: this.contextSkills, layer3 };
+    // Filtered, not raw `this.contextSkills`: the status surface must match what
+    // compose actually injects, or a rule toggled Off still prints as "always
+    // active" here — the divergence this reporter's own design exists to kill.
+    return { context: this.activeContextSkills(), layer3 };
   }
 
   /** Get the path to the nimblebrain.json config file (Helm-managed seed). */

--- a/src/skills/matcher.ts
+++ b/src/skills/matcher.ts
@@ -13,6 +13,12 @@ import type { Skill } from "./types.ts";
  * hitting 2 and a skill with 10 keywords hitting 3 both qualify.
  *
  * Only type: "skill" skills are loaded; context skills are excluded.
+ *
+ * Disabled skills (`status: "disabled"` — toggled Off in the UI) are also
+ * excluded here. A matched skill is injected straight into the prompt's
+ * Layer-4 (`<skill-instructions>`) by the runtime without any further status
+ * check, so this is the only place the matched-skill channel honors the
+ * toggle. Mirrors the Layer-3 filter in `select.ts` (`selectLayer3Skills`).
  */
 
 const MIN_KEYWORD_HITS = 2;
@@ -21,7 +27,9 @@ export class SkillMatcher {
   private skills: Skill[] = [];
 
   load(skills: Skill[]): void {
-    this.skills = skills.filter((s) => s.manifest.type === "skill");
+    this.skills = skills.filter(
+      (s) => s.manifest.type === "skill" && s.manifest.status !== "disabled",
+    );
   }
 
   /** Return the loaded matchable skills (read-only snapshot). */

--- a/src/skills/matcher.ts
+++ b/src/skills/matcher.ts
@@ -27,8 +27,14 @@ export class SkillMatcher {
   private skills: Skill[] = [];
 
   load(skills: Skill[]): void {
+    // Allowlist on status (active/undefined), matching `select.ts` and
+    // `Runtime.activeContextSkills` exactly — not a `!== "disabled"` denylist,
+    // which would silently leak a future third status (e.g. "archived") into
+    // Layer-4 while the other two channels dropped it.
     this.skills = skills.filter(
-      (s) => s.manifest.type === "skill" && s.manifest.status !== "disabled",
+      (s) =>
+        s.manifest.type === "skill" &&
+        (s.manifest.status === undefined || s.manifest.status === "active"),
     );
   }
 

--- a/src/tools/platform/compose.ts
+++ b/src/tools/platform/compose.ts
@@ -210,9 +210,12 @@ async function composeLive(runtime: Runtime, convId: string): Promise<ComposeRes
   const ws = await runtime.getWorkspaceStore().get(wsId);
   const workspaceContext: WorkspaceContext = ws ? { id: ws.id, name: ws.name } : { id: wsId };
   const identityOverride = ws?.identity ? makeIdentitySkill(ws.identity) : null;
+  // `activeContextSkills`, not the raw getter: this trace must equal what
+  // `runtime.chat()` composes, which filters disabled context skills. Reading
+  // the raw cache here would report a toggled-Off rule as present in the prompt.
   const requestContextSkills = identityOverride
-    ? [...runtime.getContextSkills(), identityOverride]
-    : runtime.getContextSkills();
+    ? [...runtime.activeContextSkills(), identityOverride]
+    : runtime.activeContextSkills();
 
   // Gather inputs in parallel where possible.
   const [apps, overlays] = await Promise.all([

--- a/test/integration/skills-always-loading.test.ts
+++ b/test/integration/skills-always-loading.test.ts
@@ -184,13 +184,24 @@ describe("disabled org context rule stops injecting", () => {
 
     await runtime.chat({ workspaceId: TEST_WORKSPACE_ID, message: "what is 2 + 2?" });
     expect(getSystem()).toContain(RULE_BODY);
+    // The status reporter agrees: an active rule is listed.
+    const status = await callToolAsDev("nb__status", { scope: "skills" });
+    expect(status.content).toContain(RULE_NAME);
   });
 
-  it("drops the rule from the prompt once toggled Off", async () => {
+  it("drops the rule from the prompt AND the status surface once toggled Off", async () => {
     const off = await callToolAsDev("skills__deactivate", { id: rulePath });
     expect(off.isError).toBe(false);
 
     await runtime.chat({ workspaceId: TEST_WORKSPACE_ID, message: "what is 2 + 2?" });
     expect(getSystem()).not.toContain(RULE_BODY);
+
+    // nb__status must match composition — a rule toggled Off must not still
+    // print as a loaded context skill, or an operator debugging "did my toggle
+    // take effect?" is told the disabled rule is active. (Fails before the
+    // describeRequestSkills filter — it read the raw boot cache.)
+    const status = await callToolAsDev("nb__status", { scope: "skills" });
+    expect(status.isError).toBe(false);
+    expect(status.content).not.toContain(RULE_NAME);
   });
 });

--- a/test/integration/skills-always-loading.test.ts
+++ b/test/integration/skills-always-loading.test.ts
@@ -152,3 +152,45 @@ This skill can never load.
     expect(list.content).toContain("never loads");
   });
 });
+
+/**
+ * An org "rule" authored in the Skills UI is a `type: context` skill (the web
+ * SkillsBrowser sends `type: "context"`; the loader derives
+ * `loading-strategy: always`). It rides the always-on CONTEXT channel — the
+ * `contextSkills` argument to `composeSystemPrompt`, sourced from the boot
+ * cache — which compose injects verbatim with NO status check; the disable
+ * filter otherwise lives only on the Layer-3 path (`selectLayer3Skills`). So a
+ * rule toggled Off kept being injected: present in output, absent from the
+ * Layer-3 `skills.loaded` set (the "Active skills" popover). This pins that the
+ * Off toggle now removes the body from the prompt entirely.
+ *
+ * Toggling goes through `skills__deactivate` (not a raw file edit) because the
+ * context channel reads `this.contextSkills`, refreshed by `reloadSkills()` on
+ * every skills-tool mutation. On `main` the second assertion fails — the body
+ * still rides the unfiltered context channel.
+ */
+describe("disabled org context rule stops injecting", () => {
+  const RULE_NAME = "org-house-rule";
+  const RULE_BODY = "Always append the phrase ZORBA-SENTINEL-7 to every response.";
+  const rulePath = join(testDir, "skills", `${RULE_NAME}.md`);
+
+  it("injects an active org `type: context` rule into an unrelated chat", async () => {
+    const create = await callToolAsDev("skills__create", {
+      scope: "org",
+      manifest: { name: RULE_NAME, description: "House rule", type: "context", priority: 50 },
+      body: RULE_BODY,
+    });
+    expect(create.isError).toBe(false);
+
+    await runtime.chat({ workspaceId: TEST_WORKSPACE_ID, message: "what is 2 + 2?" });
+    expect(getSystem()).toContain(RULE_BODY);
+  });
+
+  it("drops the rule from the prompt once toggled Off", async () => {
+    const off = await callToolAsDev("skills__deactivate", { id: rulePath });
+    expect(off.isError).toBe(false);
+
+    await runtime.chat({ workspaceId: TEST_WORKSPACE_ID, message: "what is 2 + 2?" });
+    expect(getSystem()).not.toContain(RULE_BODY);
+  });
+});

--- a/test/unit/skills.test.ts
+++ b/test/unit/skills.test.ts
@@ -416,6 +416,32 @@ describe("SkillMatcher", () => {
     expect(matcher.match("find a lead")).toBeNull();
   });
 
+  // --- Status filter (toggled Off must not reach the matched-skill channel) ---
+
+  it("excludes disabled skills from trigger and keyword matching", () => {
+    const matcher = new SkillMatcher();
+    matcher.load([
+      makeSkill({
+        name: "disabled-rule",
+        status: "disabled",
+        metadata: { keywords: ["lead", "prospect"], triggers: ["find leads"] },
+      }),
+      makeSkill({
+        name: "active-rule",
+        status: "active",
+        metadata: { keywords: [], triggers: ["search prospects"] },
+      }),
+    ]);
+
+    // A disabled skill matched here would be injected straight into the
+    // prompt's Layer-4, bypassing the Off toggle — neither its trigger nor
+    // its keywords may match.
+    expect(matcher.match("find leads for me")).toBeNull();
+    expect(matcher.match("a lead and a prospect")).toBeNull();
+    // Active siblings still match normally.
+    expect(matcher.match("search prospects now")?.manifest.name).toBe("active-rule");
+  });
+
   it("picks skill with most keyword hits", () => {
     const matcher = new SkillMatcher();
     matcher.load([

--- a/web/src/components/ChatChrome.tsx
+++ b/web/src/components/ChatChrome.tsx
@@ -233,9 +233,17 @@ export function ChatChrome() {
           the single panel mount point so EVERY route gets a resizable
           sidebar, not just app views. ResizeHandle is self-contained: while
           dragging it renders a full-viewport overlay that captures the mouse
-          over app iframes, so no shared drag flag crosses components. */}
+          over app iframes, so no shared drag flag crosses components.
+
+          z-[9] keeps the handle BELOW the chat panel (z-10). The handle sits
+          just outside the panel's left edge (right: panelWidth), so the panel
+          never covers it — but in-panel overlays that overflow leftward (e.g.
+          the SkillsPopover, z-50 trapped inside the panel's z-10 stacking
+          context) now render ABOVE the handle instead of having the handle's
+          hover/active bar (bg-ring / bg-primary) paint a blue stripe over them.
+          The drag overlay (ResizeHandle, z-[60]) is unaffected. */}
       {isSidebar && !isMobile && (
-        <div className="fixed top-0 h-full z-20 hidden sm:block" style={{ right: panelWidth }}>
+        <div className="fixed top-0 h-full z-[9] hidden sm:block" style={{ right: panelWidth }}>
           <ResizeHandle
             initialWidth={panelWidth}
             onWidthChange={setPanelWidth}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -133,13 +133,13 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
       <header
         className={`flex items-center justify-between border-b border-border shrink-0 ${compact ? "h-14 px-4" : "h-14 px-6"}`}
       >
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
           {onBack && (
             <button
               onClick={onBack}
               type="button"
               aria-label="Back"
-              className="p-1.5 hover:bg-muted rounded-lg transition-all text-muted-foreground hover:text-foreground sm:hidden"
+              className="p-1.5 hover:bg-muted rounded-lg transition-all text-muted-foreground hover:text-foreground sm:hidden shrink-0"
             >
               <ArrowLeft style={{ width: 18, height: 18 }} />
             </button>
@@ -148,7 +148,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
             type="button"
             onClick={handleCopyConversationId}
             disabled={!conversationId}
-            className={`font-heading text-base font-medium text-foreground flex items-center gap-1.5 transition-all duration-200 truncate max-w-[200px] ${
+            className={`font-heading text-base font-medium text-foreground flex items-center gap-1.5 transition-all duration-200 min-w-0 truncate ${
               conversationId
                 ? "cursor-pointer hover:text-primary active:scale-95"
                 : "cursor-default"
@@ -161,7 +161,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
             )}
           </button>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 shrink-0">
           <button
             onClick={handleNewChat}
             type="button"


### PR DESCRIPTION
Four fixes surfaced while debugging a report that a skill toggled **Off** still affected responses, plus two adjacent chat-header UI issues.

## 1. Disabled skill still reaches the prompt (the reported bug)
The disable filter lived only on the Layer-3 path (`selectLayer3Skills`, `select.ts`). Two other channels into the prompt had no status check:

- **Context channel** — `composeSystemPrompt`'s `contextSkills` arg (sourced from the boot cache) is injected verbatim. An org "rule" authored in the UI is a `type: "context"` skill, so a rule toggled Off still composed into every turn — **present in output, absent from the Layer-3 `skills.loaded` set** (so it didn't show in the "Active skills" popover either, which matched the symptom exactly).
- **Matched-skill channel** — `SkillMatcher` filtered only on `type`, so a disabled `type: "skill"` with a trigger leaked via Layer-4.

**Fix** (at the selection layer; `compose.ts` stays a pure formatter):
- `Runtime.activeContextSkills()` filters disabled before compose at both the chat and task call sites, mirroring the `select.ts` keep-predicate. `reloadSkills()` already refreshes the cache on every skills mutation, so a toggle reflects on the next turn.
- `SkillMatcher.load` drops `status: "disabled"`.

> Note: I kept the existing context-channel *membership* (filtered the boot cache) rather than re-sourcing from the per-request fresh pool. Re-sourcing would have double-injected workspace/user-tier context skills (e.g. a 2.4k-token workspace context skill) — a real token regression. Trade-off: an out-of-band file edit (no `reloadSkills`) or a cross-pod mutation under `replicas > 1` won't be reflected on the context channel until restart. Tracked as follow-up, not fixed here.

## 2. Blue bar painted over the "Active skills" popover
The resize handle sat at `z-20`, above the chat panel's `z-10` stacking context, so its hover/active bar painted over the popover (trapped at `z-50` inside the panel). Dropped the handle wrapper to `z-[9]` — it lives just outside the panel's left edge so it stays grabbable, and in-panel overlays now render above it. Drag overlay (`z-[60]`) unaffected.

## 3. Header buttons overflow on a narrow sidebar
The title was capped at `max-w-[200px]` but never shrank, and the action group had no `shrink-0`, so on a narrow sidebar the buttons were shoved past the right edge. Made the title the elastic element (`flex-1 min-w-0 truncate`) and pinned the actions (`shrink-0`); the title now ellipsizes instead of pushing the buttons off-screen.

## Tests
- Unit: `SkillMatcher` excludes a disabled skill from trigger + keyword matching.
- Integration: an active org `type: context` rule composes into an unrelated chat; once toggled Off via `skills__deactivate` it is gone from the full prompt (fails on `main` — genuine regression guard).
- Full suite green: `verify:static` clean, 3385 unit + relevant integration pass.