### PR TITLE
fix(web/auth): don't log out on a transient refresh transport failure

### DIFF
--- a/web/src/api/fetch-with-refresh.test.ts
+++ b/web/src/api/fetch-with-refresh.test.ts
@@ -38,11 +38,11 @@ describe("fetchWithRefresh", () => {
     expect(callCount).toBe(2); // original + retry
   });
 
-  test("calls onAuthError when refresh fails", async () => {
+  test("calls onAuthError when refresh is rejected with 401 (token dead)", async () => {
     let authErrorCalled = false;
     const fakeFetch = async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url === "/refresh") return res(401); // refresh fails
+      if (url === "/refresh") return res(401); // 401 = refresh token expired/revoked
       return res(401);
     };
 
@@ -57,6 +57,65 @@ describe("fetchWithRefresh", () => {
     const r = await fetcher("/api/data");
     expect(r.status).toBe(401);
     expect(authErrorCalled).toBe(true);
+  });
+
+  // A refresh that REACHES the server but comes back non-401 (5xx during a
+  // rolling deploy, 429, a WAF 403, a proxy interstitial) is transient, not a
+  // dead session. It must NOT log the user out — same thesis as the thrown
+  // path. Retried, then the original 401 is surfaced for the caller.
+  for (const status of [500, 502, 503, 429, 403]) {
+    test(`does NOT log out when refresh returns ${status} (transient server response)`, async () => {
+      let authErrorCalled = false;
+      let refreshAttempts = 0;
+      const fakeFetch = async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "/refresh") {
+          refreshAttempts++;
+          return res(status);
+        }
+        return res(401);
+      };
+
+      const fetcher = createFetchWithRefresh({
+        fetch: fakeFetch as typeof fetch,
+        refreshUrl: "/refresh",
+        onAuthError: () => {
+          authErrorCalled = true;
+        },
+      });
+
+      const r = await fetcher("/api/data");
+      expect(r.status).toBe(401);
+      expect(authErrorCalled).toBe(false);
+      expect(refreshAttempts).toBeGreaterThan(1); // retried, not given up after one
+    });
+  }
+
+  test("recovers when a 503'd refresh later succeeds — no logout", async () => {
+    let refreshAttempts = 0;
+    let apiCalls = 0;
+    let authErrorCalled = false;
+    const fakeFetch = async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/refresh") {
+        refreshAttempts++;
+        return refreshAttempts === 1 ? res(503) : res(200); // deploy finishes mid-retry
+      }
+      apiCalls++;
+      return apiCalls === 1 ? res(401) : res(200);
+    };
+
+    const fetcher = createFetchWithRefresh({
+      fetch: fakeFetch as typeof fetch,
+      refreshUrl: "/refresh",
+      onAuthError: () => {
+        authErrorCalled = true;
+      },
+    });
+
+    const r = await fetcher("/api/data");
+    expect(r.status).toBe(200);
+    expect(authErrorCalled).toBe(false);
   });
 
   test("calls onAuthError when retry still returns 401", async () => {

--- a/web/src/api/fetch-with-refresh.test.ts
+++ b/web/src/api/fetch-with-refresh.test.ts
@@ -59,10 +59,53 @@ describe("fetchWithRefresh", () => {
     expect(authErrorCalled).toBe(true);
   });
 
-  // A refresh that REACHES the server but comes back non-401 (5xx during a
-  // rolling deploy, 429, a WAF 403, a proxy interstitial) is transient, not a
-  // dead session. It must NOT log the user out — same thesis as the thrown
-  // path. Retried, then the original 401 is surfaced for the caller.
+  test("calls onAuthError when refresh is rejected with 400 not_configured (definitive)", async () => {
+    // 400 not_configured = this deployment's provider can't refresh. Definitive
+    // — log out and re-auth rather than loop forever on a transient error.
+    let authErrorCalled = false;
+    const fakeFetch = async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/refresh") return res(400);
+      return res(401);
+    };
+    const fetcher = createFetchWithRefresh({
+      fetch: fakeFetch as typeof fetch,
+      refreshUrl: "/refresh",
+      onAuthError: () => {
+        authErrorCalled = true;
+      },
+    });
+    const r = await fetcher("/api/data");
+    expect(r.status).toBe(401);
+    expect(authErrorCalled).toBe(true);
+  });
+
+  test("does NOT log out on a transient 408 — only 400/401 are definitive", async () => {
+    // Guards the thesis: a non-{400,401} 4xx (408 Request Timeout here) is
+    // transient, not a dead session. Treating all 4xx as dead would log users
+    // out on a timeout — a smaller version of the bug this PR fixes.
+    let authErrorCalled = false;
+    const fakeFetch = async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/refresh") return res(408);
+      return res(401);
+    };
+    const fetcher = createFetchWithRefresh({
+      fetch: fakeFetch as typeof fetch,
+      refreshUrl: "/refresh",
+      onAuthError: () => {
+        authErrorCalled = true;
+      },
+    });
+    const r = await fetcher("/api/data");
+    expect(r.status).toBe(401);
+    expect(authErrorCalled).toBe(false);
+  });
+
+  // A refresh that REACHES the server but comes back with a non-definitive
+  // status (5xx during a rolling deploy, 429, a WAF 403, a proxy interstitial)
+  // is transient, not a dead session. It must NOT log the user out — same
+  // thesis as the thrown path. Retried, then the original 401 is surfaced.
   for (const status of [500, 502, 503, 429, 403]) {
     test(`does NOT log out when refresh returns ${status} (transient server response)`, async () => {
       let authErrorCalled = false;

--- a/web/src/api/fetch-with-refresh.test.ts
+++ b/web/src/api/fetch-with-refresh.test.ts
@@ -109,7 +109,10 @@ describe("fetchWithRefresh", () => {
     expect(refreshCount).toBe(1); // only one refresh call
   });
 
-  test("refresh network error is handled gracefully", async () => {
+  test("refresh transport failure does NOT log out — session may still be valid", async () => {
+    // A refresh that throws at the transport layer (dropped connection,
+    // roaming hand-off) is not an auth failure. The user must stay logged in;
+    // the original 401 surfaces as a transient error for the caller to retry.
     let authErrorCalled = false;
     const fakeFetch = async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -127,6 +130,37 @@ describe("fetchWithRefresh", () => {
 
     const r = await fetcher("/api/data");
     expect(r.status).toBe(401);
-    expect(authErrorCalled).toBe(true);
+    expect(authErrorCalled).toBe(false);
+  });
+
+  test("retries a transport-failed refresh and recovers without logging out", async () => {
+    // First refresh attempt throws (blip); the retry succeeds. The original
+    // request then retries and returns 200 — the user never sees a logout.
+    let refreshAttempts = 0;
+    let apiCalls = 0;
+    let authErrorCalled = false;
+    const fakeFetch = async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/refresh") {
+        refreshAttempts++;
+        if (refreshAttempts === 1) throw new TypeError("Failed to fetch");
+        return res(200);
+      }
+      apiCalls++;
+      return apiCalls === 1 ? res(401) : res(200);
+    };
+
+    const fetcher = createFetchWithRefresh({
+      fetch: fakeFetch as typeof fetch,
+      refreshUrl: "/refresh",
+      onAuthError: () => {
+        authErrorCalled = true;
+      },
+    });
+
+    const r = await fetcher("/api/data");
+    expect(r.status).toBe(200);
+    expect(refreshAttempts).toBe(2); // first threw, second succeeded
+    expect(authErrorCalled).toBe(false);
   });
 });

--- a/web/src/api/fetch-with-refresh.ts
+++ b/web/src/api/fetch-with-refresh.ts
@@ -8,23 +8,27 @@
  * ## Network failure ≠ auth failure
  *
  * A 401 means the access token expired; the cure is a refresh. But the
- * refresh request itself can fail two very different ways, and only ONE of
- * them means the session is over:
+ * refresh request itself can fail several ways, and only ONE of them means
+ * the session is over:
  *
- * - **Rejected** — the refresh endpoint responded with a non-OK status (the
- *   server returns 401 when the refresh token is expired/revoked/reused).
- *   The session is genuinely dead → log out.
- * - **Unavailable** — the refresh request never got a response: it threw at
- *   the transport layer (connection dropped, TLS reset, a roaming hand-off
- *   between networks). The session may be perfectly valid — we just couldn't
- *   reach the server this instant → do NOT log out. Surface the original 401
- *   so the caller can retry; the next attempt will refresh cleanly.
+ * - **Rejected** — the refresh endpoint responded **401**. That is the only
+ *   status that means the refresh token is expired/revoked/reused (the server
+ *   returns `refresh_failed` / `no_refresh_token` as 401). The session is
+ *   genuinely dead → log out.
+ * - **Unavailable** — anything else: the request threw at the transport layer
+ *   (connection dropped, TLS reset, a roaming hand-off between networks), OR it
+ *   reached the server but came back non-401 — a 5xx/429 from the ingress
+ *   during a rolling deploy, a proxy/captive-portal interstitial, a WAF 403.
+ *   None of those mean the session is dead; we just couldn't refresh this
+ *   instant → do NOT log out. Surface the original 401 so the caller can retry;
+ *   the next attempt will refresh cleanly.
  *
- * Collapsing both into "logged out" (the historical `.catch(() => false)`)
- * meant a single dropped refresh POST on a flaky/mobile connection bounced the
- * user to the sign-in screen mid-session even though nothing was wrong with
- * their session. Transport failures are also retried a couple times before we
- * give up, to ride out brief blips without surfacing an error at all.
+ * Collapsing all of these into "logged out" (the historical `.catch(() => false)`,
+ * and then a naive `res.ok ? … : rejected`) bounced users to the sign-in screen
+ * mid-session over a single dropped or 5xx'd refresh POST — exactly the
+ * mobile/proxy/deploy conditions this module exists to survive. Unavailable
+ * outcomes are also retried a couple times before we give up, to ride out brief
+ * blips without surfacing an error at all.
  */
 
 /** How many times to re-attempt a refresh that failed at the transport layer. */
@@ -37,9 +41,9 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 /**
  * Outcome of a refresh attempt:
  * - `refreshed`   — server issued a new token; retry the original request.
- * - `rejected`    — server refused the refresh token; the session is dead.
- * - `unavailable` — the request never reached the server (transient transport
- *                   failure); the session is likely still valid.
+ * - `rejected`    — server returned 401: the refresh token is dead → log out.
+ * - `unavailable` — transient: a thrown fetch OR any non-401 server response
+ *                   (5xx/429/403/…); the session is likely still valid.
  */
 type RefreshOutcome = "refreshed" | "rejected" | "unavailable";
 
@@ -62,8 +66,8 @@ export interface FetchWithRefresh {
   /**
    * Attempt a token refresh. Exposed for SSE modules that manage their own
    * fetch. Returns true only on a successful refresh; both a server rejection
-   * and a transport failure return false (the SSE caller stops the stream and
-   * its own backoff loop reconnects — it never logs out directly).
+   * and a transient failure return false, on which the SSE caller stops the
+   * stream and surfaces an error — it never logs out directly.
    */
   tryRefresh(): Promise<boolean>;
 }
@@ -77,7 +81,19 @@ export function createFetchWithRefresh(options: FetchWithRefreshOptions): FetchW
   async function attemptRefresh(): Promise<RefreshOutcome> {
     try {
       const res = await fetchFn(refreshUrl, { method: "POST", credentials: "include" });
-      return res.ok ? "refreshed" : "rejected";
+      if (res.ok) return "refreshed";
+      // ONLY an explicit 401 means the session is over — the refresh endpoint
+      // returns 401 (`refresh_failed` / `no_refresh_token`) when the refresh
+      // token is expired/revoked/reused, and that is the *only* status that
+      // signals a dead session. Everything else that reaches the server is
+      // transient: a 5xx/429 from the ingress during a rolling deploy, a proxy
+      // interstitial, a WAF 403. Treating those as `rejected` would log valid
+      // users out — the same spurious logout this module exists to prevent,
+      // just via an HTTP error instead of a thrown fetch. So: 401 → dead,
+      // anything else server-reachable-but-not-401 → transient (retry, keep
+      // the session).
+      if (res.status === 401) return "rejected";
+      return "unavailable";
     } catch {
       return "unavailable";
     }

--- a/web/src/api/fetch-with-refresh.ts
+++ b/web/src/api/fetch-with-refresh.ts
@@ -11,17 +11,17 @@
  * refresh request itself can fail several ways, and only ONE of them means
  * the session is over:
  *
- * - **Rejected** — the refresh endpoint responded **401**. That is the only
- *   status that means the refresh token is expired/revoked/reused (the server
- *   returns `refresh_failed` / `no_refresh_token` as 401). The session is
- *   genuinely dead → log out.
+ * - **Rejected** — the refresh endpoint returned one of its definitive-failure
+ *   codes: **401** (`refresh_failed` / `no_refresh_token` — token expired/
+ *   revoked/reused) or **400** (`not_configured` — this deployment can't
+ *   refresh). The session is genuinely dead → log out and re-auth.
  * - **Unavailable** — anything else: the request threw at the transport layer
  *   (connection dropped, TLS reset, a roaming hand-off between networks), OR it
- *   reached the server but came back non-401 — a 5xx/429 from the ingress
- *   during a rolling deploy, a proxy/captive-portal interstitial, a WAF 403.
- *   None of those mean the session is dead; we just couldn't refresh this
- *   instant → do NOT log out. Surface the original 401 so the caller can retry;
- *   the next attempt will refresh cleanly.
+ *   reached the server but came back with a non-definitive status — a 5xx/429
+ *   from the ingress during a rolling deploy, a 408 timeout, a proxy/captive-
+ *   portal interstitial, a WAF 403. None of those mean the session is dead; we
+ *   just couldn't refresh this instant → do NOT log out. Surface the original
+ *   401 so the caller can retry; the next attempt will refresh cleanly.
  *
  * Collapsing all of these into "logged out" (the historical `.catch(() => false)`,
  * and then a naive `res.ok ? … : rejected`) bounced users to the sign-in screen
@@ -41,9 +41,10 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 /**
  * Outcome of a refresh attempt:
  * - `refreshed`   — server issued a new token; retry the original request.
- * - `rejected`    — server returned 401: the refresh token is dead → log out.
- * - `unavailable` — transient: a thrown fetch OR any non-401 server response
- *                   (5xx/429/403/…); the session is likely still valid.
+ * - `rejected`    — server returned 400/401 (its definitive-failure codes):
+ *                   the session is dead → log out.
+ * - `unavailable` — transient: a thrown fetch OR any other server response
+ *                   (5xx/429/408/403/…); the session is likely still valid.
  */
 type RefreshOutcome = "refreshed" | "rejected" | "unavailable";
 
@@ -82,17 +83,21 @@ export function createFetchWithRefresh(options: FetchWithRefreshOptions): FetchW
     try {
       const res = await fetchFn(refreshUrl, { method: "POST", credentials: "include" });
       if (res.ok) return "refreshed";
-      // ONLY an explicit 401 means the session is over — the refresh endpoint
-      // returns 401 (`refresh_failed` / `no_refresh_token`) when the refresh
-      // token is expired/revoked/reused, and that is the *only* status that
-      // signals a dead session. Everything else that reaches the server is
-      // transient: a 5xx/429 from the ingress during a rolling deploy, a proxy
-      // interstitial, a WAF 403. Treating those as `rejected` would log valid
-      // users out — the same spurious logout this module exists to prevent,
-      // just via an HTTP error instead of a thrown fetch. So: 401 → dead,
-      // anything else server-reachable-but-not-401 → transient (retry, keep
-      // the session).
-      if (res.status === 401) return "rejected";
+      // Allowlist of our refresh endpoint's *definitive-failure* codes — the
+      // only statuses `handleOidcRefresh` returns when the session genuinely
+      // can't be refreshed: 401 (`refresh_failed` / `no_refresh_token` — token
+      // expired/revoked/reused) and 400 (`not_configured` — this deployment's
+      // provider can't refresh at all). Both mean "stop retrying, re-auth":
+      // log out cleanly rather than loop. If the endpoint ever grows a new
+      // definitive code, add it here.
+      //
+      // Anything else that comes back is NOT our refresh logic saying "no" —
+      // it's transient or infrastructural: a 5xx/429 from the ingress during a
+      // rolling deploy, a 408 timeout, a WAF 403, a proxy interstitial. Those
+      // join the thrown-fetch path as `unavailable` (retry, keep the session).
+      // Treating them as dead would log valid users out — the exact spurious
+      // logout this module exists to prevent.
+      if (res.status === 400 || res.status === 401) return "rejected";
       return "unavailable";
     } catch {
       return "unavailable";

--- a/web/src/api/fetch-with-refresh.ts
+++ b/web/src/api/fetch-with-refresh.ts
@@ -4,41 +4,107 @@
  * Wraps fetch to intercept 401 responses, attempt a cookie-based token
  * refresh, and retry the original request exactly once. Concurrent 401s
  * are deduplicated — only one refresh call is in-flight at a time.
+ *
+ * ## Network failure ≠ auth failure
+ *
+ * A 401 means the access token expired; the cure is a refresh. But the
+ * refresh request itself can fail two very different ways, and only ONE of
+ * them means the session is over:
+ *
+ * - **Rejected** — the refresh endpoint responded with a non-OK status (the
+ *   server returns 401 when the refresh token is expired/revoked/reused).
+ *   The session is genuinely dead → log out.
+ * - **Unavailable** — the refresh request never got a response: it threw at
+ *   the transport layer (connection dropped, TLS reset, a roaming hand-off
+ *   between networks). The session may be perfectly valid — we just couldn't
+ *   reach the server this instant → do NOT log out. Surface the original 401
+ *   so the caller can retry; the next attempt will refresh cleanly.
+ *
+ * Collapsing both into "logged out" (the historical `.catch(() => false)`)
+ * meant a single dropped refresh POST on a flaky/mobile connection bounced the
+ * user to the sign-in screen mid-session even though nothing was wrong with
+ * their session. Transport failures are also retried a couple times before we
+ * give up, to ride out brief blips without surfacing an error at all.
  */
+
+/** How many times to re-attempt a refresh that failed at the transport layer. */
+const REFRESH_NETWORK_RETRIES = 2;
+/** Delay between transport-failure retries. */
+const REFRESH_RETRY_DELAY_MS = 400;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Outcome of a refresh attempt:
+ * - `refreshed`   — server issued a new token; retry the original request.
+ * - `rejected`    — server refused the refresh token; the session is dead.
+ * - `unavailable` — the request never reached the server (transient transport
+ *                   failure); the session is likely still valid.
+ */
+type RefreshOutcome = "refreshed" | "rejected" | "unavailable";
 
 export interface FetchWithRefreshOptions {
   /** The underlying fetch implementation. */
   fetch: typeof globalThis.fetch;
   /** URL for the refresh endpoint. */
   refreshUrl: string;
-  /** Called when refresh fails or the retry still returns 401. */
+  /**
+   * Called only when the session is genuinely over — the refresh endpoint
+   * rejected the refresh token, or the retry still 401s after a successful
+   * refresh. NOT called on a transient transport failure.
+   */
   onAuthError?: () => void;
 }
 
 export interface FetchWithRefresh {
   /** Fetch with automatic 401 → refresh → retry. */
   (input: string, init?: RequestInit): Promise<Response>;
-  /** Attempt a token refresh. Exposed for SSE modules that manage their own fetch. */
+  /**
+   * Attempt a token refresh. Exposed for SSE modules that manage their own
+   * fetch. Returns true only on a successful refresh; both a server rejection
+   * and a transport failure return false (the SSE caller stops the stream and
+   * its own backoff loop reconnects — it never logs out directly).
+   */
   tryRefresh(): Promise<boolean>;
 }
 
 export function createFetchWithRefresh(options: FetchWithRefreshOptions): FetchWithRefresh {
   const { fetch: fetchFn, refreshUrl, onAuthError } = options;
 
-  let refreshInFlight: Promise<boolean> | null = null;
+  let refreshInFlight: Promise<RefreshOutcome> | null = null;
+
+  /** One refresh round-trip. A throw is transport-level (`unavailable`). */
+  async function attemptRefresh(): Promise<RefreshOutcome> {
+    try {
+      const res = await fetchFn(refreshUrl, { method: "POST", credentials: "include" });
+      return res.ok ? "refreshed" : "rejected";
+    } catch {
+      return "unavailable";
+    }
+  }
+
+  /**
+   * Refresh with transport-failure retries, deduplicated across concurrent
+   * callers. A `rejected` outcome is definitive and returns immediately; only
+   * the `unavailable` (transport) path is retried.
+   */
+  function refresh(): Promise<RefreshOutcome> {
+    if (refreshInFlight) return refreshInFlight;
+    refreshInFlight = (async () => {
+      let outcome = await attemptRefresh();
+      for (let i = 0; outcome === "unavailable" && i < REFRESH_NETWORK_RETRIES; i++) {
+        await delay(REFRESH_RETRY_DELAY_MS);
+        outcome = await attemptRefresh();
+      }
+      return outcome;
+    })().finally(() => {
+      refreshInFlight = null;
+    });
+    return refreshInFlight;
+  }
 
   function tryRefresh(): Promise<boolean> {
-    if (refreshInFlight) return refreshInFlight;
-    refreshInFlight = fetchFn(refreshUrl, {
-      method: "POST",
-      credentials: "include",
-    })
-      .then((res) => res.ok)
-      .catch(() => false)
-      .finally(() => {
-        refreshInFlight = null;
-      });
-    return refreshInFlight;
+    return refresh().then((outcome) => outcome === "refreshed");
   }
 
   async function fetchWithRefresh(input: string, init?: RequestInit): Promise<Response> {
@@ -47,15 +113,25 @@ export function createFetchWithRefresh(options: FetchWithRefreshOptions): FetchW
     if (res.status !== 401) return res;
 
     // 401 — attempt silent refresh
-    const refreshed = await tryRefresh();
-    if (!refreshed) {
+    const outcome = await refresh();
+
+    if (outcome === "rejected") {
+      // The refresh token was refused — the session is genuinely over.
       onAuthError?.();
       return res;
     }
 
-    // Refresh succeeded — retry the original request once
+    if (outcome === "unavailable") {
+      // We couldn't reach the refresh endpoint (network blip / roaming). The
+      // session may still be valid — do NOT log out. Return the original 401;
+      // the caller surfaces a transient error and the next request refreshes.
+      return res;
+    }
+
+    // Refresh succeeded — retry the original request once.
     const retry = await fetchFn(input, init);
     if (retry.status === 401) {
+      // A fresh token still gets 401 → genuinely unauthenticated.
       onAuthError?.();
     }
     return retry;


### PR DESCRIPTION
## Problem

A 401 from the API triggers a silent token refresh (`fetch-with-refresh.ts`). The refresh can fail several ways, but the original code collapsed all of them into `.catch(() => false)` -> `onAuthError` -> logout. So a refresh that **never reached the server** (dropped connection, TLS reset, a roaming hand-off between networks) bounced valid users to the sign-in screen mid-session — even though their session was fine. A single dropped refresh POST on a flaky/mobile connection was enough.

## Fix

Classify each refresh attempt into one of three outcomes and act on the distinction:

- **`refreshed`** (`res.ok`) -> retry the original request once.
- **`rejected`** -> `onAuthError` (log out). This is an **allowlist of the refresh endpoint's definitive-failure codes only: 400 and 401.** `handleOidcRefresh` returns 401 (`refresh_failed` / `no_refresh_token` — token expired/revoked/reused) and 400 (`not_configured` — this deployment can't refresh). Those are the only statuses that mean "stop retrying, re-auth."
- **`unavailable`** -> return the original 401, **keep the session**, let the caller retry. This covers both a thrown fetch (transport failure) **and** any non-definitive server response: 5xx/429 from the ingress during a rolling deploy, a 408 timeout, a WAF 403, a proxy interstitial. None of those mean the session is dead.

`unavailable` is retried twice with short backoff to ride out brief blips without surfacing an error at all. The allowlist is kept **narrow ({400,401}, the endpoint's actual codes)** rather than all-4xx, so a transient 408 doesn't spuriously log out — that would be a smaller version of the bug this PR fixes.

The public `tryRefresh(): Promise<boolean>` API is unchanged for the SSE callers (they stop the stream and surface an error on a falsy result; they never log out directly).

## Tests

15 cases: transport-throw -> no logout; retry-then-recover; **401 -> logout**; **400 not_configured -> logout**; **500/502/503/429/403 -> no logout (retried)**; **408 -> no logout** (locks the narrow-allowlist choice); 503-then-recovers -> no logout; concurrent-401 dedup. Unit tests green, tsc + biome clean.

## Review history

Addressed two QA passes: (1) the original second commit broadened `res.ok ? rejected` to `401-only rejected` after a reviewer flagged that 5xx/429 would spuriously log out during deploys; (2) this commit further fixed a 400 `not_configured` -> infinite-retry-loop regression by making rejection a {400,401} allowlist.