### PR TITLE
fix(conversations): count aux.usage in the bundle's conversation totals

### DIFF
--- a/src/bundles/conversations/src/jsonl-reader.ts
+++ b/src/bundles/conversations/src/jsonl-reader.ts
@@ -180,6 +180,22 @@ interface LlmResponseEvent {
   llmMs: number;
 }
 
+/**
+ * Usage for a forked fast-slot model call (compaction summarizer, auto-title,
+ * briefing) that runs outside the agentic loop and emits no `llm.response`.
+ * Mirrors the runtime's `AuxUsageEvent`. Carries no content and is never a
+ * message — `reconstructFromEvents` skips it — but its usage is summed into
+ * the conversation totals so the bundle matches the runtime aggregator.
+ */
+interface AuxUsageEvent {
+  ts: string;
+  type: "aux.usage";
+  source?: string;
+  model?: string;
+  usage?: UsageShape;
+  llmMs?: number;
+}
+
 interface ToolStartEvent {
   ts: string;
   type: "tool.start";
@@ -220,6 +236,7 @@ type KnownEvent =
   | UserMessageEvent
   | RunStartEvent
   | LlmResponseEvent
+  | AuxUsageEvent
   | ToolStartEvent
   | ToolDoneEvent
   | RunDoneEvent
@@ -233,6 +250,9 @@ function isRunStart(e: { type: string }): e is RunStartEvent {
 }
 function isLlmResponse(e: { type: string }): e is LlmResponseEvent {
   return e.type === "llm.response";
+}
+function isAuxUsage(e: { type: string }): e is AuxUsageEvent {
+  return e.type === "aux.usage";
 }
 function isToolStart(e: { type: string }): e is ToolStartEvent {
   return e.type === "tool.start";
@@ -287,6 +307,12 @@ function deriveMetricsFromLines(lines: string[]): DerivedMetrics {
         totalInputTokens += evt.usage?.inputTokens ?? 0;
         totalOutputTokens += evt.usage?.outputTokens ?? 0;
         lastModel = evt.model;
+      } else if (isAuxUsage(evt)) {
+        // Forked fast-slot calls (compaction/title/briefing) emit no
+        // llm.response; count their usage so the bundle's totals match the
+        // runtime aggregator (which counts aux.usage too).
+        totalInputTokens += evt.usage?.inputTokens ?? 0;
+        totalOutputTokens += evt.usage?.outputTokens ?? 0;
       }
       continue;
     }

--- a/test/unit/bundles/conversations/jsonl-reader.test.ts
+++ b/test/unit/bundles/conversations/jsonl-reader.test.ts
@@ -254,6 +254,43 @@ describe("readConversation (event format)", () => {
 		expect(assistant.timestamp).toBe("2025-06-01T00:00:06.000Z");
 	});
 
+	test("counts aux.usage toward conversation totals but emits no message", async () => {
+		const runId = "run_aux";
+		const lines = [
+			JSON.stringify(eventMeta("conv_aux")),
+			JSON.stringify({ ts: "2025-06-01T00:00:00.000Z", type: "user.message", content: [{ type: "text", text: "hi" }] }),
+			JSON.stringify({ ts: "2025-06-01T00:00:01.000Z", type: "run.start", runId }),
+			JSON.stringify({
+				ts: "2025-06-01T00:00:02.000Z",
+				type: "llm.response",
+				runId,
+				model: "m1",
+				content: [{ type: "text", text: "ok" }],
+				usage: { inputTokens: 100, outputTokens: 20 },
+				llmMs: 50,
+			}),
+			JSON.stringify({ ts: "2025-06-01T00:00:03.000Z", type: "run.done", runId, stopReason: "complete" }),
+			// Forked compaction summarizer call: no run, no message, just cost.
+			JSON.stringify({
+				ts: "2025-06-01T00:00:04.000Z",
+				type: "aux.usage",
+				source: "compaction",
+				model: "fast-m",
+				usage: { inputTokens: 400, outputTokens: 60 },
+				llmMs: 120,
+			}),
+		];
+		const path = writeTmpFile("conv_aux.jsonl", lines);
+
+		const result = await readConversation(path);
+		expect(result).not.toBeNull();
+		// Totals include both the turn (100/20) and the forked call (400/60).
+		expect(result!.meta.totalInputTokens).toBe(500);
+		expect(result!.meta.totalOutputTokens).toBe(80);
+		// aux.usage is never a message — just user + assistant.
+		expect(result!.messages).toHaveLength(2);
+	});
+
 	test("flags an in-flight run (no run.done) as pending", async () => {
 		const runId = "run_pending";
 		const lines = [


### PR DESCRIPTION
## Why

The conversations bundle reads each conversation's JSONL and derives per-conversation usage **for the UI** by summing `llm.response` events — its own reader (`jsonl-reader.ts`), separate from the runtime's usage aggregator.

After #428, forked fast-slot calls (compaction summarizer, auto-title, briefing) persist their cost as `aux.usage` events, and the **runtime** aggregator counts them. The **bundle** didn't — so its displayed conversation totals undercounted those calls, drifting from the runtime's numbers for the same file.

## What changed

- Mirror the runtime's `AuxUsageEvent` in the bundle's event union (the bundle is a self-contained build and can't import runtime types).
- Sum `aux.usage` usage in `deriveMetricsFromLines`, right alongside `llm.response`.
- `aux.usage` is **never a message** — `reconstructFromEvents` skips any event that isn't a `user.message`/`run.start` via its existing fall-through — so totals pick up the forked-call cost while the rendered message list is unchanged.

One file of logic (`jsonl-reader.ts`); ~15 lines.

## Why not the broader "reconstructor unification"

This was scoped as the start of unifying the two reconstructors (`event-reconstructor.ts` and this bundle reader). On inspection they're genuinely different by design — different output shapes (`StoredMessage` vs `DisplayMessage`) and different concerns (the bundle also handles legacy formats, title derivation, file parsing, display metrics), and the bundle can't import runtime `src/`. The only byte-identical shared code is `parseToolInput` (13 lines), not worth a shared-module dependency. The genuinely valuable piece was this usage-accounting drift, so that's all this PR does.

## Tests

`jsonl-reader.test.ts`: a conversation with a turn (100/20) plus an `aux.usage` event (400/60) reports totals of 500/80 and still renders exactly the two real messages. `usage-shape-sync` still passes.

`verify:static` clean, `test:unit` 3527 pass.