### PR TITLE
fix(connectors): detect mid-session auth loss, flip to reauth_required

### DIFF
--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -471,6 +471,13 @@ export class BundleLifecycleManager {
       });
     };
 
+    // Mid-session auth loss on the running connection (a tool call hit
+    // UnauthorizedError because the refresh token was rejected). Flip to
+    // reauth_required so the UI offers "Reconnect" instead of failing silently.
+    const onAuthLost = () => {
+      this.recordConnectionStateChange(serverName, wsId, "_workspace", "reauth_required");
+    };
+
     let sourceName: string;
     let meta: Awaited<ReturnType<typeof startBundleSource>>["meta"];
     try {
@@ -484,6 +491,7 @@ export class BundleLifecycleManager {
           wsId,
           workDir: nbWorkDir,
           onInteractiveAuthRequired,
+          onAuthLost,
           bundleMcp: this.resolveBundleMcpDeps(wsId),
         },
       );
@@ -1239,6 +1247,13 @@ export class BundleLifecycleManager {
           authorizationUrl: url,
         });
         resolveAuthUrl(url);
+      },
+      // Mid-session auth loss on this connection (a tool call hit
+      // UnauthorizedError because the refresh token was rejected). Flip to
+      // reauth_required so the UI offers "Reconnect" instead of silently
+      // failing every call. No authorizationUrl — Reconnect re-initiates.
+      onAuthLost: () => {
+        this.recordConnectionStateChange(serverName, wsId, principalId, "reauth_required");
       },
       ...(staticClient ? { staticClient } : {}),
       ...(ref.scopes ? { scopes: ref.scopes } : {}),

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -226,6 +226,15 @@ export async function startBundleSource(
      */
     onInteractiveAuthRequired?: (authorizationUrl: string) => void;
     /**
+     * Optional callback fired when an established connection loses its
+     * authorization mid-session — a tool call threw `UnauthorizedError`
+     * because the persisted refresh token was rejected. Threaded into
+     * `WorkspaceOAuthProvider`; receivers transition the Connection to
+     * `reauth_required` (the documented `running → reauth_required` step) so
+     * the UI offers "Reconnect". No-op for non-URL bundles.
+     */
+    onAuthLost?: () => void;
+    /**
      * Per-workspace host-resources deps. When present, the spawned
      * McpSource registers inbound handlers for
      * `ai.nimblebrain/resources/{read,list}` so the bundle can read
@@ -372,6 +381,7 @@ export async function startBundleSource(
         // issuer (the fleet authorizer), never to a vendor.
         ...fleetIssuerOption(),
         onInteractiveAuthRequired: wrappedCallback,
+        ...(opts?.onAuthLost ? { onAuthLost: opts.onAuthLost } : {}),
         ...(staticClient ? { staticClient } : {}),
         ...(ref.scopes ? { scopes: ref.scopes } : {}),
         ...(ref.additionalAuthorizationParams

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -860,6 +860,18 @@ export class Runtime {
           // a platform restart doesn't silently drop the capability for
           // already-installed bundles.
           getBundleMcpDeps: bundleMcpDepsFactory,
+          // Late-bound: a boot-started connection that loses auth mid-session
+          // fires this on a post-boot tool call, by which point `rt.lifecycle`
+          // is constructed. Flip the Connection to reauth_required so the UI
+          // offers "Reconnect" instead of every call failing silently.
+          onAuthLost: (wsId, serverName) => {
+            rt.lifecycle?.recordConnectionStateChange(
+              serverName,
+              wsId,
+              "_workspace",
+              "reauth_required",
+            );
+          },
         },
       );
     rt._workspaceRegistries = workspaceRegistries;

--- a/src/runtime/workspace-runtime.ts
+++ b/src/runtime/workspace-runtime.ts
@@ -152,6 +152,16 @@ export async function startWorkspaceBundles(
      * through here.
      */
     getBundleMcpDeps?: (wsId: string) => BundleMcpDeps | undefined;
+    /**
+     * Fired when a boot-started URL bundle's connection later loses its
+     * authorization mid-session (a tool call hit `UnauthorizedError`). Unlike
+     * `onInteractiveAuthRequired` — which buffers via `setPendingAuth` because
+     * `BundleLifecycleManager` doesn't exist yet at boot — this fires LATER
+     * (on a post-boot tool call), by which time the runtime's late-bound
+     * lifecycle exists, so the runtime wires it straight to
+     * `recordConnectionStateChange(... "reauth_required")`.
+     */
+    onAuthLost?: (wsId: string, serverName: string) => void;
   },
 ): Promise<{ registries: Map<string, ToolRegistry>; entries: ProcessInventoryEntry[] }> {
   const workDir = opts?.workDir ?? join(process.env.NB_WORK_DIR ?? "", ".nimblebrain");
@@ -258,6 +268,12 @@ export async function startWorkspaceBundles(
         onInteractiveAuthRequired: (authorizationUrl) => {
           setPendingAuth(entry.wsId, entry.serverName, authorizationUrl);
         },
+        // Mid-session auth loss fires post-boot (a tool call), so the
+        // runtime's late-bound lifecycle exists by then — wire straight
+        // through to flip the Connection to reauth_required.
+        ...(opts?.onAuthLost
+          ? { onAuthLost: () => opts.onAuthLost?.(entry.wsId, entry.serverName) }
+          : {}),
         // Re-register inbound host-resources handlers on respawn so bundles
         // installed with host-resources support don't silently lose the
         // capability across platform restarts.

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -1083,6 +1083,32 @@ export class McpSource implements ToolSource {
         };
       }
 
+      // Authorization loss is not a crash. A remote tool call that throws
+      // UnauthorizedError means the persisted refresh token was rejected
+      // (expired / revoked / conditional-access pulled) — restarting the
+      // transport can't fix a dead credential, and routing it through the
+      // crash/restart path below wrongly escalates the connection toward
+      // `dead`. Flip the connection to `reauth_required` via the provider
+      // (which holds the (wsId, serverName) owner context) so the UI shows
+      // "Reconnect" and a `connection.state_changed` event fires, then surface
+      // a clear, structured reauth error instead of a generic crash. This
+      // wires the documented `running → reauth_required` transition
+      // (see connection.ts) that nothing else triggered.
+      if (err instanceof UnauthorizedError && this.mode.type === "remote") {
+        this.mode.authProvider?.notifyAuthLost();
+        return {
+          content: textContent(
+            `${this.name} needs to be reconnected — its authorization has expired. Open the connector and click Reconnect.`,
+          ),
+          isError: true,
+          structuredContent: {
+            error: "auth_required",
+            reason: "reauth_required",
+            source: this.name,
+          },
+        };
+      }
+
       // De-duped via the `dead` guard inside emitSourceCrashed: if the
       // transport's `onclose` already fired (subprocess died before our
       // catch ran), this is a no-op and the onclose-side payload — which

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -1094,8 +1094,20 @@ export class McpSource implements ToolSource {
       // a clear, structured reauth error instead of a generic crash. This
       // wires the documented `running → reauth_required` transition
       // (see connection.ts) that nothing else triggered.
-      if (err instanceof UnauthorizedError && this.mode.type === "remote") {
-        this.mode.authProvider?.notifyAuthLost();
+      //
+      // Gated on `authProvider`: only an OAuth-provider remote can be
+      // "reconnected" by the user — a 401 there means the refresh token died
+      // and re-running OAuth fixes it. A static-auth remote (e.g. a Composio
+      // bundle's `x-api-key` header) that 401s is a bad OPERATOR credential,
+      // not user-reconnectable: there's no flow to re-run, and `notifyAuthLost`
+      // would no-op anyway (no provider). Fall through to the normal error
+      // path rather than show a misleading "Reconnect".
+      if (
+        err instanceof UnauthorizedError &&
+        this.mode.type === "remote" &&
+        this.mode.authProvider
+      ) {
+        this.mode.authProvider.notifyAuthLost();
         return {
           content: textContent(
             `${this.name} needs to be reconnected — its authorization has expired. Open the connector and click Reconnect.`,

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -130,6 +130,19 @@ export interface WorkspaceOAuthProviderOptions {
    */
   onInteractiveAuthRequired?: (authorizationUrl: string) => void;
   /**
+   * Fired when an already-established connection loses its authorization
+   * mid-session — i.e. a tool call fails with `UnauthorizedError` because the
+   * persisted refresh token was rejected (expired / revoked / conditional-access
+   * pulled). The owner (`(wsId, serverName)`) is implicit in this provider, so
+   * the callback carries no args; the wiring records the documented
+   * `running → reauth_required` transition (see `connection.ts`) so the UI shows
+   * "Reconnect" instead of silently failing every call. Distinct from
+   * `onInteractiveAuthRequired` (an active flow → `pending_auth`); this is the
+   * passive "your live connection just went stale" signal. Invoked via
+   * `notifyAuthLost()`, which de-dupes so repeated failing calls flip state once.
+   */
+  onAuthLost?: () => void;
+  /**
    * Pre-registered OAuth client (Track A). When present, the provider
    * skips DCR — `clientInformation()` returns this static client and
    * `saveClientInformation()` is a no-op. The client_secret is supplied
@@ -519,6 +532,10 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
   private readonly canonicalCallback: string;
   private readonly allowInsecureRemotes: boolean;
   private readonly onInteractiveAuthRequired?: (authorizationUrl: string) => void;
+  private readonly onAuthLost?: () => void;
+  /** De-dupe guard: a flurry of in-flight tool calls can each throw
+   *  UnauthorizedError; the connection should flip to reauth_required once. */
+  private authLostNotified = false;
   private readonly staticClient?: WorkspaceOAuthProviderOptions["staticClient"];
   private readonly scopes?: string[];
   private readonly additionalAuthorizationParams?: Record<string, string>;
@@ -599,6 +616,7 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
     this.canonicalCallback = canonicalEndpoint(new URL(opts.callbackUrl));
     this.allowInsecureRemotes = opts.allowInsecureRemotes === true;
     this.onInteractiveAuthRequired = opts.onInteractiveAuthRequired;
+    this.onAuthLost = opts.onAuthLost;
     this.staticClient = opts.staticClient;
     this.scopes = opts.scopes;
     // Validate at construction so a bad config fails fast — same boundary
@@ -899,6 +917,11 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
     this.cachedTokens = tokens;
+    // Fresh tokens landed — a subsequent auth loss is a NEW episode, so
+    // re-arm the one-shot `notifyAuthLost` guard. Without this, a connection
+    // that went reauth_required, reconnected, then expired again would never
+    // re-signal (the guard stays latched for the provider's lifetime).
+    this.authLostNotified = false;
     await this.writeJson(this.dataDir, "tokens.json", tokens);
     // OIDC identity capture (best-effort). When the AS returns an
     // id_token alongside the tokens — Google, Microsoft, and Zoom all
@@ -922,6 +945,28 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
           `[oauth] ${this.serverName} id_token parse failed: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
+    }
+  }
+
+  /**
+   * Signal that an established connection lost its authorization mid-session
+   * (a tool call threw `UnauthorizedError` because the persisted refresh token
+   * was rejected). Fires the `onAuthLost` callback once per auth episode —
+   * the wiring records `running → reauth_required`. De-duped because a burst of
+   * concurrent tool calls can each surface the same failure; `saveTokens`
+   * re-arms it after a successful reconnect. Best-effort: a throwing callback
+   * is swallowed so it can never turn a tool-call failure into a worse one.
+   */
+  notifyAuthLost(): void {
+    if (this.authLostNotified) return;
+    this.authLostNotified = true;
+    try {
+      this.onAuthLost?.();
+    } catch (err) {
+      log.debug(
+        "mcp",
+        `[oauth] onAuthLost callback threw: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/test/unit/mcp-source-auth-loss.test.ts
+++ b/test/unit/mcp-source-auth-loss.test.ts
@@ -1,0 +1,78 @@
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { describe, expect, it, mock } from "bun:test";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { McpSource } from "../../src/tools/mcp-source.ts";
+import type { McpTransportMode } from "../../src/tools/mcp-source.ts";
+import type { WorkspaceOAuthProvider } from "../../src/tools/workspace-oauth-provider.ts";
+
+// Detect-on-use: a remote tool call that throws UnauthorizedError means the
+// connection's refresh token was rejected (expired / revoked). The execute()
+// catch must treat that as "needs reconnection" — NOT a crash. It flips the
+// connection to reauth_required via the provider's notifyAuthLost, returns a
+// structured reauth error, and does NOT route through the crash/restart path
+// (a restart can't fix a dead credential, and would escalate toward `dead`).
+
+function startedRemoteSource(opts: {
+  callTool: () => Promise<unknown>;
+  notifyAuthLost: () => void;
+}): McpSource {
+  const authProvider = {
+    notifyAuthLost: opts.notifyAuthLost,
+  } as unknown as WorkspaceOAuthProvider;
+
+  const mode: McpTransportMode = {
+    type: "remote",
+    url: new URL("https://teams.example.com/mcp"),
+    authProvider,
+  };
+  const source = new McpSource("teams", mode, new NoopEventSink());
+
+  // Drive execute() down callToolInline with a client that fails on auth.
+  // No real transport — we exercise the catch branch in isolation. `close`
+  // is stubbed so the non-auth crash path's stop() doesn't blow up, and
+  // `start` is neutralized so tryRestart never reaches the network.
+  const internal = source as unknown as {
+    client: { callTool: () => Promise<unknown>; close: () => Promise<void> };
+    dead: boolean;
+    start: () => Promise<void>;
+  };
+  internal.client = { callTool: opts.callTool, close: () => Promise.resolve() };
+  internal.dead = false;
+  internal.start = () => Promise.resolve();
+  return source;
+}
+
+describe("McpSource — auth loss on a tool call (detect-on-use)", () => {
+  it("UnauthorizedError → structured reauth_required result + notifyAuthLost", async () => {
+    const notifyAuthLost = mock(() => {});
+    const source = startedRemoteSource({
+      callTool: () => Promise.reject(new UnauthorizedError("token rejected")),
+      notifyAuthLost,
+    });
+
+    const result = await source.execute("send_message", { text: "hi" });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.reason).toBe("reauth_required");
+    expect(result.structuredContent?.error).toBe("auth_required");
+    expect(notifyAuthLost).toHaveBeenCalledTimes(1);
+    // Must NOT have fallen through to the crash/restart copy.
+    const text = result.content.map((c) => ("text" in c ? c.text : "")).join(" ");
+    expect(text).not.toMatch(/crashed|restart/i);
+    expect(text).toMatch(/reconnect/i);
+  });
+
+  it("a non-auth tool-call error still goes through the crash path (not reauth)", async () => {
+    const notifyAuthLost = mock(() => {});
+    const source = startedRemoteSource({
+      callTool: () => Promise.reject(new Error("some transport blip")),
+      notifyAuthLost,
+    });
+
+    const result = await source.execute("send_message", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.reason).not.toBe("reauth_required");
+    expect(notifyAuthLost).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/mcp-source-auth-loss.test.ts
+++ b/test/unit/mcp-source-auth-loss.test.ts
@@ -14,16 +14,19 @@ import type { WorkspaceOAuthProvider } from "../../src/tools/workspace-oauth-pro
 
 function startedRemoteSource(opts: {
   callTool: () => Promise<unknown>;
-  notifyAuthLost: () => void;
+  // Omit to model a static-auth remote (e.g. a Composio x-api-key bundle)
+  // that has no OAuth provider — the reauth branch must NOT fire for it.
+  notifyAuthLost?: () => void;
 }): McpSource {
-  const authProvider = {
-    notifyAuthLost: opts.notifyAuthLost,
-  } as unknown as WorkspaceOAuthProvider;
+  const authProvider =
+    opts.notifyAuthLost === undefined
+      ? undefined
+      : ({ notifyAuthLost: opts.notifyAuthLost } as unknown as WorkspaceOAuthProvider);
 
   const mode: McpTransportMode = {
     type: "remote",
     url: new URL("https://teams.example.com/mcp"),
-    authProvider,
+    ...(authProvider ? { authProvider } : {}),
   };
   const source = new McpSource("teams", mode, new NoopEventSink());
 
@@ -60,6 +63,25 @@ describe("McpSource — auth loss on a tool call (detect-on-use)", () => {
     const text = result.content.map((c) => ("text" in c ? c.text : "")).join(" ");
     expect(text).not.toMatch(/crashed|restart/i);
     expect(text).toMatch(/reconnect/i);
+  });
+
+  it("UnauthorizedError on a static-auth remote (no provider) does NOT show reauth", async () => {
+    // A Composio bundle authenticates with a static x-api-key header — no
+    // OAuth provider. A 401 there is a bad operator credential, not a
+    // user-reconnectable token: the branch is gated on authProvider, so it
+    // falls through to the normal error path instead of a misleading
+    // "Reconnect" message.
+    const source = startedRemoteSource({
+      callTool: () => Promise.reject(new UnauthorizedError("bad api key")),
+      // no notifyAuthLost → no authProvider on the mode
+    });
+
+    const result = await source.execute("send_message", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.reason).not.toBe("reauth_required");
+    const text = result.content.map((c) => ("text" in c ? c.text : "")).join(" ");
+    expect(text).not.toMatch(/reconnect/i);
   });
 
   it("a non-auth tool-call error still goes through the crash path (not reauth)", async () => {

--- a/test/unit/workspace-oauth-provider.test.ts
+++ b/test/unit/workspace-oauth-provider.test.ts
@@ -837,3 +837,76 @@ describe("WorkspaceOAuthProvider — WorkspaceContext construction (Stage 0)", (
     expect(p.getOwner()).toEqual(owner);
   });
 });
+
+describe("WorkspaceOAuthProvider — notifyAuthLost (mid-session auth loss)", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "nb-oauth-authlost-"));
+  });
+
+  const TOKENS: OAuthTokens = { access_token: "a", token_type: "bearer" };
+
+  it("fires onAuthLost once even when called repeatedly (de-dupes a burst)", () => {
+    let calls = 0;
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "teams",
+      workDir,
+      callbackUrl: CALLBACK,
+      onAuthLost: () => {
+        calls++;
+      },
+    });
+
+    p.notifyAuthLost();
+    p.notifyAuthLost();
+    p.notifyAuthLost();
+
+    expect(calls).toBe(1);
+  });
+
+  it("re-arms after saveTokens so a later auth loss signals again", async () => {
+    let calls = 0;
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "teams",
+      workDir,
+      callbackUrl: CALLBACK,
+      onAuthLost: () => {
+        calls++;
+      },
+    });
+
+    p.notifyAuthLost();
+    expect(calls).toBe(1);
+
+    // Successful reconnect persists fresh tokens → next loss is a new episode.
+    await p.saveTokens(TOKENS);
+    p.notifyAuthLost();
+    expect(calls).toBe(2);
+  });
+
+  it("is a no-op (no throw) when no onAuthLost callback is wired", () => {
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "teams",
+      workDir,
+      callbackUrl: CALLBACK,
+    });
+    expect(() => p.notifyAuthLost()).not.toThrow();
+  });
+
+  it("swallows a throwing onAuthLost callback (never worsens a tool-call failure)", () => {
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "teams",
+      workDir,
+      callbackUrl: CALLBACK,
+      onAuthLost: () => {
+        throw new Error("boom");
+      },
+    });
+    expect(() => p.notifyAuthLost()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

Connectors were only auth-evaluated at **boot**. After that, nothing re-checked validity, and a tool-call auth failure **didn't update connection state**. `reauth_required` (the honest amber "Reconnect" state) was set in exactly one place — `lifecycle.ts` seedInstance, at boot — so the documented `running → reauth_required (refresh failed mid-session)` transition (`connection.ts`) had **no trigger**. A remote OAuth connector whose refresh token died mid-session kept reporting healthy while every call failed, with no "Reconnect" affordance.

## Scope (read this)

This covers **OAuth-provider remote bundles** — ones that connect via a `WorkspaceOAuthProvider` (Granola, Notion, and future OAuth remotes). It does **NOT** cover **Composio** connectors (e.g. Microsoft Teams): Composio authenticates the platform→Composio transport with a static `x-api-key` header (no provider), and a downstream account expiry surfaces *past* that still-valid key — not as a transport `401`. Composio disconnect detection needs the separate Composio connected-account status check (in progress, tracked separately).

## Fix — detect-on-use

When an **OAuth-provider** remote tool call throws `UnauthorizedError` (refresh token expired / revoked / conditional-access pulled), `McpSource.execute()` now:

- calls the provider's `notifyAuthLost()` → records `running → reauth_required` (fires the existing `connection.state_changed` SSE event), and
- returns a structured `{ error: "auth_required", reason: "reauth_required" }` result,
- instead of routing through `emitSourceCrashed`/`tryRestart` — a restart can't fix a dead credential and wrongly escalates toward `dead`.

The branch is **gated on `authProvider` presence**: a static-auth remote (Composio `x-api-key`) that `401`s is a bad operator credential, not user-reconnectable — it falls through to the normal error path rather than show a misleading "Reconnect".

`WorkspaceOAuthProvider` gains an `onAuthLost` callback + `notifyAuthLost()`, de-duped (a burst of concurrent failing calls flips state once) and re-armed by `saveTokens`. `onAuthLost` is wired at the OAuth-provider remote construction paths: `startAuth` (live), `installRemote` (install), and the boot reload (late-bound via `rt.lifecycle`). `ensureSourceRegistered` is Composio-only (no provider), so it is intentionally not wired today; a future "derive `onAuthLost` once at the `startBundleSource` boundary" refactor would future-proof any new OAuth path that registers through it (deferred — no live gap).

## Integration with #416 (the automations de-mask)

This PR is the **emitter** of a tool-result `reason: "reauth_required"`. #416 is the **consumer** (its `UNREACHABLE_CONNECTOR_REASONS` set de-masks a run that hit such a reason). Per review, #416 was kept grounded in the reasons it can itself produce and does **not** forward-declare `reauth_required`. So once **both** land, a one-line change adds `reauth_required` to #416's set **with an integration test against this PR's real emission** (mcp-source emits → executor de-masks). That wiring belongs here-or-after, alongside the real test — not as dead config in #416.

## Tests

- Provider: `notifyAuthLost` de-dupe, re-arm after `saveTokens`, no-op when unwired, swallows a throwing callback.
- `McpSource.execute`: `UnauthorizedError` (with provider) → reauth result + `notifyAuthLost`; `UnauthorizedError` on a static-auth remote (no provider) → no reauth, falls through; a non-auth error still takes the crash path.

`verify:static` green; full unit suite passes.