### PR TITLE
fix(automations): de-mask runs that hit a reauth_required connector

### DIFF
--- a/src/bundles/automations/src/executor.ts
+++ b/src/bundles/automations/src/executor.ts
@@ -152,22 +152,31 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): TaskFnRequ
  *                                 owner isn't a member of (e.g. another user's
  *                                 personal workspace) — unreachable by design.
  *                                 (Orchestrator reason.)
+ *   - `reauth_required`         → the run ATTEMPTED a call to an INSTALLED
+ *                                 connector whose authorization had expired /
+ *                                 been revoked — the call routed fine but failed
+ *                                 downstream on auth. Emitted by the connector
+ *                                 auth-loss path (`McpSource.execute`), NOT the
+ *                                 orchestrator — a reactive 401 (OAuth-provider
+ *                                 remote) or a proactive revalidation flip
+ *                                 (Composio, via `ConnectionRevalidator`) both
+ *                                 surface this same reason.
  *
- * KEY LIMITATION — both reasons require the agent to have ATTEMPTED the call.
- * A required connector that never appears in the agent's toolset (so it never
- * tries) produces no reason and is NOT de-masked. The production standup
+ * KEY LIMITATION — every reason here requires the agent to have ATTEMPTED the
+ * call. A required connector that never appears in the agent's toolset (so it
+ * never tries) produces no reason and is NOT de-masked. The production standup
  * incident was actually this never-attempted variant: the agent ran `nb__search`,
  * found no Teams connector in any reachable workspace, and "completed" by
- * documenting the gap — never calling a Teams tool. So this fix de-masks the
+ * documenting the gap — never calling a Teams tool. So this de-masks the
  * attempted-call class (a strict improvement, zero false positives); the
  * never-attempted class needs a different signal (the agent self-reporting an
  * incomplete required step) and is tracked separately.
  *
- * These are the only two *connector-unreachable* reasons. The orchestrator
- * (`error-mapping.ts`) emits FIVE reasons in all; the other three are agent /
- * typo errors, not connector gaps, and are excluded below — the taxonomy is NOT
- * closed at two. Both reasons here are really produced and tested, so the set
- * stays grounded in values that actually occur.
+ * These are the *connector-unreachable* reasons. Two are orchestrator routing
+ * reasons (`error-mapping.ts`); `reauth_required` is the connector auth-loss
+ * reason. The orchestrator emits five reasons in all — the other three are
+ * agent / typo errors, not connector gaps, excluded below. Every reason in the
+ * set is really produced and tested, so it stays grounded in values that occur.
  *
  * Deliberately narrower than the full reason taxonomy. Excluded on purpose:
  *   - `invalid_tool_name` / `unknown_identity_source` — usually the agent probing
@@ -177,14 +186,12 @@ function buildRequest(automation: Automation, ctx?: ExecutorContext): TaskFnRequ
  *     Real but rare, and the taxonomy frames it as a typo / cross-tenant accident
  *     (agent error) rather than a connector gap. Left out for now; revisit if it
  *     shows up in practice.
- *
- * NOT covered here: an installed connector whose authorization expired mid-run.
- * That surfaces a `reason: "reauth_required"` tool result only once the connector
- * auth-loss detection lands (a separate change). Add `reauth_required` to this
- * set in THAT change, alongside a test against its real emission — not as a
- * forward-declaration here, which would assert a value no current path produces.
  */
