### PR TITLE
ci: cache Docker layers, add concurrency, parallelize smoke, pin bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs on a PR branch (new push kills the old run), but never
+# cancel a push to main: each main commit must complete so its SHA-tagged image
+# lands in ECR (see build-and-push). On push events head_ref is empty, so the
+# group falls back to the unique run_id — making every main run its own group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+# Single source of truth for the bun toolchain version across every job.
+# Pinned (not `latest`) for deterministic CI; bump here to upgrade.
+env:
+  BUN_VERSION: "1.3.14"
+
 # Each job runs a single `bun run verify:*` (or underlying) script. Do not
 # inline individual check steps here — package.json is the source of truth
 # for what "verify" means. If a job needs a new check, add it to the matching
@@ -18,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
         run: bun install
       - name: Install web dependencies
@@ -33,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
         run: bun install
       - name: Install web dependencies
@@ -56,7 +69,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
         run: bun install
       - name: Integration tests
@@ -64,10 +77,12 @@ jobs:
 
   smoke:
     name: Smoke Tests
-    # Runs on PRs and on main. Smoke hits the live mpak registry + downloads
-    # bundles (~15s, network); gating it to main-only previously let a stale
-    # smoke assertion merge green and turn main red post-merge.
-    needs: [test-unit, test-integration]
+    # Runs on PRs and on main, in parallel with the other test jobs — NOT chained
+    # behind unit/integration. build-and-push gates on all four test jobs (incl.
+    # smoke), so nothing builds until every test is green; chaining smoke only
+    # delayed that gate without adding safety. Smoke hits the live mpak registry +
+    # downloads bundles (~15s, network). Not gated to main-only: that previously
+    # let a stale smoke assertion merge green and turn main red post-merge.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -76,7 +91,7 @@ jobs:
           python-version: "3.13"
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
         run: bun install
       - name: Install mpak
@@ -105,6 +120,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+      # buildx (docker-container driver) is required for the GitHub Actions
+      # layer cache below. The cache restores the base layers (apt deps, node,
+      # bun, mpak) that don't change between commits, so a warm build skips them.
+      - uses: docker/setup-buildx-action@v3
       - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -115,19 +134,30 @@ jobs:
         id: tag
         run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Build and push platform image
-        run: |
-          docker build --platform linux/amd64 \
-            --build-arg BUILD_SHA=${{ steps.tag.outputs.sha }} \
-            -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tag.outputs.sha }} \
-            -f Dockerfile .
-          docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tag.outputs.sha }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            BUILD_SHA=${{ steps.tag.outputs.sha }}
+          tags: ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tag.outputs.sha }}
+          # Per-image cache scope so the platform and web caches never overwrite
+          # each other. mode=max caches intermediate (multi-stage) layers too.
+          cache-from: type=gha,scope=platform
+          cache-to: type=gha,mode=max,scope=platform
       # NOTE: web is built without VITE_TURNSTILE_SITE_KEY (a build-time Vite
       # var), matching release.yml. The Makefile `push` target injects a
       # per-env key from 1Password; if a build-time Turnstile key is required
       # in prod, this image won't carry it. See the deployments Makefile.
       - name: Build and push web image
-        run: |
-          docker build --platform linux/amd64 \
-            -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tag.outputs.sha }} \
-            -f web/Dockerfile web/
-          docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tag.outputs.sha }}
+        uses: docker/build-push-action@v6
+        with:
+          context: web
+          file: web/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tag.outputs.sha }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Install mpak
+        # Intentionally @latest: smoke validates the live registry against the
+        # current mpak. Do NOT pin — a fixed version blinds the check it exists for.
         run: npm install -g @nimblebrain/mpak@latest
       - name: Smoke tests
         run: bun run smoke


### PR DESCRIPTION
Speeds up CI without weakening the test gate. Measured baseline (run for \`9495ea9\`): three serial waves, ~3.2 min wall-clock to a pushed image, with the image build not even starting until ~93s in.

## Changes

### 1. Docker layer caching (the big win)
Both images used raw \`docker build\` with no cross-run cache, rebuilding identical base layers (\`apt-get install curl/git/nodejs\`, \`bun.sh/install\`, \`npm i -g @nimblebrain/mpak\`) every run. Now built via \`docker/build-push-action@v6\` with \`type=gha\` cache (per-image \`scope\` so platform/web don't clobber each other; \`mode=max\` for multi-stage layers). Warm builds skip the unchanged base.

Expected: platform ~65s → ~20–30s, web ~28s → ~10s.

### 2. Concurrency
No \`concurrency\` existed — stale PR runs ran to completion. Now cancels superseded **PR-branch** runs. **Never cancels a push to main**: on push events \`head_ref\` is empty so the group falls back to the unique \`run_id\`, keeping every main commit's SHA-tagged image build intact.

### 3. Ordering (test gate unchanged)
\`smoke\` no longer chains behind \`test-unit\`/\`test-integration\`. **\`build-and-push\` still \`needs\` all four test jobs including smoke** — nothing builds until every test is green. Chaining smoke serially only pushed the build's start later without adding safety. Build now starts when the slowest test finishes (~54s) instead of after smoke runs in a second wave (~93s).

### 4. Pin bun, DRY
\`bun-version: latest\` (duplicated in 4 jobs) → single workflow-level \`env.BUN_VERSION\` pinned to \`1.3.14\` (what \`latest\` resolves to today). Deterministic, one place to bump.

## Expected critical path
\`\`\`
before: wave1 tests(~54) → wave2 smoke(~93) → wave3 build(~192)   ~3.2 min
after:  wave1 all tests(~54) → wave2 build, warm cache(~30–40)    ~1.5 min
\`\`\`

## Notes
- Native amd64 on GitHub runners (no QEMU), so the cache is the whole win.
- \`release.yml\` has the same two hand-maintained build blocks and could take the same cache treatment — deferred (ties into deduplicating the two workflows).