### PR TITLE
fix(automations): de-mask runs that hit an unreachable connector

### DIFF
--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -1,7 +1,8 @@
 /**
  * Automation executor: runs an automation's prompt through the chat engine.
  *
- * `createDirectExecutor` calls `runtime.chat()` in-process — the only path now
+ * `createDirectExecutor` runs each automation via `runtime.executeTask()`
+ * in-process (wired in `tools/platform/automations.ts`) — the only path now
  * that automations is an in-process platform source (the former HTTP executor
  * + standalone MCP server were removed). A scheduled run fires as the
  * automation's owner; see `getExecutorContext` in the platform source.
@@ -154,15 +155,10 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): TaskFnRequ
  *                                 isn't a member of (e.g. another user's personal
  *                                 workspace) — unreachable by design. (Orchestrator
  *                                 reason.)
- *   - `reauth_required`         → the connector IS installed but its authorization
- *                                 expired/was revoked, so a tool call hit it and
- *                                 failed on auth. Distinct from the two above: the
- *                                 source routes fine, the failure is downstream.
- *                                 Emitted by the connector auth-loss path
- *                                 (`McpSource.execute`); harmless to list before
- *                                 that lands — no call carries this reason until
- *                                 then. This is the literal "the connector is
- *                                 disconnected" case the others do NOT cover.
+ *
+ * These are the only two reasons any code emits as a tool-result
+ * `structuredContent.reason` today (the orchestrator's `error-mapping.ts`), so
+ * the set stays grounded in values that are actually produced and tested.
  *
  * Deliberately narrower than the full reason taxonomy. Excluded on purpose:
  *   - `invalid_tool_name` / `unknown_identity_source` — usually the agent probing
@@ -172,12 +168,14 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): TaskFnRequ
  *     Real but rare, and the taxonomy frames it as a typo / cross-tenant accident
  *     (agent error) rather than a connector gap. Left out for now; revisit if it
  *     shows up in practice.
+ *
+ * NOT covered here: an installed connector whose authorization expired mid-run.
+ * That surfaces a `reason: "reauth_required"` tool result only once the connector
+ * auth-loss detection lands (a separate change). Add `reauth_required` to this
+ * set in THAT change, alongside a test against its real emission — not as a
+ * forward-declaration here, which would assert a value no current path produces.
  */
