### PR TITLE
ci: dedup image build across ci/release + parallelize bundle UI builds

### DIFF
--- a/.github/actions/build-push-image/action.yml
+++ b/.github/actions/build-push-image/action.yml
@@ -1,0 +1,46 @@
+name: Build and push image
+description: >-
+  Build a linux/amd64 image with the GitHub Actions layer cache and push it to
+  the given tags. Single source of truth for how CI (ci.yml) and releases
+  (release.yml) build the platform and web images — keep the build mechanics
+  here; keep tag/registry *policy* in the calling workflow, where it differs.
+  The caller must run docker/setup-buildx-action once per job (the gha cache
+  needs the docker-container driver) and log in to every registry referenced
+  in `tags` before calling this action.
+
+inputs:
+  context:
+    description: Docker build context
+    required: true
+  file:
+    description: Path to the Dockerfile
+    required: true
+  tags:
+    description: Newline-separated list of fully-qualified image tags to push
+    required: true
+  cache-scope:
+    description: >-
+      gha cache scope. Use a distinct scope per image (e.g. platform, web) so
+      the caches never overwrite each other.
+    required: true
+  build-args:
+    description: Newline-separated build args (KEY=value)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: docker/build-push-action@v6
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        platforms: linux/amd64
+        push: true
+        build-args: ${{ inputs.build-args }}
+        tags: ${{ inputs.tags }}
+        # mode=max caches intermediate (multi-stage) layers too, which the web
+        # image needs — its bun install + vite build live in a build stage that
+        # is discarded from the final image.
+        cache-from: type=gha,scope=${{ inputs.cache-scope }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}

--- a/.github/workflows/catalog-check.yml
+++ b/.github/workflows/catalog-check.yml
@@ -24,6 +24,11 @@ on:
       - "scripts/check-catalog-dcr.ts"
       - ".github/workflows/catalog-check.yml"
 
+# Pinned (not `latest`) for deterministic CI; matches ci.yml / release.yml.
+# Bump here to upgrade.
+env:
+  BUN_VERSION: "1.3.14"
+
 jobs:
   catalog-dcr:
     name: DCR connector probe
@@ -33,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
         run: bun install
       - name: Probe DCR entries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       # buildx (docker-container driver) is required for the GitHub Actions
-      # layer cache below. The cache restores the base layers (apt deps, node,
-      # bun, mpak) that don't change between commits, so a warm build skips them.
+      # layer cache used by ./.github/actions/build-push-image. The cache
+      # restores the base layers (apt deps, node, bun, mpak) that don't change
+      # between commits, so a warm build skips them.
       - uses: docker/setup-buildx-action@v3
       - uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -136,30 +137,21 @@ jobs:
         id: tag
         run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Build and push platform image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-push-image
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64
-          push: true
-          build-args: |
-            BUILD_SHA=${{ steps.tag.outputs.sha }}
+          cache-scope: platform
+          build-args: BUILD_SHA=${{ steps.tag.outputs.sha }}
           tags: ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tag.outputs.sha }}
-          # Per-image cache scope so the platform and web caches never overwrite
-          # each other. mode=max caches intermediate (multi-stage) layers too.
-          cache-from: type=gha,scope=platform
-          cache-to: type=gha,mode=max,scope=platform
       # NOTE: web is built without VITE_TURNSTILE_SITE_KEY (a build-time Vite
       # var), matching release.yml. The Makefile `push` target injects a
       # per-env key from 1Password; if a build-time Turnstile key is required
       # in prod, this image won't carry it. See the deployments Makefile.
       - name: Build and push web image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-push-image
         with:
           context: web
           file: web/Dockerfile
-          platforms: linux/amd64
-          push: true
+          cache-scope: web
           tags: ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tag.outputs.sha }}
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ permissions:
   id-token: write
   packages: write
 
+# Single source of truth for the bun toolchain version (matches ci.yml).
+# Pinned (not `latest`) for deterministic builds; bump here to upgrade.
+env:
+  BUN_VERSION: "1.3.14"
+
 jobs:
   # Each step below runs a `bun run verify:*` subscript; package.json is the
   # source of truth for what "verify" means. Do not inline individual check
@@ -21,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
         run: bun install
       - name: Install web dependencies
@@ -39,6 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # buildx (docker-container driver) is required for the GitHub Actions
+      # layer cache used by ./.github/actions/build-push-image.
+      - uses: docker/setup-buildx-action@v3
       - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -50,70 +58,76 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
 
+      # Compute the full tag list per image up front. `:latest` (GHCR only —
+      # ECR has immutable tags and can't reuse it) is appended for stable
+      # releases. SemVer pre-release tags always contain a hyphen
+      # (v0.4.0-beta.1, v1.0.0-rc.1); GA tags don't — so the hyphen test keeps
+      # `:latest` pointing at the most recent GA release. Building `:latest`
+      # into the push (rather than a post-build `docker tag`) is also required
+      # by the buildx docker-container driver, which never loads the image into
+      # the local daemon for a subsequent retag.
       - name: Set image tags
         id: tags
         run: |
           VERSION=${GITHUB_REF_NAME}
           SHA=$(git rev-parse --short HEAD)
