### PR TITLE
fix(tools): coerce string-encoded structured args at the MCP dispatch boundary

### DIFF
--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -22,6 +22,7 @@ import {
   type HostResourcesResolver,
   hostExtensions,
 } from "../host-resources/index.ts";
+import { coerceInputForSchema } from "./coerce-input.ts";
 import { promoteHiddenErrors } from "./promote-hidden-errors.ts";
 import { createRemoteTransport } from "./remote-transport.ts";
 import { scrubArgsForDispatch } from "./scrub-args.ts";
@@ -1028,13 +1029,41 @@ export class McpSource implements ToolSource {
     const taskSupport = tool?.execution?.taskSupport;
     const isTaskAugmented = taskSupport === "optional" || taskSupport === "required";
 
+    // Recover string-encoded structured args against THIS server's own
+    // advertised schema, then strip no-op optional values — both keyed off
+    // `tool.inputSchema`, the schema this source advertised at `tools/list`.
+    //
+    // Coerce first: models routinely emit object/array parameters as
+    // JSON-encoded strings (`to_recipients: "[\"a@b.com\"]"` instead of the
+    // array). The engine runs the same coercion against the schema it built
+    // for the LLM, but that view can diverge from this source's live schema
+    // (search-promoted tools, cross-workspace dispatch) — and any divergence
+    // means a stringified array reaches the wire and the upstream validator
+    // rejects it ("Input should be a valid list on parameter to_recipients").
+    // Re-coercing here, at the dispatch boundary, against the source's own
+    // schema closes that gap for every call routed through `execute` — the
+    // agent loop's inline and task-augmented paths both flow through here.
+    // `coerceInputForSchema` is pure and idempotent: an already-correct array
+    // survives unchanged, so the redundant engine-side pass is harmless.
+    //
+    // Scope: this covers the `execute` path only. The external `/mcp` task
+    // surface dispatches via `startToolAsTask` directly (see mcp-server.ts),
+    // bypassing this; that path is folded into the separate `/mcp` overhaul (#423).
+    // Limitation: coercion is a no-op when the array/object param is expressed
+    // via `$ref`/`allOf` (see `coerce-input.ts`) — Composio's flat `type:
+    // "array"` schemas are covered; richer shapes are tracked in #424.
+    //
+    // Order matters: coerce before scrub so a stringified empty array
+    // (`"[]"`) becomes `[]` and is then eligible for no-op stripping.
+    const coerced = tool?.inputSchema ? coerceInputForSchema(input, tool.inputSchema) : input;
+
     // Strip no-op values models routinely emit for optional fields (empty
     // strings, nil UUIDs, empty arrays). Some upstream APIs treat these as
     // real values and reject with HTTP 400. Equivalent to the model having
     // omitted the field. Required fields pass through unchanged.
     const scrubbed = tool?.inputSchema
-      ? scrubArgsForDispatch(input, tool.inputSchema)
-      : { args: input, stripped: [] };
+      ? scrubArgsForDispatch(coerced, tool.inputSchema)
+      : { args: coerced, stripped: [] };
     if (scrubbed.stripped.length > 0) {
       log.debug(
         "mcp",

--- a/test/unit/mcp-source-dispatch-coercion.test.ts
+++ b/test/unit/mcp-source-dispatch-coercion.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "bun:test";
+import type { CallToolResult, Task } from "@modelcontextprotocol/sdk/types.js";
+import type { EventSink } from "../../src/engine/types.ts";
+import { McpSource } from "../../src/tools/mcp-source.ts";
+
+// Regression coverage for the dispatch-boundary argument normalization in
+// McpSource.execute (inline path).
+//
+// Models routinely emit object/array tool parameters as JSON-encoded strings
+// (`to_recipients: "[\"a@b.com\"]"` instead of the array). The upstream
+// validator then rejects them ("Input should be a valid list on parameter
+// to_recipients"). McpSource.execute coerces such misencodings against the
+// server's OWN advertised schema — the authoritative oracle and the one place
+// every caller path (agent loop, search-promoted tools, /mcp, delegate)
+// converges — before the request reaches the wire. These tests pin that the
+// coerced shape, not the model's raw string, is what gets dispatched.
+
+const noopSink: EventSink = { emit: () => {} };
+
+/** Composio's OUTLOOK_CREATE_DRAFT-style schema: required array of strings. */
+const OUTLOOK_SCHEMA = {
+  type: "object",
+  required: ["subject", "body", "to_recipients"],
+  properties: {
+    subject: { type: "string" },
+    body: { type: "string" },
+    to_recipients: { type: "array", items: { type: "string" } },
+    cc_recipients: { type: "array", items: { type: "string" } },
+    is_html: { type: "boolean" },
+  },
+};
+
+interface DispatchCapture {
+  source: McpSource;
+  /** Arguments the fake client received on the last callTool dispatch. */
+  lastArgs: () => Record<string, unknown> | undefined;
+}
+
+/**
+ * Build an McpSource with a scripted inline client that records the
+ * `arguments` it is dispatched, and a pre-seeded tool cache so `execute()`
+ * resolves the tool's schema without hitting start()/tools().
+ */
+function buildInlineSource(schema: Record<string, unknown>): DispatchCapture {
+  const source = new McpSource(
+    "outlook",
+    { type: "stdio", spawn: { command: "echo", args: [], env: {} } },
+    noopSink,
+  );
+
+  let captured: Record<string, unknown> | undefined;
+  const fakeClient = {
+    callTool: async (req: { name: string; arguments?: Record<string, unknown> }) => {
+      captured = req.arguments;
+      const result: CallToolResult = { content: [{ type: "text", text: "ok" }], isError: false };
+      return result;
+    },
+    close: async () => {},
+  };
+
+  const internals = source as unknown as { client: unknown; cachedTools: unknown };
+  internals.client = fakeClient;
+  internals.cachedTools = [
+    {
+      name: "outlook__OUTLOOK_CREATE_DRAFT",
+      description: "",
+      inputSchema: schema,
+      source: "mcpb:outlook",
+      // No `execution` → inline (non-task) dispatch path.
+    },
+  ];
+
+  return { source, lastArgs: () => captured };
+}
+
+describe("McpSource.execute — dispatch-boundary coercion", () => {
+  it("coerces a JSON-string-encoded array into a real array before dispatch", async () => {
+    const { source, lastArgs } = buildInlineSource(OUTLOOK_SCHEMA);
+
+    const result = await source.execute("OUTLOOK_CREATE_DRAFT", {
+      subject: "Hi",
+      body: "<p>hello</p>",
+      to_recipients: '["broker@firm.com"]', // the model's misemission
+    });
+
+    expect(result.isError).toBe(false);
+    expect(lastArgs()?.to_recipients).toEqual(["broker@firm.com"]);
+    expect(Array.isArray(lastArgs()?.to_recipients)).toBe(true);
+  });
+
+  it("handles a stringified multi-recipient array", async () => {
+    const { source, lastArgs } = buildInlineSource(OUTLOOK_SCHEMA);
+
+    await source.execute("OUTLOOK_CREATE_DRAFT", {
+      subject: "Hi",
+      body: "x",
+      to_recipients: '["a@x.com", "b@y.com"]',
+    });
+
+    expect(lastArgs()?.to_recipients).toEqual(["a@x.com", "b@y.com"]);
+  });
+
+  it("leaves an already-correct array untouched (idempotent)", async () => {
+    const { source, lastArgs } = buildInlineSource(OUTLOOK_SCHEMA);
+
+    await source.execute("OUTLOOK_CREATE_DRAFT", {
+      subject: "Hi",
+      body: "x",
+      to_recipients: ["broker@firm.com"],
+    });
+
+    expect(lastArgs()?.to_recipients).toEqual(["broker@firm.com"]);
+  });
+
+  it("coerce-then-scrub: a stringified empty array on an OPTIONAL field is dropped", async () => {
+    const { source, lastArgs } = buildInlineSource(OUTLOOK_SCHEMA);
+
+    await source.execute("OUTLOOK_CREATE_DRAFT", {
+      subject: "Hi",
+      body: "x",
+      to_recipients: ["broker@firm.com"],
+      cc_recipients: "[]", // stringified empty array on an optional field
+    });
+
+    // Coercion turns "[]" into [], then scrub strips the empty optional —
+    // the field never reaches the wire as a string the vendor would reject.
+    expect(lastArgs()?.cc_recipients).toBeUndefined();
+    expect(lastArgs()?.to_recipients).toEqual(["broker@firm.com"]);
+  });
+
+  it("leaves a stringified scalar (boolean) untouched — scalar coercion is out of scope", async () => {
+    const { source, lastArgs } = buildInlineSource(OUTLOOK_SCHEMA);
+
+    await source.execute("OUTLOOK_CREATE_DRAFT", {
+      subject: "Hi",
+      body: "x",
+      to_recipients: ["broker@firm.com"],
+      is_html: "true", // model stringifies the boolean; coercion only handles object/array
+    });
+
+    // Pinned deliberately: coerce-input recovers structured (object/array)
+    // misencodings, not scalars. If a future change starts mangling scalars
+    // this fails loudly. (Stringified booleans are a separate, smaller issue.)
+    expect(lastArgs()?.is_html).toBe("true");
+  });
+});
+
+/**
+ * Build an McpSource whose tool is task-augmented (execution.taskSupport:
+ * "optional"), with a scripted task stream that records the dispatched
+ * `arguments`. Proves the task path THROUGH execute() — execute → callToolAsTask
+ * → startToolAsTask → callToolStream — also coerces. (The external `/mcp`
+ * surface that calls startToolAsTask directly is out of scope here.)
+ */
+function buildTaskSource(schema: Record<string, unknown>): DispatchCapture {
+  const source = new McpSource(
+    "outlook",
+    { type: "stdio", spawn: { command: "echo", args: [], env: {} } },
+    noopSink,
+  );
+
+  let captured: Record<string, unknown> | undefined;
+  const now = new Date().toISOString();
+  const task: Task = {
+    taskId: "t1",
+    status: "working",
+    ttl: 60_000,
+    createdAt: now,
+    lastUpdatedAt: now,
+  };
+  async function* taskStream(): AsyncGenerator<unknown, void, void> {
+    yield { type: "taskCreated", task };
+    yield {
+      type: "result",
+      result: { content: [{ type: "text", text: "ok" }], isError: false } as CallToolResult,
+    };
+  }
+  const fakeClient = {
+    experimental: {
+      tasks: {
+        callToolStream: (req: { name: string; arguments?: Record<string, unknown> }) => {
+          captured = req.arguments;
+          return taskStream();
+        },
+      },
+    },
+    close: async () => {},
+  };
+
+  const internals = source as unknown as { client: unknown; cachedTools: unknown };
+  internals.client = fakeClient;
+  internals.cachedTools = [
+    {
+      name: "outlook__OUTLOOK_CREATE_DRAFT",
+      description: "",
+      inputSchema: schema,
+      source: "mcpb:outlook",
+      execution: { taskSupport: "optional" }, // → task-augmented dispatch path
+    },
+  ];
+
+  return { source, lastArgs: () => captured };
+}
+
+describe("McpSource.execute — dispatch-boundary coercion (task-augmented path)", () => {
+  it("coerces a stringified array before dispatching a task-augmented call", async () => {
+    const { source, lastArgs } = buildTaskSource(OUTLOOK_SCHEMA);
+
+    const result = await source.execute("OUTLOOK_CREATE_DRAFT", {
+      subject: "Hi",
+      body: "x",
+      to_recipients: '["broker@firm.com"]',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(lastArgs()?.to_recipients).toEqual(["broker@firm.com"]);
+  });
+});


### PR DESCRIPTION
## Problem

Composio-backed tools (e.g. `OUTLOOK_CREATE_DRAFT`) intermittently fail with:

> `Invalid request data provided - Input should be a valid list on parameter to_recipients`

It presented as a stateful pattern — *first call in a session succeeds, every subsequent call fails*.

## Root cause (confirmed against prod wire logs)

Not Composio state corruption (the original hypothesis). The conversation logs show the **model emits the argument as a JSON-encoded string** on the failing calls:

- ✅ first call: `to_recipients: ["a@example.com"]`  (real array)
- ❌ later calls: `to_recipients: "[\"a@example.com\"]"`  (stringified array)

Composio's schema for `to_recipients` is a plain `type: "array"` (its description even says *"Do not pass as a JSON-encoded string"*), so Composio is correctly rejecting a malformed payload.

The platform already has `coerceInputForSchema` (built for exactly this misemission) running in the engine loop, `/v1/tools/call`, and in-process apps. But for **search-promoted / cross-workspace remote tools**, the schema view the engine coerces against can diverge from the source's live schema, so the stringified value slips through to the wire. Verified: the real coercer converts the real failing payload correctly given the real schema — it simply wasn't applied effectively on this dispatch path.

## Fix

Re-coerce against the **source's own advertised schema** (`tool.inputSchema`) in `McpSource.execute`, immediately before `scrubArgsForDispatch`. This covers both the inline and task-augmented agent dispatch paths (both flow through `execute`). `coerceInputForSchema` is pure and idempotent, so the redundant engine-side pass is harmless. Order is coerce-then-scrub so a stringified empty array (`"[]"`) normalizes to `[]` and is then eligible for no-op stripping.

## Scope & follow-ups (not in this PR)

- **External `/mcp` task surface:** calls `startToolAsTask` directly (`mcp-server.ts:888`), bypassing `execute`, so it isn't covered here. Folded into the separate `/mcp` overhaul — tracked in #423.
- **`$ref` / `allOf` array params:** `coerceInputForSchema` is a no-op for these (out of scope in `coerce-input.ts`). Composio's flat `type: "array"` schemas are covered; richer shapes tracked in #424.
- Stringified **scalars** (e.g. `is_html: "true"`) are deliberately not coerced (separate, smaller issue); a test pins this behavior so it can't change silently.

## Tests

`test/unit/mcp-source-dispatch-coercion.test.ts` — failing-first verified: **4 of 6 tests fail without the fix** (3 inline cases + the task-augmented case; the idempotent and scalar-passthrough cases correctly pass either way):
- stringified single / multi-recipient array → coerced to array before dispatch
- already-correct array unchanged (idempotent)
- coerce-then-scrub: stringified empty array on an optional field is dropped
- task-augmented path (via `execute`) is coerced
- stringified scalar passes through untouched

`bun run verify:static` ✅ · `bun run test:unit` ✅ (3427 pass)