-const UNREACHABLE_CONNECTOR_REASONS = new Set([
-  "unknown_tool_source",
-  "workspace_access_denied",
-  "reauth_required",
-]);
+const UNREACHABLE_CONNECTOR_REASONS = new Set(["unknown_tool_source", "workspace_access_denied"]);
 
 /** Tool-call entries (loosely typed in `TaskFnResult`) whose routing failed. */
 function unreachableConnectorCalls(toolCalls: TaskFnResult["toolCalls"]): string[] {

--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -139,26 +139,45 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): TaskFnRequ
 }
 
 /**
- * Orchestrator routing-failure reasons (see `src/orchestrator/error-mapping.ts`)
- * that mean a tool call could not be ROUTED to a connector at all:
+ * Per-tool-call failure reasons that mean a connector the run NEEDED was not
+ * usable — so a `complete` stop is not an honest success:
  *
- *   - `unknown_tool_source`     → the connector isn't installed/running in the
- *                                 workspace the run can see (a disconnected or
- *                                 missing app). This is the standup-automation
- *                                 case: the agent searched, found no Teams
- *                                 connector, and "completed" by writing around it.
- *   - `workspace_access_denied` → the connector lives in a workspace the run's
- *                                 owner isn't a member of (e.g. another user's
- *                                 personal workspace) — unreachable by design.
+ *   - `unknown_tool_source`     → the tool's source isn't registered in the
+ *                                 workspace the run can see — i.e. the app isn't
+ *                                 installed there (`route.ts`: `getSource()`
+ *                                 returned nothing). This is the standup case:
+ *                                 the agent searched, found no Teams connector
+ *                                 in any reachable workspace, and "completed" by
+ *                                 writing around it. (Orchestrator reason; see
+ *                                 `src/orchestrator/error-mapping.ts`.)
+ *   - `workspace_access_denied` → the tool lives in a workspace the run's owner
+ *                                 isn't a member of (e.g. another user's personal
+ *                                 workspace) — unreachable by design. (Orchestrator
+ *                                 reason.)
+ *   - `reauth_required`         → the connector IS installed but its authorization
+ *                                 expired/was revoked, so a tool call hit it and
+ *                                 failed on auth. Distinct from the two above: the
+ *                                 source routes fine, the failure is downstream.
+ *                                 Emitted by the connector auth-loss path
+ *                                 (`McpSource.execute`); harmless to list before
+ *                                 that lands — no call carries this reason until
+ *                                 then. This is the literal "the connector is
+ *                                 disconnected" case the others do NOT cover.
  *
- * These are deliberately narrower than the full reason taxonomy: a malformed
- * name (`invalid_tool_name`) or a bad identity source is usually the agent
- * probing and self-correcting, not a real connector gap — flagging those would
- * mark healthy runs failed. The two above mean "a connector the run needed was
- * not reachable," which an operator must see rather than have hidden behind a
- * green `complete`.
+ * Deliberately narrower than the full reason taxonomy. Excluded on purpose:
+ *   - `invalid_tool_name` / `unknown_identity_source` — usually the agent probing
+ *     a wrong name and self-correcting, not a real connector gap; flagging them
+ *     would mark healthy runs failed.
+ *   - `unknown_workspace` — a target workspace deleted out from under the run.
+ *     Real but rare, and the taxonomy frames it as a typo / cross-tenant accident
+ *     (agent error) rather than a connector gap. Left out for now; revisit if it
+ *     shows up in practice.
  */
-const UNREACHABLE_CONNECTOR_REASONS = new Set(["unknown_tool_source", "workspace_access_denied"]);
+const UNREACHABLE_CONNECTOR_REASONS = new Set([
+  "unknown_tool_source",
+  "workspace_access_denied",
+  "reauth_required",
+]);
 
 /** Tool-call entries (loosely typed in `TaskFnResult`) whose routing failed. */
 function unreachableConnectorCalls(toolCalls: TaskFnResult["toolCalls"]): string[] {

--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -143,22 +143,31 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): TaskFnRequ
  * Per-tool-call failure reasons that mean a connector the run NEEDED was not
  * usable — so a `complete` stop is not an honest success:
  *
- *   - `unknown_tool_source`     → the tool's source isn't registered in the
- *                                 workspace the run can see — i.e. the app isn't
- *                                 installed there (`route.ts`: `getSource()`
- *                                 returned nothing). This is the standup case:
- *                                 the agent searched, found no Teams connector
- *                                 in any reachable workspace, and "completed" by
- *                                 writing around it. (Orchestrator reason; see
- *                                 `src/orchestrator/error-mapping.ts`.)
- *   - `workspace_access_denied` → the tool lives in a workspace the run's owner
- *                                 isn't a member of (e.g. another user's personal
- *                                 workspace) — unreachable by design. (Orchestrator
- *                                 reason.)
+ *   - `unknown_tool_source`     → the run ATTEMPTED a namespaced tool call but
+ *                                 the tool's source isn't registered in that
+ *                                 workspace — the app isn't installed there
+ *                                 (`route.ts`: `getSource()` returned nothing).
+ *                                 (Orchestrator reason; see `error-mapping.ts`.)
+ *   - `workspace_access_denied` → the run ATTEMPTED a call into a workspace its
+ *                                 owner isn't a member of (e.g. another user's
+ *                                 personal workspace) — unreachable by design.
+ *                                 (Orchestrator reason.)
  *
