### PR TITLE
fix(tools): coerce stringified scalar args (number/boolean) before validation

### DIFF
--- a/src/tools/coerce-input.ts
+++ b/src/tools/coerce-input.ts
@@ -102,6 +102,9 @@ function coerceScalarString(
     return Number.isFinite(n) ? n : undefined;
   }
   if (declaresType(schema, "boolean")) {
+    // Lowercase JSON literals only, deliberately. Python-cased "True"/"False"
+    // would recover too, but we haven't observed it — keep the match tight and
+    // let anything else fall to the validator. Widen only if it shows up.
     if (trimmed === "true") return true;
     if (trimmed === "false") return false;
     return undefined;
@@ -214,7 +217,8 @@ function coerceValue(value: unknown, schema: Schema): unknown {
     // String → number/boolean recovery. Only when the schema can't already
     // accept a string (a `string` or `string | number` param takes the value
     // as-is, so coercing it would change a legitimate value's type).
-    if (effective && !declaresType(effective, "string")) {
+    // (`effective` is non-null past the line 196 guard.)
+    if (!declaresType(effective, "string")) {
       const scalar = coerceScalarString(value, effective);
       if (scalar !== undefined) return scalar;
     }

--- a/src/tools/coerce-input.ts
+++ b/src/tools/coerce-input.ts
@@ -16,16 +16,24 @@
  * the parsed value. Recurse into the parsed result so deeply nested
  * misencodings unwind in one pass.
  *
+ * The same forgiveness extends one rung further to scalars: a model that
+ * stringifies a number or boolean ("5", "true") for a param the schema types
+ * as number/integer/boolean has its value recovered too. Coercion only fires
+ * when the schema can't already accept a string, so a legitimately-string
+ * param is never retyped.
+ *
  * Non-parseable strings (and strings where the schema didn't expect an
- * object/array) pass through unchanged — the validator reports them with
- * its content-aware error. Non-string values are untouched.
+ * object/array/number/boolean) pass through unchanged — the validator reports
+ * them with its content-aware error. Non-string values are untouched.
  *
  * Idempotent: a properly shaped input survives unchanged. Safe to call at
  * multiple boundaries without amplification.
  *
- * Why not AJV's `coerceTypes`: AJV only coerces between scalar types
- * (string ↔ number, etc.). It does not parse string-as-JSON into objects
- * or arrays. This helper fills exactly that gap.
+ * Why not AJV's `coerceTypes`: it does not parse string-as-JSON into objects
+ * or arrays (the original gap this helper fills), and its scalar coercion is
+ * loose and mutating (`[]`↔scalar, `""`→0). Owning coercion here keeps it
+ * schema-aware and conservative — we recover a clean misencoding and leave
+ * anything ambiguous for the validator, rather than globally retyping inputs.
  *
  * ## Union schemas (`anyOf` / `oneOf`)
  *
@@ -59,13 +67,46 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+type JsonType = "object" | "array" | "number" | "integer" | "boolean" | "string";
+
 /** True iff the (effective) schema declares a concrete type matching `target`. */
-function declaresType(schema: Schema, target: "object" | "array"): boolean {
+function declaresType(schema: Schema, target: JsonType): boolean {
   if (!schema) return false;
   const t = schema.type;
   if (t === target) return true;
   if (Array.isArray(t) && t.includes(target)) return true;
   return false;
+}
+
+/**
+ * Recover a stringified scalar against a schema that declares a numeric or
+ * boolean type — the same model-misencoding class as the object/array case,
+ * one rung down: a model emits `"5"` or `"true"` for a param typed as
+ * number/integer/boolean. Returns the coerced primitive, or `undefined` when
+ * the string isn't a clean match (leave it for the validator's content-aware
+ * error rather than guess). A schema that also accepts `string` is handled by
+ * the caller — we never coerce a value the schema would take as-is.
+ */
+function coerceScalarString(
+  value: string,
+  schema: Record<string, unknown>,
+): number | boolean | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  if (declaresType(schema, "integer")) {
+    const n = Number(trimmed);
+    return Number.isInteger(n) ? n : undefined;
+  }
+  if (declaresType(schema, "number")) {
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  if (declaresType(schema, "boolean")) {
+    if (trimmed === "true") return true;
+    if (trimmed === "false") return false;
+    return undefined;
+  }
+  return undefined;
 }
 
 /**
@@ -169,6 +210,13 @@ function coerceValue(value: unknown, schema: Schema): unknown {
       // Parse failed — leave as string. Validator will surface the
       // content-aware error ("must be object", "must be array").
       return value;
+    }
+    // String → number/boolean recovery. Only when the schema can't already
+    // accept a string (a `string` or `string | number` param takes the value
+    // as-is, so coercing it would change a legitimate value's type).
+    if (effective && !declaresType(effective, "string")) {
+      const scalar = coerceScalarString(value, effective);
+      if (scalar !== undefined) return scalar;
     }
     return value;
   }

--- a/test/unit/mcp-source-dispatch-coercion.test.ts
+++ b/test/unit/mcp-source-dispatch-coercion.test.ts
@@ -128,20 +128,21 @@ describe("McpSource.execute — dispatch-boundary coercion", () => {
     expect(lastArgs()?.to_recipients).toEqual(["broker@firm.com"]);
   });
 
-  it("leaves a stringified scalar (boolean) untouched — scalar coercion is out of scope", async () => {
+  it("coerces a stringified scalar (boolean) at the dispatch boundary", async () => {
     const { source, lastArgs } = buildInlineSource(OUTLOOK_SCHEMA);
 
     await source.execute("OUTLOOK_CREATE_DRAFT", {
       subject: "Hi",
       body: "x",
       to_recipients: ["broker@firm.com"],
-      is_html: "true", // model stringifies the boolean; coercion only handles object/array
+      is_html: "true", // model stringifies the boolean (is_html is type: boolean)
     });
 
-    // Pinned deliberately: coerce-input recovers structured (object/array)
-    // misencodings, not scalars. If a future change starts mangling scalars
-    // this fails loudly. (Stringified booleans are a separate, smaller issue.)
-    expect(lastArgs()?.is_html).toBe("true");
+    // coerce-input recovers stringified scalars (number/boolean) against a
+    // schema that declares that type — the same misencoding class as the
+    // object/array recovery above, one rung down. The vendor receives a real
+    // boolean, not the string "true".
+    expect(lastArgs()?.is_html).toBe(true);
   });
 });
 

--- a/test/unit/tools/coerce-input.test.ts
+++ b/test/unit/tools/coerce-input.test.ts
@@ -103,6 +103,83 @@ describe("coerceInputForSchema — nested array recovery", () => {
   });
 });
 
+describe("coerceInputForSchema — scalar string recovery", () => {
+  // Mirrors the real failure: automations__runs `limit` is Type.Number, the
+  // model sent "5", and validation rejected the whole call.
+  it("coerces a stringified number for a number param", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { limit: { type: "number" } },
+    };
+    expect(coerceInputForSchema({ limit: "5" }, schema)).toEqual({ limit: 5 });
+  });
+
+  it("coerces a stringified integer for an integer param", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { top: { type: "integer" } },
+    };
+    expect(coerceInputForSchema({ top: "30" }, schema)).toEqual({ top: 30 });
+  });
+
+  it("rejects a non-integer string for an integer param (left for the validator)", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { top: { type: "integer" } },
+    };
+    expect(coerceInputForSchema({ top: "30.5" }, schema)).toEqual({ top: "30.5" });
+  });
+
+  it("coerces stringified booleans for a boolean param", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { enabled: { type: "boolean" } },
+    };
+    expect(coerceInputForSchema({ enabled: "true" }, schema)).toEqual({ enabled: true });
+    expect(coerceInputForSchema({ enabled: "false" }, schema)).toEqual({ enabled: false });
+  });
+
+  it("leaves a non-numeric string for a number param (validator surfaces it)", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { limit: { type: "number" } },
+    };
+    expect(coerceInputForSchema({ limit: "abc" }, schema)).toEqual({ limit: "abc" });
+  });
+
+  it("does NOT retype a value the schema accepts as a string", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { id: { type: "string" } },
+    };
+    expect(coerceInputForSchema({ id: "42" }, schema)).toEqual({ id: "42" });
+  });
+
+  it("does NOT coerce inside a string|number union (string branch accepts it)", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { val: { anyOf: [{ type: "string" }, { type: "number" }] } },
+    };
+    expect(coerceInputForSchema({ val: "5" }, schema)).toEqual({ val: "5" });
+  });
+
+  it("recovers a stringified number through a Pydantic Optional[int] union", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { limit: { anyOf: [{ type: "integer" }, { type: "null" }] } },
+    };
+    expect(coerceInputForSchema({ limit: "5" }, schema)).toEqual({ limit: 5 });
+  });
+
+  it("leaves an already-correct number untouched (idempotent)", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { limit: { type: "number" } },
+    };
+    expect(coerceInputForSchema({ limit: 5 }, schema)).toEqual({ limit: 5 });
+  });
+});
+
 describe("coerceInputForSchema — depth and edge cases", () => {
   it("recovers a doubly-nested string-encoded object", () => {
     const schema = {


### PR DESCRIPTION
## Problem

The schema-aware input coercion (`coerce-input.ts`) already recovers string-encoded **objects and arrays** (a known model misencoding) but deliberately left string-encoded **scalars** to the validator, which rejects them. A model sending `limit: "5"` for a `Type.Number` param hard-failed the whole call — e.g. `automations__runs` returning `Invalid arguments for "runs": /limit: must be number` — so routine introspection calls failed on a type technicality.

## Fix

Extend `coerceValue` to recover a stringified number/integer/boolean against a schema that declares that scalar type, keeping the same conservative contract as the object/array path:

- coerce only a **clean** match (a non-numeric string, or a non-integer for an `integer` param, is left for the validator's content-aware error);
- only when the schema **can't already accept a string** (a `string` or `string | number` param — both the `anyOf` and `type: ["string","number"]` forms — is never retyped);
- resolves through Pydantic `Optional[T]` unions like the existing path.
- booleans match lowercase JSON `true`/`false` only, by intent (Python-cased `"True""/"False"` falls to the validator until observed in the wild).

Kept in this helper rather than enabling AJV `coerceTypes` (which is loose/mutating and doesn't do the object/array case this module exists for). All five tool-call entry points (in-process-app, mcp-source, handlers, engine) funnel through this one `coerceInputForSchema`, so every boundary benefits uniformly — no parallel scalar-handling to drift.

## Tests

Two files:
- `coerce-input.test.ts` — scalar coercion cases: number/integer/boolean coercion, non-numeric left as-is, non-integer rejected for `integer`, string param not retyped, `string | number` union untouched, `Optional[int]` union resolved, idempotent.
- `mcp-source-dispatch-coercion.test.ts` — updated the existing `is_html: "true"` case (a `boolean` field): it previously pinned the old 'scalars pass through untouched' behavior; now asserts the dispatch boundary coerces it to a real `true`.

37 tests across the two files green; full unit suite green; tsc + biome clean.

## Review notes

QA pass (no criticals): dropped a redundant `effective &&` guard and documented the lowercase-only boolean boundary as a conscious choice.