### PR TITLE
test(web): fix CI-only events-client flake (inject SSE connector, drop mock.module)

### DIFF
--- a/web/src/__tests__/events-client.test.ts
+++ b/web/src/__tests__/events-client.test.ts
@@ -1,13 +1,25 @@
 // ---------------------------------------------------------------------------
 // events-client.ts — workspace event stream singleton
 //
-// Mocks `./api/sse` so tests don't touch the network. The fake exposes
-// hooks to drive events / reconnects into the singleton and to count
-// real `connectEvents` invocations, which is the property the whole
-// refactor exists to enforce: N subscribers → 1 connection.
+// Injects a fake connector via `__internal__.setConnectorForTest` so tests
+// don't touch the network. The fake exposes hooks to drive events / reconnects
+// into the singleton and to count real `connectEvents` invocations, which is
+// the property the whole refactor exists to enforce: N subscribers → 1
+// connection.
+//
+// Why injection and not `mock.module("../api/sse")`: module mocks are
+// process-global and only intercept the singleton's static `connectEvents`
+// import if they register before events-client.ts is first evaluated. Another
+// file importing events-client first (e.g. via a hook) leaves the mock a
+// silent no-op — subscribe() then calls the real connector, connectCalls stays
+// 0, and every assertion here fails. That ordering tracks filesystem
+// enumeration order, so it flaked only on CI. Injecting on the one real module
+// instance the test imports is deterministic regardless of load order.
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { setAuthLifecycleHandler, setAuthToken } from "../api/client";
+import { __internal__, closeEventsClient, onReconnect, subscribe } from "../api/events-client";
 import type { ConnectEventsOptions, EventConnection } from "../api/sse";
 
 let connectCalls = 0;
@@ -37,14 +49,6 @@ function fakeConnectEvents(options: ConnectEventsOptions): EventConnection {
   return conn;
 }
 
-mock.module("../api/sse", () => ({
-  connectEvents: fakeConnectEvents,
-}));
-
-// Import AFTER mocking so the singleton sees the fake.
-import { setAuthLifecycleHandler, setAuthToken } from "../api/client";
-import { __internal__, closeEventsClient, onReconnect, subscribe } from "../api/events-client";
-
 function resetCounters(): void {
   connectCalls = 0;
   closeCalls = 0;
@@ -57,10 +61,12 @@ beforeEach(() => {
   setAuthLifecycleHandler(null);
   setAuthToken("tok-initial");
   __internal__.resetForTest();
+  __internal__.setConnectorForTest(fakeConnectEvents);
 });
 
 afterEach(() => {
   __internal__.resetForTest();
+  __internal__.setConnectorForTest(null);
   setAuthLifecycleHandler(null);
   setAuthToken(null);
 });

--- a/web/src/api/events-client.ts
+++ b/web/src/api/events-client.ts
@@ -33,10 +33,22 @@
 
 import type { SseEventMap, SseEventType } from "../types";
 import { addAuthLifecycleHandler, getAuthToken } from "./client";
-import { connectEvents, type EventConnection } from "./sse";
+import { connectEvents, type ConnectEventsOptions, type EventConnection } from "./sse";
 
 type Handler<K extends SseEventType> = (data: SseEventMap[K]) => void;
 type ReconnectHandler = () => void;
+
+// The connector the singleton actually calls. Defaults to the real SSE
+// `connectEvents`; tests inject a fake via `__internal__.setConnectorForTest`.
+// This is a dependency-injection seam, NOT a `mock.module("./sse")`: module
+// mocking is process-global and only intercepts the static import if it
+// registers before this module is first evaluated, which is load-order
+// dependent across a multi-file suite (it silently no-ops when another file
+// imports events-client first — the source of a CI-only flake). Injecting on
+// the single real module instance the test imports removes that ordering
+// dependence entirely.
+type Connector = (options: ConnectEventsOptions) => EventConnection;
+let connectImpl: Connector = connectEvents;
 
 // biome-ignore lint/suspicious/noExplicitAny: subscriber set is keyed by event type; type-safety is enforced by `subscribe<K>` at the public boundary
 const eventHandlers = new Map<SseEventType, Set<Handler<any>>>();
@@ -54,7 +66,7 @@ function hasAnySubscribers(): boolean {
 
 function ensureOpen(): void {
   if (connection) return;
-  connection = connectEvents({
+  connection = connectImpl({
     token: getAuthToken() ?? undefined,
     onEvent: <K extends SseEventType>(type: K, data: SseEventMap[K]) => {
       const set = eventHandlers.get(type);
@@ -156,6 +168,15 @@ export const __internal__ = {
     let n = reconnectHandlers.size;
     for (const set of eventHandlers.values()) n += set.size;
     return n;
+  },
+  /**
+   * Inject the connector the singleton calls. Pass a fake to intercept SSE
+   * setup deterministically; pass `null` to restore the real `connectEvents`.
+   * Replaces `mock.module("./sse")` so the test never depends on module
+   * load order. Test-only.
+   */
+  setConnectorForTest(fn: Connector | null): void {
+    connectImpl = fn ?? connectEvents;
   },
   resetForTest(): void {
     closeEventsClient();


### PR DESCRIPTION
## Problem

`web/src/__tests__/events-client.test.ts` fails intermittently **only on CI** — all 12 tests fail together with `connectCalls === 0`, `hasConnection() === false`, and `TypeError: null is not an object (evaluating 'lastOptions.onEvent')`. Locally it passes every time.

Example failing run: https://github.com/NimbleBrainInc/nimblebrain/actions/runs/27228481472/job/80401943829 (it had also *passed* on the immediately prior run of the same branch — the definition of a flake).

## Root cause

The test stubbed the SSE transport with `mock.module("../api/sse", …)`. Bun's `mock.module` is **process-global** and only intercepts `events-client.ts`'s static `import { connectEvents } from "./sse"` if it registers **before** `events-client.ts` is first evaluated.

When another test file imports `events-client` first — e.g. `useEvents.test.tsx`, whose subject `useEvents.ts` imports the real `events-client` — the module is already evaluated with the **real** `connectEvents` bound. The later `mock.module` is then a silent no-op: `subscribe()` calls the real connector, the test's `connectCalls` counter never moves, `lastOptions` stays `null`, and every assertion fails.

Whether that happens depends on bun's test-file enumeration order, which differs between local (macOS/APFS) and CI (Linux/ext4) — hence CI-only.

Confirmed from the CI log: `__internal__.hasConnection()` returns a value (not "undefined is not a function"), so the test *did* get the real `events-client` module — ruling out a competing module-mock-leak theory. The failure is purely that the `sse` mock didn't intercept.

## Fix

Replace the module mock with a **dependency-injection seam**:

- `events-client.ts` now calls `connectImpl` (defaults to the real `connectEvents`).
- Tests inject a fake via `__internal__.setConnectorForTest(fake)` on the **single real module instance they import**, and restore with `setConnectorForTest(null)` in `afterEach`.

`subscribe`, `__internal__`, and the injected connector all come from the same import, so there is no load-order dependence. Production behavior is unchanged — the default connector is the real `connectEvents`.

## Validation

- Full web suite (`cd web && bun test`, the exact CI invocation): **503 pass / 0 fail**, run 6× consecutively, stable.
- Adverse order (`useEvents.test.tsx` first, then `events-client.test.ts`): green.
- `bun run verify:static`: green (format, lint, typecheck, web checks).