- * These are the only two reasons any code emits as a tool-result
- * `structuredContent.reason` today (the orchestrator's `error-mapping.ts`), so
- * the set stays grounded in values that are actually produced and tested.
+ * KEY LIMITATION — both reasons require the agent to have ATTEMPTED the call.
+ * A required connector that never appears in the agent's toolset (so it never
+ * tries) produces no reason and is NOT de-masked. The production standup
+ * incident was actually this never-attempted variant: the agent ran `nb__search`,
+ * found no Teams connector in any reachable workspace, and "completed" by
+ * documenting the gap — never calling a Teams tool. So this fix de-masks the
+ * attempted-call class (a strict improvement, zero false positives); the
+ * never-attempted class needs a different signal (the agent self-reporting an
+ * incomplete required step) and is tracked separately.
+ *
+ * These are the only two *connector-unreachable* reasons. The orchestrator
+ * (`error-mapping.ts`) emits FIVE reasons in all; the other three are agent /
+ * typo errors, not connector gaps, and are excluded below — the taxonomy is NOT
+ * closed at two. Both reasons here are really produced and tested, so the set
+ * stays grounded in values that actually occur.
  *
  * Deliberately narrower than the full reason taxonomy. Excluded on purpose:
  *   - `invalid_tool_name` / `unknown_identity_source` — usually the agent probing

--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -138,13 +138,74 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): TaskFnRequ
   return req;
 }
 
