### PR TITLE
test(engine): token-shape regression harness for cache/cost invariants

### DIFF
--- a/test/eval/token-shape.eval.test.ts
+++ b/test/eval/token-shape.eval.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Token-shape eval (Tier 3) — realized cross-provider cache behavior.
+ *
+ * The unit-tier `test/unit/token-shape.test.ts` proves the REQUEST shape is
+ * correct with a scripted fake model and zero API calls (fast, every PR). This
+ * eval is the complement: drive the SAME agentic scenario against the REAL
+ * Anthropic / OpenAI / Google APIs and check two things that only a real
+ * provider can tell you:
+ *
+ *   1. Structural invariants still hold under a real model's (non-uniform)
+ *      tool-calling pattern — we wrap the live model with `recordingModel` and
+ *      run the same `checkInvariants` the unit tier uses.
+ *   2. The provider actually HONORS the cache — read realized `cacheRead` /
+ *      `cacheWrite` from the run's usage and assert tolerance-banded health,
+ *      then log the realized cache-hit rate so a weekly cron can track drift.
+ *
+ * Run infrequently (weekly cron / pre-release), not per-PR — it costs real
+ * tokens and is subject to provider nondeterminism. Skips gracefully per
+ * provider when the key is absent.
+ *
+ * Requires env vars (skip if missing):
+ *   ANTHROPIC_API_KEY
+ *   OPENAI_API_KEY
+ *   GOOGLE_GENERATIVE_AI_API_KEY
+ *
+ * Run: bun run eval
+ */
+import { describe, expect, it } from "bun:test";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { AgentEngine } from "../../src/engine/engine.ts";
+import { StaticToolRouter } from "../../src/adapters/static-router.ts";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { textContent } from "../../src/engine/content-helpers.ts";
+import type { EngineConfig, EngineResult, ToolSchema } from "../../src/engine/types.ts";
+import { buildModelResolver } from "../../src/model/registry.ts";
+import { recordingModel, type RecordedCall } from "../helpers/recording-model.ts";
+import { checkInvariants, deriveShape } from "../helpers/token-shape.ts";
+
+interface ProviderSpec {
+  name: "anthropic" | "openai" | "google";
+  envVar: string;
+  modelString: string;
+  /** Anthropic places explicit breakpoints; the others auto-cache (passthrough). */
+  cacheMode: "anthropic" | "passthrough";
+}
+
+const PROVIDERS: ProviderSpec[] = [
+  {
+    name: "anthropic",
+    envVar: "ANTHROPIC_API_KEY",
+    modelString: "anthropic:claude-haiku-4-5-20251001",
+    cacheMode: "anthropic",
+  },
+  {
+    name: "openai",
+    envVar: "OPENAI_API_KEY",
+    modelString: "openai:gpt-4o-mini",
+    cacheMode: "passthrough",
+  },
+  {
+    name: "google",
+    envVar: "GOOGLE_GENERATIVE_AI_API_KEY",
+    modelString: "google:gemini-2.0-flash",
+    cacheMode: "passthrough",
+  },
+];
+
+// A deliberately large, STABLE system block. Prompt caching only engages above a
+// provider-specific floor (Anthropic ~1024 tokens; OpenAI auto-caches long
+// prefixes), so a realistic eval needs a prefix big enough to be cacheable. The
+// content is irrelevant; the size and stability are the point.
+const STABLE_PREAMBLE = Array.from(
+  { length: 80 },
+  (_, i) =>
+    `Operating principle ${i + 1}: gather evidence with the provided tool before answering, ` +
+    "prefer primary sources, cite what you used, and never fabricate facts you did not retrieve.",
+).join("\n");
+
+const SYSTEM_PROMPT = `You are a meticulous research assistant.\n\n${STABLE_PREAMBLE}\n\nWork one tool call at a time.`;
+
+const FACT_TOOL: ToolSchema = {
+  name: "get_fact",
+  description: "Return a short factual sentence about the given topic.",
+  inputSchema: {
+    type: "object",
+    properties: { topic: { type: "string", description: "The topic to look up." } },
+    required: ["topic"],
+  },
+};
+
+const TOPICS = ["alpha", "beta", "gamma", "delta", "epsilon"];
+
+const USER_TASK =
+  `Look up a fact for each of these topics, exactly one get_fact call at a time, ` +
+  `in order: ${TOPICS.join(", ")}. After you have all five, give a one-line summary.`;
+
+interface ScenarioResult {
+  calls: RecordedCall[];
+  usage: EngineResult["usage"];
+  iterations: number;
+}
+
+function resolveModel(spec: ProviderSpec): LanguageModelV3 {
+  const apiKey = process.env[spec.envVar]!;
+  const resolver = buildModelResolver({ providers: { [spec.name]: { apiKey } } });
+  return resolver(spec.modelString);
+}
+
+async function runRealScenario(spec: ProviderSpec): Promise<ScenarioResult> {
+  const { model, calls } = recordingModel(resolveModel(spec));
+  const engine = new AgentEngine(
+    model,
+    new StaticToolRouter([FACT_TOOL], (call) => ({
+      content: textContent(`${String(call.input["topic"])} is a letter of the Greek alphabet.`),
+      isError: false,
+    })),
+    new NoopEventSink(),
+  );
+  const config: EngineConfig = {
+    model: spec.modelString,
+    maxIterations: 12,
+    maxInputTokens: 500_000,
+    maxOutputTokens: 2_048,
+  };
+  const result = await engine.run(
+    config,
+    SYSTEM_PROMPT,
+    [{ role: "user", content: [{ type: "text", text: USER_TASK }] }],
+    [FACT_TOOL],
+  );
+  return { calls, usage: result.usage, iterations: result.iterations };
+}
+
+/** Realized cache-hit rate, mirroring the production admin-summary definition. */
+function cacheHitRate(usage: EngineResult["usage"]): number {
+  const read = usage.cacheReadTokens ?? 0;
+  return usage.inputTokens > 0 ? read / usage.inputTokens : 0;
+}
+
+describe("token-shape eval — realized cross-provider cache", () => {
+  for (const spec of PROVIDERS) {
+    const apiKey = process.env[spec.envVar];
+
+    describe(spec.name, () => {
+      it.skipIf(!apiKey)(
+        "holds shape invariants and reports realized cache usage",
+        async () => {
+          const { calls, usage, iterations } = await runRealScenario(spec);
+
+          // The run must have actually looped (multiple model calls) for the
+          // cache question to be meaningful.
+          expect(calls.length).toBeGreaterThanOrEqual(2);
+
+          // (1) Structural invariants hold even under the real model's pattern.
+          // Tool-set churn (a real model may stop calling the tool) makes
+          // tools-stable legitimately noisy, so we assert on the cache-correctness
+          // invariants that must hold regardless: system stability, append-only
+          // prefix, and — for Anthropic — anchor chaining.
+          const violations = checkInvariants(calls, spec.cacheMode).filter(
+            (v) => v.invariant !== "tools-stable" && v.invariant !== "anti-thrash-bounded",
+          );
+          expect(violations).toEqual([]);
+
+          // (2) Realized cache health, tolerance-banded. Thresholds are starter
+          // values to tune against the tracked time series — adjust as the
+          // baseline settles.
+          const read = usage.cacheReadTokens ?? 0;
+          const write = usage.cacheWriteTokens ?? 0;
+          const hitRate = cacheHitRate(usage);
+
+          // Emit a single machine-greppable metrics line so a weekly cron can
+          // append it to a time series and watch for drift.
+          console.log(
+            `[token-shape-eval] provider=${spec.name} model=${spec.modelString} ` +
+              `iterations=${iterations} input=${usage.inputTokens} output=${usage.outputTokens} ` +
+              `cacheRead=${read} cacheWrite=${write} hitRate=${hitRate.toFixed(3)} ` +
+              `writeReadRatio=${read > 0 ? (write / read).toFixed(2) : "n/a"}`,
+          );
+
+          if (spec.cacheMode === "anthropic") {
+            // Explicit breakpoints + a >1k-token stable prefix across a multi-
+            // iteration run: the cache MUST be read back at least once, and
+            // writes must not dominate reads (the thrash signature).
+            expect(read).toBeGreaterThan(0);
+            if (read > 0) expect(write / read).toBeLessThan(2);
+          } else {
+            // Auto-caching providers may or may not engage within a short test
+            // window; don't hard-gate on it. Assert the usage pipeline is
+            // populated and log the realized number for the time series.
+            expect(usage.inputTokens).toBeGreaterThan(0);
+          }
+        },
+        60_000,
+      );
+
+      if (!apiKey) {
+        it.skip(`skipped: ${spec.envVar} not set`, () => {});
+      }
+    });
+  }
+});
+
+// Keep the shape derivation reachable for ad-hoc inspection without an API key
+// (e.g. `bun -e` against a recorded run): re-export the harness used above.
+export { deriveShape };

