### PR TITLE
fix(connectors): correct invalid Composio tool slugs (Zoom, Box, HubSpot)

### DIFF
--- a/src/connectors/catalog.yaml
+++ b/src/connectors/catalog.yaml
@@ -387,7 +387,6 @@ servers:
             - BOX_UPDATE_FILE
             - BOX_DELETE_FILE
             - BOX_COPY_FILE
-            - BOX_MOVE_FILE
             - BOX_CREATE_FOLDER
             - BOX_GET_FOLDER
             - BOX_LIST_ITEMS_IN_FOLDER
@@ -762,7 +761,7 @@ servers:
           # with `nb__search hubspot` and expand as needs surface.
           tools:
             - HUBSPOT_SEARCH_CONTACTS_BY_CRITERIA
-            - HUBSPOT_GET_CONTACTS
+            - HUBSPOT_LIST_CONTACTS
             - HUBSPOT_CREATE_CONTACT
             - HUBSPOT_CREATE_DEAL
             - HUBSPOT_CREATE_COMPANY

--- a/src/connectors/catalog.yaml
+++ b/src/connectors/catalog.yaml
@@ -810,10 +810,10 @@ servers:
           authConfigEnv: COMPOSIO_ZOOM_AUTH_CONFIG_ID
           tools:
             - ZOOM_LIST_MEETINGS
-            - ZOOM_GET_MEETING
+            - ZOOM_GET_A_MEETING
             - ZOOM_GET_MEETING_RECORDINGS
             - ZOOM_LIST_ALL_RECORDINGS
-            - ZOOM_GET_MEETING_SUMMARY
+            - ZOOM_GET_A_MEETING_SUMMARY
             - ZOOM_GET_PAST_MEETING_PARTICIPANTS
             - ZOOM_LIST_PAST_MEETING_INSTANCES
             - ZOOM_GET_USER


### PR DESCRIPTION
## What

Fixes invalid Composio tool slugs across the connector catalog, found by auditing **all 16 Composio connectors** against the real install gate.

| Connector | Change |
|---|---|
| `us.zoom/mcp` | `ZOOM_GET_MEETING` → `ZOOM_GET_A_MEETING`, `ZOOM_GET_MEETING_SUMMARY` → `ZOOM_GET_A_MEETING_SUMMARY` |
| `com.box/files` | Remove `BOX_MOVE_FILE` (no such Composio tool; move = update parent, already covered by `BOX_UPDATE_FILE`) |
| `com.hubspot/mcp` | `HUBSPOT_GET_CONTACTS` → `HUBSPOT_LIST_CONTACTS` |

The other 13 connectors (gmail, outlook, github, googlecalendar, quickbooks, linkedin, slack, whatsapp, zoho, googledrive, googlesheets, googledocs, googleslides) pass the gate unchanged.

## Why

Zoom install was hard-failing at Composio session creation:

```
ToolRouterV2_BadRequest 4300: Invalid tool slugs in config.tools:
ZOOM_GET_MEETING, ZOOM_GET_MEETING_SUMMARY
```

Composio validates the full `config.tools` set at `composio.create(...)` (the `sessionPreset: direct_tools` path in `src/composio/sdk.ts`) and rejects the whole install if any slug is invalid. Auditing the rest of the catalog the same way surfaced two more bad slugs (Box, HubSpot).

## How it was verified

Each connector's catalog slug set was run through the **actual install gate** — `composio.create()` with the toolkit's auth config — not the public `/api/v3/tools` listing. (The listing endpoint returns a curated/aliased subset and disagrees with the gate, so it produces false positives — e.g. it lists `HUBSPOT_LIST_CONTACTS_PAGE`, which the gate rejects, and omits `HUBSPOT_LIST_CONTACTS`, which it accepts.) All three corrected sets return a valid `mcp.url` from the gate:

- `zoom` → OK (9 slugs)
- `box` → OK (14 slugs)
- `hubspot` → OK (6 slugs)

## Rollout

This is catalog data baked into the platform image — merge, then redeploy the platform and reinstall the affected connectors. No infra/secret change. Orthogonal to the `COMPOSIO_ZOOM_AUTH_CONFIG_ID` fan-out (infra#28).

Follow-up to #397.
