### PR TITLE
test(engine): cover length-continuation anchor in cache-policy (follow-up to #401)

### DIFF
--- a/src/model/cache-policy.ts
+++ b/src/model/cache-policy.ts
@@ -40,7 +40,10 @@ import type {
  * Anthropic API (cache-write ↓ ~78% over 7 turns, widening with length).
  *
  * Four breakpoints, within Anthropic's budget of four:
- *   1. tools   — last tool definition (the frozen catalog, position 0)
+ *   1. tools   — last tool definition (the tools block, position 0). Stable
+ *               across most turns, but not frozen: tripped/promoted tools can
+ *               change the set mid-run, which busts this breakpoint (a cache
+ *               miss on tools + everything after — degraded, never incorrect).
  *   2. system  — the system prompt
  *   3. anchor  — last message of the previous step (= prior request's tail)
  *   4. tail    — the current last message (cached for the NEXT turn to read)

--- a/test/unit/cache-policy.test.ts
+++ b/test/unit/cache-policy.test.ts
@@ -163,6 +163,44 @@ describe("applyCachePolicy — the chaining invariant (cache correctness)", () =
     }
   });
 
+  test("length-continuation (lone assistant append) still anchors on the prior tail", () => {
+    // The engine's length-continuation path (engine.ts) appends a SINGLE
+    // assistant message — its partial text — with no tool results, then
+    // re-calls. This is the one append pattern the tool-step builders above
+    // don't exercise, yet the whole savings story depends on it preserving the
+    // invariant: because exactly one assistant is appended, the message before
+    // the new last assistant is still precisely the prior call's tail. A
+    // regression here (e.g. appending two messages, or trailing non-assistant
+    // content) would silently slide the anchor off and bust the cache with no
+    // behavior change to notice it.
+    const history = [userMsg("go")];
+    appendStep(history, 0, 3); // one normal tool step to seed a real prefix
+
+    const anchorOf = (msgs: LanguageModelV3Message[]): number => {
+      const { prompt } = applyCachePolicy({
+        provider: "anthropic",
+        systemPrompt: "sys",
+        messages: msgs,
+        tools: TOOLS,
+      });
+      const body = prompt.slice(1); // drop system
+      const tailIdx = body.length - 1;
+      const cached = body.map((m, i) => (hasCache(m) ? i : -1)).filter((i) => i >= 0);
+      return cached.find((i) => i !== tailIdx) ?? -1;
+    };
+
+    // Two back-to-back continuations: each appends only a partial assistant.
+    for (let cont = 0; cont < 2; cont++) {
+      const prevTailContent = contentOnly(history[history.length - 1]!);
+      const prevTailIdx = history.length - 1;
+      history.push({ role: "assistant", content: [{ type: "text", text: `partial ${cont}` }] });
+
+      const anchorIdx = anchorOf([...history]);
+      expect(anchorIdx).toBe(prevTailIdx);
+      expect(contentOnly(history[anchorIdx]!)).toBe(prevTailContent);
+    }
+  });
+
   test("prefix-monotonicity: content up to the anchor is a stable prefix across turns", () => {
     const history = [userMsg("go")];
     let prevPrefix: string[] = [];


### PR DESCRIPTION
## Context

Follow-up to #401 (rolling prompt-cache breakpoint). The fix merged, but these two additions were authored after the branch was squash-merged and didn't make it into main:

1. A test for the **length-continuation** anchor path.
2. A correction to the "frozen catalog" comment.

## Why the test matters

`cache-policy`'s whole savings story rests on one invariant: each agentic iteration appends exactly one assistant message *first*, so the rolling step-anchor (`lastAssistant - 1`) always lands byte-identically on the previous call's tail — giving an exact-match cache read of the prior prefix.

The existing tests exercise only the **tool-step** append pattern (assistant + tool results). The engine has a second append shape the tests never covered: the **length-continuation** path (`engine.ts`) pushes a *lone* assistant message (its partial text, no tool results) before re-calling. That path still preserves the invariant — but nothing guarded it. A future change to the continuation logic (appending two messages, or trailing non-assistant content) would silently slide the anchor off and bust the cache with **no behavior change and no test failure** to notice it.

The new test drives two back-to-back continuations and asserts the anchor stays on the prior tail (same index, byte-identical content).

## Comment fix

The module header called the tools block "the frozen catalog." It isn't frozen — tripped/promoted tools can change the set mid-run, which busts that breakpoint (a cache miss on tools + everything after; degraded, never incorrect). Softened the wording to say so.

## Validation

- `cache-policy.test.ts`: **11 pass / 0 fail** (was 10).
- `bun run verify:static`: green.

Net: +1 test, +a comment. No production code change.