--- a/test/helpers/recording-model.ts
+++ b/test/helpers/recording-model.ts
@@ -1,0 +1,64 @@
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3FunctionTool,
+  LanguageModelV3Message,
+} from "@ai-sdk/provider";
+
+/**
+ * One captured model call: the exact prompt + tools the engine sent to the
+ * provider boundary on a single iteration.
+ *
+ * This is captured AFTER `applyCachePolicy` runs (the engine annotates the
+ * prompt with cache breakpoints, then calls `model.doStream`), so it reflects
+ * what actually goes on the wire — system message, growing message history,
+ * and every `cache_control` marker — not the pre-policy assembly. That is the
+ * load-bearing property for token-shape regression tests: the request the
+ * provider sees is the thing that determines cost.
+ */
+export interface RecordedCall {
+  prompt: LanguageModelV3Message[];
+  tools: LanguageModelV3FunctionTool[];
+}
+
+export interface RecordingModel {
+  /** Drop-in `LanguageModelV3` that records each call, then delegates to `inner`. */
+  model: LanguageModelV3;
+  /** Per-iteration captures, in call order. */
+  calls: RecordedCall[];
+}
+
+/**
+ * Wrap a `LanguageModelV3` so every `doStream` / `doGenerate` call is recorded
+ * before delegating to the inner model. Pair with `createEchoModel` (scripted
+ * responses) to drive a deterministic agentic loop and inspect the exact
+ * per-step request the engine produced — no provider API involved.
+ *
+ * Captures are deep-cloned so later in-place mutations by the engine (it reuses
+ * and extends the history array across iterations) can't corrupt earlier
+ * records.
+ */
+export function recordingModel(inner: LanguageModelV3): RecordingModel {
+  const calls: RecordedCall[] = [];
+
+  function record(opts: LanguageModelV3CallOptions): void {
+    const tools = (opts.tools ?? []).filter(
+      (t): t is LanguageModelV3FunctionTool => t.type === "function",
+    );
+    calls.push(structuredClone({ prompt: opts.prompt, tools }));
+  }
+
+  const model: LanguageModelV3 = {
+    ...inner,
+    doGenerate(opts) {
+      record(opts);
+      return inner.doGenerate(opts);
+    },
+    doStream(opts) {
+      record(opts);
+      return inner.doStream(opts);
+    },
+  };
+
+  return { model, calls };
+}

