### PR TITLE
fix(web): build image with frozen bun.lock instead of npm install

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,13 +1,19 @@
 # check=skip=SecretsUsedInArgOrEnv
 # VITE_TURNSTILE_SITE_KEY is a public client-side key, not a secret.
-FROM node:24-alpine AS build
+#
+# Install with bun against the frozen bun.lock — NOT `npm install`. npm cannot
+# read bun.lock, so it re-resolves every dependency to the newest in-range
+# version on each build, leaving us exposed to upstream publish races (e.g. a
+# transitive dep pinned to a version not yet live on the registry). Bun honors
+# the lockfile and builds deterministically, matching the platform Dockerfile.
+FROM oven/bun:1-alpine AS build
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN npm install
+RUN bun install --frozen-lockfile
 COPY . .
 ARG VITE_TURNSTILE_SITE_KEY=""
 ENV VITE_TURNSTILE_SITE_KEY=$VITE_TURNSTILE_SITE_KEY
-RUN npm run build
+RUN bun run build
 
 FROM caddy:2-alpine
 


### PR DESCRIPTION
## Problem

The \`Build & Push Images\` CI job started failing on the **web image** build:

\`\`\`
npm error code ETARGET
npm error notarget No matching version found for @posthog/core@1.32.0
\`\`\`

Nothing changed in this repo. The break was an upstream **publish race** at PostHog:

| Time (UTC) | Event |
|---|---|
| 17:43:34 | PostHog publishes \`posthog-js@1.386.0\` |
| ~17:43:44 | Our \`npm install\` picks \`1.386.0\` as newest match for \`^1.363.5\`; it requires \`@posthog/core@1.32.0\` (exact pin) |
| 17:43:57 | PostHog publishes \`@posthog/core@1.32.0\` — 23s too late |
| 17:44:06 | npm fails with ETARGET |

\`web/Dockerfile\` copied \`bun.lock\` but installed with \`npm install\`, which **ignores the lockfile** and re-resolves to the newest in-range version on every build — continuously exposing CI to PostHog's frequent, non-atomic releases.

## Fix

Build the web image with bun against the frozen lockfile, matching the platform \`Dockerfile\`:

- \`FROM oven/bun:1-alpine\` for the build stage
- \`bun install --frozen-lockfile\` (honors \`bun.lock\`)
- \`bun run build\`

Now deterministic: resolves to the pinned \`posthog-js@1.363.5\` / \`@posthog/core@1.24.1\`, immune to registry churn.

## Verification

\`bun install --frozen-lockfile\` validated locally against the committed \`bun.lock\` — resolves to \`posthog-js@1.363.5\` / \`@posthog/core@1.24.1\`, vite present, exit 0. Full native image build runs in CI.