### PR TITLE
feat(metrics): domain Prometheus counters for tokens, tool calls, promotions

### DIFF
--- a/src/adapters/metrics-events.ts
+++ b/src/adapters/metrics-events.ts
@@ -1,0 +1,39 @@
+import { recordLlmUsage, toolCallsTotal, toolPromotionsTotal } from "../api/metrics.ts";
+import type { EngineEvent, EventSink } from "../engine/types.ts";
+import type { TokenUsage } from "../usage/types.ts";
+
+/**
+ * Translates engine events into Prometheus counters (see `api/metrics.ts`).
+ *
+ * Observe-only and process-local: it only increments in-memory counters, so it
+ * is always safe to wire in — in-cluster the counters are scraped per tenant
+ * pod, and in a local `bun run dev` they simply accumulate, unscraped, with no
+ * Prometheus or k8s required.
+ *
+ * Covers the main agentic loop. The forked fast-slot calls (compaction
+ * summarizer, auto-title, briefing) run outside the engine and emit no
+ * `llm.done`, so their usage is recorded at their own call sites via
+ * `recordLlmUsage(source, ...)`.
+ */
+export class MetricsEventSink implements EventSink {
+  emit(event: EngineEvent): void {
+    const { type, data } = event;
+    switch (type) {
+      case "llm.done": {
+        const usage = data.usage as TokenUsage | undefined;
+        if (usage) recordLlmUsage("main", (data.model as string) ?? "unknown", usage);
+        break;
+      }
+      case "tool.done": {
+        toolCallsTotal.inc({ ok: data.ok === false ? "false" : "true" });
+        break;
+      }
+      case "tool.promoted": {
+        toolPromotionsTotal.inc();
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -55,3 +55,80 @@ export const httpRequestDurationSeconds = new Histogram({
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
   registers: [metricsRegistry],
 });
+
+// ---------------------------------------------------------------------------
+// Domain metrics — LLM tokens, calls, tool execution, and tool promotion.
+//
+// All labels are bounded: `direction` (input/output), `kind` (fresh/cache_read/
+// cache_write/text), `source` (main + the forked fast-slot calls), `model`
+// (the catalog set), `ok` (true/false). No tool names or ids — those would be
+// client-unbounded and aren't needed for fleet-level optimization. Per-tenant
+// breakdown comes for free from the scrape (one pod per tenant); these are not
+// labeled by tenant. Purely observe-only and process-local: they increment in
+// memory whether or not anything scrapes `/metrics`, so they work identically
+// in a local `bun run dev` with no Prometheus.
+// ---------------------------------------------------------------------------
+
+/**
+ * LLM tokens processed. `kind` splits input into fresh / cache_read / cache_write
+ * (the cache-cost story: a large `cache_read` next to small `fresh` is the
+ * cheap-re-read pattern; a spike in `cache_write` is a prefix re-write).
+ */
+export const llmTokensTotal = new Counter({
+  name: "nb_llm_tokens_total",
+  help: "LLM tokens processed, by direction, cache kind, call source, and model.",
+  labelNames: ["direction", "kind", "source", "model"] as const,
+  registers: [metricsRegistry],
+});
+
+/** LLM calls, by source (main loop vs forked fast-slot) and model. */
+export const llmCallsTotal = new Counter({
+  name: "nb_llm_calls_total",
+  help: "LLM calls, by source and model.",
+  labelNames: ["source", "model"] as const,
+  registers: [metricsRegistry],
+});
+
+/** Tool executions, by outcome. */
+export const toolCallsTotal = new Counter({
+  name: "nb_tool_calls_total",
+  help: "Tool executions, by outcome.",
+  labelNames: ["ok"] as const,
+  registers: [metricsRegistry],
+});
+
+/** Tools promoted into the active set (progressive-disclosure discovery). */
+export const toolPromotionsTotal = new Counter({
+  name: "nb_tool_promotions_total",
+  help: "Tools promoted into the active set (progressive disclosure).",
+  registers: [metricsRegistry],
+});
+
+/** Token usage subset needed for metrics — a structural slice of `TokenUsage`. */
+interface UsageForMetrics {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+/**
+ * Record one LLM call's usage: a call increment plus token counts split into
+ * fresh / cache_read / cache_write / output. Called for both the main agentic
+ * loop (`source: "main"`) and the forked fast-slot calls (`compaction` /
+ * `title` / `briefing`), so fleet token spend is attributable by origin.
+ */
+export function recordLlmUsage(source: string, model: string, usage: UsageForMetrics): void {
+  const cacheRead = usage.cacheReadTokens ?? 0;
+  const cacheWrite = usage.cacheWriteTokens ?? 0;
+  const fresh = Math.max(usage.inputTokens - cacheRead - cacheWrite, 0);
+
+  llmCallsTotal.inc({ source, model });
+  if (fresh > 0) llmTokensTotal.inc({ direction: "input", kind: "fresh", source, model }, fresh);
+  if (cacheRead > 0)
+    llmTokensTotal.inc({ direction: "input", kind: "cache_read", source, model }, cacheRead);
+  if (cacheWrite > 0)
+    llmTokensTotal.inc({ direction: "input", kind: "cache_write", source, model }, cacheWrite);
+  if (usage.outputTokens > 0)
+    llmTokensTotal.inc({ direction: "output", kind: "text", source, model }, usage.outputTokens);
+}

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -113,12 +113,23 @@ interface UsageForMetrics {
 }
 
 /**
+ * Origin of an LLM call. Closed set by design — the whole point of these
+ * metrics is bounded label cardinality, so a typo at a call site is a compile
+ * error rather than a silently-minted new series.
+ */
+export type LlmUsageSource = "main" | "title" | "compaction" | "briefing";
+
+/**
  * Record one LLM call's usage: a call increment plus token counts split into
  * fresh / cache_read / cache_write / output. Called for both the main agentic
  * loop (`source: "main"`) and the forked fast-slot calls (`compaction` /
  * `title` / `briefing`), so fleet token spend is attributable by origin.
  */
-export function recordLlmUsage(source: string, model: string, usage: UsageForMetrics): void {
+export function recordLlmUsage(
+  source: LlmUsageSource,
+  model: string,
+  usage: UsageForMetrics,
+): void {
   const cacheRead = usage.cacheReadTokens ?? 0;
   const cacheWrite = usage.cacheWriteTokens ?? 0;
   const fresh = Math.max(usage.inputTokens - cacheRead - cacheWrite, 0);

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -61,8 +61,10 @@ export const httpRequestDurationSeconds = new Histogram({
 //
 // All labels are bounded: `direction` (input/output), `kind` (fresh/cache_read/
 // cache_write/text), `source` (main + the forked fast-slot calls), `model`
-// (the catalog set), `ok` (true/false). No tool names or ids — those would be
-// client-unbounded and aren't needed for fleet-level optimization. Per-tenant
+// (the catalog set — bounded by deployment config today; if custom model ids
+// ever become user-settable, this label would need capping), `ok`
+// (true/false). No tool names or ids — those would be client-unbounded and
+// aren't needed for fleet-level optimization. Per-tenant
 // breakdown comes for free from the scrape (one pod per tenant); these are not
 // labeled by tenant. Purely observe-only and process-local: they increment in
 // memory whether or not anything scrapes `/metrics`, so they work identically

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -3,8 +3,10 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { LanguageModelV3, LanguageModelV3Message } from "@ai-sdk/provider";
+import { MetricsEventSink } from "../adapters/metrics-events.ts";
 import { NoopEventSink } from "../adapters/noop-events.ts";
 import { WorkspaceLogSink } from "../adapters/workspace-log-sink.ts";
+import { recordLlmUsage } from "../api/metrics.ts";
 import type { AutomationDomainContext } from "../bundles/automations/src/domain.ts";
 import { BundleLifecycleManager } from "../bundles/lifecycle.ts";
 import { deriveServerName } from "../bundles/paths.ts";
@@ -412,7 +414,10 @@ export class Runtime {
 
     // Create delegate tracker and include it in the event pipeline
     const delegateTracker = new DelegateTracker();
-    const sinkList: EventSink[] = [baseEvents, delegateTracker];
+    // Always-on, observe-only Prometheus counters. Process-local: increments in
+    // memory whether or not `/metrics` is scraped, so it's safe in a local
+    // `bun run dev` with no Prometheus/k8s.
+    const sinkList: EventSink[] = [baseEvents, delegateTracker, new MetricsEventSink()];
     if (eventStore) {
       sinkList.push(eventStore);
     }
@@ -1822,7 +1827,8 @@ export class Runtime {
       // The title call runs the `fast` slot outside the agentic loop; persist
       // its usage as an aux.usage event so it isn't invisible to cost accounting.
       const appendTitleUsage = store.appendEvent?.bind(store);
-      void generateTitle(titleModel, titleInput, result.output, (usage, llmMs) =>
+      void generateTitle(titleModel, titleInput, result.output, (usage, llmMs) => {
+        recordLlmUsage("title", titleSlot, usage);
         appendTitleUsage?.(conversation.id, {
           ts: new Date().toISOString(),
           type: "aux.usage",
@@ -1830,8 +1836,8 @@ export class Runtime {
           model: titleSlot,
           usage,
           llmMs,
-        }),
-      )
+        });
+      })
         .then(async (title) => {
           await store.update(conversation.id, { title });
           // `wsId: sessionWsId` (the owner's personal workspace) — NOT
@@ -3208,7 +3214,8 @@ export class Runtime {
       // The summarizer runs the `fast` slot outside the agentic loop, so it
       // emits no llm.response. Persist its usage as an aux.usage event so the
       // fold's cost isn't invisible to the usage aggregator.
-      onUsage: (usage, llmMs) =>
+      onUsage: (usage, llmMs) => {
+        recordLlmUsage("compaction", fastSlot, usage);
         appendEvent(conversationId, {
           ts: new Date().toISOString(),
           type: "aux.usage",
@@ -3216,7 +3223,8 @@ export class Runtime {
           model: fastSlot,
           usage,
           llmMs,
-        }),
+        });
+      },
     });
     // No-op contract: the helper returns the SAME array reference when nothing
     // was compacted (below threshold or best-effort failure). A future helper

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { readFile, rename, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { recordLlmUsage } from "../api/metrics.ts";
 import { log } from "../cli/log.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
@@ -810,6 +811,11 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
                 // (bgCtx) has no conversationId, so it's skipped here — a known
                 // workspace-scoped gap with no conversation to attribute to.
                 (usage, llmMs) => {
+                  // Metric fires for every briefing generation, including the
+                  // background refresh — Prometheus has no conversation to
+                  // attribute to, so it captures the cost the aux.usage event
+                  // (below) can't.
+                  recordLlmUsage("briefing", modelString ?? "unknown", usage);
                   const convId = getRequestContext()?.conversationId;
                   if (!convId) return;
                   runtime.findConversationStore()?.appendEvent?.(convId, {

--- a/test/integration/compaction-wiring.test.ts
+++ b/test/integration/compaction-wiring.test.ts
@@ -139,6 +139,12 @@ describe("history compaction — wired path", () => {
         ),
       ).toBe(true);
 
+      // (a.3) The summarizer's usage is ALSO recorded to Prometheus — proves
+      // the forked-call metric wiring (recordLlmUsage("compaction", ...) at the
+      // onUsage site) fires end-to-end, not just the aux.usage append.
+      const metricsBody = await (await fetch(`${baseUrl}/metrics`)).text();
+      expect(metricsBody).toMatch(/nb_llm_tokens_total\{[^}]*source="compaction"[^}]*\}\s+[1-9]/);
+
       // (b) The model-facing projection is compacted: it carries the summary
       //     seed and NOT the oldest turn's text.
       const modelView = JSON.stringify(reconstructMessages(events));

--- a/test/integration/metrics-endpoint.test.ts
+++ b/test/integration/metrics-endpoint.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Proves the domain metrics are safe with NO Prometheus configured.
+ *
+ * There is nothing to configure: `prom-client` is an in-process registry, the
+ * `MetricsEventSink` only increments in-memory counters, and `/metrics` is
+ * mounted unconditionally. This test boots the full Runtime + HTTP server with
+ * zero metrics infra (no Prometheus, no k8s, no scraper, no env), runs a real
+ * chat turn through the metrics sink, and confirms nothing breaks and the
+ * counters populate — exactly the local `bun run dev` case.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startServer } from "../../src/api/server.ts";
+import type { ServerHandle } from "../../src/api/server.ts";
+import { Runtime } from "../../src/runtime/runtime.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+import { createTestAuthAdapter } from "../helpers/test-auth-adapter.ts";
+import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
+
+const API_KEY = "metrics-endpoint-test-key-1234";
+let runtime: Runtime;
+let handle: ServerHandle;
+let baseUrl: string;
+const workDir = join(tmpdir(), `nimblebrain-metrics-${Date.now()}`);
+
+beforeAll(async () => {
+  mkdirSync(workDir, { recursive: true });
+  // No metrics config of any kind — this is the bare local/no-k8s setup.
+  runtime = await Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    logging: { disabled: true },
+    workDir,
+  });
+  await provisionTestWorkspace(runtime);
+  handle = startServer({
+    runtime,
+    port: 0,
+    provider: createTestAuthAdapter(API_KEY, runtime),
+  });
+  baseUrl = `http://localhost:${handle.port}`;
+});
+
+afterAll(async () => {
+  handle?.stop(true);
+  await runtime?.shutdown();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("metrics with no Prometheus configured", () => {
+  test("server boots and /metrics serves with zero metrics infra", async () => {
+    const res = await fetch(`${baseUrl}/metrics`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // Domain counters are registered at module load, so they're exposed even
+    // before any increment — no scraper or config required.
+    expect(body).toContain("nb_llm_tokens_total");
+    expect(body).toContain("nb_tool_promotions_total");
+  });
+
+  test("a chat turn drives the metrics sink without error and populates a counter", async () => {
+    const chat = await fetch(`${baseUrl}/v1/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_KEY}`,
+        "X-Workspace-Id": TEST_WORKSPACE_ID,
+      },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    // The turn runs through MetricsEventSink (always wired) — must not throw.
+    expect(chat.status).toBe(200);
+
+    const body = await (await fetch(`${baseUrl}/metrics`)).text();
+    // The echo turn emitted llm.done → recordLlmUsage("main"), so the main-loop
+    // call counter is present and positive.
+    expect(body).toMatch(/nb_llm_calls_total\{[^}]*source="main"[^}]*\}\s+[1-9]/);
+  });
+});

--- a/test/unit/metrics.test.ts
+++ b/test/unit/metrics.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import { MetricsEventSink } from "../../src/adapters/metrics-events.ts";
+import type { Counter } from "prom-client";
+import {
+  llmCallsTotal,
+  llmTokensTotal,
+  recordLlmUsage,
+  toolCallsTotal,
+  toolPromotionsTotal,
+} from "../../src/api/metrics.ts";
+
+// Read one label-series value off a counter. Tests use deltas (read → act →
+// read) rather than reset(), so they're robust to the shared process-global
+// registry that other test files also touch.
+// biome-ignore lint/suspicious/noExplicitAny: prom-client's generic Counter is awkward to type structurally here.
+async function read(counter: Counter<any>, labels: Record<string, string> = {}): Promise<number> {
+  const metric = await counter.get();
+  for (const s of metric.values) {
+    if (Object.entries(labels).every(([k, v]) => s.labels[k] === v)) return s.value;
+  }
+  return 0;
+}
+
+describe("recordLlmUsage", () => {
+  it("splits input into fresh/cache_read/cache_write and counts output + calls", async () => {
+    const base = { source: "compaction", model: "tm-record" };
+    const fresh = { direction: "input", kind: "fresh", ...base };
+    const cr = { direction: "input", kind: "cache_read", ...base };
+    const cw = { direction: "input", kind: "cache_write", ...base };
+    const out = { direction: "output", kind: "text", ...base };
+
+    const before = {
+      fresh: await read(llmTokensTotal, fresh),
+      cr: await read(llmTokensTotal, cr),
+      cw: await read(llmTokensTotal, cw),
+      out: await read(llmTokensTotal, out),
+      calls: await read(llmCallsTotal, base),
+    };
+
+    // fresh = 1000 - 600 - 300 = 100
+    recordLlmUsage("compaction", "tm-record", {
+      inputTokens: 1000,
+      outputTokens: 50,
+      cacheReadTokens: 600,
+      cacheWriteTokens: 300,
+    });
+
+    expect((await read(llmTokensTotal, fresh)) - before.fresh).toBe(100);
+    expect((await read(llmTokensTotal, cr)) - before.cr).toBe(600);
+    expect((await read(llmTokensTotal, cw)) - before.cw).toBe(300);
+    expect((await read(llmTokensTotal, out)) - before.out).toBe(50);
+    expect((await read(llmCallsTotal, base)) - before.calls).toBe(1);
+  });
+});
+
+describe("MetricsEventSink", () => {
+  it("records main-loop tokens, tool outcomes, and promotions", async () => {
+    const sink = new MetricsEventSink();
+    const fresh = { direction: "input", kind: "fresh", source: "main", model: "tm-sink" };
+
+    const before = {
+      fresh: await read(llmTokensTotal, fresh),
+      okTrue: await read(toolCallsTotal, { ok: "true" }),
+      okFalse: await read(toolCallsTotal, { ok: "false" }),
+      promo: await read(toolPromotionsTotal),
+    };
+
+    sink.emit({
+      type: "llm.done",
+      data: {
+        model: "tm-sink",
+        usage: { inputTokens: 200, outputTokens: 10, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      },
+    });
+    sink.emit({ type: "tool.done", data: { ok: true } });
+    sink.emit({ type: "tool.done", data: { ok: false } });
+    sink.emit({ type: "tool.promoted", data: { toolName: "x" } });
+
+    expect((await read(llmTokensTotal, fresh)) - before.fresh).toBe(200);
+    expect((await read(toolCallsTotal, { ok: "true" })) - before.okTrue).toBe(1);
+    expect((await read(toolCallsTotal, { ok: "false" })) - before.okFalse).toBe(1);
+    expect((await read(toolPromotionsTotal)) - before.promo).toBe(1);
+  });
+
+  it("ignores events it doesn't track", async () => {
+    const sink = new MetricsEventSink();
+    // Must not throw on an unrelated event.
+    expect(() => sink.emit({ type: "run.start", data: { runId: "r1" } })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why

The platform already exposes `/metrics` (prom-client, dedicated registry, scraped in-cluster by the kube-prometheus-stack ServiceMonitor) — but it only carries HTTP RED metrics. Nothing about what the agent actually *does*. So questions like "where are tokens going?", "is compaction actually saving cache writes?", and "is #426's aggressive auto-promote wasting work?" require code spelunking.

This adds the domain counters that turn those into Grafana queries.

## Counters

All labels are **bounded** (no tool names/ids — those would be client-unbounded):

| Metric | Labels | Answers |
|---|---|---|
| `nb_llm_tokens_total` | `direction, kind, source, model` | where tokens go: input split into **fresh / cache_read / cache_write** + output, attributed by **source** (main loop vs forked `compaction`/`title`/`briefing`) and model. The 401k pattern (huge cache_read next to tiny fresh) and compaction's cache-write impact become dashboards. |
| `nb_llm_calls_total` | `source, model` | call volume by origin |
| `nb_tool_calls_total` | `ok` | tool exec success/failure rate |
| `nb_tool_promotions_total` | — | progressive-disclosure promotion rate |

## How it's wired

- A **`MetricsEventSink`** translates engine events (`llm.done` / `tool.done` / `tool.promoted`) into counters; it's added to the base sink list **always-on**.
- The forked fast-slot calls run *outside* the engine (no `llm.done`), so they record usage at their own `onUsage` sites via `recordLlmUsage(source, …)` — the same hooks #428 added. The **briefing** one fires even on the **background refresh**, capturing the cost the conversation-scoped `aux.usage` event can't attribute.

## Local + cross-tenant (the two constraints)

- **Local without k8s:** `/metrics` is mounted unconditionally and the counters live in an in-process registry — they increment in memory whether or not anything scrapes them. A local `bun run dev` runs identically with zero metrics infra; you can `curl :27247/metrics` if you want. **Observe-only and additive — no behavior depends on it.**
- **Cross-tenant:** each tenant is its own pod, scraped individually, so Prometheus labels every series by namespace (= tenant). Per-tenant and fleet-wide breakdowns come free; no app-level `tenant` label baked in.

## Tests

`recordLlmUsage` splits input into fresh/cache_read/cache_write + output by label; `MetricsEventSink` increments on the three events; unrelated events are ignored. `verify:static` clean, `test:unit` 3530 pass, no import cycles.

## Follow-ups (now cheap, separate)

- **Promoted-but-never-called** rate (#426 validation) needs a `used=true|false` label set at run end — small engine change, builds directly on `nb_tool_promotions_total`.
- A starter **Grafana dashboard** for these (tokens-by-source, cache split, tool/promotion rates) in `infra`.