### PR TITLE
feat(oauth): mint workspace-scoped service tokens on demand (tenant-key grant)

### DIFF
--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -49,7 +49,16 @@ export interface RemoteTransportConfig {
   auth?:
     | { type: "bearer"; token: string }
     | { type: "header"; name: string; value: string }
-    | { type: "none" };
+    | { type: "none" }
+    /**
+     * Machine-plane auth for platform data-plane services (artifacts,
+     * nimbletasks, web-search). The runtime mints a short-lived,
+     * workspace-scoped service token on demand via the tenant-key grant
+     * (`NB_MCP_AUTHORIZER_TENANT_KEY` + `NB_FLEET_AUTHORIZER_ISSUER`), naming
+     * this `audience`/`scope`, and re-mints on expiry. No interactive OAuth, no
+     * static secret. The workspace dimension is the connection's own workspace.
+     */
+    | { type: "tenant-key"; audience: string; scope: string };
   headers?: Record<string, string>;
   reconnection?: {
     maxReconnectionDelay?: number;

--- a/src/oauth/envelope.ts
+++ b/src/oauth/envelope.ts
@@ -160,6 +160,36 @@ export function isUniformByte(buf: Buffer, byte: number): boolean {
   return true;
 }
 
+/**
+ * Low-level MAC envelope: serialize a payload object to the versioned wire
+ * `v1.<b64url(json)>.<b64url(hmac)>`, with the HMAC taken over the
+ * `v1.<b64url(json)>` prefix (NOT the raw JSON), so the version is bound into
+ * the signature.
+ *
+ * This is the single crypto construction shared by the two payload schemas that
+ * ride this envelope: the LOGIN assertion (`signEnvelope`, payload carries
+ * `inner`) and the tenant-key MINT request (`buildMintRequest` in
+ * `tenant-key-mint.ts`, payload carries `workspace`/`audience`/`scope`). The
+ * authorizer mirrors this exactly with a single `verifyMac` over both schemas —
+ * keeping sign and verify as one construction on each side, not two copies of a
+ * security-critical path.
+ *
+ * The caller owns the payload schema, including the temporal fields (`iat` /
+ * `exp`): this function does serialization + MAC only, never clock or field
+ * semantics. Throws `invalid_payload` if the serialized payload exceeds the
+ * verifier's wire cap, so an over-long payload fails at the signer rather than
+ * producing bytes every peer refuses.
+ */
+export function signMacEnvelope(payload: object, tenantKey: Buffer): string {
+  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  if (payloadB64.length > MAX_PAYLOAD_BYTES) {
+    throw new EnvelopeError("invalid_payload");
+  }
+  const signed = `${VERSION_PREFIX}${payloadB64}`;
+  const macB64 = base64UrlEncode(createHmac("sha256", tenantKey).update(signed).digest());
+  return `${signed}.${macB64}`;
+}
+
 export function signEnvelope(opts: SignOptions): string {
   if (!ALLOWED_TID_PATTERN.test(opts.tid)) {
     throw new EnvelopeError("invalid_tid");
@@ -182,13 +212,7 @@ export function signEnvelope(opts: SignOptions): string {
     iat: now,
     exp: now + ttl,
   };
-  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
-  if (payloadB64.length > MAX_PAYLOAD_BYTES) {
-    throw new EnvelopeError("invalid_payload");
-  }
-  const signed = `${VERSION_PREFIX}${payloadB64}`;
-  const macB64 = base64UrlEncode(createHmac("sha256", opts.tenantKey).update(signed).digest());
-  return `${signed}.${macB64}`;
+  return signMacEnvelope(payload, opts.tenantKey);
 }
 
 /**

--- a/src/oauth/tenant-key-mint.ts
+++ b/src/oauth/tenant-key-mint.ts
@@ -53,8 +53,9 @@ const RENEW_SKEW_SECONDS = 30;
 
 export interface MintRequestParams {
   tid: string;
-  /** Workspace dimension — becomes the token's `workspace_id` claim. Must pass
-   *  the authorizer's DNS-label grammar (shared with tid). */
+  /** Workspace dimension — becomes the token's `workspace_id` claim. Validated
+   *  against the runtime's canonical workspace-id grammar (`WORKSPACE_ID_RE`);
+   *  the authorizer accepts it via its own bounded safe-id grammar. */
   workspace: string;
   audience: string;
   scope: string;

--- a/src/oauth/tenant-key-mint.ts
+++ b/src/oauth/tenant-key-mint.ts
@@ -1,0 +1,411 @@
+import { WORKSPACE_ID_RE } from "../workspace/workspace-id-pattern.ts";
+import { ALLOWED_TID_PATTERN, EnvelopeError, signMacEnvelope } from "./envelope.ts";
+
+/**
+ * Tenant-key MINT grant — the machine plane.
+ *
+ * A tenant's runtime is authoritative over its own workspaces. To talk to a
+ * platform data-plane service (artifacts, nimbletasks, web-search) it signs a
+ * mint request with its per-tenant key — `NB_MCP_AUTHORIZER_TENANT_KEY` =
+ * HKDF(authorizer-master, salt=tid, info="mcp-authorizer/v1"), provisioned at
+ * deploy time — naming exactly the `(workspace, audience, scope)` it wants, and
+ * POSTs it to the authorizer's `/token`. The authorizer re-derives the key from
+ * the master, MAC-verifies, and mints a short-lived workspace-scoped service
+ * token (`aud=<service>`, `workspace_id=<workspace>`). RLS in the service fences
+ * the data by `(tenant_id, workspace_id)`.
+ *
+ * The request rides the SAME MAC envelope as the OAuth login assertion
+ * (`signEnvelope`) — one crypto construction, `signMacEnvelope` — but its
+ * payload carries `(workspace, audience, scope)` instead of a PKCE `inner`. The
+ * authorizer mirrors this with a single `verifyMac` feeding either
+ * `verifyAssertion` (login) or `verifyMintRequest` (mint).
+ *
+ * Unlike the login assertion, a missing key here is a HARD error, not a graceful
+ * no-op: a service configured for tenant-key auth cannot be reached without it,
+ * and silently falling back would surface as an opaque downstream 401. Fail at
+ * the signer with a message that names the missing env var.
+ */
+
+/** Grant type — must byte-match the authorizer's `TENANT_KEY_GRANT`. */
+const TENANT_KEY_GRANT = "urn:nimblebrain:params:oauth:grant-type:tenant-key";
+
+/** Mirrors the authorizer's `verifyMintRequest` field caps so an over-long
+ *  audience/scope fails at the signer with a clear cause rather than a generic
+ *  400 from the wire. */
+const MAX_AUDIENCE_LENGTH = 128;
+const MAX_SCOPE_LENGTH = 512;
+const MIN_TENANT_KEY_BYTES = 32;
+
+/**
+ * TTL of the mint REQUEST envelope itself (not the minted token). The request
+ * only has to survive the POST round-trip; the authorizer caps any envelope at
+ * 30 min regardless. Short by design — a leaked request grants nothing the key
+ * holder couldn't already mint, but there's no reason to let it linger.
+ */
+const MINT_REQUEST_TTL_SECONDS = 120;
+
+/**
+ * Re-mint this many seconds BEFORE the token's stated expiry. Covers clock skew
+ * between runtime and service plus in-flight request latency, so a token handed
+ * to a caller is never about to expire mid-request.
+ */
+const RENEW_SKEW_SECONDS = 30;
+
+export interface MintRequestParams {
+  tid: string;
+  /** Workspace dimension — becomes the token's `workspace_id` claim. Must pass
+   *  the authorizer's DNS-label grammar (shared with tid). */
+  workspace: string;
+  audience: string;
+  scope: string;
+  tenantKey: Buffer;
+  ttlSeconds?: number;
+  now?: number;
+}
+
+/**
+ * Build the signed mint-request wire string. Pure — no I/O, no env. Validates
+ * the same shape the authorizer enforces so failures surface here with a named
+ * field instead of a generic wire rejection.
+ */
+export function buildMintRequest(params: MintRequestParams): string {
+  if (!ALLOWED_TID_PATTERN.test(params.tid)) {
+    throw new EnvelopeError("invalid_tid");
+  }
+  // Validate against the runtime's OWN canonical workspace-id grammar — the
+  // runtime is authoritative over its workspaces and mints only for real ids
+  // (`ws_<hex>`, `ws_user_<userId>`). This is stricter than the authorizer's
+  // generic safe-id gate, and fails loud here if a non-workspace string ever
+  // reaches the signer. The real id flows through verbatim — no rewriting.
+  if (!WORKSPACE_ID_RE.test(params.workspace)) {
+    throw new MintError(
+      "invalid_workspace",
+      `mint workspace must be a valid NimbleBrain workspace id (got '${params.workspace}')`,
+    );
+  }
+  if (
+    typeof params.audience !== "string" ||
+    params.audience.length === 0 ||
+    params.audience.length > MAX_AUDIENCE_LENGTH
+  ) {
+    throw new MintError(
+      "invalid_audience",
+      `mint audience must be 1..${MAX_AUDIENCE_LENGTH} chars`,
+    );
+  }
+  if (
+    typeof params.scope !== "string" ||
+    params.scope.length === 0 ||
+    Buffer.byteLength(params.scope, "utf8") > MAX_SCOPE_LENGTH
+  ) {
+    throw new MintError("invalid_scope", `mint scope must be 1..${MAX_SCOPE_LENGTH} bytes`);
+  }
+  if (params.tenantKey.length < MIN_TENANT_KEY_BYTES) {
+    throw new MintError(
+      "invalid_key",
+      `tenant key must decode to >= ${MIN_TENANT_KEY_BYTES} bytes (got ${params.tenantKey.length})`,
+    );
+  }
+  const now = params.now ?? Math.floor(Date.now() / 1000);
+  const ttl = params.ttlSeconds ?? MINT_REQUEST_TTL_SECONDS;
+  const payload = {
+    tid: params.tid,
+    workspace: params.workspace,
+    audience: params.audience,
+    scope: params.scope,
+    iat: now,
+    exp: now + ttl,
+  };
+  return signMacEnvelope(payload, params.tenantKey);
+}
+
+export type MintFailureCode =
+  | "invalid_workspace"
+  | "invalid_audience"
+  | "invalid_scope"
+  | "invalid_key"
+  | "unprovisioned"
+  | "http_error"
+  | "bad_response";
+
+export class MintError extends Error {
+  readonly code: MintFailureCode;
+  constructor(code: MintFailureCode, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "MintError";
+  }
+}
+
+/** A minted service token plus the absolute epoch-second at which it expires. */
+export interface ServiceToken {
+  accessToken: string;
+  /** Epoch seconds. Derived from the response `expires_in` at mint time. */
+  expiresAt: number;
+}
+
+/** Identity the runtime mints AS — its own tenant. Read once from the env the
+ *  authorizer provisioned. Exposed for override in tests. */
+export interface TenantIdentity {
+  tid: string;
+  tenantKey: Buffer;
+}
+
+/**
+ * Read `(tid, tenantKey)` from the deploy-provisioned env. Throws `unprovisioned`
+ * — with the exact missing var — if either is absent, because a tenant-key
+ * service is unreachable without them and a downstream 401 would not name the
+ * cause.
+ */
+export function readTenantIdentityFromEnv(env: NodeJS.ProcessEnv = process.env): TenantIdentity {
+  const tid = env.NB_TENANT_ID;
+  const keyB64 = env.NB_MCP_AUTHORIZER_TENANT_KEY;
+  if (!tid) {
+    throw new MintError("unprovisioned", "NB_TENANT_ID is not set; cannot mint service tokens");
+  }
+  if (!keyB64) {
+    throw new MintError(
+      "unprovisioned",
+      "NB_MCP_AUTHORIZER_TENANT_KEY is not set; cannot mint service tokens (run `make derive-authorizer-tenant-key`)",
+    );
+  }
+  const tenantKey = Buffer.from(keyB64, "base64");
+  if (tenantKey.length < MIN_TENANT_KEY_BYTES) {
+    throw new MintError(
+      "invalid_key",
+      `NB_MCP_AUTHORIZER_TENANT_KEY must decode to >= ${MIN_TENANT_KEY_BYTES} bytes (got ${tenantKey.length})`,
+    );
+  }
+  return { tid, tenantKey };
+}
+
+export interface MintServiceTokenOptions {
+  /** Authorizer issuer, e.g. `https://mcp-authorizer.mcp-shared.svc`. The mint
+   *  POST goes to `${issuer}/token`. */
+  issuer: string;
+  workspace: string;
+  audience: string;
+  scope: string;
+  identity: TenantIdentity;
+  /** Injectable for tests; defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+/**
+ * Mint one workspace-scoped service token via a single `/token` POST. No retry,
+ * no cache — that's the cache layer's job. Throws `MintError` on any non-200 or
+ * malformed response.
+ */
+export async function mintServiceToken(opts: MintServiceTokenOptions): Promise<ServiceToken> {
+  const nowSeconds = (opts.now ?? (() => Math.floor(Date.now() / 1000)))();
+  const wire = buildMintRequest({
+    tid: opts.identity.tid,
+    workspace: opts.workspace,
+    audience: opts.audience,
+    scope: opts.scope,
+    tenantKey: opts.identity.tenantKey,
+    now: nowSeconds,
+  });
+
+  const tokenUrl = new URL("/token", opts.issuer).toString();
+  const body = new URLSearchParams({ grant_type: TENANT_KEY_GRANT, tenant_assertion: wire });
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  let res: Response;
+  try {
+    res = await doFetch(tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+  } catch (cause) {
+    throw new MintError(
+      "http_error",
+      `mint POST to ${tokenUrl} failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  if (!res.ok) {
+    // The authorizer returns an OAuth-style form error; include its text so a
+    // misconfig (audience not allowed, key drift) is diagnosable from logs.
+    const detail = await res.text().catch(() => "");
+    throw new MintError(
+      "http_error",
+      `mint for aud=${opts.audience} workspace=${opts.workspace} rejected ${res.status}: ${detail.slice(0, 300)}`,
+    );
+  }
+
+  let json: { access_token?: unknown; expires_in?: unknown };
+  try {
+    json = (await res.json()) as typeof json;
+  } catch {
+    throw new MintError("bad_response", "mint response was not JSON");
+  }
+  if (typeof json.access_token !== "string" || json.access_token.length === 0) {
+    throw new MintError("bad_response", "mint response missing access_token");
+  }
+  if (
+    typeof json.expires_in !== "number" ||
+    !Number.isFinite(json.expires_in) ||
+    json.expires_in <= 0
+  ) {
+    throw new MintError("bad_response", "mint response missing a positive expires_in");
+  }
+  return { accessToken: json.access_token, expiresAt: nowSeconds + json.expires_in };
+}
+
+/** Cache key — one minted token per distinct `(issuer, tid, workspace, audience,
+ *  scope)`. tid is included so a key-rotation that changes identity can't serve a
+ *  stale token. */
+function cacheKey(
+  issuer: string,
+  tid: string,
+  workspace: string,
+  audience: string,
+  scope: string,
+): string {
+  return [issuer, tid, workspace, audience, scope].join("|");
+}
+
+interface CacheSlot {
+  token?: ServiceToken;
+  /** Single-flight: concurrent callers awaiting an in-progress mint share it. */
+  inflight?: Promise<ServiceToken>;
+}
+
+export interface TokenRequest {
+  issuer: string;
+  workspace: string;
+  audience: string;
+  scope: string;
+}
+
+/**
+ * Expiry-aware, single-flight cache over `mintServiceToken`. One instance backs
+ * all tenant-key connections in a runtime: it dedupes concurrent mints for the
+ * same `(issuer, workspace, audience, scope)` and re-mints just before expiry
+ * (or on demand after a 401).
+ *
+ * Identity (`tid` + key) is read once from the env at construction and reused —
+ * the runtime mints only ever AS its own tenant.
+ */
+export class ServiceTokenCache {
+  private readonly slots = new Map<string, CacheSlot>();
+  private readonly identity: TenantIdentity;
+  private readonly fetchImpl?: typeof fetch;
+  private readonly now: () => number;
+
+  constructor(
+    opts: { identity?: TenantIdentity; fetchImpl?: typeof fetch; now?: () => number } = {},
+  ) {
+    this.identity = opts.identity ?? readTenantIdentityFromEnv();
+    this.fetchImpl = opts.fetchImpl;
+    this.now = opts.now ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  /**
+   * Return a valid bearer for the request, minting (and caching) if none is
+   * fresh. `forceRefresh` discards any cached token first — the 401-retry path.
+   */
+  async getToken(req: TokenRequest, opts: { forceRefresh?: boolean } = {}): Promise<string> {
+    const key = cacheKey(req.issuer, this.identity.tid, req.workspace, req.audience, req.scope);
+    const slot = this.slots.get(key) ?? {};
+
+    if (opts.forceRefresh) {
+      slot.token = undefined;
+    }
+
+    const nowSeconds = this.now();
+    if (slot.token && slot.token.expiresAt - RENEW_SKEW_SECONDS > nowSeconds) {
+      return slot.token.accessToken;
+    }
+    if (slot.inflight) {
+      return (await slot.inflight).accessToken;
+    }
+
+    const inflight = mintServiceToken({
+      issuer: req.issuer,
+      workspace: req.workspace,
+      audience: req.audience,
+      scope: req.scope,
+      identity: this.identity,
+      fetchImpl: this.fetchImpl,
+      now: this.now,
+    });
+    slot.inflight = inflight;
+    this.slots.set(key, slot);
+
+    try {
+      const token = await inflight;
+      slot.token = token;
+      return token.accessToken;
+    } finally {
+      // Clear the in-flight marker whether the mint resolved or threw, so a
+      // failed mint doesn't pin every future caller to the rejected promise.
+      slot.inflight = undefined;
+    }
+  }
+}
+
+/**
+ * Process-wide default cache. One instance backs every tenant-key connection in
+ * the runtime, so concurrent connections to the same `(workspace, audience,
+ * scope)` share a single minted token. Lazily constructed so a runtime with no
+ * tenant-key bundles never reads the (possibly absent) provisioning env.
+ */
+let defaultCache: ServiceTokenCache | undefined;
+export function getDefaultServiceTokenCache(): ServiceTokenCache {
+  if (!defaultCache) defaultCache = new ServiceTokenCache();
+  return defaultCache;
+}
+
+export interface MintingFetchOptions {
+  cache: ServiceTokenCache;
+  /** Authorizer issuer the cache mints against. */
+  issuer: string;
+  workspace: string;
+  audience: string;
+  scope: string;
+  /** Underlying fetch the authorized request is sent with. Defaults to global. */
+  baseFetch?: typeof fetch;
+}
+
+/**
+ * Build a `fetch` that authorizes every outbound request with a freshly-minted
+ * (cached) tenant-key service token for one `(workspace, audience, scope)`. On a
+ * 401/403 — the service rejected the token (early expiry, key rotation) — it
+ * force-re-mints and retries exactly once, then surfaces the result.
+ *
+ * Intended as the MCP transport's `fetch` override, so the runtime reaches a
+ * tenant-key data-plane service unattended: no interactive OAuth, no static
+ * secret, a short-lived workspace-scoped bearer minted on demand.
+ */
+export function createMintingFetch(opts: MintingFetchOptions): typeof fetch {
+  const base = opts.baseFetch ?? fetch;
+  const req: TokenRequest = {
+    issuer: opts.issuer,
+    workspace: opts.workspace,
+    audience: opts.audience,
+    scope: opts.scope,
+  };
+  const minting = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    const send = async (forceRefresh: boolean): Promise<Response> => {
+      const token = await opts.cache.getToken(req, { forceRefresh });
+      // We own Authorization for this connection; the transport's own headers
+      // (content-type, session id) ride through via `init`.
+      const headers = new Headers(init?.headers);
+      headers.set("Authorization", `Bearer ${token}`);
+      return base(input, { ...init, headers });
+    };
+    const res = await send(false);
+    if (res.status === 401 || res.status === 403) {
+      return send(true);
+    }
+    return res;
+  };
+  return minting as typeof fetch;
+}

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -378,6 +378,7 @@ export class McpSource implements ToolSource {
         this.mode.url,
         this.mode.transportConfig,
         this.mode.authProvider,
+        { workspaceId: this.bundleContext?.workspaceId },
       );
 
       // Remote: watch for transport close — wired AFTER successful start
@@ -642,6 +643,7 @@ export class McpSource implements ToolSource {
       this.mode.url,
       this.mode.transportConfig,
       this.mode.authProvider,
+      { workspaceId: this.bundleContext?.workspaceId },
     );
     // onclose is wired in `start()` AFTER the connect succeeds — same
     // reason as the initial-construction site: a transport close that

--- a/src/tools/remote-transport.ts
+++ b/src/tools/remote-transport.ts
@@ -1,8 +1,9 @@
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { FetchLike, Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { RemoteTransportConfig } from "../bundles/types.ts";
+import { createMintingFetch, getDefaultServiceTokenCache } from "../oauth/tenant-key-mint.ts";
 
 /**
  * Resolve `${ENV_VAR}` placeholders against `process.env`.
@@ -49,6 +50,12 @@ export function createRemoteTransport(
   url: URL,
   config?: RemoteTransportConfig,
   authProvider?: OAuthClientProvider,
+  opts?: {
+    /** Workspace of the connection — required for `auth.type: "tenant-key"`, the
+     *  dimension the minted token is scoped to. Threaded from the McpSource's
+     *  `BundleMcpContext`. */
+    workspaceId?: string;
+  },
 ): Transport {
   const headers: Record<string, string> = { ...(config?.headers ?? {}) };
 
@@ -64,6 +71,35 @@ export function createRemoteTransport(
     headers[k] = resolveEnvTemplate(v);
   }
 
+  // Machine-plane auth: mint a workspace-scoped service token on demand and
+  // attach it as the transport's `fetch`. This is NOT a static header (the
+  // token is short-lived and re-minted on expiry / 401) and it is NOT OAuth
+  // (no interactive flow). Fail loud here if the connection's workspace or the
+  // authorizer issuer is missing — a tenant-key bundle is unreachable without
+  // both, and a downstream 401 would not name the cause.
+  let mintingFetch: FetchLike | undefined;
+  if (config?.auth?.type === "tenant-key") {
+    const workspaceId = opts?.workspaceId;
+    if (!workspaceId) {
+      throw new Error(
+        "tenant-key transport auth requires a workspaceId (the connection's workspace dimension)",
+      );
+    }
+    const issuer = process.env.NB_FLEET_AUTHORIZER_ISSUER;
+    if (!issuer) {
+      throw new Error(
+        "tenant-key transport auth requires NB_FLEET_AUTHORIZER_ISSUER (the mcp-authorizer issuer)",
+      );
+    }
+    mintingFetch = createMintingFetch({
+      cache: getDefaultServiceTokenCache(),
+      issuer,
+      workspace: workspaceId,
+      audience: config.auth.audience,
+      scope: config.auth.scope,
+    }) as FetchLike;
+  }
+
   // Only wire the OAuth provider if no static auth is configured. Static
   // auth is the simpler, explicit contract — don't second-guess it.
   const effectiveAuthProvider =
@@ -75,12 +111,14 @@ export function createRemoteTransport(
     return new SSEClientTransport(url, {
       requestInit,
       authProvider: effectiveAuthProvider,
+      fetch: mintingFetch,
     });
   }
 
   return new StreamableHTTPClientTransport(url, {
     requestInit,
     authProvider: effectiveAuthProvider,
+    fetch: mintingFetch,
     reconnectionOptions: config?.reconnection
       ? {
           maxReconnectionDelay: config.reconnection.maxReconnectionDelay ?? 30_000,

--- a/test/unit/remote-transport-factory.test.ts
+++ b/test/unit/remote-transport-factory.test.ts
@@ -1,4 +1,5 @@
-import { describe, test, expect } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { afterEach, describe, expect, test } from "bun:test";
 import { createRemoteTransport } from "../../src/tools/remote-transport.ts";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -111,5 +112,61 @@ describe("createRemoteTransport", () => {
 		if (sessionId !== undefined) {
 			expect(sessionId).toBe("session-abc");
 		}
+	});
+});
+
+describe("createRemoteTransport — tenant-key auth", () => {
+	const saved = {
+		tid: process.env.NB_TENANT_ID,
+		key: process.env.NB_MCP_AUTHORIZER_TENANT_KEY,
+		iss: process.env.NB_FLEET_AUTHORIZER_ISSUER,
+	};
+	afterEach(() => {
+		const restore: [string, string | undefined][] = [
+			["NB_TENANT_ID", saved.tid],
+			["NB_MCP_AUTHORIZER_TENANT_KEY", saved.key],
+			["NB_FLEET_AUTHORIZER_ISSUER", saved.iss],
+		];
+		for (const [k, v] of restore) {
+			if (v === undefined) delete process.env[k];
+			else process.env[k] = v;
+		}
+	});
+
+	const tenantKeyConfig = {
+		auth: { type: "tenant-key" as const, audience: "artifacts", scope: "artifacts:write" },
+	};
+
+	test("throws when the connection has no workspaceId (fail loud, not a silent 401)", () => {
+		process.env.NB_FLEET_AUTHORIZER_ISSUER = "https://authz.test";
+		expect(() =>
+			createRemoteTransport(new URL("https://artifacts.test/mcp"), tenantKeyConfig),
+		).toThrow(/workspaceId/);
+	});
+
+	test("throws when NB_FLEET_AUTHORIZER_ISSUER is unset", () => {
+		delete process.env.NB_FLEET_AUTHORIZER_ISSUER;
+		expect(() =>
+			createRemoteTransport(new URL("https://artifacts.test/mcp"), tenantKeyConfig, undefined, {
+				workspaceId: "ws_smoke",
+			}),
+		).toThrow(/NB_FLEET_AUTHORIZER_ISSUER/);
+	});
+
+	test("attaches a minting fetch and NO static Authorization when fully provisioned", () => {
+		process.env.NB_TENANT_ID = "hq";
+		process.env.NB_MCP_AUTHORIZER_TENANT_KEY = randomBytes(32).toString("base64");
+		process.env.NB_FLEET_AUTHORIZER_ISSUER = "https://authz.test";
+		const t = createRemoteTransport(new URL("https://artifacts.test/mcp"), tenantKeyConfig, undefined, {
+			workspaceId: "ws_smoke",
+		});
+		expect(t).toBeInstanceOf(StreamableHTTPClientTransport);
+		const internal = t as unknown as Record<string, unknown>;
+		// The minted token is attached via the transport's fetch override, not a
+		// static header — so `_fetch` is wired and `Authorization` is absent.
+		expect(internal["_fetch"]).toBeDefined();
+		const reqInit = internal["_requestInit"] as RequestInit | undefined;
+		const headers = (reqInit?.headers ?? {}) as Record<string, string>;
+		expect(headers["Authorization"]).toBeUndefined();
 	});
 });

--- a/test/unit/tenant-key-mint.test.ts
+++ b/test/unit/tenant-key-mint.test.ts
@@ -1,0 +1,351 @@
+import { createHmac, hkdfSync, randomBytes, timingSafeEqual } from "node:crypto";
+import { describe, expect, it } from "bun:test";
+import {
+  buildMintRequest,
+  createMintingFetch,
+  MintError,
+  mintServiceToken,
+  readTenantIdentityFromEnv,
+  ServiceTokenCache,
+  type TenantIdentity,
+} from "../../src/oauth/tenant-key-mint.ts";
+
+// ---------------------------------------------------------------------------
+// Faithful inline mirror of the authorizer's verifier
+// (platform/services/mcp-authorizer/src/tenant-assertion.ts). The MINT request
+// is verified there by `verifyMac` → `verifyMintRequest`; we reproduce both so a
+// drift in HKDF info / MAC framing / payload shape / field caps breaks CI on the
+// runtime side. The live cross-impl proof is /tmp/tenant-key-e2e.sh, which mints
+// against the deployed authorizer; this keeps the guard in-repo and offline.
+// ---------------------------------------------------------------------------
+const HKDF_INFO = Buffer.from("mcp-authorizer/v1");
+const ALLOWED_TID = /^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$/;
+// Mirrors the authorizer's ALLOWED_WORKSPACE_PATTERN — a bounded, injection-safe
+// opaque id, distinct from the tid DNS-label rule.
+const ALLOWED_WORKSPACE = /^[A-Za-z0-9_-]{1,80}$/;
+const MAX_ENVELOPE_LIFETIME = 30 * 60;
+const CLOCK_SKEW = 60;
+
+function deriveTenantKey(master: Buffer, tid: string): Buffer {
+  return Buffer.from(hkdfSync("sha256", master, Buffer.from(tid, "utf8"), HKDF_INFO, 32));
+}
+
+type VerifyResult =
+  | { ok: true; tid: string; workspace: string; audience: string; scope: string; exp: number }
+  | { ok: false; reason: string };
+
+function verifyMintAsAuthorizer(wire: string, master: Buffer, nowSeconds: number): VerifyResult {
+  const parts = wire.split(".");
+  if (parts.length !== 3 || parts[0] !== "v1") return { ok: false, reason: "invalid_format" };
+  const payloadB64 = parts[1] as string;
+  const macB64 = parts[2] as string;
+  const payloadRaw = Buffer.from(payloadB64, "base64url");
+  const peeked = JSON.parse(payloadRaw.toString("utf8")) as Record<string, unknown>;
+  const tid = peeked.tid;
+  if (typeof tid !== "string" || !ALLOWED_TID.test(tid)) return { ok: false, reason: "invalid_tid" };
+
+  const tenantKey = deriveTenantKey(master, tid);
+  const macExpected = createHmac("sha256", tenantKey).update(`v1.${payloadB64}`).digest();
+  const macProvided = Buffer.from(macB64, "base64url");
+  if (macProvided.length !== macExpected.length || !timingSafeEqual(macProvided, macExpected)) {
+    return { ok: false, reason: "bad_mac" };
+  }
+
+  const { workspace, audience, scope, iat, exp } = peeked;
+  if (typeof workspace !== "string" || !ALLOWED_WORKSPACE.test(workspace)) {
+    return { ok: false, reason: "invalid_workspace" };
+  }
+  if (typeof audience !== "string" || audience.length === 0 || audience.length > 128) {
+    return { ok: false, reason: "invalid_audience" };
+  }
+  if (typeof scope !== "string" || scope.length === 0 || Buffer.byteLength(scope, "utf8") > 512) {
+    return { ok: false, reason: "invalid_scope" };
+  }
+  if (typeof iat !== "number" || typeof exp !== "number" || exp <= iat) {
+    return { ok: false, reason: "invalid_payload" };
+  }
+  if (exp - iat > MAX_ENVELOPE_LIFETIME) return { ok: false, reason: "lifetime_too_long" };
+  if (nowSeconds > exp) return { ok: false, reason: "expired" };
+  if (nowSeconds < iat - CLOCK_SKEW) return { ok: false, reason: "issued_in_future" };
+  return { ok: true, tid, workspace, audience, scope, exp };
+}
+
+const MASTER = randomBytes(32);
+const TID = "hq";
+const TENANT_KEY = deriveTenantKey(MASTER, TID);
+const IDENTITY: TenantIdentity = { tid: TID, tenantKey: TENANT_KEY };
+
+describe("buildMintRequest — authorizer parity", () => {
+  it("produces a wire the authorizer's verifier accepts, carrying the named fields", () => {
+    const now = 1_700_000_000;
+    const wire = buildMintRequest({
+      tid: TID,
+      workspace: "ws_smoke",
+      audience: "artifacts",
+      scope: "artifacts:write",
+      tenantKey: TENANT_KEY,
+      now,
+    });
+    const v = verifyMintAsAuthorizer(wire, MASTER, now);
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(v).toMatchObject({
+      tid: "hq",
+      workspace: "ws_smoke",
+      audience: "artifacts",
+      scope: "artifacts:write",
+    });
+  });
+
+  it("is rejected when signed with the wrong tenant key (the key is the boundary)", () => {
+    const now = 1_700_000_000;
+    const wrongKey = deriveTenantKey(randomBytes(32), TID);
+    const wire = buildMintRequest({
+      tid: TID,
+      workspace: "ws_smoke",
+      audience: "artifacts",
+      scope: "artifacts:write",
+      tenantKey: wrongKey,
+      now,
+    });
+    const v = verifyMintAsAuthorizer(wire, MASTER, now);
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.reason).toBe("bad_mac");
+  });
+
+  it("rejects an expired request at the verifier (short request TTL is enforced end-to-end)", () => {
+    const iat = 1_700_000_000;
+    const wire = buildMintRequest({
+      tid: TID,
+      workspace: "ws_smoke",
+      audience: "artifacts",
+      scope: "artifacts:write",
+      tenantKey: TENANT_KEY,
+      now: iat,
+      ttlSeconds: 60,
+    });
+    const v = verifyMintAsAuthorizer(wire, MASTER, iat + 61);
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.reason).toBe("expired");
+  });
+});
+
+describe("buildMintRequest — local validation", () => {
+  const base = {
+    tid: TID,
+    workspace: "ws_smoke",
+    audience: "artifacts",
+    scope: "artifacts:write",
+    tenantKey: TENANT_KEY,
+  };
+
+  it("accepts the runtime's real workspace ids (ws_<hex>, ws_user_<id>) verbatim", () => {
+    expect(() => buildMintRequest({ ...base, workspace: "ws_1a2b3c4d5e6f7a8b" })).not.toThrow();
+    expect(() => buildMintRequest({ ...base, workspace: "ws_user_01HXYZ" })).not.toThrow();
+  });
+
+  it("rejects a string that is not a NimbleBrain workspace id", () => {
+    // No ws_ prefix, traversal, and whitespace all fail the runtime's own grammar.
+    expect(() => buildMintRequest({ ...base, workspace: "not-a-workspace" })).toThrow(MintError);
+    expect(() => buildMintRequest({ ...base, workspace: "ws_../etc" })).toThrow(MintError);
+    expect(() => buildMintRequest({ ...base, workspace: "ws_a b" })).toThrow(MintError);
+  });
+
+  it("rejects an over-long audience", () => {
+    expect(() => buildMintRequest({ ...base, audience: "a".repeat(129) })).toThrow(MintError);
+  });
+
+  it("rejects an empty scope", () => {
+    expect(() => buildMintRequest({ ...base, scope: "" })).toThrow(MintError);
+  });
+
+  it("rejects a short tenant key", () => {
+    expect(() => buildMintRequest({ ...base, tenantKey: randomBytes(16) })).toThrow(MintError);
+  });
+});
+
+describe("readTenantIdentityFromEnv", () => {
+  it("throws unprovisioned with the missing var named", () => {
+    expect(() => readTenantIdentityFromEnv({ NB_TENANT_ID: "hq" } as NodeJS.ProcessEnv)).toThrow(
+      /NB_MCP_AUTHORIZER_TENANT_KEY/,
+    );
+    expect(() =>
+      readTenantIdentityFromEnv({ NB_MCP_AUTHORIZER_TENANT_KEY: TENANT_KEY.toString("base64") } as NodeJS.ProcessEnv),
+    ).toThrow(/NB_TENANT_ID/);
+  });
+
+  it("reads and decodes a provisioned identity", () => {
+    const id = readTenantIdentityFromEnv({
+      NB_TENANT_ID: "hq",
+      NB_MCP_AUTHORIZER_TENANT_KEY: TENANT_KEY.toString("base64"),
+    } as NodeJS.ProcessEnv);
+    expect(id.tid).toBe("hq");
+    expect(id.tenantKey.equals(TENANT_KEY)).toBe(true);
+  });
+});
+
+/** A fake authorizer `/token` endpoint: verifies the inbound mint and returns a
+ *  token whose value encodes the requested audience, so the test can assert the
+ *  right token reached the caller. Counts calls for single-flight assertions. */
+function fakeAuthorizer(opts: { expiresIn?: number; failStatus?: number; now?: () => number } = {}) {
+  let calls = 0;
+  const now = opts.now ?? (() => Math.floor(Date.now() / 1000));
+  const fetchImpl: typeof fetch = async (input, init) => {
+    calls++;
+    const url = String(input);
+    if (!url.endsWith("/token")) return new Response("not found", { status: 404 });
+    if (opts.failStatus) {
+      return new Response(`{"error":"invalid_request"}`, { status: opts.failStatus });
+    }
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.get("grant_type")).toBe("urn:nimblebrain:params:oauth:grant-type:tenant-key");
+    const wire = body.get("tenant_assertion") ?? "";
+    const v = verifyMintAsAuthorizer(wire, MASTER, now());
+    if (!v.ok) return new Response(`{"error":"${v.reason}"}`, { status: 400 });
+    return Response.json({
+      access_token: `tok-${v.audience}-${calls}`,
+      token_type: "Bearer",
+      expires_in: opts.expiresIn ?? 300,
+    });
+  };
+  return { fetchImpl, calls: () => calls };
+}
+
+describe("mintServiceToken", () => {
+  it("mints a token and computes absolute expiry from expires_in", async () => {
+    const { fetchImpl } = fakeAuthorizer({ expiresIn: 300, now: () => 1000 });
+    const tok = await mintServiceToken({
+      issuer: "https://authz.test",
+      workspace: "ws_smoke",
+      audience: "artifacts",
+      scope: "artifacts:write",
+      identity: IDENTITY,
+      fetchImpl,
+      now: () => 1000,
+    });
+    expect(tok.accessToken).toBe("tok-artifacts-1");
+    expect(tok.expiresAt).toBe(1300);
+  });
+
+  it("throws http_error with the authorizer's detail on a non-200", async () => {
+    const { fetchImpl } = fakeAuthorizer({ failStatus: 400 });
+    await expect(
+      mintServiceToken({
+        issuer: "https://authz.test",
+        workspace: "ws_smoke",
+        audience: "artifacts",
+        scope: "artifacts:write",
+        identity: IDENTITY,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(MintError);
+  });
+});
+
+describe("ServiceTokenCache", () => {
+  const req = { issuer: "https://authz.test", workspace: "ws_smoke", audience: "artifacts", scope: "artifacts:write" };
+
+  it("serves a cached token until the renew skew, then re-mints", async () => {
+    let clock = 1000;
+    const authz = fakeAuthorizer({ expiresIn: 300, now: () => clock });
+    const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl: authz.fetchImpl, now: () => clock });
+
+    expect(await cache.getToken(req)).toBe("tok-artifacts-1");
+    clock = 1100; // well within 300s - 30s skew → cache hit
+    expect(await cache.getToken(req)).toBe("tok-artifacts-1");
+    expect(authz.calls()).toBe(1);
+
+    clock = 1271; // past expiresAt(1300) - 30s skew → re-mint
+    expect(await cache.getToken(req)).toBe("tok-artifacts-2");
+    expect(authz.calls()).toBe(2);
+  });
+
+  it("dedupes concurrent mints for the same key (single-flight)", async () => {
+    const authz = fakeAuthorizer({ expiresIn: 300, now: () => 1000 });
+    const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl: authz.fetchImpl, now: () => 1000 });
+
+    const [a, b, c] = await Promise.all([cache.getToken(req), cache.getToken(req), cache.getToken(req)]);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(authz.calls()).toBe(1);
+  });
+
+  it("forceRefresh discards the cached token and re-mints (the 401-retry path)", async () => {
+    const authz = fakeAuthorizer({ expiresIn: 300, now: () => 1000 });
+    const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl: authz.fetchImpl, now: () => 1000 });
+
+    expect(await cache.getToken(req)).toBe("tok-artifacts-1");
+    expect(await cache.getToken(req, { forceRefresh: true })).toBe("tok-artifacts-2");
+    expect(authz.calls()).toBe(2);
+  });
+
+  it("does not pin callers to a failed mint (in-flight marker cleared on error)", async () => {
+    let mode: "fail" | "ok" = "fail";
+    const okAuthz = fakeAuthorizer({ now: () => 1000 });
+    const fetchImpl: typeof fetch = async (input, init) => {
+      if (mode === "fail") return new Response(`{"error":"boom"}`, { status: 500 });
+      return okAuthz.fetchImpl(input, init);
+    };
+    const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl, now: () => 1000 });
+
+    await expect(cache.getToken(req)).rejects.toThrow(MintError);
+    mode = "ok";
+    expect(await cache.getToken(req)).toBe("tok-artifacts-1");
+  });
+});
+
+describe("createMintingFetch", () => {
+  const req = { issuer: "https://authz.test", workspace: "ws_smoke", audience: "artifacts", scope: "artifacts:write" };
+
+  it("attaches a freshly-minted bearer to each outbound request", async () => {
+    const authz = fakeAuthorizer({ now: () => 1000 });
+    const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl: authz.fetchImpl, now: () => 1000 });
+    let seenAuth: string | null = null;
+    const baseFetch: typeof fetch = async (_input, init) => {
+      seenAuth = new Headers(init?.headers).get("Authorization");
+      return new Response("ok", { status: 200 });
+    };
+    const f = createMintingFetch({ cache, ...req, baseFetch });
+
+    const res = await f("https://artifacts.test/v1/artifacts", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(seenAuth).toBe("Bearer tok-artifacts-1");
+  });
+
+  it("force-re-mints and retries exactly once on a 401", async () => {
+    const authz = fakeAuthorizer({ now: () => 1000 });
+    const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl: authz.fetchImpl, now: () => 1000 });
+    let serviceCalls = 0;
+    const seen: (string | null)[] = [];
+    const baseFetch: typeof fetch = async (_input, init) => {
+      serviceCalls++;
+      seen.push(new Headers(init?.headers).get("Authorization"));
+      // Reject the first token, accept the (re-minted) second.
+      return serviceCalls === 1 ? new Response("no", { status: 401 }) : new Response("ok", { status: 200 });
+    };
+    const f = createMintingFetch({ cache, ...req, baseFetch });
+
+    const res = await f("https://artifacts.test/v1/artifacts");
+    expect(res.status).toBe(200);
+    expect(serviceCalls).toBe(2);
+    expect(authz.calls()).toBe(2); // initial mint + one forced re-mint
+    expect(seen).toEqual(["Bearer tok-artifacts-1", "Bearer tok-artifacts-2"]);
+  });
+
+  it("does not retry on a non-auth error (e.g. 500)", async () => {
+    const authz = fakeAuthorizer({ now: () => 1000 });
+    const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl: authz.fetchImpl, now: () => 1000 });
+    let serviceCalls = 0;
+    const baseFetch: typeof fetch = async () => {
+      serviceCalls++;
+      return new Response("boom", { status: 500 });
+    };
+    const f = createMintingFetch({ cache, ...req, baseFetch });
+
+    const res = await f("https://artifacts.test/v1/artifacts");
+    expect(res.status).toBe(500);
+    expect(serviceCalls).toBe(1); // 500 is surfaced, not retried
+  });
+});


### PR DESCRIPTION
## Why

The runtime needs to reach platform data-plane services (`artifacts`, `nimbletasks`, web-search) with **short-lived, workspace-scoped** tokens — minted on demand from its per-tenant key, with no interactive OAuth and no static secret. This is the machine-plane half of the auth model; the per-tenant key was provisioned on staging, and this PR makes the runtime use it.

## What

- **`oauth/envelope`**: extract `signMacEnvelope` — the single MAC construction now shared by the login assertion (`signEnvelope`) and the new mint request. Mirrors the authorizer's single `verifyMac`. `signEnvelope`'s wire is unchanged (cross-impl vector still matches byte-for-byte).
- **`oauth/tenant-key-mint`** (new): `buildMintRequest` (signs `{tid, workspace, audience, scope}`), `mintServiceToken` (POSTs the tenant-key grant to `{issuer}/token`), `ServiceTokenCache` (expiry-aware, single-flight, keyed by `issuer|tid|workspace|audience|scope`), `createMintingFetch` (per-request bearer + re-mint on 401).
- **remote transport**: new `auth.type: "tenant-key" {audience, scope}`; the connection mints for **its own workspace** (threaded from `McpSource`'s `BundleMcpContext`) and attaches the token via the transport's `fetch` override. Additive — non-tenant-key transports are byte-identical to before.

The workspace dimension flows through **verbatim** as the runtime's real ws id, validated against the canonical `WORKSPACE_ID_RE` — never rewritten. (The authorizer side accepts it via NimbleBrainInc/platform#13, which must deploy first.)

## Audience model

Narrow per-service audience: the runtime mints `aud=artifacts` / `aud=nimbletasks` / etc. separately; each service validates its own audience. Least-privilege — a compromised service can't replay its token elsewhere.

## Tests

- Authorizer-parity vector (faithful inline mirror of `verifyMintRequest`): wire is accepted, wrong key → `bad_mac`, expiry enforced.
- Cache: expiry re-mint, single-flight dedupe, `forceRefresh`, failed-mint not pinned.
- Minting fetch: bearer injection, 401 → re-mint + retry once, 500 not retried.
- `verify:static` + 19 new unit + 590 integration: all green.

## Dependency

Requires **NimbleBrainInc/platform#13** (authorizer workspace grammar) deployed before a real `ws_<hex>` workspace can mint end-to-end.