### PR TITLE
fix(compaction): bound the summary call to the summarizer's context

### DIFF
--- a/src/conversation/compaction.ts
+++ b/src/conversation/compaction.ts
@@ -41,6 +41,14 @@ export interface CompactionOptions {
   keepRatio?: number;
   /** Don't bother compacting unless at least this many messages would be folded in. */
   minSummarizedMessages?: number;
+  /**
+   * Context window (tokens) of the summarizer model — the `fast` slot. The fold
+   * is sized by the MAIN model's window, which can be far larger than the
+   * summarizer's, so the summary call is bounded to a deflated fraction of this
+   * to keep it inside the summarizer's context. Undefined → a conservative
+   * fallback (never unbounded). See `summarizerTranscriptBudgetTokens`.
+   */
+  summarizerContextTokens?: number;
 }
 
 const DEFAULTS = {
@@ -201,12 +209,101 @@ function formatPart(p: TranscriptPart): string {
   }
 }
 
-function formatTranscript(messages: readonly StoredMessage[]): string {
-  const lines: string[] = ["<conversation-transcript>"];
-  for (const m of messages) {
-    const text = typeof m.content === "string" ? m.content : m.content.map(formatPart).join(" ");
-    lines.push(`<${m.role}>`, escapeClosingTags(text), `</${m.role}>`);
+// The summarizer is the `fast` slot, usually a smaller-context model than the
+// main model whose window sizes the fold — so the fold can exceed the
+// summarizer's context and the call is rejected (`prompt is too long`), which
+// made compaction silently no-op on exactly the long conversations it exists to
+// bound. The transcript is bounded to the summarizer's context, DEFLATED to
+// absorb the gap between the chars/4 estimate and the provider's real tokenizer
+// (the same reason `resolveMessageBudget` reserves a margin). A catalog miss
+// yields a conservative floor so an unknown summarizer is never handed an
+// unbounded prompt.
+const SUMMARIZER_CTX_FALLBACK_TOKENS = 32_000;
+const SUMMARIZER_OUTPUT_RESERVE_TOKENS = 1_024;
+const SUMMARIZER_SYSTEM_RESERVE_TOKENS = 512;
+const SUMMARIZER_SAFETY_MARGIN_TOKENS = 8_192;
+const SUMMARIZER_ESTIMATE_DEFLATE = 0.6;
+const TRANSCRIPT_ELISION_MARKER = "[…older history elided to fit the summarizer's context…]";
+
+/** Max transcript tokens to feed the summarizer given its context window. */
+export function summarizerTranscriptBudgetTokens(contextTokens?: number): number {
+  const ctx = contextTokens ?? SUMMARIZER_CTX_FALLBACK_TOKENS;
+  const net =
+    ctx -
+    SUMMARIZER_OUTPUT_RESERVE_TOKENS -
+    SUMMARIZER_SYSTEM_RESERVE_TOKENS -
+    SUMMARIZER_SAFETY_MARGIN_TOKENS;
+  return Math.max(4_000, Math.floor(net * SUMMARIZER_ESTIMATE_DEFLATE));
+}
+
+interface TranscriptBlock {
+  role: StoredMessage["role"];
+  body: string;
+}
+
+// Role tags + surrounding newlines that wrap each block in the rendered transcript.
+const BLOCK_WRAP_CHARS = "<>\n\n</>\n".length;
+
+/**
+ * Keep the NEWEST fold blocks that fit `budgetTokens` (chars/4), dropping the
+ * oldest — they're the least relevant to continuity (the recent tail is already
+ * kept verbatim by the planner). A single block larger than the whole budget is
+ * hard-truncated rather than dropped, so even one oversized message (a giant
+ * paste or tool result) stays representable and the call never exceeds the
+ * summarizer's context. Returns kept blocks (chronological) + whether anything
+ * was elided.
+ */
+function boundBlocks(
+  blocks: readonly TranscriptBlock[],
+  budgetTokens: number,
+): { kept: TranscriptBlock[]; elided: boolean } {
+  const budgetChars = budgetTokens * 4;
+  const kept: TranscriptBlock[] = [];
+  let usedChars = 0;
+  let elided = false;
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = { ...blocks[i]! };
+    let blockChars = b.role.length * 2 + b.body.length + BLOCK_WRAP_CHARS;
+    if (kept.length > 0 && usedChars + blockChars > budgetChars) {
+      elided = true;
+      break;
+    }
+    if (blockChars > budgetChars) {
+      // Single oversized message: truncate its body to fit rather than drop it.
+      b.body = truncate(b.body, Math.max(0, budgetChars - (b.role.length * 2 + BLOCK_WRAP_CHARS)));
+      blockChars = b.role.length * 2 + b.body.length + BLOCK_WRAP_CHARS;
+      if (i > 0) elided = true;
+    }
+    kept.unshift(b);
+    usedChars += blockChars;
+    if (usedChars >= budgetChars && i > 0) {
+      elided = true;
+      break;
+    }
   }
+  return { kept, elided };
+}
+
+/**
+ * Render the fold as the summarizer transcript. When `budgetTokens` is given the
+ * transcript is bounded to it (newest-kept, oldest-elided/truncated); otherwise
+ * every message is rendered verbatim.
+ */
+function formatTranscript(messages: readonly StoredMessage[], budgetTokens?: number): string {
+  const blocks: TranscriptBlock[] = messages.map((m) => ({
+    role: m.role,
+    body: escapeClosingTags(
+      typeof m.content === "string" ? m.content : m.content.map(formatPart).join(" "),
+    ),
+  }));
+  const { kept, elided } =
+    budgetTokens === undefined
+      ? { kept: blocks, elided: false }
+      : boundBlocks(blocks, budgetTokens);
+
+  const lines = ["<conversation-transcript>"];
+  if (elided) lines.push(TRANSCRIPT_ELISION_MARKER);
+  for (const b of kept) lines.push(`<${b.role}>`, b.body, `</${b.role}>`);
   lines.push("</conversation-transcript>");
   return lines.join("\n");
 }
@@ -219,21 +316,27 @@ const SUMMARIZE_SYSTEM =
   "mention yourself, apologize, or refuse. Output only the summary.";
 
 /**
- * Summarize the given messages with the injected model (use the `fast` slot).
- * Throws on model failure — the caller treats compaction as best-effort and
- * falls back to the un-compacted history.
+ * Summarize the given messages with the injected model (the `fast` slot). The
+ * transcript is bounded to the summarizer's context (`summarizerContextTokens`)
+ * so the fold — sized by the larger main-model window — can't overflow the
+ * summarizer and silently fail. Throws on model failure; the caller treats
+ * compaction as best-effort and falls back to the un-compacted history.
  */
 export async function summarizeMessages(
   model: LanguageModelV3,
   messages: readonly StoredMessage[],
-  maxOutputTokens = 1024,
+  opts: { maxOutputTokens?: number; summarizerContextTokens?: number } = {},
 ): Promise<string> {
+  const transcript = formatTranscript(
+    messages,
+    summarizerTranscriptBudgetTokens(opts.summarizerContextTokens),
+  );
   const result = await model.doGenerate({
     prompt: [
       { role: "system", content: SUMMARIZE_SYSTEM },
-      { role: "user", content: [{ type: "text", text: formatTranscript(messages) }] },
+      { role: "user", content: [{ type: "text", text: transcript }] },
     ],
-    maxOutputTokens,
+    maxOutputTokens: opts.maxOutputTokens ?? 1024,
   });
   const textBlock = result.content.find((b) => b.type === "text");
   const summary = textBlock?.type === "text" ? textBlock.text.trim() : "";
@@ -253,7 +356,9 @@ export async function runCompaction(
 ): Promise<CompactionOutcome | null> {
   const plan = planCompaction(messages, opts);
   if (!plan.shouldCompact) return null;
-  const summary = await summarizeMessages(model, messages.slice(0, plan.boundaryIndex));
+  const summary = await summarizeMessages(model, messages.slice(0, plan.boundaryIndex), {
+    summarizerContextTokens: opts.summarizerContextTokens,
+  });
   return {
     summary,
     compactedThroughTs: plan.boundaryTs,

--- a/src/conversation/compaction.ts
+++ b/src/conversation/compaction.ts
@@ -219,7 +219,15 @@ function formatPart(p: TranscriptPart): string {
 // yields a conservative floor so an unknown summarizer is never handed an
 // unbounded prompt.
 const SUMMARIZER_CTX_FALLBACK_TOKENS = 32_000;
-const SUMMARIZER_OUTPUT_RESERVE_TOKENS = 1_024;
+// The summary's output ceiling. The re-anchor compresses the older fold (the
+// recent tail is kept verbatim), and a fold can be 200k+ tokens, so a too-small
+// ceiling flattens real detail (decisions, ids, file refs). The model self-
+// sizes under this cap — a small fold yields a short summary — so a generous
+// ceiling only costs more when there's substance to preserve. Output is cheap
+// (summarizer is the `fast` slot) and rides as a cached prefix afterward, so the
+// cost is negligible; well under the summarizer's max output. This same value is
+// reserved against the summarizer's context below so `input + output ≤ context`.
+const SUMMARY_MAX_OUTPUT_TOKENS = 8_192;
 const SUMMARIZER_SYSTEM_RESERVE_TOKENS = 512;
 const SUMMARIZER_SAFETY_MARGIN_TOKENS = 8_192;
 const SUMMARIZER_ESTIMATE_DEFLATE = 0.6;
@@ -230,7 +238,7 @@ export function summarizerTranscriptBudgetTokens(contextTokens?: number): number
   const ctx = contextTokens ?? SUMMARIZER_CTX_FALLBACK_TOKENS;
   const net =
     ctx -
-    SUMMARIZER_OUTPUT_RESERVE_TOKENS -
+    SUMMARY_MAX_OUTPUT_TOKENS -
     SUMMARIZER_SYSTEM_RESERVE_TOKENS -
     SUMMARIZER_SAFETY_MARGIN_TOKENS;
   return Math.max(4_000, Math.floor(net * SUMMARIZER_ESTIMATE_DEFLATE));
@@ -336,7 +344,7 @@ export async function summarizeMessages(
       { role: "system", content: SUMMARIZE_SYSTEM },
       { role: "user", content: [{ type: "text", text: transcript }] },
     ],
-    maxOutputTokens: opts.maxOutputTokens ?? 1024,
+    maxOutputTokens: opts.maxOutputTokens ?? SUMMARY_MAX_OUTPUT_TOKENS,
   });
   const textBlock = result.content.find((b) => b.type === "text");
   const summary = textBlock?.type === "text" ? textBlock.text.trim() : "";

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -62,7 +62,7 @@ import { createIdentityProvider } from "../identity/provider.ts";
 import { DEV_IDENTITY } from "../identity/providers/dev.ts";
 import { UserStore } from "../identity/user.ts";
 import { InstructionsStore } from "../instructions/index.ts";
-import { getProviderFromModel } from "../model/catalog.ts";
+import { getModelByString, getProviderFromModel } from "../model/catalog.ts";
 import { buildModelResolver, resolveModelString } from "../model/registry.ts";
 import { installOAuthFetchDebug } from "../oauth/oauth-fetch-debug.ts";
 import {
@@ -3163,9 +3163,14 @@ export class Runtime {
   ): Promise<StoredMessage[] | null> {
     if (!this.config.features?.compaction || !store.appendEvent) return null;
     const appendEvent = store.appendEvent.bind(store);
-    const model = this.resolveModelFn(this.getModelSlot("fast"));
+    const fastSlot = this.getModelSlot("fast");
+    const model = this.resolveModelFn(fastSlot);
     const compacted = await compactConversationMessages(model, history, {
       budget,
+      // Bound the summary call to the summarizer's own context — the fold is
+      // sized by the main model's (larger) window, so without this it overflows
+      // a smaller `fast` model and compaction silently no-ops.
+      summarizerContextTokens: getModelByString(fastSlot)?.limits.context,
       now: new Date().toISOString(),
       onEvent: (event) => appendEvent(conversationId, event),
       onError: (err) => console.error("[runtime] history compaction failed:", err),

--- a/test/unit/compaction.test.ts
+++ b/test/unit/compaction.test.ts
@@ -171,6 +171,72 @@ describe("summarizeMessages + runCompaction", () => {
   });
 });
 
+// --- summarizer context bounding (regression: large folds silently no-op'd) ---
+
+/** Mimics the provider rejecting an over-context prompt, like the real API. */
+function contextLimitedModel(summaryText: string, contextTokens: number): LanguageModelV3 {
+  return {
+    doGenerate: async (opts: { prompt: unknown }) => {
+      const tokens = Math.ceil(JSON.stringify(opts.prompt).length / 4);
+      if (tokens > contextTokens) {
+        throw new Error(`prompt is too long: ${tokens} tokens > ${contextTokens} maximum`);
+      }
+      return { content: [{ type: "text", text: summaryText }] };
+    },
+  } as unknown as LanguageModelV3;
+}
+
+/** Records the prompt-token size the model was actually handed. */
+function sizeCapturingModel(): { model: LanguageModelV3; lastPromptTokens: () => number } {
+  let last = 0;
+  const model = {
+    doGenerate: async (opts: { prompt: unknown }) => {
+      last = Math.ceil(JSON.stringify(opts.prompt).length / 4);
+      return { content: [{ type: "text", text: "s" }] };
+    },
+  } as unknown as LanguageModelV3;
+  return { model, lastPromptTokens: () => last };
+}
+
+describe("summarizeMessages — bounds the transcript to the summarizer context", () => {
+  test("a fold far larger than the summarizer context is bounded under it", async () => {
+    const fold = conversation(100, 4000); // ~200k tokens of fold
+    const { model, lastPromptTokens } = sizeCapturingModel();
+    await summarizeMessages(model, fold, { summarizerContextTokens: 50_000 });
+    expect(lastPromptTokens()).toBeLessThanOrEqual(50_000);
+  });
+
+  test("a single message larger than the whole budget is truncated, not dropped or overflowed", async () => {
+    const huge = user("X".repeat(2_000_000), ts(0)); // ~500k tokens in ONE message
+    const { model, lastPromptTokens } = sizeCapturingModel();
+    const out = await summarizeMessages(model, [huge], { summarizerContextTokens: 40_000 });
+    expect(out).toBe("s"); // the call happened (didn't throw / infinite-loop)
+    expect(lastPromptTokens()).toBeLessThanOrEqual(40_000);
+  });
+});
+
+describe("compactConversationMessages — large fold + small summarizer (production regression)", () => {
+  test("compacts instead of silently failing when the fold exceeds the summarizer context", async () => {
+    // Repro of the prod bug: fold ≫ summarizer context. Old behavior: doGenerate
+    // throws `prompt is too long`, best-effort swallows it, ZERO events, history
+    // never bounded. New: the transcript is bounded so the call fits and a
+    // history.compacted event is emitted.
+    const msgs = conversation(120, 4000); // ~240k tokens of history
+    const events: HistoryCompactedEvent[] = [];
+    const errors: unknown[] = [];
+    const out = await compactConversationMessages(contextLimitedModel("SUMMARY", 12_500), msgs, {
+      budget: 100_000,
+      summarizerContextTokens: 12_500, // tiny summarizer window
+      now: ts(999),
+      onEvent: (e) => events.push(e),
+      onError: (e) => errors.push(e),
+    });
+    expect(errors).toEqual([]); // did NOT fall back on an over-context error
+    expect(events).toHaveLength(1); // it actually compacted
+    expect(out).not.toBe(msgs);
+  });
+});
+
 // --- compactConversationMessages (the wiring helper) -----------------------
 
 describe("compactConversationMessages", () => {


### PR DESCRIPTION
## Bug

History compaction (`features.compaction`) silently no-ops on long conversations. `summarizeMessages` (`compaction.ts`) summarized the entire pre-boundary fold in a **single** `doGenerate` call with no bound on the summarizer model's context. The fold is sized by the **main** model's window (up to 1M), while the summarizer is the smaller `fast` slot (Haiku, 200k) — so a large fold is rejected with `prompt is too long: N tokens > 200000 maximum`, `compactConversationMessages` swallows it best-effort, and history is never bounded. The feature failed worst on exactly the large sessions it exists to bound (observed: a conversation grew to ~1M tokens with zero `history.compacted` events).

## Triage

- **Verdict: Confirmed.** Mechanism matches source: `runCompaction` → `summarizeMessages(model, fold)` → one `doGenerate` from `formatTranscript(fold)`, no context bound.
- **Root cause:** nothing reconciles the fold size (main-model window) with the summarizer's (smaller) context. Right layer: `src/conversation/compaction.ts`.

## Fix

Bound the transcript fed to the summarizer to its own context:
- Runtime threads the `fast` model's catalog `limits.context` into compaction (`maybeCompactHistory`); a catalog miss falls back to a conservative floor, never unbounded.
- The transcript budget deflates that context (×0.6) and reserves room for the system prompt + output + a safety margin — absorbing the `chars/4`-estimate vs real-tokenizer gap (the same reason `resolveMessageBudget` reserves a margin).
- Keep the **newest** fold messages (most relevant to continuity; the recent tail is already kept verbatim by the planner), elide the oldest. A **single message larger than the whole budget is truncated, not dropped**, so the call can never overflow even on one giant paste/tool-result.

Chosen over (1) blindly truncating the final string — silent data loss, boundary lies — and (2) map-reduce — its reduce step adds recursion/termination hazards and still needs this truncation floor for the single-oversized-message case, while the summary output is capped at ~1024 tokens regardless. Map-reduce / model-escalation are noted as fidelity follow-ups.

An independent adversarial review drove the design here: it showed `formatTranscript` doesn't bound text parts (so message-granularity chunking alone re-tears on one fat message), that `chars/4` under-counts and needs a deflation margin, and that a catalog miss must floor rather than go unbounded — all handled above.

## Tests

- New regression test reproduces the production failure (large fold + small summarizer context → over-context error → zero events) and is green under the fix. Verified it fails on the pre-fix code with the exact `prompt is too long` error.
- New unit tests: transcript bounded under the summarizer context; a single oversized message is truncated (not dropped/overflowed).
- Full suite: 3424 unit tests pass; format / lint / `tsc` clean.