### PR TITLE
feat(connectors): move Zoom to Composio-managed OAuth

### DIFF
--- a/src/connectors/catalog.yaml
+++ b/src/connectors/catalog.yaml
@@ -670,20 +670,28 @@ servers:
 
   - name: us.zoom/mcp
     title: Zoom
-    description: Meetings, recordings, contacts
+    description: Meetings, recordings, contacts (via Composio)
     version: "1.0.0"
     icons:
       - src: https://static.nimblebrain.ai/icons/zoom.png
         sizes: ["any"]
     remotes:
       - type: streamable-http
-        url: https://mcp.zoom.us/mcp
+        url: https://backend.composio.dev/v3/mcp
     _meta:
       ai.nimblebrain/connector:
-        auth: static
-        requiredScopes: [meeting:read, recording:read]
-        operatorSetup:
-          portalUrl: https://marketplace.zoom.us/develop/create
-          hint: Create an OAuth User-Managed app in Zoom Marketplace; add scopes; copy client_id + client_secret
-          clientSecretKey: zoom.client_secret
-        tags: [meetings, video]
+        auth: composio
+        composio:
+          toolkit: zoom
+          authConfigEnv: COMPOSIO_ZOOM_AUTH_CONFIG_ID
+          tools:
+            - ZOOM_LIST_MEETINGS
+            - ZOOM_GET_MEETING
+            - ZOOM_GET_MEETING_RECORDINGS
+            - ZOOM_LIST_ALL_RECORDINGS
+            - ZOOM_GET_MEETING_SUMMARY
+            - ZOOM_GET_PAST_MEETING_PARTICIPANTS
+            - ZOOM_LIST_PAST_MEETING_INSTANCES
+            - ZOOM_GET_USER
+            - ZOOM_SEARCH_COMPANY_CONTACTS
+        tags: [meetings, video, composio]


### PR DESCRIPTION
## What

Converts the Zoom connector (`us.zoom/mcp`) from `auth: static` (bring-your-own OAuth app, per workspace) to `auth: composio` (one-click Connect, provisioned once platform-wide).

## Why

Zoom was the last meetings connector still on `auth: static`. Operator OAuth credentials for static connectors are **workspace-scoped** (`workspace.json#oauthOperatorApps[zoom]` + per-workspace credential store at `zoom.client_secret`, see `connector-tools.ts:1073,1080`). So a Zoom OAuth app set up in one workspace never carried to another — every tenant hit the "Set up Zoom → create a Marketplace app, paste client_id/secret" modal from scratch. That's the "works in workspace A, not workspace B" symptom.

Moving to Composio matches Slack / Gmail / Google Calendar / GitHub / etc.: the OAuth app is created once in the Composio dashboard, and every workspace gets one-click Connect with no per-workspace setup.

## Changes

- `src/connectors/catalog.yaml`: Zoom entry → `auth: composio`, `toolkit: zoom`, `authConfigEnv: COMPOSIO_ZOOM_AUTH_CONFIG_ID`, remote repointed to `https://backend.composio.dev/v3/mcp`, curated read-focused tool allowlist (list/get meetings, recordings, summaries, participants, user, contacts) mirroring the prior `meeting:read` / `recording:read` scopes.

## Deploy dependencies (must land before/with this ships)

1. **1Password** — `auth-config-zoom` field added to the `composio` item in each env vault (done in staging/prod).
2. **Infra** — `COMPOSIO_ZOOM_AUTH_CONFIG_ID` line added to `infra/.../composio-cluster-external-secret.yaml` (separate change in the `infra` submodule); `kubectl apply` per cluster so every tenant namespace gets the env var.
3. **Composio dashboard** — Zoom auth config (`ac_…`) backed by a real Zoom Marketplace OAuth app.

Until the env var is present in a namespace, install hard-errors by design (`connector-tools.ts:973`).

## Tests

`bun test` catalog + composio-install suites pass (46 tests). Note: the `tools:` slugs were sourced from Composio's published Zoom toolkit docs; an incorrect slug silently drops that one action rather than breaking the connector.