-const UNREACHABLE_CONNECTOR_REASONS = new Set(["unknown_tool_source", "workspace_access_denied"]);
+const UNREACHABLE_CONNECTOR_REASONS = new Set([
+  "unknown_tool_source",
+  "workspace_access_denied",
+  "reauth_required",
+]);
 
 /** Tool-call entries (loosely typed in `TaskFnResult`) whose routing failed. */
 function unreachableConnectorCalls(toolCalls: TaskFnResult["toolCalls"]): string[] {

--- a/test/unit/bundles/automations/executor.test.ts
+++ b/test/unit/bundles/automations/executor.test.ts
@@ -290,6 +290,26 @@ describe("createDirectExecutor — connector-unreachable de-masking", () => {
 		expect(run.error).toMatch(/Connector unavailable/);
 	});
 
+	test("complete + reauth_required (installed connector, auth expired) → failure", async () => {
+		// reauth_required is emitted by the connector auth-loss path
+		// (McpSource.execute), proven to flow onto errorReason by the engine test
+		// in engine.test.ts. Here: a run that attempted such a connector and got
+		// the reauth result must not be a green success.
+		const run = await runWith([
+			{
+				id: "t1",
+				name: "ws_founders-teams__send_message",
+				input: {},
+				output: "teams needs to be reconnected — its authorization has expired",
+				ok: false,
+				ms: 14,
+				errorReason: "reauth_required",
+			},
+		]);
+		expect(run.status).toBe("failure");
+		expect(run.error).toMatch(/Connector unavailable/);
+	});
+
 	test("complete + all tool calls ok → success (no false downgrade)", async () => {
 		const run = await runWith([
 			{ id: "t1", name: "nb__briefing", input: {}, output: "ok", ok: true, ms: 20 },

--- a/test/unit/engine.test.ts
+++ b/test/unit/engine.test.ts
@@ -125,6 +125,53 @@ describe("AgentEngine", () => {
     expect(result.stopReason).toBe("complete");
   });
 
+  it("lifts a failed tool result's structuredContent.reason onto errorReason", async () => {
+    // The exact envelope McpSource.execute returns on mid-session auth loss
+    // (a disconnected OAuth/Composio connector). The engine must surface that
+    // reason on the ToolCallRecord so downstream consumers (the automations
+    // de-masker) can tell an unreachable connector from a generic tool error.
+    let callCount = 0;
+    const model = createMockModel(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_1",
+              toolName: "teams__send",
+              input: JSON.stringify({}),
+            },
+          ],
+          inputTokens: 10,
+          outputTokens: 5,
+        };
+      }
+      return { content: [{ type: "text", text: "ok" }], inputTokens: 10, outputTokens: 5 };
+    });
+
+    const tools = {
+      schemas: [{ name: "teams__send", description: "send", inputSchema: {} }],
+      handler: (): ToolResult => ({
+        content: textContent("teams needs to be reconnected"),
+        isError: true,
+        structuredContent: { error: "auth_required", reason: "reauth_required", source: "teams" },
+      }),
+    };
+
+    const engine = makeEngine(model, tools);
+    const result = await engine.run(
+      defaultConfig,
+      "",
+      [{ role: "user", content: [{ type: "text", text: "send it" }] }],
+      tools.schemas,
+    );
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]!.ok).toBe(false);
+    expect(result.toolCalls[0]!.errorReason).toBe("reauth_required");
+  });
+
   it("does not promote tools discovered by nb__search implicitly", async () => {
     let callCount = 0;
     const seenToolLists: string[][] = [];


### PR DESCRIPTION
## What

Wires the de-mask **consumer** (#416, merged) to the **emitter** (#421, merged; #427, open) — the deliberately-deferred step from those reviews. Adds `reauth_required` to the automations executor's `UNREACHABLE_CONNECTOR_REASONS` so a run that called an installed connector whose authorization had lapsed is recorded `failure`, not a green `complete`.

## Why now (not before)

Earlier reviews correctly removed `reauth_required` from #416 because, on that branch, *nothing produced the value* — a unit test feeding it would assert a fabricated input. That's no longer true: `McpSource.execute` (merged via #421) returns `{ error: "auth_required", reason: "reauth_required" }` on mid-session auth loss — reactively for an OAuth-provider remote's 401, and proactively once `ConnectionRevalidator` (#427) flips a Composio account. So the value is now really emitted, and this lands it **with a test against that real emission**, exactly as the reviews asked.

## Grounded in real emission

- `engine.test.ts` — a failed tool result carrying `structuredContent.reason: "reauth_required"` (the exact `McpSource.execute` envelope) lands as `errorReason` on the `ToolCallRecord`. This pins the emit→lift link.
- `executor.test.ts` — a run whose tool call carries `errorReason: "reauth_required"` de-masks to `failure`.

## Scope note (unchanged)

Like the other two reasons, this only fires when the agent **attempted** the call. A connector absent from the toolset entirely (never attempted) is still the separate never-attempted gap, tracked elsewhere.

`verify:static` green; engine + automations suites pass (100 tests in the two touched files).