### PR TITLE
feat(tools): nb__search auto-promotes its top matches into the active set

### DIFF
--- a/src/prompt/compose.ts
+++ b/src/prompt/compose.ts
@@ -556,7 +556,7 @@ function formatAppsSection(apps: PromptAppInfo[], hasProxiedTools?: boolean): st
   if (hasProxiedTools) {
     lines.push(
       "",
-      '**Important:** These apps have tools that are not in your direct tool list. To use an app\'s tools, call `nb__search` with `scope: "tools"` and a keyword (e.g., "contact", "invoice", "document") to discover exact tool names, then call `nb__manage_tools` with `{ "add": ["source__tool", ...] }` to make them callable on the next turn. When you switch domains, patch in one call with `{ "add": [...], "remove": [...] }`. Tool names use the format `source__tool` (e.g., `synapse-crm__create_contact`). Never guess tool names — always discover them first.',
+      '**Important:** These apps have tools that are not in your direct tool list. Call `nb__search` with `scope: "tools"` and a keyword (e.g., "contact", "invoice", "document") to discover them — the top matches are **activated automatically** and callable on the next turn. Use `nb__manage_tools` only to activate a different match from the results, or to remove tools when switching domains (`{ "add": [...], "remove": [...] }`). Tool names use the format `source__tool` (e.g., `synapse-crm__create_contact`). Never guess tool names — always discover them first.',
     );
   }
   return lines.join("\n");
@@ -566,11 +566,11 @@ const INTERACTION_RULES = `### Interaction Rules
 
 - When the user describes a change, identify which tool achieves it and call it directly. Do not ask for confirmation unless the action is destructive or ambiguous.
 - After making changes, briefly confirm what you did. The app view refreshes automatically — do not describe the UI.
-- If unsure which tool to use, call \`nb__search\` with \`scope: "tools"\` and a keyword. If the chosen tool is not currently callable, add it via \`nb__manage_tools({ add: ["source__tool"] })\` before using it. Default to retain — only remove tools when clearly switching domains, batched into the same patch as the new adds.
+- If unsure which tool to use, call \`nb__search\` with \`scope: "tools"\` and a keyword. Its top matches are activated automatically — call them directly. Only use \`nb__manage_tools\` to activate a different match from the results, or to remove tools when clearly switching domains (batch removes with the next adds).
 - When the user says "undo" or "go back," check if the app has undo, snapshot, or history tools. If not, say undo is not available for this app.
 - When the user gives vague feedback ("I don't like it," "make it better"), ask ONE clarifying question about what specifically to change.
 - Messages may include an \`[App Context: ...]\` header with metadata from the app. Use it to understand what the user was looking at.
-- Other apps are still available via \`nb__search\` (scope: "tools") if the user's request spans apps; add discovered tools via \`nb__manage_tools\` before calling them.`;
+- Other apps are still available via \`nb__search\` (scope: "tools") if the user's request spans apps; its top matches are auto-activated, so you can usually call them directly.`;
 
 function formatFocusedAppSection(focusedApp: FocusedAppInfo): string {
   const safeName = sanitizeLineField(focusedApp.name);

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -169,12 +169,35 @@ export async function createSystemTools(
             _meta: { [NON_ADVANCING_META_KEY]: true },
           };
         const shown = matches.slice(0, 25);
+        // Auto-promote the top matches straight into the active set, so the
+        // model can call them on the NEXT turn without a separate
+        // nb__manage_tools round-trip — which would re-send the whole cached
+        // prefix for zero state the model couldn't infer. The prefix
+        // cache-write on the next call is irreducible either way (tool
+        // definitions are wire position 0; changing them busts the prefix);
+        // this just removes one model round-trip per discovery. addTool is
+        // idempotent, eligibility-guarded, and LRU-bounded, and no-ops when
+        // there's no active run.
+        const AUTO_PROMOTE_LIMIT = 3;
+        const promoted: string[] = [];
+        if (toolPromotionCtx) {
+          for (const t of shown.slice(0, AUTO_PROMOTE_LIMIT)) {
+            if (toolPromotionCtx.addTool(t.name).ok) promoted.push(t.name);
+          }
+        }
         const suffix = matches.length > shown.length ? ` (showing top ${shown.length})` : "";
         const lines = [`Found ${matches.length} tool(s) for "${query}"${suffix}:\n`];
         for (const t of shown) lines.push(`- **${t.name}**: ${t.description}`);
+        if (promoted.length > 0) {
+          const subj = promoted.length === 1 ? "This tool is" : `The top ${promoted.length} are`;
+          const obj = promoted.length === 1 ? "it" : "them";
+          lines.push(
+            `\n${subj} now active — call ${obj} directly. Use nb__manage_tools only to activate a different match from the list above.`,
+          );
+        }
         return {
           content: textContent(lines.join("\n")),
-          structuredContent: { tools: shown.map((t) => ({ name: t.name })) },
+          structuredContent: { tools: shown.map((t) => ({ name: t.name })), promoted },
           isError: false,
         };
       },

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -117,6 +117,47 @@ describe("System Tools", () => {
 		]);
 	});
 