+          REG=${{ steps.ecr.outputs.registry }}
           # Strip the leading `v` for injection into the running binary
           # (package.json-style versions have no `v` prefix).
           PKG_VERSION=${VERSION#v}
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "pkg_version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
 
-      # ECR tags deliberately exclude `:latest` — repositories have immutable
-      # tags enabled, so `latest` can't be reused across releases. Deploys pin
-      # to the version tag or short sha. GHCR gets `:latest` too, but only
-      # for stable releases (see the gated steps below).
+          platform_tags=(
+            "$REG/nimblebrain/agent-platform:$VERSION"
+            "$REG/nimblebrain/agent-platform:$SHA"
+            "ghcr.io/nimblebraininc/nimblebrain:$VERSION"
+            "ghcr.io/nimblebraininc/nimblebrain:$SHA"
+          )
+          web_tags=(
+            "$REG/nimblebrain/agent-web:$VERSION"
+            "$REG/nimblebrain/agent-web:$SHA"
+            "ghcr.io/nimblebraininc/nimblebrain-web:$VERSION"
+            "ghcr.io/nimblebraininc/nimblebrain-web:$SHA"
+          )
+
+          # Stable releases (no hyphen in the semver tag) also move GHCR :latest.
+          case "$VERSION" in
+            *-*) ;;  # pre-release: leave :latest alone
+            *)
+              platform_tags+=("ghcr.io/nimblebraininc/nimblebrain:latest")
+              web_tags+=("ghcr.io/nimblebraininc/nimblebrain-web:latest")
+              ;;
+          esac
+
+          {
+            echo "sha=$SHA"
+            echo "pkg_version=$PKG_VERSION"
+            echo "platform_tags<<TAGS_EOF"
+            printf '%s\n' "${platform_tags[@]}"
+            echo "TAGS_EOF"
+            echo "web_tags<<TAGS_EOF"
+            printf '%s\n' "${web_tags[@]}"
+            echo "TAGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push platform image
-        run: |
-          docker build --platform linux/amd64 \
-            --build-arg BUILD_SHA=${{ steps.tags.outputs.sha }} \
-            --build-arg VERSION=${{ steps.tags.outputs.pkg_version }} \
-            -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.version }} \
-            -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.sha }} \
-            -t ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.version }} \
-            -t ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.sha }} \
-            -f Dockerfile .
-          docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.version }}
-          docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tags.outputs.sha }}
-          docker push ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.version }}
-          docker push ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.sha }}
+        uses: ./.github/actions/build-push-image
+        with:
+          context: .
+          file: Dockerfile
+          cache-scope: platform
+          build-args: |
+            BUILD_SHA=${{ steps.tags.outputs.sha }}
+            VERSION=${{ steps.tags.outputs.pkg_version }}
+          tags: ${{ steps.tags.outputs.platform_tags }}
 
       - name: Build and push web image
-        run: |
-          docker build --platform linux/amd64 \
-            -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.version }} \
-            -t ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.sha }} \
-            -t ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.version }} \
-            -t ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.sha }} \
-            -f web/Dockerfile web/
-          docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.version }}
-          docker push ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tags.outputs.sha }}
-          docker push ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.version }}
-          docker push ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.sha }}
-
-      # Stable-release-only. SemVer pre-release tags always contain a hyphen
-      # (v0.4.0-beta.1, v1.0.0-rc.1); GA tags don't. Gating on the hyphen
-      # keeps `:latest` pointing at the most recent GA release.
-      - name: Promote platform image to :latest (stable releases only)
-        if: ${{ !contains(github.ref_name, '-') }}
-        run: |
-          docker tag ghcr.io/nimblebraininc/nimblebrain:${{ steps.tags.outputs.version }} \
-                     ghcr.io/nimblebraininc/nimblebrain:latest
-          docker push ghcr.io/nimblebraininc/nimblebrain:latest
-
-      - name: Promote web image to :latest (stable releases only)
-        if: ${{ !contains(github.ref_name, '-') }}
-        run: |
-          docker tag ghcr.io/nimblebraininc/nimblebrain-web:${{ steps.tags.outputs.version }} \
-                     ghcr.io/nimblebraininc/nimblebrain-web:latest
-          docker push ghcr.io/nimblebraininc/nimblebrain-web:latest
+        uses: ./.github/actions/build-push-image
+        with:
+          context: web
+          file: web/Dockerfile
+          cache-scope: web
+          tags: ${{ steps.tags.outputs.web_tags }}
 
   github-release:
     name: GitHub Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,14 @@ COPY --chown=1000:1000 scripts/ scripts/
 # Built in parallel (each bundle does its own install + build) rather than
 # serially — they're independent. PIDs are collected and waited on individually
 # so any single bundle's failure fails the whole RUN (a bare `wait` would mask