--- a/test/helpers/token-shape.ts
+++ b/test/helpers/token-shape.ts
@@ -1,0 +1,286 @@
+import type { LanguageModelV3Message } from "@ai-sdk/provider";
+import type { RecordedCall } from "./recording-model.ts";
+
+/**
+ * Token-shape harness: derive a deterministic, provider-agnostic fingerprint of
+ * what the engine sent to the model on each iteration, and assert the cache
+ * invariants the cost story depends on.
+ *
+ * Why this exists: the expensive token-usage regressions (cache-write thrash,
+ * a system-prompt append busting the whole cached prefix, an anchor sliding off
+ * the prior tail) are all properties of the REQUEST the engine builds, which is
+ * fully deterministic given a fixed conversation. So they can be caught with a
+ * scripted fake model and zero API calls. Realized cost (did the provider
+ * actually honor the cache) is a separate, real-API concern — not this file.
+ *
+ * Token counts here are a stable proxy (~4 chars/token, matching the repo's own
+ * estimate in `conversation/compaction.ts`), used to compare shapes across
+ * steps, NOT to predict a bill. Absolute billed tokens are a real-provider
+ * concern.
+ */
+
+const CHARS_PER_TOKEN = 4;
+
+function estTokens(s: string): number {
+  return Math.ceil(s.length / CHARS_PER_TOKEN);
+}
+
+function shortHash(s: string): string {
+  return new Bun.CryptoHasher("sha256").update(s).digest("hex").slice(0, 12);
+}
+
+/** TTL of a message's / tool's Anthropic cache breakpoint, or undefined. */
+function ttlOf(x: { providerOptions?: Record<string, unknown> } | undefined): string | undefined {
+  const anthropic = x?.providerOptions?.["anthropic"] as
+    | { cacheControl?: { ttl?: string } }
+    | undefined;
+  return anthropic?.cacheControl?.ttl;
+}
+
+/** Underlying message content, stripped of cache markers (so we compare bytes, not breakpoints). */
+function contentOnly(m: LanguageModelV3Message): string {
+  const { providerOptions: _drop, ...rest } = m as LanguageModelV3Message & {
+    providerOptions?: unknown;
+  };
+  return JSON.stringify(rest);
+}
+
+function systemTextOf(prompt: LanguageModelV3Message[]): string {
+  const head = prompt[0];
+  if (head && head.role === "system") {
+    return typeof head.content === "string" ? head.content : JSON.stringify(head.content);
+  }
+  return "";
+}
+
+/**
+ * Compact, human-scannable fingerprint of one model call. The `hash` fields are
+ * the point: a system-prompt edit flips `system.hash`, surfacing as a reviewable
+ * golden diff instead of a silent production regression.
+ */
+export interface StepShape {
+  /** 1-based model-call index within the run. */
+  step: number;
+  /** Total messages in the prompt (incl. the leading system message). */
+  messages: number;
+  /** Estimated tokens across the whole prompt (proxy, not a bill). */
+  promptTokens: number;
+  system: { tokens: number; hash: string; ttl?: string };
+  tools: { count: number; hash: string; breakpointIdx: number; breakpointTtl?: string };
+  /** Body index (system excluded) of the rolling step-anchor breakpoint, or -1. */
+  anchorIdx: number;
+  /** Body index of the tail breakpoint. */
+  tailIdx: number;
+  anchorTtl?: string;
+  tailTtl?: string;
+  /**
+   * Estimated tokens of the body messages AFTER the anchor — the per-step
+   * delta that gets cache-WRITTEN each turn. With the rolling anchor working,
+   * this stays ~flat (one step's worth) across the run. If it grows with turn
+   * count, the prefix is being re-written every turn: thrash. `null` when there
+   * is no anchor yet (first call).
+   */
+  deltaTokensAfterAnchor: number | null;
+}
+
+/** Derive the per-step shape table from recorded calls (used for golden snapshots). */
+export function deriveShape(calls: RecordedCall[]): StepShape[] {
+  return calls.map((call, idx) => {
+    const { prompt } = call;
+    const systemText = systemTextOf(prompt);
+    const body = prompt.slice(1);
+    const bodyTtls = body.map((m) => ttlOf(m));
+    const tailIdx = body.length - 1;
+
+    let anchorIdx = -1;
+    for (let i = 0; i < body.length; i++) {
+      if (bodyTtls[i] !== undefined && i !== tailIdx) anchorIdx = i;
+    }
+
+    const toolBreakpointIdx = call.tools.findIndex((t) => ttlOf(t) !== undefined);
+    const toolsSig = `${call.tools.map((t) => t.name).join(",")}|bp=${toolBreakpointIdx}`;
+
+    const promptTokens = prompt.reduce((n, m) => n + estTokens(contentOnly(m)), 0);
+    const deltaTokensAfterAnchor =
+      anchorIdx >= 0
+        ? body.slice(anchorIdx + 1).reduce((n, m) => n + estTokens(contentOnly(m)), 0)
+        : null;
+
+    return {
+      step: idx + 1,
+      messages: prompt.length,
+      promptTokens,
+      system: {
+        tokens: estTokens(systemText),
+        hash: shortHash(systemText),
+        ttl: ttlOf(prompt[0]),
+      },
+      tools: {
+        count: call.tools.length,
+        hash: shortHash(toolsSig),
+        breakpointIdx: toolBreakpointIdx,
+        breakpointTtl: toolBreakpointIdx >= 0 ? ttlOf(call.tools[toolBreakpointIdx]) : undefined,
+      },
+      anchorIdx,
+      tailIdx,
+      anchorTtl: anchorIdx >= 0 ? bodyTtls[anchorIdx] : undefined,
+      tailTtl: tailIdx >= 0 ? bodyTtls[tailIdx] : undefined,
+      deltaTokensAfterAnchor,
+    };
+  });
+}
+
+export interface ShapeViolation {
+  invariant: string;
+  step?: number;
+  detail: string;
+}
+
+export type CacheMode = "anthropic" | "passthrough";
+
+/**
+ * Assert the cache-shape invariants over a recorded run. Returns the list of
+ * violations (empty = healthy) so callers can `expect(violations).toEqual([])`
+ * and get a readable failure naming the broken invariant and step.
+ *
+ * The invariants, and the regression each one fences:
+ *  - system-stable     — the system block is byte-identical every step. Guards
+ *                        the class of bug where a per-turn hint is appended to
+ *                        the system prompt, busting its 1h breakpoint and the
+ *                        entire prefix after it (see engine.ts final-step hint).
+ *  - tools-stable      — the tools block doesn't churn (no trips in this scenario).
+ *  - prefix-monotonic  — each call's body extends the prior call's body append-
+ *                        only; no pre-anchor message is ever rewritten.
+ *  - anchor-chaining   — (Anthropic) the anchor breakpoint of call N+1 lands on
+ *                        the exact bytes that were call N's tail → exact-match
+ *                        cache read of the whole prior prefix.
+ *  - ttl-*             — (Anthropic) 1h on the stable system+tools prefix, 5m on
+ *                        the rolling anchor+tail.
+ *  - anti-thrash-bounded — (Anthropic) the post-anchor write delta stays ~flat
+ *                        across the run instead of growing with turn count.
+ *  - passthrough-no-cache — (non-Anthropic) no inline cache markers are emitted.
+ */
+export function checkInvariants(calls: RecordedCall[], mode: CacheMode): ShapeViolation[] {
+  const v: ShapeViolation[] = [];
+  if (calls.length === 0) {
+    v.push({ invariant: "non-empty", detail: "no model calls were recorded" });
+    return v;
+  }
+  const shapes = deriveShape(calls);
+
+  // system-stable
+  const sys0 = shapes[0]!.system.hash;
+  for (const s of shapes) {
+    if (s.system.hash !== sys0) {
+      v.push({
+        invariant: "system-stable",
+        step: s.step,
+        detail: `system hash ${s.system.hash} != first-call ${sys0}`,
+      });
+    }
+  }
+
+  // tools-stable
+  const tools0 = shapes[0]!.tools.hash;
+  for (const s of shapes) {
+    if (s.tools.hash !== tools0) {
+      v.push({ invariant: "tools-stable", step: s.step, detail: "tools block changed mid-run" });
+    }
+  }
+
+  // prefix-monotonic
+  for (let i = 1; i < calls.length; i++) {
+    const prev = calls[i - 1]!.prompt.slice(1).map(contentOnly);
+    const cur = calls[i]!.prompt.slice(1).map(contentOnly);
+    for (let j = 0; j < prev.length; j++) {
+      if (cur[j] !== prev[j]) {
+        v.push({
+          invariant: "prefix-monotonic",
+          step: i + 1,
+          detail: `body[${j}] was rewritten vs the prior call (prefix must be append-only)`,
+        });
+        break;
+      }
+    }
+  }
+
+  if (mode === "anthropic") {
+    // anchor-chaining
+    for (let i = 1; i < calls.length; i++) {
+      const prevBody = calls[i - 1]!.prompt.slice(1);
+      const curBody = calls[i]!.prompt.slice(1);
+      const prevTail = contentOnly(prevBody[prevBody.length - 1]!);
+      const a = shapes[i]!.anchorIdx;
+      if (a < 0) {
+        v.push({
+          invariant: "anchor-chaining",
+          step: i + 1,
+          detail: "no anchor breakpoint on a continued call",
+        });
+        continue;
+      }
+      if (contentOnly(curBody[a]!) !== prevTail) {
+        v.push({
+          invariant: "anchor-chaining",
+          step: i + 1,
+          detail: "anchor content != prior call's tail (cache read will miss)",
+        });
+      }
+    }
+
+    // ttl tiering
+    for (const s of shapes) {
+      if (s.system.ttl !== "1h") {
+        v.push({ invariant: "ttl-system-1h", step: s.step, detail: `system ttl=${s.system.ttl}` });
+      }
+      if (s.tools.breakpointIdx >= 0 && s.tools.breakpointTtl !== "1h") {
+        v.push({
+          invariant: "ttl-tools-1h",
+          step: s.step,
+          detail: `tools ttl=${s.tools.breakpointTtl}`,
+        });
+      }
+      if (s.tailTtl !== "5m") {
+        v.push({ invariant: "ttl-tail-5m", step: s.step, detail: `tail ttl=${s.tailTtl}` });
+      }
+      if (s.anchorIdx >= 0 && s.anchorTtl !== "5m") {
+        v.push({ invariant: "ttl-anchor-5m", step: s.step, detail: `anchor ttl=${s.anchorTtl}` });
+      }
+    }
+
+    // anti-thrash: post-anchor write delta must not grow with turn count
+    const deltas = shapes
+      .map((s) => s.deltaTokensAfterAnchor)
+      .filter((d): d is number => d !== null);
+    if (deltas.length >= 2) {
+      const min = Math.min(...deltas);
+      const max = Math.max(...deltas);
+      // A uniform scenario yields exact equality; allow a small tolerance for
+      // step-to-step byte jitter (e.g. tool-call id width).
+      const tolerance = Math.max(2, Math.ceil(min * 0.1));
+      if (max - min > tolerance) {
+        v.push({
+          invariant: "anti-thrash-bounded",
+          detail: `post-anchor write delta grows across the run (min=${min}, max=${max} tokens): the prefix is being re-written each turn, not appended`,
+        });
+      }
+    }
+  } else {
+    for (const s of shapes) {
+      if (
+        s.system.ttl !== undefined ||
+        s.tailTtl !== undefined ||
+        s.anchorTtl !== undefined ||
+        s.tools.breakpointIdx >= 0
+      ) {
+        v.push({
+          invariant: "passthrough-no-cache",
+          step: s.step,
+          detail: "inline cache markers were emitted for a non-Anthropic provider",
+        });
+      }
+    }
+  }
+
+  return v;
+}

