### PR TITLE
fix(web): token chip shows fresh tokens, not the cache-inflated sum

### DIFF
--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -12,6 +12,29 @@ function formatTokens(count: number): string {
   return count.toString();
 }
 
+/**
+ * Per-turn usage chip. Shows the *new* work inline — fresh (non-cached) input,
+ * output, and (when present) the cached re-reads. The raw input total sums
+ * every agentic-loop iteration AND counts cache reads at face value, so a
+ * cache-heavy turn reads as a scary number (e.g. "401k") that's almost all
+ * re-reads. Inline (not a hover title) so the breakdown is actually visible.
+ */
+function UsageChip({ usage }: { usage: NonNullable<ChatMessage["usage"]> }) {
+  const cacheRead = usage.cacheReadTokens ?? 0;
+  const cacheWrite = usage.cacheWriteTokens ?? 0;
+  const freshIn = Math.max(usage.inputTokens - cacheRead - cacheWrite, 0);
+
+  const parts = [`${formatTokens(freshIn)} new`];
+  if (cacheRead > 0) parts.push(`${formatTokens(cacheRead)} cached`);
+
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground tabular-nums">
+      <Zap style={{ width: 10, height: 10 }} className="opacity-70" />
+      <span>{parts.join(" · ")}</span>
+    </span>
+  );
+}
+
 const APP_CONTEXT_RE = /^\[App Context:[^\]]*\]\n/;
 
 function formatRelativeTime(iso: string): string {
@@ -426,17 +449,7 @@ export function MessageList({
                       {formatRelativeTime(msg.timestamp)}
                     </span>
                   )}
-                  {msg.usage && (
-                    <span
-                      className="inline-flex items-center gap-1 text-[10px] text-muted-foreground"
-                      title={`${formatTokens(msg.usage.inputTokens)} in, ${formatTokens(msg.usage.outputTokens)} out${msg.usage.cacheReadTokens ? ` (${formatTokens(msg.usage.cacheReadTokens)} cached)` : ""} · ${msg.usage.model} · ${Math.round(msg.usage.llmMs)}ms`}
-                    >
-                      <Zap style={{ width: 10, height: 10 }} className="opacity-70" />
-                      <span className="tabular-nums">
-                        {formatTokens(msg.usage.inputTokens + msg.usage.outputTokens)}
-                      </span>
-                    </span>
-                  )}
+                  {msg.usage && <UsageChip usage={msg.usage} />}
                 </div>
               </div>
             );

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -13,11 +13,13 @@ function formatTokens(count: number): string {
 }
 
 /**
- * Per-turn usage chip. Shows the *new* work inline — fresh (non-cached) input,
- * output, and (when present) the cached re-reads. The raw input total sums
- * every agentic-loop iteration AND counts cache reads at face value, so a
- * cache-heavy turn reads as a scary number (e.g. "401k") that's almost all
- * re-reads. Inline (not a hover title) so the breakdown is actually visible.
+ * Per-turn usage chip. Shows the *new* work inline — fresh (non-cached) input
+ * as "N new", plus the cached re-reads as "Nk cached" when present. The raw
+ * input total sums every agentic-loop iteration AND counts cache reads at face
+ * value, so a cache-heavy turn reads as a scary number (e.g. "401k") that's
+ * almost all re-reads. Output, cache *writes*, model, and latency are
+ * deliberately omitted to keep the bar ambient ("new" is noCache only). Inline
+ * (not a hover title) so the breakdown is actually visible.
  */
 function UsageChip({ usage }: { usage: NonNullable<ChatMessage["usage"]> }) {
   const cacheRead = usage.cacheReadTokens ?? 0;

--- a/web/test/MessageList.copy.test.tsx
+++ b/web/test/MessageList.copy.test.tsx
@@ -142,7 +142,7 @@ describe("MessageList CopyButton feedback", () => {
 describe("MessageList usage chip", () => {
 	// Real numbers from the conv that prompted this: 400k "input" was almost
 	// all cached re-reads. The chip must show the fresh work inline
-	// (16.4k new · 870 out · 225.3k cached), never the 401k raw sum.
+	// (16.4k new · 225.3k cached), never the 401k raw sum.
 	const usageMsg: ChatMessage = {
 		role: "assistant",
 		content: "done",

--- a/web/test/MessageList.copy.test.tsx
+++ b/web/test/MessageList.copy.test.tsx
@@ -138,3 +138,37 @@ describe("MessageList CopyButton feedback", () => {
 		});
 	});
 });
+
+describe("MessageList usage chip", () => {
+	// Real numbers from the conv that prompted this: 400k "input" was almost
+	// all cached re-reads. The chip must show the fresh work inline
+	// (16.4k new · 870 out · 225.3k cached), never the 401k raw sum.
+	const usageMsg: ChatMessage = {
+		role: "assistant",
+		content: "done",
+		usage: {
+			inputTokens: 400304,
+			outputTokens: 870,
+			cacheReadTokens: 225328,
+			cacheWriteTokens: 158550,
+			model: "anthropic:claude-opus-4-7",
+			llmMs: 1240,
+		},
+	};
+
+	it("shows fresh tokens + cached inline, not the cache-inflated input sum", () => {
+		const { container } = render(
+			<MessageList
+				messages={[usageMsg]}
+				isStreaming={false}
+				streamingState="idle"
+				displayDetail="balanced"
+			/>,
+		);
+
+		const text = container.textContent ?? "";
+		expect(text).toContain("16.4k new");
+		expect(text).toContain("225.3k cached");
+		expect(text).not.toContain("401");
+	});
+});


### PR DESCRIPTION
## Why

The per-turn usage chip rendered `inputTokens + outputTokens`, but `inputTokens` is the **cumulative sum across every agentic-loop iteration** and counts cache reads at face value. A cache-heavy multi-step turn reads as an alarming number — e.g. **401.2k** — that's almost entirely cached re-reads. In the turn that prompted this, only **~16k** was genuinely new; the rest was the same prefix re-sent and cache-read across the loop.

## What changed (web only)

The chip now shows the **new work inline**, as plain muted text:

- **`⚡ 10 new · 11.0k cached`** on a follow-up turn (fresh non-cached input + the cached re-reads).
- **`⚡ 10 new`** on a first turn — `cached` is omitted when there are no reads, so the quiet case stays a single number.

`new` = `inputTokens − cacheRead − cacheWrite` (the genuinely fresh input). Inline rather than a hover `title` so the breakdown is actually visible (the native tooltip was unreliable). Output / cost / step-count are intentionally left off the always-on bar to keep it ambient.

No engine/runtime/API/persistence changes. The chip is live-turn only (reloaded history carries no usage), so nothing to migrate.

## Tests

`web/test/MessageList.copy.test.tsx` renders the real 400,304-input / 225k-cached turn and asserts it reads as **`16.4k new · 225.3k cached`**, never `401`.

`check:web` clean, lint clean, web production build green, **512 web tests pass**.

## Not in scope

The other half of the original token investigation — collapsing the `nb__search` → `nb__manage_tools` round-trip so a tool promotion doesn't re-send the prefix mid-turn — is a behavior change to search semantics, tracked separately.