+	it("search auto-promotes its top matches into the active set", async () => {
+		const registry = await makeRegistry();
+		const added: string[] = [];
+		const toolPromotionCtx: ToolPromotionContext = {
+			addTool: (name) => {
+				added.push(name);
+				return { ok: true, toolName: name, changed: true, message: "active" };
+			},
+			removeTool: (name) => ({ ok: true, toolName: name, changed: false, message: "" }),
+		};
+		// toolPromotionCtx is the 17th positional arg (15 reserved slots after getRegistry).
+		const systemTools = await createSystemTools(
+			() => registry,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			toolPromotionCtx,
+		);
+		const result = await systemTools.execute("search", { scope: "tools", query: "greet" });
+
+		expect(result.isError).toBe(false);
+		// The matched tool was promoted into the active set (one fewer round-trip
+		// than search → manage_tools → call).
+		expect(added).toContain("test__greet");
+		// The model is told it can call it directly, and the result reports it.
+		expect(extractText(result.content)).toContain("now active");
+		expect(getStructured<{ promoted?: string[] }>(result)?.promoted).toContain("test__greet");
+	});
+
 	it("search with scope=tools preserves single-word prefix substring matches", async () => {
 		const registry = new ToolRegistry();
 		const source = await makeInProcessSource("test", [
@@ -571,6 +612,11 @@ describe("System Tools", () => {
 		expect(getStructured<{ tools?: Array<{ name: string }> }>(searchResult)?.tools).toEqual([
 			{ name: "test__tool.with.dot" },
 		]);
+
+		// search now auto-promotes its top match; clear the log to isolate the
+		// manage_tools call below (intent: manage_tools accepts the searched name).
+		expect(calls).toEqual(["add:test__tool.with.dot"]);
+		calls.length = 0;
 
 		const result = await systemTools.execute("manage_tools", {
 			add: ["test__tool.with.dot"],


### PR DESCRIPTION
## Why

Tool discovery under progressive disclosure was a **3-round-trip** dance:

1. `nb__search` to find a tool,
2. `nb__manage_tools` to promote it into the active set,
3. call the tool.

Step 2 is a full model round-trip that re-sends the entire cached prompt prefix for *zero state the model couldn't infer*. And because tool definitions sit at **wire position 0** (before the prompt-cache breakpoint), promoting a tool busts the cached prefix regardless. The bust is irreducible — but the round-trip isn't. This is the round-trip behind the "401k token" turn we investigated (search → manage_tools → query → list, with the prefix re-write on the promote).

## What changed

`nb__search` now **auto-promotes its top 3 matches** into the active set as a side effect of returning, so the model can call them on the next turn directly — collapsing discovery from **3 round-trips to 2**.

- Reuses the engine's `addTool` promotion primitive unchanged: idempotent, eligibility-guarded, LRU-bounded (so the active set stays capped), and a graceful no-op when there's no active run.
- The result prose tells the model the top matches are "now active — call them directly," and `structuredContent.promoted` reports exactly what was promoted.
- Prompt guidance (`compose.ts`) updated: the model is no longer told to call `manage_tools` after a search — that's now only for activating a *different* listed match or removing tools when switching domains.

This is the **aggressive** promotion policy (top 3 of any non-empty result). The cache bust on the next call is unchanged (irreducible); this removes one model round-trip — and its prefix re-send — per discovery.

## Not changed / not possible

- The cache bust itself: tools are position 0 in Anthropic's `tools → system → messages` order, so changing the tool set invalidates the prefix. No append semantics exist.
- Progressive disclosure: the search corpus is still the full cross-workspace union; only the *act* of promotion moves one step earlier. The active set stays LRU-bounded.

## Tests

`test/unit/system-tools.test.ts`: new test asserts a search promotes its top match (`addTool` called), the prose says "now active", and `structuredContent.promoted` reports it. Updated the existing `manage_tools accepts exact tool names` test to isolate `manage_tools` from the new search side effect.

`verify:static` clean, `test:unit` 3432 pass.

## Follow-up (separate, not in scope)

Option C "pre-emptive surfacing" — when the *first* user message names a domain, surface those tools before turn 1 so there's zero mid-turn promotion at all. Composes with this; tracked separately.