### PR TITLE
fix(automations): teach the correct cross-workspace scoping model

### DIFF
--- a/src/bundles/automations/src/schemas.ts
+++ b/src/bundles/automations/src/schemas.ts
@@ -31,7 +31,15 @@ export const TOOL_SCHEMAS: ToolSchema[] = [
     description:
       "Create a scheduled automation. `manifest` is the config; `body` is the prompt sent " +
       "to POST /v1/chat on each run. Generates a kebab-case id from `manifest.name`. " +
-      "Idempotent: returns the existing automation if one with the same id exists.",
+      "Idempotent: returns the existing automation if one with the same id exists. " +
+      "Scope: automations are owned by the creating user and are NOT locked to one workspace — " +
+      "a scheduled run executes as the owner and can use tools and connectors from any workspace " +
+      "the owner is a member of (the workspace it was created in is just the default focus). " +
+      "A connector is reachable only where it is installed AND the owner is a member; a connector " +
+      "in another user's personal workspace is never reachable. So for an automation that posts to " +
+      "a shared destination (e.g. Teams/Slack), the connector must live in a SHARED workspace the " +
+      "owner belongs to — not a personal one. Do not tell users automations only see the tools of " +
+      "the workspace they were created in.",
     inputSchema: AutomationsCreateInput,
   },
   {

--- a/src/bundles/automations/src/schemas.ts
+++ b/src/bundles/automations/src/schemas.ts
@@ -38,8 +38,7 @@ export const TOOL_SCHEMAS: ToolSchema[] = [
       "A connector is reachable only where it is installed AND the owner is a member; a connector " +
       "in another user's personal workspace is never reachable. So for an automation that posts to " +
       "a shared destination (e.g. Teams/Slack), the connector must live in a SHARED workspace the " +
-      "owner belongs to — not a personal one. Do not tell users automations only see the tools of " +
-      "the workspace they were created in.",
+      "owner belongs to — not a personal one.",
     inputSchema: AutomationsCreateInput,
   },
   {


### PR DESCRIPTION
## Problem

Asked "can automations run across workspaces?", the assistant answered "no — each automation runs in the context of its workspace, with access only to that workspace's installed apps and tools."

That is false. Automations are **identity-owned**: a scheduled run executes as its owner and has reach into every workspace the owner is a member of (the workspace it was created in is only the default focus). The wrong answer also steered a user toward connecting a shared Teams connector in a **personal** workspace — where no other member's automation can ever reach it — when the correct move is a shared workspace.

## Why the description, not the prompt

The model learns about automations **only** from the `automations__*` tool descriptions:

- `automations` is a kernel identity source, so its tools are always in the active set (good — the description is reliably read).
- The core system prompt never describes automations.
- App-level `initialize.instructions` is **not** surfaced for identity sources — only workspace bundles flow through `buildAppsList`, so putting guidance there would be a silent no-op. (Latent trap worth a separate follow-up.)

So the corrected scoping model goes in the `create` tool description: identity ownership, cross-workspace reach, and that a connector is reachable only where it's installed *and* the owner is a member — for team-wide use it must live in a shared workspace, not a personal one.

## Tests

No behavior change; description-only. `verify:static` green; 202 automations + schema-shape unit tests pass.