-# a nonzero exit).
+# a nonzero exit). Each subshell tags its own failure with the bundle path so
+# the culprit is greppable even though parallel output is interleaved.
 RUN set -e; \
     pids=""; \
     for ui in src/bundles/*/ui; do \
       [ -f "$ui/package.json" ] || continue; \
-      ( cd "$ui" && bun install && bun run build && rm -rf node_modules ) & \
+      ( cd "$ui" && bun install && bun run build && rm -rf node_modules \
+        || { echo "ERROR: bundle UI build failed: $ui" >&2; exit 1; } ) & \
       pids="$pids $!"; \
     done; \
     for p in $pids; do wait "$p"; done

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,24 @@ RUN bun install --frozen-lockfile --production --ignore-scripts
 COPY --chown=1000:1000 src/ src/
 COPY --chown=1000:1000 scripts/ scripts/
 
-# Build bundle UIs (dist/ is gitignored, must build in container).
-# UI deps are installed fresh here and removed after build — the source tree's
-# nested node_modules are excluded by .dockerignore (**/node_modules) so they
-# never enter the build context or bloat the COPY layer.
-RUN for ui in src/bundles/*/ui; do \
-      [ -f "$ui/package.json" ] && (cd "$ui" && bun install && bun run build && rm -rf node_modules); \
-    done
+# Build the built-in bundle UIs (home, conversations, files, automations,
+# usage) — each is its own single-file Vite app and must build in the container
+# because dist/ is gitignored. UI deps are installed fresh here and removed
+# after build; the source tree's nested node_modules are excluded by
+# .dockerignore (**/node_modules) so they never enter the build context.
+#
+# Built in parallel (each bundle does its own install + build) rather than
+# serially — they're independent. PIDs are collected and waited on individually
+# so any single bundle's failure fails the whole RUN (a bare `wait` would mask
+# a nonzero exit).
+RUN set -e; \
+    pids=""; \
+    for ui in src/bundles/*/ui; do \
+      [ -f "$ui/package.json" ] || continue; \
+      ( cd "$ui" && bun install && bun run build && rm -rf node_modules ) & \
+      pids="$pids $!"; \
+    done; \
+    for p in $pids; do wait "$p"; done
 
 USER 1000
 


### PR DESCRIPTION
Two related build-hardening changes in one pass.

## 1. Deduplicate the image build (ci.yml + release.yml)

The platform/web build was four hand-maintained copies (2 images × 2 workflows) and had **already drifted**: `release.yml` never received the `type=gha` layer cache from #413 and still floated `bun-version: latest`. This is the same class of divergence that caused the original `web/Dockerfile` incident.

- **New composite action** `.github/actions/build-push-image` owns the `docker/build-push-action@v6` call + gha cache (action pin, platform flag, cache scope). Single source of truth for *how* we build.
- **`ci.yml`** and **`release.yml`** both call it. Tag/registry **policy** stays in each workflow, where it legitimately differs (ci → ECR `:sha`; release → ECR + GHCR, `:version` + `:sha` + stable `:latest`).
- **`release.yml` gains the layer cache for free**, pins bun via a shared `BUN_VERSION` env, and drops an unused `setup-bun` from the build job.

### Bug fixed in passing
`release.yml`'s `:latest` promotion used a post-build `docker tag … && docker push`. The buildx **docker-container driver never loads the built image into the local daemon**, so that retag would have broken the moment release moved to `build-push-action`. Folded `:latest` into the computed tag list instead — built and pushed atomically.

Tag computation verified locally:
- `v1.2.0` (stable) → GHCR `:latest` on both images; ECR gets `:version` + `:sha`, never `:latest` (immutable).
- `v0.4.0-beta.1` (pre-release) → no `:latest`.

## 2. Parallelize the bundle UI builds

The 5 built-in bundle UIs (home, conversations, files, automations, usage) built **serially**, each running its own cold `bun install` of a near-identical dep tree. They're independent — now built in parallel. PIDs are collected and `wait`ed individually so any single bundle's failure fails the `RUN` (a bare `wait` masks nonzero exits). Verified under both bash and dash (Docker `RUN` uses `/bin/sh`).

## Verification & rollout notes
- All three YAML files parse; tag-computation and parallel-loop failure-propagation tested locally.
- **Neither build path runs on this PR** — `build-and-push` is push-to-main-gated, and release only fires on `v*` tags. So:
  - The **composite action + parallel bundle build** get exercised on the **first main push after merge** (I'll watch it).
  - **`release.yml` is exercised only on the next release tag.** Its logic is unchanged in intent and tag output, but reviewers should scrutinize since it can't run here.