### PR TITLE
feat(connectors): add Microsoft Teams and Jira (Composio)

### DIFF
--- a/src/connectors/catalog.yaml
+++ b/src/connectors/catalog.yaml
@@ -818,3 +818,74 @@ servers:
             - ZOOM_GET_USER
             - ZOOM_SEARCH_COMPANY_CONTACTS
         tags: [meetings, video, composio]
+
+  - name: com.microsoft/teams
+    title: Microsoft Teams
+    description: Read and post Teams channel and chat messages (via Composio)
+    version: "0.1.0"
+    icons:
+      - src: https://static.nimblebrain.ai/icons/teams.png
+        sizes: ["any"]
+    remotes:
+      - type: streamable-http
+        url: https://backend.composio.dev/v3/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: microsoft_teams
+          authConfigEnv: COMPOSIO_MICROSOFT_TEAMS_AUTH_CONFIG_ID
+          tools:
+            - MICROSOFT_TEAMS_TEAMS_POST_CHANNEL_MESSAGE
+            - MICROSOFT_TEAMS_TEAMS_POST_CHAT_MESSAGE
+            - MICROSOFT_TEAMS_TEAMS_POST_MESSAGE_REPLY
+            - MICROSOFT_TEAMS_TEAMS_LIST_CHAT_MESSAGES
+            - MICROSOFT_TEAMS_CHATS_GET_ALL_MESSAGES
+            - MICROSOFT_TEAMS_LIST_MESSAGE_REPLIES
+            - MICROSOFT_TEAMS_GET_CHAT_MESSAGE
+            - MICROSOFT_TEAMS_TEAMS_LIST
+            - MICROSOFT_TEAMS_TEAMS_LIST_CHANNELS
+            - MICROSOFT_TEAMS_GET_CHANNEL
+            - MICROSOFT_TEAMS_CHATS_GET_ALL_CHATS
+            - MICROSOFT_TEAMS_LIST_TEAM_MEMBERS
+            - MICROSOFT_TEAMS_LIST_USERS
+            - MICROSOFT_TEAMS_TEAMS_CREATE_CHAT
+            - MICROSOFT_TEAMS_TEAMS_CREATE_CHANNEL
+            - MICROSOFT_TEAMS_CREATE_MEETING
+        tags: [communication, productivity, composio]
+
+  - name: com.atlassian/jira
+    title: Jira
+    description: Create, search, and update Jira issues (via Composio)
+    version: "0.1.0"
+    icons:
+      - src: https://static.nimblebrain.ai/icons/jira.png
+        sizes: ["any"]
+    remotes:
+      - type: streamable-http
+        url: https://backend.composio.dev/v3/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: jira
+          authConfigEnv: COMPOSIO_JIRA_AUTH_CONFIG_ID
+          tools:
+            - JIRA_CREATE_ISSUE
+            - JIRA_GET_ISSUE
+            - JIRA_EDIT_ISSUE
+            - JIRA_DELETE_ISSUE
+            - JIRA_ASSIGN_ISSUE
+            - JIRA_TRANSITION_ISSUE
+            - JIRA_GET_TRANSITIONS
+            - JIRA_SEARCH_FOR_ISSUES_USING_JQL_POST
+            - JIRA_SEARCH_ISSUES
+            - JIRA_ADD_COMMENT
+            - JIRA_LIST_ISSUE_COMMENTS
+            - JIRA_GET_ALL_PROJECTS
+            - JIRA_GET_ISSUE_TYPES
+            - JIRA_LIST_BOARDS
+            - JIRA_LIST_SPRINTS
+            - JIRA_FIND_USERS
+            - JIRA_GET_CURRENT_USER
+        tags: [project-management, productivity, composio]


### PR DESCRIPTION
## What

Adds two Composio-managed connectors to the catalog:

| Connector | Toolkit | Tools |
|---|---|---|
| `com.microsoft/teams` | `microsoft_teams` (OAuth2) | 16 — channel/chat messaging, replies, message/chat/channel/team listing, members/users, create chat/channel/meeting |
| `com.atlassian/jira` | `jira` (OAuth2) | 17 — issue CRUD, JQL search, transitions, comments, projects, boards/sprints, users |

## How the tool sets were chosen

Every slug was validated against the **real install gate** — `composio.create()` with `sessionPreset: direct_tools`, the exact call the platform makes at install — not the public `/api/v3/tools` listing. The listing returns a curated/aliased subset that disagrees with the gate in both directions (e.g. it listed 4 Teams slugs the gate rejects, and the gate accepts slugs the listing omits). Both curated sets return a valid `mcp.url` from the gate (Teams 16/16, Jira 17/17).

Curation favors read + messaging/search + create; destructive admin (delete team, archive, version/worklog management, etc.) was left out to keep the agent surface focused. Easy to extend later from the confirmed-valid pool.

## Prereqs (separate changes)

- `COMPOSIO_MICROSOFT_TEAMS_AUTH_CONFIG_ID` and `COMPOSIO_JIRA_AUTH_CONFIG_ID` must be present in each tenant env — wired via the `composio` ClusterExternalSecret (infra PR) sourced from the `composio` 1Password item.
- `teams.png` icon asset (static repo); `jira.png` already exists.

Both auth configs (`ac_Zqaf_XjuJ_SQ`, `ac_gD9ZjUgmN7P_`) are ENABLED in the production Composio project.