+/**
+ * Orchestrator routing-failure reasons (see `src/orchestrator/error-mapping.ts`)
+ * that mean a tool call could not be ROUTED to a connector at all:
+ *
+ *   - `unknown_tool_source`     → the connector isn't installed/running in the
+ *                                 workspace the run can see (a disconnected or
+ *                                 missing app). This is the standup-automation
+ *                                 case: the agent searched, found no Teams
+ *                                 connector, and "completed" by writing around it.
+ *   - `workspace_access_denied` → the connector lives in a workspace the run's
+ *                                 owner isn't a member of (e.g. another user's
+ *                                 personal workspace) — unreachable by design.
+ *
+ * These are deliberately narrower than the full reason taxonomy: a malformed
+ * name (`invalid_tool_name`) or a bad identity source is usually the agent
+ * probing and self-correcting, not a real connector gap — flagging those would
+ * mark healthy runs failed. The two above mean "a connector the run needed was
+ * not reachable," which an operator must see rather than have hidden behind a
+ * green `complete`.
+ */
+const UNREACHABLE_CONNECTOR_REASONS = new Set(["unknown_tool_source", "workspace_access_denied"]);
+
+/** Tool-call entries (loosely typed in `TaskFnResult`) whose routing failed. */
+function unreachableConnectorCalls(toolCalls: TaskFnResult["toolCalls"]): string[] {
+  if (!Array.isArray(toolCalls)) return [];
+  const names: string[] = [];
+  for (const tc of toolCalls) {
+    const reason = tc.errorReason;
+    const name = tc.name;
+    if (typeof reason === "string" && UNREACHABLE_CONNECTOR_REASONS.has(reason)) {
+      names.push(typeof name === "string" ? name : "(unknown tool)");
+    }
+  }
+  return names;
+}
+
 function mapResultToRun(
   automation: Automation,
   startedAt: string,
   data: TaskFnResult,
 ): AutomationRun {
   const stopReason = data.stopReason as AutomationRun["stopReason"];
-  const status: AutomationRun["status"] = mapStopReasonToStatus(stopReason);
+  let status: AutomationRun["status"] = mapStopReasonToStatus(stopReason);
+
+  // De-mask the silent connector failure: when the model reports `complete`,
+  // the run would otherwise be a green `success` — even if a tool call hit a
+  // connector that couldn't be routed (missing, disconnected, or in another
+  // workspace the owner can't reach). The agent commonly "completes" by
+  // documenting the gap instead of doing the work, which is precisely the
+  // failure operators reported (a standup summary that never reached Teams,
+  // recorded as success). A connector-unreachable call means the automation
+  // did not actually do its job: downgrade to `failure` and name the tool(s)
+  // so the run list shows it instead of burying it in the conversation.
+  //
+  // Only overrides an otherwise-`success` run; a run already classified
+  // failure/timeout keeps its (stronger) status.
+  let error: string | undefined;
+  if (status === "success") {
+    const unreachable = unreachableConnectorCalls(data.toolCalls);
+    if (unreachable.length > 0) {
+      status = "failure";
+      const unique = [...new Set(unreachable)];
+      error =
+        `Connector unavailable during run: ${unique.length} tool call type(s) could not be ` +
+        `routed (${unique.join(", ")}). The required connector is missing, disconnected, or ` +
+        `in a workspace this automation cannot reach — the run did not complete its intended action.`;
+    }
+  }
 
   return {
     id: `run_${crypto.randomUUID().slice(0, 12)}`,
@@ -159,6 +220,7 @@ function mapResultToRun(
     iterations: data.usage.iterations,
     resultPreview: data.output || undefined,
     stopReason,
+    ...(error ? { error } : {}),
   };
 }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1022,6 +1022,12 @@ export class AgentEngine {
             output: llmText,
             ok: !result.isError,
             ms,
+            // Surface the structured failure reason (orchestrator routing
+            // classes, etc.) so consumers can tell an unroutable connector
+            // from a tool that ran and errored. See ToolCallRecord.errorReason.
+            ...(result.isError && typeof result.structuredContent?.reason === "string"
+              ? { errorReason: result.structuredContent.reason }
+              : {}),
             ...(uri ? { resourceUri: uri } : {}),
             ...(links && links.length > 0 ? { resourceLinks: links } : {}),
           });

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -387,6 +387,18 @@ export interface ToolCallRecord {
   output: string;
   ok: boolean;
   ms: number;
+  /**
+   * Structured error reason when `ok === false`, lifted from the tool
+   * result's `structuredContent.reason`. Lets downstream consumers
+   * distinguish a tool call that could not be ROUTED (a connector missing
+   * from the workspace, disconnected, or in a workspace the caller can't
+   * reach — `unknown_tool_source`, `workspace_access_denied`, …; see
+   * `src/orchestrator/error-mapping.ts`) from a tool that ran and returned a
+   * logical error the agent handled. The automations executor reads this to
+   * de-mask runs that "completed" only by writing around an unreachable
+   * connector. Absent when the call succeeded or carried no structured reason.
+   */
+  errorReason?: string;
   resourceUri?: string;
   /**
    * MCP `resource_link` content blocks surfaced by the tool result.

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -2163,6 +2163,12 @@ export class Runtime {
           partial.inputTokens += usage.inputTokens ?? 0;
           partial.outputTokens += usage.outputTokens ?? 0;
         } else if (type === "tool.done") {
+          // `errorReason` is intentionally absent here: this accumulator only
+          // feeds the abort/timeout path, which always returns
+          // `stopReason: "aborted"` (never "complete"), so the automations
+          // de-masker's `status === "success"` guard never reads it. (The
+          // `tool.done` event doesn't carry `errorReason` either — no point
+          // threading it through for a path that can't de-mask.)
           partialToolCalls.push({
             id: (data.id as string) ?? "",
             name: (data.name as string) ?? "",

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -324,6 +324,8 @@ export interface ChatResult {
     output: string;
     ok: boolean;
     ms: number;
+    /** Structured failure reason when `ok === false`. See ToolCallRecord.errorReason. */
+    errorReason?: string;
   }>;
   stopReason: string;
   /** Detailed usage breakdown for this turn. */
@@ -430,6 +432,8 @@ export interface TaskResult {
     output: string;
     ok: boolean;
     ms: number;
+    /** Structured failure reason when `ok === false`. See ToolCallRecord.errorReason. */
+    errorReason?: string;
   }>;
   stopReason: string;
   usage: TurnUsage;

--- a/test/unit/bundles/automations/executor.test.ts
+++ b/test/unit/bundles/automations/executor.test.ts
@@ -274,6 +274,22 @@ describe("createDirectExecutor — connector-unreachable de-masking", () => {
 		expect(run.error).toMatch(/ws_x-teams__send_message/);
 	});
 
