### PR TITLE
feat(usage): account for forked summarizer + auto-title model calls

### DIFF
--- a/src/conversation/auto-title.ts
+++ b/src/conversation/auto-title.ts
@@ -1,16 +1,23 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { type TokenUsage, tokenUsageFromV3 } from "../usage/types.ts";
 
 /**
  * Generate a short conversation title using the provided model.
  * Non-blocking — call fire-and-forget after first turn.
+ *
+ * `onUsage` observes the title call's token usage — it runs the `fast` slot
+ * outside the agentic loop, so without this its cost is invisible to the
+ * usage aggregator.
  */
 export async function generateTitle(
   model: LanguageModelV3,
   userMessage: string,
   assistantResponse: string,
+  onUsage?: (usage: TokenUsage, llmMs: number) => void,
 ): Promise<string> {
   try {
     const transcript = formatTitleTranscript(userMessage, assistantResponse);
+    const startedAt = Date.now();
     const result = await model.doGenerate({
       prompt: [
         {
@@ -31,6 +38,7 @@ export async function generateTitle(
       ],
       maxOutputTokens: 30,
     });
+    onUsage?.(tokenUsageFromV3(result.usage), Date.now() - startedAt);
     const textBlock = result.content.find((b) => b.type === "text");
     if (textBlock?.type === "text") {
       return sanitizeGeneratedTitle(textBlock.text, userMessage);

--- a/src/conversation/compaction.ts
+++ b/src/conversation/compaction.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { type TokenUsage, tokenUsageFromV3 } from "../usage/types.ts";
 import type { HistoryCompactedEvent, StoredMessage } from "./types.ts";
 
 /**
@@ -49,6 +50,12 @@ export interface CompactionOptions {
    * fallback (never unbounded). See `summarizerTranscriptBudgetTokens`.
    */
   summarizerContextTokens?: number;
+  /**
+   * Observe the summarizer model call's token usage (the call runs outside the
+   * agentic loop, so it emits no `llm.response`). The runtime uses this to
+   * persist an `aux.usage` event so the fold's cost isn't invisible.
+   */
+  onUsage?: (usage: TokenUsage, llmMs: number) => void;
 }
 
 const DEFAULTS = {
@@ -333,12 +340,17 @@ const SUMMARIZE_SYSTEM =
 export async function summarizeMessages(
   model: LanguageModelV3,
   messages: readonly StoredMessage[],
-  opts: { maxOutputTokens?: number; summarizerContextTokens?: number } = {},
+  opts: {
+    maxOutputTokens?: number;
+    summarizerContextTokens?: number;
+    onUsage?: (usage: TokenUsage, llmMs: number) => void;
+  } = {},
 ): Promise<string> {
   const transcript = formatTranscript(
     messages,
     summarizerTranscriptBudgetTokens(opts.summarizerContextTokens),
   );
+  const startedAt = Date.now();
   const result = await model.doGenerate({
     prompt: [
       { role: "system", content: SUMMARIZE_SYSTEM },
@@ -346,6 +358,9 @@ export async function summarizeMessages(
     ],
     maxOutputTokens: opts.maxOutputTokens ?? SUMMARY_MAX_OUTPUT_TOKENS,
   });
+  // Report usage before the empty-summary guard — the call was billed
+  // regardless of whether its output is usable.
+  opts.onUsage?.(tokenUsageFromV3(result.usage), Date.now() - startedAt);
   const textBlock = result.content.find((b) => b.type === "text");
   const summary = textBlock?.type === "text" ? textBlock.text.trim() : "";
   if (!summary) throw new Error("compaction summary was empty");
@@ -366,6 +381,7 @@ export async function runCompaction(
   if (!plan.shouldCompact) return null;
   const summary = await summarizeMessages(model, messages.slice(0, plan.boundaryIndex), {
     summarizerContextTokens: opts.summarizerContextTokens,
+    onUsage: opts.onUsage,
   });
   return {
     summary,

--- a/src/conversation/types.ts
+++ b/src/conversation/types.ts
@@ -449,7 +449,7 @@ export interface AuxUsageEvent {
   ts: string;
   type: "aux.usage";
   /** Which forked call produced this usage. */
-  source: "compaction" | "title";
+  source: "compaction" | "title" | "briefing";
   model: string;
   usage: TokenUsage;
   llmMs: number;

--- a/src/conversation/types.ts
+++ b/src/conversation/types.ts
@@ -278,7 +278,8 @@ export type ConversationEventType =
   | "skills.loaded"
   | "context.assembled"
   | "metadata.title"
-  | "history.compacted";
+  | "history.compacted"
+  | "aux.usage";
 
 export interface UserMessageEvent {
   ts: string;
@@ -436,6 +437,24 @@ export interface HistoryCompactedEvent {
   summarizedMessageCount: number;
 }
 
+/**
+ * Token usage for a forked model call that is NOT a conversation turn — the
+ * compaction summarizer and the auto-title generator. These run the `fast`
+ * slot outside the agentic loop and so emit no `llm.response`; without this
+ * event their cost is invisible to the usage aggregator. It carries no
+ * content (the produced text lands elsewhere — the summary seed, the title),
+ * and reconstruction skips it, so it never becomes a message.
+ */
+export interface AuxUsageEvent {
+  ts: string;
+  type: "aux.usage";
+  /** Which forked call produced this usage. */
+  source: "compaction" | "title";
+  model: string;
+  usage: TokenUsage;
+  llmMs: number;
+}
+
 /** Discriminated union of all conversation event types. */
 export type ConversationEvent =
   | UserMessageEvent
@@ -449,4 +468,5 @@ export type ConversationEvent =
   | SkillsLoadedEvent
   | ContextAssembledEvent
   | TitleChangeEvent
-  | HistoryCompactedEvent;
+  | HistoryCompactedEvent
+  | AuxUsageEvent;

--- a/src/conversation/usage-aggregator.ts
+++ b/src/conversation/usage-aggregator.ts
@@ -378,7 +378,10 @@ export async function aggregateUsage(
         continue;
       }
 
-      if (entry.type === "llm.response" && entry.usage) {
+      // `aux.usage` carries the same {ts, model, usage, llmMs} shape for forked
+      // model calls (compaction summarizer, auto-title) that emit no
+      // llm.response — count them so their cost isn't undercounted.
+      if ((entry.type === "llm.response" || entry.type === "aux.usage") && entry.usage) {
         const ts = (entry.ts as string) ?? "";
         if (!isDateInRange(ts.slice(0, 10), range)) continue;
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -18,7 +18,7 @@ import { coerceInputForSchema } from "../tools/coerce-input.ts";
 import { bareToolName } from "../tools/namespace.ts";
 import { validateToolInput } from "../tools/validate-input.ts";
 import type { TokenUsage } from "../usage/types.ts";
-import { addUsage, emptyUsage } from "../usage/types.ts";
+import { addUsage, emptyUsage, tokenUsageFromV3 } from "../usage/types.ts";
 import {
   boundToolResultForModel,
   estimateContentSize,
@@ -698,12 +698,10 @@ export class AgentEngine {
             | undefined
         )?.cache_creation;
         const cacheWrite1h = rawCreation?.ephemeral_1h_input_tokens;
+        // Canonical mapping + the engine-only 1h/5m cache-write split that the
+        // base V3 usage struct doesn't carry (from provider metadata above).
         const turnUsage: TokenUsage = {
-          inputTokens: response.usage.inputTokens.total ?? 0,
-          outputTokens: response.usage.outputTokens.total ?? 0,
-          cacheReadTokens: response.usage.inputTokens.cacheRead ?? 0,
-          cacheWriteTokens: response.usage.inputTokens.cacheWrite ?? 0,
-          reasoningTokens: response.usage.outputTokens.reasoning ?? 0,
+          ...tokenUsageFromV3(response.usage),
           ...(cacheWrite1h != null ? { cacheWrite1hTokens: cacheWrite1h } : {}),
         };
         addUsage(cumulativeUsage, turnUsage);

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1814,11 +1814,24 @@ export class Runtime {
     // and the title landing) surfaces in the catch instead of as an unhandled
     // rejection that would fail the whole run.
     if (conversation.title === null) {
-      const titleModel = this.resolveModelFn(this.getModelSlot("fast"));
+      const titleSlot = this.getModelSlot("fast");
+      const titleModel = this.resolveModelFn(titleSlot);
       const titleInput =
         request.message ||
         `[Uploaded: ${request.fileRefs?.map((f) => f.filename).join(", ") || "files"}]`;
-      void generateTitle(titleModel, titleInput, result.output)
+      // The title call runs the `fast` slot outside the agentic loop; persist
+      // its usage as an aux.usage event so it isn't invisible to cost accounting.
+      const appendTitleUsage = store.appendEvent?.bind(store);
+      void generateTitle(titleModel, titleInput, result.output, (usage, llmMs) =>
+        appendTitleUsage?.(conversation.id, {
+          ts: new Date().toISOString(),
+          type: "aux.usage",
+          source: "title",
+          model: titleSlot,
+          usage,
+          llmMs,
+        }),
+      )
         .then(async (title) => {
           await store.update(conversation.id, { title });
           // `wsId: sessionWsId` (the owner's personal workspace) — NOT
@@ -3186,6 +3199,18 @@ export class Runtime {
       now: new Date().toISOString(),
       onEvent: (event) => appendEvent(conversationId, event),
       onError: (err) => console.error("[runtime] history compaction failed:", err),
+      // The summarizer runs the `fast` slot outside the agentic loop, so it
+      // emits no llm.response. Persist its usage as an aux.usage event so the
+      // fold's cost isn't invisible to the usage aggregator.
+      onUsage: (usage, llmMs) =>
+        appendEvent(conversationId, {
+          ts: new Date().toISOString(),
+          type: "aux.usage",
+          source: "compaction",
+          model: fastSlot,
+          usage,
+          llmMs,
+        }),
     });
     // No-op contract: the helper returns the SAME array reference when nothing
     // was compacted (below threshold or best-effort failure). A future helper

--- a/src/services/briefing-generator.ts
+++ b/src/services/briefing-generator.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV3, SharedV3ProviderOptions } from "@ai-sdk/provider";
 import { getModelByString, getProviderFromModel } from "../model/catalog.ts";
+import { type TokenUsage, tokenUsageFromV3 } from "../usage/types.ts";
 import type { BriefingContext } from "./briefing-collector.ts";
 import { debugBriefing } from "./briefing-debug.ts";
 import type {
@@ -148,6 +149,12 @@ export class BriefingGenerator {
     private model: LanguageModelV3,
     private modelString: string | null,
     private config: HomeConfig,
+    /**
+     * Observe the `fast`-slot generation's usage — the call runs outside the
+     * agentic loop and emits no llm.response, so without this its cost is
+     * invisible to the usage aggregator.
+     */
+    private onUsage?: (usage: TokenUsage, llmMs: number) => void,
   ) {}
 
   async generate(
@@ -260,6 +267,7 @@ export class BriefingGenerator {
 
     const providerOptions = shortCallProviderOptions(this.modelString);
     const abort = AbortSignal.timeout(BRIEFING_TIMEOUT_MS);
+    const startedAt = Date.now();
     const response = await this.model.doGenerate({
       prompt: [
         { role: "system", content: BRIEFING_SYSTEM_PROMPT },
@@ -278,6 +286,8 @@ export class BriefingGenerator {
       abortSignal: abort,
       ...(Object.keys(providerOptions).length > 0 ? { providerOptions } : {}),
     });
+
+    this.onUsage?.(tokenUsageFromV3(response.usage), Date.now() - startedAt);
 
     const finishReason = response.finishReason?.unified ?? "unknown";
     if (finishReason === "length") {

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -6,7 +6,11 @@ import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
 import { ORG_ADMIN_ROLES } from "../identity/types.ts";
 import { getAvailableModels, isModelAllowed } from "../model/catalog.ts";
-import { type RequestContext, runWithRequestContext } from "../runtime/request-context.ts";
+import {
+  getRequestContext,
+  type RequestContext,
+  runWithRequestContext,
+} from "../runtime/request-context.ts";
 import type { Runtime } from "../runtime/runtime.ts";
 import { canWriteWorkspaceScoped } from "../workspace/authz.ts";
 import type { InProcessTool } from "./in-process-app.ts";
@@ -799,6 +803,23 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
                   userName: homeConfig.userName,
                   timezone: homeConfig.timezone,
                   cacheTtlMinutes: homeConfig.cacheTtlMinutes,
+                },
+                // The briefing's fast-slot generation emits no llm.response, so
+                // persist its usage as an aux.usage event. Foreground generation
+                // runs in the caller's conversation; the background SWR refresh
+                // (bgCtx) has no conversationId, so it's skipped here — a known
+                // workspace-scoped gap with no conversation to attribute to.
+                (usage, llmMs) => {
+                  const convId = getRequestContext()?.conversationId;
+                  if (!convId) return;
+                  runtime.findConversationStore()?.appendEvent?.(convId, {
+                    ts: new Date().toISOString(),
+                    type: "aux.usage",
+                    source: "briefing",
+                    model: modelString ?? "unknown",
+                    usage,
+                    llmMs,
+                  });
                 },
               );
               return generator.generate(activity, facetContext);

--- a/src/usage/types.ts
+++ b/src/usage/types.ts
@@ -16,6 +16,8 @@
  * compiler enforces that callers supply the full struct, which is what
  * keeps cost computation from silently dropping a field.
  */
+import type { LanguageModelV3Usage } from "@ai-sdk/provider";
+
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
@@ -32,6 +34,22 @@ export interface TokenUsage {
    * all-1h so historical figures stay correct.
    */
   cacheWrite1hTokens?: number;
+}
+
+/**
+ * Map an AI SDK V3 `doGenerate`/`doStream` usage struct into the canonical
+ * `TokenUsage`. The engine maps inline (it also tiers the 1h cache-write split
+ * from provider metadata); forked utility calls — the compaction summarizer and
+ * auto-title — use this to report their usage without that engine-only detail.
+ */
+export function tokenUsageFromV3(usage: LanguageModelV3Usage): TokenUsage {
+  return {
+    inputTokens: usage.inputTokens.total ?? 0,
+    outputTokens: usage.outputTokens.total ?? 0,
+    cacheReadTokens: usage.inputTokens.cacheRead ?? 0,
+    cacheWriteTokens: usage.inputTokens.cacheWrite ?? 0,
+    reasoningTokens: usage.outputTokens.reasoning ?? 0,
+  };
 }
 
 /** Zero-valued TokenUsage. Convenience for accumulators. */

--- a/src/usage/types.ts
+++ b/src/usage/types.ts
@@ -38,9 +38,16 @@ export interface TokenUsage {
 
 /**
  * Map an AI SDK V3 `doGenerate`/`doStream` usage struct into the canonical
- * `TokenUsage`. The engine maps inline (it also tiers the 1h cache-write split
- * from provider metadata); forked utility calls — the compaction summarizer and
- * auto-title — use this to report their usage without that engine-only detail.
+ * `TokenUsage`.
+ *
+ * Deliberately omits `cacheWrite1hTokens` — that 1h/5m split comes from
+ * provider metadata the engine reads separately, not from this usage struct.
+ * Cost treats an absent split as all-1h (the 2x rate; see `cost.ts`), so a
+ * caller that sets `cache_control` breakpoints AND maps usage only through here
+ * would over-cost its cache writes. Safe for the current callers (the forked
+ * `fast`-slot utility calls — compaction summarizer, auto-title, briefing —
+ * issue raw `doGenerate` with no breakpoints, so `cacheWriteTokens` is ~0); the
+ * engine layers the 1h split on top of this for the main loop.
  */
 export function tokenUsageFromV3(usage: LanguageModelV3Usage): TokenUsage {
   return {

--- a/test/integration/compaction-wiring.test.ts
+++ b/test/integration/compaction-wiring.test.ts
@@ -128,6 +128,17 @@ describe("history compaction — wired path", () => {
       // (a) The wired path actually persisted a compaction event.
       expect(events.some((e) => e.type === "history.compacted")).toBe(true);
 
+      // (a.2) The summarizer's usage is persisted as an aux.usage event, so the
+      // fold's cost is visible to the usage aggregator (not undercounted).
+      expect(
+        events.some(
+          (e) =>
+            e.type === "aux.usage" &&
+            (e as { source?: string }).source === "compaction" &&
+            (e as { usage?: { inputTokens?: number } }).usage?.inputTokens !== undefined,
+        ),
+      ).toBe(true);
+
       // (b) The model-facing projection is compacted: it carries the summary
       //     seed and NOT the oldest turn's text.
       const modelView = JSON.stringify(reconstructMessages(events));

--- a/test/unit/auto-title.test.ts
+++ b/test/unit/auto-title.test.ts
@@ -57,6 +57,20 @@ describe("generateTitle", () => {
 		expect(transcript).toContain("<\\/user-message>");
 	});
 
+	it("reports the title call's usage via onUsage", async () => {
+		const model = createMockModel(() => ({
+			content: [{ type: "text", text: "My Title" }],
+			inputTokens: 120,
+			outputTokens: 8,
+		}));
+		let seen: { inputTokens: number; outputTokens: number } | undefined;
+		await generateTitle(model, "hello", "hi there", (usage) => {
+			seen = { inputTokens: usage.inputTokens, outputTokens: usage.outputTokens };
+		});
+		expect(seen?.inputTokens).toBe(120);
+		expect(seen?.outputTokens).toBe(8);
+	});
+
 	it("falls back when the model returns refusal text", async () => {
 		const model = createMockModel(() => ({
 			content: [

--- a/test/unit/briefing-generator.test.ts
+++ b/test/unit/briefing-generator.test.ts
@@ -371,6 +371,24 @@ describe("briefing-generator", () => {
 			expect(calls[0].abortSignal).toBeDefined();
 		});
 
+		it("reports the generation's usage via onUsage", async () => {
+			const llmResponse = JSON.stringify({ lede: "Ok.", sections: [] });
+			const { model } = createTrackingModelV3(llmResponse);
+			let seen: { inputTokens: number; outputTokens: number } | undefined;
+			const gen = new BriefingGenerator(
+				model,
+				"anthropic:claude-sonnet-4-6",
+				makeConfig(),
+				(usage) => {
+					seen = { inputTokens: usage.inputTokens, outputTokens: usage.outputTokens };
+				},
+			);
+			await gen.generate(activeActivity());
+
+			expect(seen?.inputTokens).toBe(100);
+			expect(seen?.outputTokens).toBe(50);
+		});
+
 		it("disables Anthropic thinking for reasoning-capable Claude models", async () => {
 			const llmResponse = JSON.stringify({ lede: "Ok.", sections: [] });
 			const { model, calls } = createTrackingModelV3(llmResponse);

--- a/test/unit/compaction.test.ts
+++ b/test/unit/compaction.test.ts
@@ -107,6 +107,31 @@ describe("summarizeMessages + runCompaction", () => {
     expect(out).toBe("a dense summary");
   });
 
+  test("summarizeMessages reports the call's usage via onUsage", async () => {
+    const model = {
+      doGenerate: async () => ({
+        content: [{ type: "text", text: "a dense summary" }],
+        usage: {
+          inputTokens: { total: 1200, cacheRead: 300, cacheWrite: 100 },
+          outputTokens: { total: 40 },
+        },
+      }),
+    } as unknown as LanguageModelV3;
+    let seen:
+      | { usage: { inputTokens: number; outputTokens: number; cacheReadTokens?: number }; ms: number }
+      | undefined;
+    const out = await summarizeMessages(model, conversation(2, 40), {
+      onUsage: (usage, ms) => {
+        seen = { usage, ms };
+      },
+    });
+    expect(out).toBe("a dense summary");
+    expect(seen?.usage.inputTokens).toBe(1200);
+    expect(seen?.usage.outputTokens).toBe(40);
+    expect(seen?.usage.cacheReadTokens).toBe(300);
+    expect(typeof seen?.ms).toBe("number");
+  });
+
   test("summarizeMessages throws on an empty model response", async () => {
     await expect(summarizeMessages(fakeModel(""), conversation(2, 40))).rejects.toThrow();
   });
@@ -355,6 +380,23 @@ describe("reconstructMessages — history.compacted", () => {
       { ts: ts(0), type: "user.message", content: [{ type: "text", text: "hi" }] },
     ];
     const msgs = reconstructMessages(events);
+    expect((msgs[0]!.content as { text?: string }[])[0]?.text).toBe("hi");
+  });
+
+  test("aux.usage events are skipped — forked-call cost, never a message", () => {
+    const events: ConversationEvent[] = [
+      { ts: ts(0), type: "user.message", content: [{ type: "text", text: "hi" }] },
+      {
+        ts: ts(1),
+        type: "aux.usage",
+        source: "title",
+        model: "m",
+        usage: { inputTokens: 10, outputTokens: 5 },
+        llmMs: 1,
+      },
+    ];
+    const msgs = reconstructMessages(events);
+    expect(msgs).toHaveLength(1);
     expect((msgs[0]!.content as { text?: string }[])[0]?.text).toBe("hi");
   });
 

--- a/test/unit/conversation/usage-aggregator.test.ts
+++ b/test/unit/conversation/usage-aggregator.test.ts
@@ -100,6 +100,29 @@ describe("usage-aggregator", () => {
     expect(report.totals.conversations).toBe(1);
   });
 
+  it("counts aux.usage events (forked compaction/title calls) toward totals", async () => {
+    const dir = makeTmpDir();
+    const content = buildJsonl({ id: "conv-aux", updatedAt: "2026-04-10T14:00:00Z" }, [
+      llmEvent({ inputTokens: 1000, outputTokens: 500 }),
+      {
+        type: "aux.usage",
+        ts: "2026-04-10T12:05:00Z",
+        source: "compaction",
+        model: "claude-haiku-4-5-20251001",
+        usage: { inputTokens: 400, outputTokens: 60, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        llmMs: 120,
+      },
+    ]);
+    writeFileSync(join(dir, "conv-aux.jsonl"), content);
+
+    const report = await aggregateUsage(dir, "all", "day");
+
+    // Both the main turn and the forked summarizer call are counted.
+    expect(report.totals.tokens.input).toBe(1400);
+    expect(report.totals.tokens.output).toBe(560);
+    expect(report.totals.llmCalls).toBe(2);
+  });
+
   it("filters usage by llm.response timestamp, not conversation updatedAt", async () => {
     const dir = makeTmpDir();
 


### PR DESCRIPTION
## Why

Three model calls run the `fast` slot **directly** via `model.doGenerate`, outside the agentic loop:

- the **compaction summarizer** (`summarizeMessages`)
- the **auto-title** generator (`generateTitle`)
- the **daily-briefing** generator (`BriefingGenerator`)

All discarded `result.usage`. Because they emit no `llm.response` event — and the usage aggregator's source of truth *is* `llm.response` events — their cost was **invisible** to cost/usage accounting. A systematic undercount, worst on long conversations that compact repeatedly.

## What changed

A new conversation event records forked-call cost:

```ts
interface AuxUsageEvent {
  ts: string;
  type: "aux.usage";
  source: "compaction" | "title" | "briefing";
  model: string;
  usage: TokenUsage;
  llmMs: number;
}
```

- The three functions surface their usage via a **non-breaking** `onUsage?` callback (existing callers/tests unaffected — optional-chaining short-circuits when no callback is passed).
- The **runtime** / tool handler persists an `aux.usage` event at each call site with the correct `fast`-slot model id.
- The **usage aggregator** counts `aux.usage` alongside `llm.response` (same `{ts, model, usage, llmMs}` shape).
- **Reconstruction skips it** — it's a cost record, never a conversation message.
- A shared `tokenUsageFromV3` helper maps the AI SDK V3 usage struct. The engine now uses it too (layering its 1h cache-write split on top), removing the duplicated mapping.

**Briefing caveat:** the briefing's *foreground* generation is conversation-scoped and metered like the others. Its *background* stale-while-revalidate refresh runs in a workspace-only context with no `conversationId`, so it's guard-skipped — a known workspace-scoped gap (no conversation to attach a conversation-event to), documented at the call site.

No persistence migration: `aux.usage` is additive and only read by the aggregator.

## Tests

- `summarizeMessages` / `generateTitle` / `BriefingGenerator` report usage via `onUsage`.
- Aggregator counts `aux.usage` toward token + call totals.
- Reconstruction skips `aux.usage` (no phantom message).
- The compaction-wiring **integration** test asserts an `aux.usage` (source `compaction`) event lands on disk end-to-end.
- `usage-pipeline` pins the engine's mapping after the `tokenUsageFromV3` dedup.

`verify:static` clean, `test:unit` 3444 pass, relevant integration tests green.

## Follow-ups (not in scope)

- **Briefing background refresh** is workspace-scoped and unmetered — closing it needs a workspace-scoped usage path (not a conversation event), separate from this PR.
- The conversations **bundle** (`jsonl-reader`) does its own per-conversation usage aggregation for the UI and doesn't yet count `aux.usage`. Best fixed as part of **reconstructor unification** (next item).
- The **promoted-but-never-called** signal (validating #426): `tool.promoted` goes to the workspace log sink but isn't persisted to the conversation log (PostHog intentionally omits tool names). Its own small change — tracked separately.