### PR TITLE
feat(connectors): Composio batch — Gmail dedupe, HubSpot, Zoho CRM, Google Workspace

### DIFF
--- a/src/connectors/catalog.yaml
+++ b/src/connectors/catalog.yaml
@@ -600,50 +600,174 @@ servers:
             - WHATSAPP_UPLOAD_MEDIA
         tags: [messaging, composio]
 
-  # ── Member-scoped (personal account per user) ─────────────────
-  - name: com.google.gmail/mcp
-    title: Gmail
-    description: Read, send, label your email
-    version: "1.0.0"
+  - name: com.zoho/crm
+    title: Zoho CRM
+    description: Contacts, leads, deals, and modules (via Composio)
+    version: "0.1.0"
     icons:
-      - src: https://static.nimblebrain.ai/icons/gmail.png
+      - src: https://static.nimblebrain.ai/icons/zoho.png
         sizes: ["any"]
     remotes:
       - type: streamable-http
-        url: https://gmailmcp.googleapis.com/mcp/v1
+        url: https://backend.composio.dev/v3/mcp
     _meta:
       ai.nimblebrain/connector:
-        auth: static
-        requiredScopes:
-          - https://www.googleapis.com/auth/gmail.readonly
-          - https://www.googleapis.com/auth/gmail.send
-        additionalAuthorizationParams:
-          access_type: offline
-          prompt: consent
-        operatorSetup:
-          portalUrl: https://console.cloud.google.com/apis/credentials
-          hint: Create an OAuth 2.0 Client ID (web application) in Google Cloud Console; add the NimbleBrain callback URL as an authorized redirect URI
-          clientSecretKey: google.client_secret
-        tags: [email, google]
+        auth: composio
+        composio:
+          toolkit: zoho
+          authConfigEnv: COMPOSIO_ZOHO_AUTH_CONFIG_ID
+          tools:
+            - ZOHO_GET_ZOHO_RECORDS
+            - ZOHO_SEARCH_ZOHO_RECORDS
+            - ZOHO_CREATE_ZOHO_RECORD
+            - ZOHO_UPDATE_ZOHO_RECORD
+            - ZOHO_CONVERT_ZOHO_LEAD
+            - ZOHO_LIST_MODULES
+            - ZOHO_GET_MODULE_FIELDS
+            - ZOHO_GET_RELATED_RECORDS
+            - ZOHO_GET_ZOHO_USERS
+            - ZOHO_CREATE_ZOHO_TAG
+        tags: [crm, sales, composio]
+
+  - name: com.google/drive
+    title: Google Drive
+    description: Find, read, and manage Drive files (via Composio)
+    version: "0.1.0"
+    icons:
+      - src: https://static.nimblebrain.ai/icons/googledrive.png
+        sizes: ["any"]
+    remotes:
+      - type: streamable-http
+        url: https://backend.composio.dev/v3/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: googledrive
+          authConfigEnv: COMPOSIO_GOOGLEDRIVE_AUTH_CONFIG_ID
+          tools:
+            - GOOGLEDRIVE_FIND_FILE
+            - GOOGLEDRIVE_LIST_FILES
+            - GOOGLEDRIVE_GET_FILE_METADATA
+            - GOOGLEDRIVE_DOWNLOAD_FILE
+            - GOOGLEDRIVE_CREATE_FILE_FROM_TEXT
+            - GOOGLEDRIVE_CREATE_FOLDER
+            - GOOGLEDRIVE_FIND_FOLDER
+            - GOOGLEDRIVE_CREATE_PERMISSION
+            - GOOGLEDRIVE_COPY_FILE_ADVANCED
+            - GOOGLEDRIVE_MOVE_FILE
+        tags: [files, google, composio]
+
+  - name: com.google/sheets
+    title: Google Sheets
+    description: Read and write spreadsheet data (via Composio)
+    version: "0.1.0"
+    icons:
+      - src: https://static.nimblebrain.ai/icons/googlesheets.png
+        sizes: ["any"]
+    remotes:
+      - type: streamable-http
+        url: https://backend.composio.dev/v3/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: googlesheets
+          authConfigEnv: COMPOSIO_GOOGLESHEETS_AUTH_CONFIG_ID
+          tools:
+            - GOOGLESHEETS_GET_SPREADSHEET_INFO
+            - GOOGLESHEETS_BATCH_GET
+            - GOOGLESHEETS_VALUES_UPDATE
+            - GOOGLESHEETS_BATCH_UPDATE
+            - GOOGLESHEETS_SPREADSHEETS_VALUES_APPEND
+            - GOOGLESHEETS_CLEAR_VALUES
+            - GOOGLESHEETS_CREATE_GOOGLE_SHEET1
+            - GOOGLESHEETS_ADD_SHEET
+            - GOOGLESHEETS_GET_SHEET_NAMES
+        tags: [productivity, google, composio]
+
+  - name: com.google/docs
+    title: Google Docs
+    description: Create, read, and edit documents (via Composio)
+    version: "0.1.0"
+    icons:
+      - src: https://static.nimblebrain.ai/icons/googledocs.png
+        sizes: ["any"]
+    remotes:
+      - type: streamable-http
+        url: https://backend.composio.dev/v3/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: googledocs
+          authConfigEnv: COMPOSIO_GOOGLEDOCS_AUTH_CONFIG_ID
+          tools:
+            - GOOGLEDOCS_CREATE_DOCUMENT
+            - GOOGLEDOCS_CREATE_DOCUMENT_MARKDOWN
+            - GOOGLEDOCS_GET_DOCUMENT_BY_ID
+            - GOOGLEDOCS_GET_DOCUMENT_PLAINTEXT
+            - GOOGLEDOCS_SEARCH_DOCUMENTS
+            - GOOGLEDOCS_INSERT_TEXT_ACTION
+            - GOOGLEDOCS_REPLACE_ALL_TEXT
+            - GOOGLEDOCS_UPDATE_DOCUMENT_MARKDOWN
+            - GOOGLEDOCS_COPY_DOCUMENT
+            - GOOGLEDOCS_EXPORT_DOCUMENT_AS_PDF
+        tags: [productivity, google, composio]
+
+  - name: com.google/slides
+    title: Google Slides
+    description: Create and edit presentations (via Composio)
+    version: "0.1.0"
+    icons:
+      - src: https://static.nimblebrain.ai/icons/googleslides.png
+        sizes: ["any"]
+    remotes:
+      - type: streamable-http
+        url: https://backend.composio.dev/v3/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: googleslides
+          authConfigEnv: COMPOSIO_GOOGLESLIDES_AUTH_CONFIG_ID
+          tools:
+            - GOOGLESLIDES_CREATE_PRESENTATION
+            - GOOGLESLIDES_CREATE_SLIDES_MARKDOWN
+            - GOOGLESLIDES_PRESENTATIONS_GET
+            - GOOGLESLIDES_PRESENTATIONS_PAGES_GET
+            - GOOGLESLIDES_PRESENTATIONS_BATCH_UPDATE
+            - GOOGLESLIDES_PRESENTATIONS_COPY_FROM_TEMPLATE
+            - GOOGLESLIDES_GET_PAGE_THUMBNAIL2
+        tags: [productivity, google, composio]
 
   - name: com.hubspot/mcp
     title: HubSpot