+	test("complete + reauth_required (installed but auth expired) → failure", async () => {
+		const run = await runWith([
+			{
+				id: "t1",
+				name: "ws_x-teams__send_message",
+				input: {},
+				output: "teams needs to be reconnected",
+				ok: false,
+				ms: 18,
+				errorReason: "reauth_required",
+			},
+		]);
+		expect(run.status).toBe("failure");
+		expect(run.error).toMatch(/Connector unavailable/);
+	});
+
 	test("complete + workspace_access_denied → failure", async () => {
 		const run = await runWith([
 			{

--- a/test/unit/bundles/automations/executor.test.ts
+++ b/test/unit/bundles/automations/executor.test.ts
@@ -274,22 +274,6 @@ describe("createDirectExecutor — connector-unreachable de-masking", () => {
 		expect(run.error).toMatch(/ws_x-teams__send_message/);
 	});
 
-	test("complete + reauth_required (installed but auth expired) → failure", async () => {
-		const run = await runWith([
-			{
-				id: "t1",
-				name: "ws_x-teams__send_message",
-				input: {},
-				output: "teams needs to be reconnected",
-				ok: false,
-				ms: 18,
-				errorReason: "reauth_required",
-			},
-		]);
-		expect(run.status).toBe("failure");
-		expect(run.error).toMatch(/Connector unavailable/);
-	});
-
 	test("complete + workspace_access_denied → failure", async () => {
 		const run = await runWith([
 			{

--- a/test/unit/bundles/automations/executor.test.ts
+++ b/test/unit/bundles/automations/executor.test.ts
@@ -12,7 +12,7 @@ import {
 	type TaskFn,
 	type TaskFnResult,
 } from "../../../../src/bundles/automations/src/executor.ts";
-import type { Automation } from "../../../../src/bundles/automations/src/types.ts";
+import type { Automation, AutomationRun } from "../../../../src/bundles/automations/src/types.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -226,6 +226,98 @@ describe("createDirectExecutor — stopReason → status", () => {
 
 	test("unrecognized stopReason → failure (fail-closed default)", async () => {
 		expect(await statusFor("some_future_reason")).toBe("failure");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Connector-unreachable de-masking. A run can end `complete` (→ would-be
+// `success`) while a tool call hit a connector that couldn't be routed — the
+// agent "completes" by writing around the gap. That is the silent failure
+// operators reported (a standup summary that never reached Teams, recorded as
+// success). mapResultToRun downgrades such runs to `failure` and names the
+// tool, keyed on the orchestrator routing reason carried per tool call
+// (`errorReason`), NOT on a generic `ok: false` (which would flag healthy
+// runs where the agent probed and self-corrected).
+// ---------------------------------------------------------------------------
+
+describe("createDirectExecutor — connector-unreachable de-masking", () => {
+	function taskFnWithToolCalls(toolCalls: Array<Record<string, unknown>>): TaskFn {
+		return async (): Promise<TaskFnResult> => ({
+			output: "I documented the gap in the deliverable.",
+			conversationId: "conv_test",
+			toolCalls,
+			stopReason: "complete",
+			usage: { inputTokens: 10, outputTokens: 5, iterations: 1 },
+		});
+	}
+
+	async function runWith(toolCalls: Array<Record<string, unknown>>): Promise<AutomationRun> {
+		const executor = createDirectExecutor(taskFnWithToolCalls(toolCalls), () => ({}));
+		return executor(makeAutomation());
+	}
+
+	test("complete + unknown_tool_source → failure naming the tool", async () => {
+		const run = await runWith([
+			{ id: "t1", name: "nb__search", input: {}, output: "ok", ok: true, ms: 20 },
+			{
+				id: "t2",
+				name: "ws_x-teams__send_message",
+				input: {},
+				output: "[orchestrator] no source …",
+				ok: false,
+				ms: 15,
+				errorReason: "unknown_tool_source",
+			},
+		]);
+		expect(run.status).toBe("failure");
+		expect(run.error).toMatch(/Connector unavailable/);
+		expect(run.error).toMatch(/ws_x-teams__send_message/);
+	});
+
+	test("complete + workspace_access_denied → failure", async () => {
+		const run = await runWith([
+			{
+				id: "t1",
+				name: "ws_other-teams__send_message",
+				input: {},
+				output: "[orchestrator] not a member …",
+				ok: false,
+				ms: 12,
+				errorReason: "workspace_access_denied",
+			},
+		]);
+		expect(run.status).toBe("failure");
+		expect(run.error).toMatch(/Connector unavailable/);
+	});
+
+	test("complete + all tool calls ok → success (no false downgrade)", async () => {
+		const run = await runWith([
+			{ id: "t1", name: "nb__briefing", input: {}, output: "ok", ok: true, ms: 20 },
+			{ id: "t2", name: "synapse-crm__list", input: {}, output: "ok", ok: true, ms: 30 },
+		]);
+		expect(run.status).toBe("success");
+		expect(run.error).toBeUndefined();
+	});
+
+	test("complete + a non-routing tool error (handled by agent) → stays success", async () => {
+		// `invalid_tool_name` is deliberately NOT in the unreachable set: it's
+		// usually the agent probing a wrong name and recovering, not a real
+		// connector gap. A logical tool error with no errorReason likewise must
+		// not flip the run.
+		const run = await runWith([
+			{
+				id: "t1",
+				name: "nb__search",
+				input: {},
+				output: "bad name",
+				ok: false,
+				ms: 10,
+				errorReason: "invalid_tool_name",
+			},
+			{ id: "t2", name: "synapse-crm__create", input: {}, output: "validation error", ok: false, ms: 10 },
+		]);
+		expect(run.status).toBe("success");
+		expect(run.error).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## Problem

A scheduled automation run is marked `success` whenever the model stops with `stopReason: "complete"` — regardless of whether the agent actually reached the tools it needed. When a tool call hits a connector that can't be **routed** (missing from the workspace, or in a workspace the owner can't reach), the agent gets back an `isError` tool result and commonly "completes" by writing around the gap. The run is recorded green.

## Fix

Thread the structured failure reason per tool call so the run record can tell *why* a call failed, not just *that* it did:

- `ToolCallRecord.errorReason` (new, optional) — lifted from the tool result's `structuredContent.reason` at `engine.ts`, carried through `ChatResult` and `TaskResult`.
- The automations executor downgrades an otherwise-`success` run to `failure` and names the tool when a call failed with an orchestrator routing reason that means **connector unreachable**: `unknown_tool_source`, `workspace_access_denied`.

Deliberately narrower than a generic `ok: false`: a malformed name or an agent probing and self-correcting must not flip a healthy run. This is the visibility/status layer only — it does not touch OAuth or connection logic.

## Scope — important (verified against the production runs)

Both reasons fire **only when the agent ATTEMPTS a namespaced tool call**. The originally-reported standup runs are the **never-attempted** variant: the agent ran `nb__search`, found no Teams connector in any reachable workspace, and "completed" by documenting the gap — it never called a Teams tool, so no reason was emitted. **This PR therefore does not de-mask those specific runs.** It de-masks the *attempted-call* class — a strict improvement with zero false positives — which is the broader recurring shape. The never-attempted class (a required connector absent from the toolset entirely) needs a different signal: the unattended agent self-reporting an incomplete required step. That's tracked as a follow-up. (The exact Bayze incident's real resolution is operational — connect Teams in a *shared* workspace so it becomes reachable, per #417.)

## Relationship to the other connector PRs

- #421 emits a `reason: "reauth_required"` tool result for OAuth-provider remotes; #427 flips Composio connectors to `reauth_required` proactively. Once those land, `reauth_required` is added to this PR's reason set **with a test against real emission** (deliberately not forward-declared here).

## Tests

`test/unit/bundles/automations/executor.test.ts` — connector-unreachable de-masking: `unknown_tool_source` and `workspace_access_denied` → `failure` (naming the tool); all-ok and handled-logical-error → `success`.

`verify:static` green; full unit suite passes.