--- a/test/unit/__golden__/anthropic-10step.json
+++ b/test/unit/__golden__/anthropic-10step.json
@@ -1,0 +1,232 @@
+[
+  {
+    "step": 1,
+    "messages": 2,
+    "promptTokens": 80,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": -1,
+    "tailIdx": 0,
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": null
+  },
+  {
+    "step": 2,
+    "messages": 4,
+    "promptTokens": 153,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 0,
+    "tailIdx": 2,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 3,
+    "messages": 6,
+    "promptTokens": 226,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 2,
+    "tailIdx": 4,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 4,
+    "messages": 8,
+    "promptTokens": 299,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 4,
+    "tailIdx": 6,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 5,
+    "messages": 10,
+    "promptTokens": 372,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 6,
+    "tailIdx": 8,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 6,
+    "messages": 12,
+    "promptTokens": 445,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 8,
+    "tailIdx": 10,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 7,
+    "messages": 14,
+    "promptTokens": 518,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 10,
+    "tailIdx": 12,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 8,
+    "messages": 16,
+    "promptTokens": 591,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 12,
+    "tailIdx": 14,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 9,
+    "messages": 18,
+    "promptTokens": 664,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 14,
+    "tailIdx": 16,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 10,
+    "messages": 20,
+    "promptTokens": 737,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 16,
+    "tailIdx": 18,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  },
+  {
+    "step": 11,
+    "messages": 22,
+    "promptTokens": 810,
+    "system": {
+      "tokens": 55,
+      "hash": "95db03dc7816",
+      "ttl": "1h"
+    },
+    "tools": {
+      "count": 1,
+      "hash": "ae474cf4fef7",
+      "breakpointIdx": 0,
+      "breakpointTtl": "1h"
+    },
+    "anchorIdx": 18,
+    "tailIdx": 20,
+    "anchorTtl": "5m",
+    "tailTtl": "5m",
+    "deltaTokensAfterAnchor": 73
+  }
+]