-    description: CRM contacts, deals, and pipeline
+    description: CRM contacts, deals, and pipeline (via Composio)
     version: "1.0.0"
     icons:
       - src: https://static.nimblebrain.ai/icons/hubspot.png
         sizes: ["any"]
     remotes:
       - type: streamable-http
-        url: https://mcp.hubspot.com
+        url: https://backend.composio.dev/v3/mcp
     _meta:
       ai.nimblebrain/connector:
-        auth: static
-        operatorSetup:
-          portalUrl: https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server
-          hint: Create an MCP Auth App in HubSpot Developer Portal; copy client_id + client_secret
-          clientSecretKey: hubspot.client_secret
-        tags: [crm, sales]
+        auth: composio
+        composio:
+          toolkit: hubspot
+          authConfigEnv: COMPOSIO_HUBSPOT_AUTH_CONFIG_ID
+          # HubSpot publishes 200+ verbose tool slugs — curate tightly.
+          # Slugs from Composio's published catalog; verify the live set
+          # with `nb__search hubspot` and expand as needs surface.
+          tools:
+            - HUBSPOT_SEARCH_CONTACTS_BY_CRITERIA
+            - HUBSPOT_GET_CONTACTS
+            - HUBSPOT_CREATE_CONTACT
+            - HUBSPOT_CREATE_DEAL
+            - HUBSPOT_CREATE_COMPANY
+            - HUBSPOT_BATCH_READ_COMPANIES_BY_PROPERTIES
+        tags: [crm, sales, composio]
 
   - name: com.microsoft.outlook/mcp
     title: Outlook


### PR DESCRIPTION
## What

A batch of connector catalog changes moving more integrations onto Composio-managed OAuth (one-click Connect, provisioned once platform-wide):

| Connector | Change |
|---|---|
| **Gmail** | Delete the leftover **static** `com.google.gmail/mcp`. The Composio Gmail (`com.google/gmail`) already exists — the static entry was a duplicate "Gmail" card requiring per-workspace BYO-OAuth setup. |
| **HubSpot** | Convert `com.hubspot/mcp` from `auth: static` → `auth: composio` (toolkit `hubspot`). |
| **Zoho CRM** | New connector `com.zoho/crm` (toolkit `zoho`). |
| **Google Drive / Sheets / Docs / Slides** | New connectors (toolkits `googledrive`, `googlesheets`, `googledocs`, `googleslides`). |

Each new/converted entry carries a curated tool allowlist (Composio toolkits publish dozens–hundreds of actions; exposing all blows up tool-search context).

## Depends on

- **infra** NimbleBrainInc/infra#28 — adds `COMPOSIO_{HUBSPOT,ZOHO,GOOGLEDRIVE,GOOGLESHEETS,GOOGLEDOCS,GOOGLESLIDES}_AUTH_CONFIG_ID` to the shared ExternalSecret.
- **1Password** — `auth-config-{hubspot,zoho,googledrive,googlesheets,googledocs,googleslides}` fields added to the `composio` item (done, placeholder values pending real `ac_…` ids).
- **Composio dashboard** — an auth config per toolkit, each backed by the appropriate OAuth app.

Until the env var + real auth config exist, install hard-errors by design.

## Review notes / risks

- **Tool slugs** were sourced from Composio's published toolkit docs via a summarizer, not the live API. A wrong slug **silently drops that one tool** (the allowlist filters against what Composio returns) — it does not break the connector. Recommend a pass with `nb__search <toolkit>` against a configured instance to confirm/expand each list. HubSpot's list is deliberately small (its slugs are long and verbose; I kept only confirmed ones).
- **Icons** — the new entries reference `static.nimblebrain.ai/icons/{zoho,googledrive,googlesheets,googledocs,googleslides}.png`. Confirm these assets exist in the static bucket or upload them, else the directory cards render a broken icon.
- **Outlook** has the *same* latent duplicate as Gmail did (`com.microsoft/outlook` composio + `com.microsoft.outlook/mcp` static). Left untouched — not in scope — but worth a follow-up.

## Tests

`bun test` catalog + connector-directory + composio-install suites pass (60 tests). Zoom (`#397`) is a separate, independently-mergeable PR.