--- a/test/unit/token-shape.test.ts
+++ b/test/unit/token-shape.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "bun:test";
+import type { LanguageModelV3Message } from "@ai-sdk/provider";
+import { AgentEngine } from "../../src/engine/engine.ts";
+import { StaticToolRouter } from "../../src/adapters/static-router.ts";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { textContent } from "../../src/engine/content-helpers.ts";
+import type { EngineConfig, ToolSchema } from "../../src/engine/types.ts";
+import { createEchoModel, type EchoModelResponse } from "../helpers/echo-model.ts";
+import { recordingModel, type RecordedCall } from "../helpers/recording-model.ts";
+import { checkInvariants, deriveShape } from "../helpers/token-shape.ts";
+
+// --- fixed scenario inputs (deterministic; the whole point is reproducibility) ---
+
+// A representative, multi-line system prompt. Held constant so its hash is
+// stable across steps and across runs — a real edit here is meant to show up as
+// a golden diff.
+const SYSTEM_PROMPT = [
+  "You are a helpful research assistant operating inside the NimbleBrain runtime.",
+  "Use the available tools to gather evidence before answering.",
+  "Prefer primary sources. Cite what you used. Stop once the question is answered.",
+].join("\n");
+
+const SEARCH_TOOL: ToolSchema = {
+  name: "search",
+  description: "Search the corpus for a query string.",
+  inputSchema: { type: "object", properties: { q: { type: "string" } }, required: ["q"] },
+};
+
+/**
+ * Script an N-step tool loop: N tool-call turns, then a final text turn that
+ * ends the run. The query VARIES per step (`q00`, `q01`, …) so the loop
+ * supervisor sees forward progress and keeps the tool active — an identical
+ * query every turn would (correctly) trip the non-advancing guard and release
+ * the tool, which isn't the agentic shape we're fingerprinting. Fixed-width ids
+ * and queries keep every step byte-identical in size, so the per-step write
+ * delta is exactly flat — the crispest possible signal if the rolling anchor
+ * ever regresses. (Steps must stay < 100 for the 2-digit padding to hold.)
+ */
+function toolLoopResponses(steps: number): EchoModelResponse[] {
+  const responses: EchoModelResponse[] = Array.from({ length: steps }, (_, i) => {
+    const pad = String(i).padStart(2, "0");
+    return {
+      text: "Looking into it.",
+      toolCalls: [{ toolCallId: `call_${pad}`, toolName: "search", input: `{"q":"q${pad}"}` }],
+    };
+  });
+  responses.push({ text: "All done. Nothing else remains." });
+  return responses;
+}
+
+async function runToolLoop(model: string, steps: number, maxIterations = 25): Promise<RecordedCall[]> {
+  const echo = createEchoModel({
+    provider: "anthropic",
+    modelId: "scenario",
+    responses: toolLoopResponses(steps),
+  });
+  const { model: recording, calls } = recordingModel(echo);
+  const engine = new AgentEngine(
+    recording,
+    new StaticToolRouter([SEARCH_TOOL], () => ({ content: textContent("ok"), isError: false })),
+    new NoopEventSink(),
+  );
+  const config: EngineConfig = {
+    model,
+    maxIterations,
+    maxInputTokens: 500_000,
+    maxOutputTokens: 16_384,
+  };
+  await engine.run(
+    config,
+    SYSTEM_PROMPT,
+    [{ role: "user", content: [{ type: "text", text: "Find the thing." }] }],
+    [SEARCH_TOOL],
+  );
+  return calls;
+}
+
+// --- golden snapshot helper ---------------------------------------------------
+
+async function assertGolden(name: string, shape: unknown): Promise<void> {
+  const path = `${import.meta.dir}/__golden__/${name}.json`;
+  const serialized = `${JSON.stringify(shape, null, 2)}\n`;
+  if (process.env["TOKEN_SHAPE_UPDATE"]) {
+    await Bun.write(path, serialized);
+    return;
+  }
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    throw new Error(
+      `Missing golden "${name}". Generate it with: TOKEN_SHAPE_UPDATE=1 bun test test/unit/token-shape.test.ts`,
+    );
+  }
+  const golden = JSON.parse(await file.text());
+  // A mismatch means the token shape changed. If intentional, regenerate with
+  // TOKEN_SHAPE_UPDATE=1 and review the diff; if not, you just caught a regression.
+  expect(shape).toEqual(golden);
+}
+
+// --- tests --------------------------------------------------------------------
+
+describe("token-shape regression (Tier 1: deterministic, no provider API)", () => {
+  it("Anthropic 10-step tool loop holds every cache-shape invariant", async () => {
+    const calls = await runToolLoop("anthropic:claude-sonnet-4-6", 10);
+    expect(calls.length).toBe(11); // 10 tool turns + 1 final text turn
+    expect(checkInvariants(calls, "anthropic")).toEqual([]);
+  });
+
+  it("Anthropic 10-step shape matches the committed golden", async () => {
+    const calls = await runToolLoop("anthropic:claude-sonnet-4-6", 10);
+    await assertGolden("anthropic-10step", deriveShape(calls));
+  });
+
+  it("post-anchor write delta stays flat across the run (no cache-write thrash)", async () => {
+    const calls = await runToolLoop("anthropic:claude-sonnet-4-6", 12);
+    const deltas = deriveShape(calls)
+      .map((s) => s.deltaTokensAfterAnchor)
+      .filter((d): d is number => d !== null);
+    expect(deltas.length).toBeGreaterThanOrEqual(10);
+    // Uniform steps ⇒ every per-turn write delta is identical. A growing delta
+    // would mean the prefix is re-written each turn instead of appended.
+    expect(new Set(deltas).size).toBe(1);
+  });
+
+  it("final-step hint rides the tail, never mutating the cached system block", async () => {
+    // Force the loop to its iteration cap so the engine injects the final-step
+    // reminder. The reminder must land in the tail (5m region), leaving the 1h
+    // system block byte-identical — otherwise the final call of every run busts
+    // the whole cached prefix.
+    const calls = await runToolLoop("anthropic:claude-sonnet-4-6", 10, 4);
+    const shapes = deriveShape(calls);
+    const sys0 = shapes[0]!.system.hash;
+    expect(shapes.every((s) => s.system.hash === sys0)).toBe(true);
+
+    const lastPrompt = calls[calls.length - 1]!.prompt;
+    const systemHead = lastPrompt[0]!;
+    const systemText =
+      systemHead.role === "system" && typeof systemHead.content === "string"
+        ? systemHead.content
+        : JSON.stringify(systemHead.content);
+    expect(systemText).not.toContain("final step");
+    const tail = lastPrompt[lastPrompt.length - 1] as LanguageModelV3Message;
+    expect(JSON.stringify(tail)).toContain("final step");
+  });
+
+  it("OpenAI passthrough: no inline cache markers, prefix still append-only", async () => {
+    const calls = await runToolLoop("openai:gpt-4o", 10);
+    expect(checkInvariants(calls, "passthrough")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

Token-usage regressions keep recurring (the #403/#405/#406/#408 cache work), and each fix has landed without a guardrail behind it. The reason they recur: the **request shape** the engine sends to the provider isn't locked anywhere. Yet the expensive bugs — cache-write thrash, a per-turn hint appended to the system prompt busting its 1h breakpoint and the whole prefix, an anchor sliding off the prior tail — are all properties of that request, which is **fully deterministic** given a fixed conversation. So they're catchable with a scripted model and zero API calls.

## What

One harness, two tiers.

**`test/helpers/recording-model.ts`** — a `LanguageModelV3` decorator that records the exact post-cache-policy `prompt` + `tools` at the provider boundary (what actually goes on the wire).

**`test/helpers/token-shape.ts`** — `deriveShape()` (compact per-step fingerprint) + `checkInvariants()` (named violations). Provider-aware (`anthropic` vs `passthrough`).

**`test/unit/token-shape.test.ts`** (+ committed golden) — runs the **real engine loop** through a recording model on a scripted tool-loop and asserts:
- `system-stable` — system block byte-identical every step (guards the system-append regression, #408)
- `anchor-chaining` — anchor of call N+1 == prior call's tail (#405)
- `anti-thrash-bounded` — post-anchor write delta stays flat across the run
- `ttl` tiering (1h stable prefix / 5m rolling), `prefix-monotonic`, `passthrough-no-cache`

The golden is the artifact: `promptTokens` climbs every step (80 → 153 → 226…) while `deltaTokensAfterAnchor` stays pinned at 73. Prompt grows, per-turn cache-write flat — the optimization, locked. A regression moves those numbers into a reviewable diff. Regenerate intentional changes with `TOKEN_SHAPE_UPDATE=1`.

**`test/eval/token-shape.eval.test.ts`** (Tier 3) — the same scenario against real Anthropic/OpenAI/Google, reusing the same harness to verify invariants under real model behavior, plus realized `cacheRead`/`cacheWrite` health checks and a greppable metrics line for weekly drift tracking. Skips gracefully per provider when keys are absent.

## Validation

- `bun run test:unit` — 3419 pass (incl. 5 new)
- format / lint / `tsc` clean
- **Negative control:** removing the rolling anchor (simulating the pre-#405 bug) turns the unit suite red on `anchor-chaining` (10×), the golden, and anti-thrash; reverting returns it to green. The guard isn't vacuous.

## Notes

- Unit tier is the per-PR fence; the eval is run-on-a-cron (real tokens, provider nondeterminism).
- Building it surfaced one real thing: a naive uniform scenario trips the loop supervisor (identical repeated tool calls → tool released), so the scenario varies the query per step like a real agent.