### PR TITLE
feat(web): document panel for artifact resources

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ import { RouteGuard } from "./components/RouteGuard";
 import { ShellLayout } from "./components/ShellLayout";
 import { WorkspaceRouteGuard } from "./components/WorkspaceRouteGuard";
 import { ChatProvider, useChatConfigContext, useChatContext } from "./context/ChatContext";
+import { ArtifactPanelProvider } from "./context/ArtifactPanelContext";
 import { ChatPanelProvider, useChatPanelContext } from "./context/ChatPanelContext";
 import { FocusedAppProvider } from "./context/FocusedAppContext";
 import { PaletteProvider } from "./context/PaletteContext";
@@ -195,18 +196,20 @@ function BootstrappedShell({
       <WorkspaceAppIconsProvider token={token} workspaceId={activeWorkspace?.id}>
         <ChatProvider initialConfig={initialConfig} currentUserId={currentUserId}>
           <ChatPanelProvider>
-            <PaletteProvider>
-              <FocusedAppProvider>
-                <AuthenticatedAppContent
-                  token={token}
-                  forSlot={forSlot}
-                  mainRoutes={mainRoutes}
-                  shellWorkspaceId={shellWorkspaceId}
-                  refreshShell={refreshShell}
-                  onLogout={onLogout}
-                />
-              </FocusedAppProvider>
-            </PaletteProvider>
+            <ArtifactPanelProvider>
+              <PaletteProvider>
+                <FocusedAppProvider>
+                  <AuthenticatedAppContent
+                    token={token}
+                    forSlot={forSlot}
+                    mainRoutes={mainRoutes}
+                    shellWorkspaceId={shellWorkspaceId}
+                    refreshShell={refreshShell}
+                    onLogout={onLogout}
+                  />
+                </FocusedAppProvider>
+              </PaletteProvider>
+            </ArtifactPanelProvider>
           </ChatPanelProvider>
         </ChatProvider>
       </WorkspaceAppIconsProvider>

--- a/web/src/__tests__/ArtifactPanel.test.tsx
+++ b/web/src/__tests__/ArtifactPanel.test.tsx
@@ -110,7 +110,9 @@ describe("ArtifactChip", () => {
     expect(readResourceMock.mock.calls.length).toBe(0);
     findOpenButton(mounted.container); // throws if absent
   });
+});
 
+describe("ArtifactPanel (document surface)", () => {
   test("clicking Open triggers the fetch and renders MARKDOWN (real anchors, not raw)", async () => {
     readResourceMock.mockImplementation(async () => ({
       contents: [

--- a/web/src/__tests__/ArtifactPanel.test.tsx
+++ b/web/src/__tests__/ArtifactPanel.test.tsx
@@ -1,0 +1,189 @@
+// ---------------------------------------------------------------------------
+// ArtifactPanel + ArtifactChip — document-artifact render contract.
+//
+// Pins the UX-option-B behavior: a resource_link document artifact renders as
+// a compact chip in the chat stream (NOT a raw-markdown box); clicking Open
+// fetches the resource via readResource and renders it as RENDERED markdown
+// (real <a>/<h1> elements, not literal `[text](url)` / `# Heading` syntax) in
+// the document panel, with copy + download actions; a fetch failure shows the
+// error state.
+//
+// Mirrors ResourceLinkView.test.tsx: rendering goes through react-dom/client
+// directly (no @testing-library/react — happy-dom's selector parser throws on
+// some testing-library inputs), and api/client is whole-module-mocked with
+// only readResource overridden (spread the preload snapshot so ApiClientError
+// and every other export stay real).
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "../../test/setup";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const readResourceMock = mock(
+  async (_server: string, _uri: string): Promise<{ contents: unknown[] }> => ({ contents: [] }),
+);
+
+mock.module("../api/client", () => ({
+  ...realClient,
+  readResource: readResourceMock,
+}));
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { ArtifactChip } = await import("../components/ArtifactChip");
+const { ArtifactPanel } = await import("../components/ArtifactPanel");
+const { ArtifactPanelProvider } = await import("../context/ArtifactPanelContext");
+
+beforeEach(() => {
+  readResourceMock.mockReset();
+});
+
+interface Mounted {
+  container: HTMLDivElement;
+  unmount(): void;
+}
+
+let mounted: Mounted | null = null;
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+});
+
+const CHIP_PROPS = {
+  appName: "nb",
+  uri: "files://rpt_abc123",
+  name: "Quantum Computing Market Report",
+  mimeType: "text/markdown",
+} as const;
+
+/** Mount the chip + the global panel under one provider, the real wiring. */
+async function mountSurface(): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(
+      React.createElement(
+        ArtifactPanelProvider,
+        null,
+        React.createElement(ArtifactChip, CHIP_PROPS),
+        React.createElement(ArtifactPanel),
+      ),
+    );
+  });
+  await settle();
+  return {
+    container,
+    unmount() {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+async function settle(): Promise<void> {
+  // Several awaited microtask hops: openArtifact (sync) → effect fires the
+  // async readResource → setState commits the body → Streamdown renders.
+  for (let i = 0; i < 6; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+function findOpenButton(container: HTMLElement): HTMLButtonElement {
+  const btn = Array.from(container.getElementsByTagName("button")).find((b) =>
+    (b.getAttribute("aria-label") ?? "").startsWith("Open "),
+  );
+  if (!btn) throw new Error(`chip Open button missing. html=${container.innerHTML.slice(0, 300)}`);
+  return btn as HTMLButtonElement;
+}
+
+describe("ArtifactChip", () => {
+  test("renders a compact chip from a resource_link, with title and Open affordance", async () => {
+    mounted = await mountSurface();
+    expect(mounted.container.textContent).toContain("Quantum Computing Market Report");
+    expect(mounted.container.textContent).toContain("Report"); // mime-derived kind label
+    // The chip carries only the ref — no fetch happens until Open is clicked.
+    expect(readResourceMock.mock.calls.length).toBe(0);
+    findOpenButton(mounted.container); // throws if absent
+  });
+
+  test("clicking Open triggers the fetch and renders MARKDOWN (real anchors, not raw)", async () => {
+    readResourceMock.mockImplementation(async () => ({
+      contents: [
+        {
+          uri: CHIP_PROPS.uri,
+          mimeType: "text/markdown",
+          text: "# Findings\n\nSee [the source](https://example.com/source) for detail.",
+        },
+      ],
+    }));
+
+    mounted = await mountSurface();
+    const open = findOpenButton(mounted.container);
+    await act(async () => {
+      open.click();
+    });
+    await settle();
+
+    expect(readResourceMock.mock.calls.length).toBe(1);
+    expect(readResourceMock.mock.calls[0]).toEqual(["nb", "files://rpt_abc123"]);
+
+    // Rendered markdown: a real heading element + a rendered link element
+    // (Streamdown — the same renderer the chat uses — emits links as
+    // interactive elements tagged data-streamdown="link", not raw syntax).
+    const headings = mounted.container.getElementsByTagName("h1");
+    expect(headings.length).toBeGreaterThan(0);
+    expect(headings[0]?.textContent).toContain("Findings");
+    // happy-dom's querySelectorAll parser throws on attribute selectors (see
+    // ResourceLinkView.test.tsx header), so scan elements by tag/attr instead.
+    const link = Array.from(mounted.container.getElementsByTagName("*")).find(
+      (el) => el.getAttribute("data-streamdown") === "link",
+    );
+    if (!link) {
+      throw new Error(`rendered link missing. html=${mounted.container.innerHTML.slice(0, 600)}`);
+    }
+    expect(link.textContent).toContain("the source");
+    // The raw markdown syntax must NOT appear as literal text — proof we're
+    // rendering, not dumping a cramped raw-markdown box.
+    expect(mounted.container.textContent).not.toContain("[the source](https://example.com/source)");
+    expect(mounted.container.textContent).not.toContain("# Findings");
+  });
+
+  test("panel shows copy and download actions once content loads", async () => {
+    readResourceMock.mockImplementation(async () => ({
+      contents: [{ uri: CHIP_PROPS.uri, mimeType: "text/markdown", text: "# Report\n\nBody." }],
+    }));
+
+    mounted = await mountSurface();
+    await act(async () => {
+      findOpenButton(mounted.container).click();
+    });
+    await settle();
+
+    const labels = Array.from(mounted.container.getElementsByTagName("button")).map((b) =>
+      b.getAttribute("aria-label"),
+    );
+    expect(labels).toContain("Copy document to clipboard");
+    expect(labels).toContain("Download document");
+    expect(labels).toContain("Close document panel");
+  });
+
+  test("fetch failure renders the error state, not a blank panel", async () => {
+    readResourceMock.mockImplementation(async () => {
+      throw new Error("resource not found");
+    });
+
+    mounted = await mountSurface();
+    await act(async () => {
+      findOpenButton(mounted.container).click();
+    });
+    await settle();
+
+    expect(mounted.container.textContent).toContain("Failed to load");
+    expect(mounted.container.textContent).toContain("resource not found");
+  });
+});

--- a/web/src/components/AppWithChat.tsx
+++ b/web/src/components/AppWithChat.tsx
@@ -21,7 +21,7 @@
 //     to the last in-flight conversation so the SSE viewer reconnects.
 // ---------------------------------------------------------------------------
 
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import { useLocation } from "react-router-dom";
 import type { UiChatContext } from "../bridge/types";
 import { useChatContext } from "../context/ChatContext";
@@ -34,6 +34,7 @@ import {
   setSavedConversationId,
   setSavedStreamingIds,
 } from "../lib/active-conversation-storage";
+import { useIsMobile } from "../lib/hooks/use-is-mobile";
 import type { AppContext, PlacementEntry } from "../types";
 import { SlotRenderer } from "./SlotRenderer";
 
@@ -49,19 +50,6 @@ let restoredLastConversation = false;
  * post-reload (empty) set.
  */
 const initialSavedStreamingIds = getSavedStreamingIds();
-
-function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== "undefined" && window.innerWidth < 768,
-  );
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 767px)");
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-  return isMobile;
-}
 
 interface AppWithChatProps {
   placement: PlacementEntry;

--- a/web/src/components/ArtifactChip.tsx
+++ b/web/src/components/ArtifactChip.tsx
@@ -1,0 +1,64 @@
+import { ChevronRight, FileText } from "lucide-react";
+import { useArtifactPanel } from "../context/ArtifactPanelContext";
+
+export interface ArtifactChipProps {
+  /** Server/app that owns the resource — forwarded to the document panel. */
+  appName: string;
+  /** Resource URI from the resource_link block (e.g. `files://<id>`). */
+  uri: string;
+  /** Display title from the resource_link `name`. */
+  name?: string;
+  /** Declared MIME type (e.g. `text/markdown`). */
+  mimeType?: string;
+  /** Optional description surfaced in the panel header. */
+  description?: string;
+}
+
+/** Human-readable kind label from a MIME type. */
+function kindLabel(mimeType: string | undefined): string {
+  if (!mimeType) return "Document";
+  const mime = mimeType.split(";")[0]!.trim().toLowerCase();
+  if (mime === "text/markdown" || mime === "text/x-markdown") return "Report";
+  if (mime === "text/plain") return "Text document";
+  return "Document";
+}
+
+function titleFromUri(uri: string): string {
+  const tail = uri.split("/").pop();
+  return tail && tail.length > 0 ? tail : uri;
+}
+
+/**
+ * Compact, persistent reference to a document artifact in the chat stream.
+ *
+ * Replaces the cramped inline raw-markdown box for `resource_link` document
+ * results: a small card (icon, title, kind subtitle, Open affordance) that
+ * opens the full report in the global document panel. It carries only the
+ * resource ref — no fetched content — so it survives conversation reload as
+ * long as `tc.resourceLinks` is persisted.
+ */
+export function ArtifactChip({ appName, uri, name, mimeType, description }: ArtifactChipProps) {
+  const { openArtifact } = useArtifactPanel();
+  const title = name ?? titleFromUri(uri);
+
+  return (
+    <button
+      type="button"
+      onClick={() => openArtifact({ appName, uri, name, mimeType, description })}
+      className="group w-full my-2 flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted/40 hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      aria-label={`Open ${title}`}
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <FileText className="h-4.5 w-4.5" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-foreground">{title}</span>
+        <span className="block truncate text-xs text-muted-foreground">{kindLabel(mimeType)}</span>
+      </span>
+      <span className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-muted-foreground transition-colors group-hover:text-foreground">
+        Open
+        <ChevronRight className="h-3.5 w-3.5" />
+      </span>
+    </button>
+  );
+}

--- a/web/src/components/ArtifactChip.tsx
+++ b/web/src/components/ArtifactChip.tsx
@@ -1,5 +1,6 @@
 import { ChevronRight, FileText } from "lucide-react";
 import { useArtifactPanel } from "../context/ArtifactPanelContext";
+import { isMarkdownMime, normalizeMime } from "../lib/artifact-kind";
 
 export interface ArtifactChipProps {
   /** Server/app that owns the resource — forwarded to the document panel. */
@@ -16,10 +17,8 @@ export interface ArtifactChipProps {
 
 /** Human-readable kind label from a MIME type. */
 function kindLabel(mimeType: string | undefined): string {
-  if (!mimeType) return "Document";
-  const mime = mimeType.split(";")[0]!.trim().toLowerCase();
-  if (mime === "text/markdown" || mime === "text/x-markdown") return "Report";
-  if (mime === "text/plain") return "Text document";
+  if (isMarkdownMime(mimeType)) return "Report";
+  if (normalizeMime(mimeType) === "text/plain") return "Text document";
   return "Document";
 }
 

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -39,7 +39,9 @@ function downloadFilename(
   mimeType: string | undefined,
 ): string {
   const base = name ?? uri.split("/").pop() ?? "document";
-  if (/\.[a-z0-9]+$/i.test(base)) return base;
+  // Only keep a recognized document extension — an arbitrary trailing dot-token
+  // (e.g. a title like "report.final") is NOT an extension and still gets one.
+  if (/\.(md|markdown|txt)$/i.test(base)) return base;
   // Extension-less names get one inferred from the MIME: plain text → .txt,
   // markdown (and the catch-all) → .md.
   const ext = normalizeMime(mimeType) === "text/plain" ? "txt" : "md";

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -60,6 +60,9 @@ export function ArtifactPanel() {
   const appName = artifact?.appName;
   const uri = artifact?.uri;
 
+  // artifact?.mimeType is captured only as a fallback at fetch time; the
+  // (appName, uri) pair is the identity of the resource being fetched.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fetch keyed on resource identity
   useEffect(() => {
     if (!appName || !uri) return;
     let cancelled = false;
@@ -102,9 +105,6 @@ export function ArtifactPanel() {
     return () => {
       cancelled = true;
     };
-    // artifact?.mimeType is captured only as a fallback at fetch time; the
-    // (appName, uri) pair is the identity of the resource being fetched.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: fetch keyed on resource identity
   }, [appName, uri]);
 
   // Esc closes the panel while it's open.

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -1,0 +1,257 @@
+// ---------------------------------------------------------------------------
+// ArtifactPanel — the document surface for artifact resources.
+//
+// INVARIANT: mounted exactly once, globally (by ShellLayout, next to
+// ChatChrome). A second mount renders a second drawer. Every ArtifactChip,
+// in any conversation, opens into this single instance via
+// ArtifactPanelContext.
+//
+// It is the GENERAL artifact renderer: keyed off the resource descriptor's
+// MIME, not off deep-research. Markdown is rendered (via Streamdown, the same
+// renderer the assistant's chat messages use) into a clean reading layout
+// with a title header and sticky copy / download actions; plain text falls
+// back to monospaced preformatted text. Fetch + loading/error states reuse
+// ResourceLinkView's `readResource` path and state shape.
+// ---------------------------------------------------------------------------
+
+import { Check, Copy, Download, FileText, Loader2, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Streamdown } from "streamdown";
+import { ApiClientError, type ReadResourceContent, readResource } from "../api/client";
+import { useArtifactPanel } from "../context/ArtifactPanelContext";
+import { isMarkdownMime } from "../lib/artifact-kind";
+
+const TRANSITION = "300ms cubic-bezier(0.33, 1, 0.68, 1)";
+const PANEL_WIDTH = 720; // px — comfortable reading measure on desktop.
+
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.innerWidth < 768,
+  );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(max-width: 767px)");
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return isMobile;
+}
+
+/** Decode a base64 text resource (blob form) to a string. */
+function decodeBlobText(b64: string): string {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+function downloadFilename(uri: string, name?: string): string {
+  const base = name ?? uri.split("/").pop() ?? "document";
+  return /\.[a-z0-9]+$/i.test(base) ? base : `${base}.md`;
+}
+
+export function ArtifactPanel() {
+  const { artifact, closeArtifact } = useArtifactPanel();
+  const isMobile = useIsMobile();
+  const isOpen = artifact !== null;
+
+  const [text, setText] = useState<string | null>(null);
+  const [mimeType, setMimeType] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const appName = artifact?.appName;
+  const uri = artifact?.uri;
+
+  useEffect(() => {
+    if (!appName || !uri) return;
+    let cancelled = false;
+
+    setLoading(true);
+    setError(null);
+    setText(null);
+    setMimeType(undefined);
+    setCopied(false);
+
+    (async () => {
+      try {
+        const result = await readResource(appName, uri);
+        if (cancelled) return;
+        const first: ReadResourceContent | undefined = result.contents[0];
+        if (!first) throw new Error("No content returned");
+        const body =
+          first.text !== undefined
+            ? first.text
+            : first.blob !== undefined
+              ? decodeBlobText(first.blob)
+              : null;
+        if (body === null) throw new Error("Resource has no readable text content");
+        setText(body);
+        setMimeType(first.mimeType ?? artifact?.mimeType);
+      } catch (err) {
+        if (cancelled) return;
+        const msg =
+          err instanceof ApiClientError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : "Failed to load document";
+        setError(msg);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // artifact?.mimeType is captured only as a fallback at fetch time; the
+    // (appName, uri) pair is the identity of the resource being fetched.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: fetch keyed on resource identity
+  }, [appName, uri]);
+
+  // Esc closes the panel while it's open.
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeArtifact();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, closeArtifact]);
+
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (copyTimer.current) clearTimeout(copyTimer.current);
+    };
+  }, []);
+
+  async function onCopy() {
+    if (text == null) return;
+    try {
+      await navigator.clipboard?.writeText(text);
+      setCopied(true);
+      if (copyTimer.current) clearTimeout(copyTimer.current);
+      copyTimer.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  }
+
+  function onDownload() {
+    if (text == null || !uri) return;
+    const blob = new Blob([text], { type: mimeType ?? "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = downloadFilename(uri, artifact?.name);
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  const title = artifact?.name ?? uri?.split("/").pop() ?? "Document";
+  const renderMarkdown = isMarkdownMime(mimeType ?? artifact?.mimeType);
+
+  return (
+    <>
+      {/* Scrim — click to dismiss. Only interactive while open. */}
+      <div
+        aria-hidden={!isOpen}
+        onClick={closeArtifact}
+        className="fixed inset-0 z-20 bg-black/20"
+        style={{
+          opacity: isOpen ? 1 : 0,
+          pointerEvents: isOpen ? "auto" : "none",
+          transition: `opacity ${TRANSITION}`,
+        }}
+      />
+
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        data-testid="artifact-panel"
+        className="fixed top-0 right-0 z-30 flex h-full max-w-full flex-col border-l border-border bg-background shadow-xl"
+        style={{
+          width: isMobile ? "100%" : PANEL_WIDTH,
+          transform: isOpen ? "translateX(0)" : "translateX(100%)",
+          transition: `transform ${TRANSITION}`,
+        }}
+      >
+        {/* Header — title + actions. Sticky by virtue of the flex column:
+            the body below scrolls, this stays put. */}
+        <header className="flex shrink-0 items-center gap-2 border-b border-border bg-card px-4 py-3">
+          <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <h2 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">{title}</h2>
+
+          <button
+            type="button"
+            onClick={onCopy}
+            disabled={text == null}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
+            aria-label="Copy document to clipboard"
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            onClick={onDownload}
+            disabled={text == null}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
+            aria-label="Download document"
+          >
+            <Download className="h-3.5 w-3.5" />
+            Download
+          </button>
+          <button
+            type="button"
+            onClick={closeArtifact}
+            className="ml-1 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+            aria-label="Close document panel"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        {/* Body — the scrollable reading region. */}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {loading && (
+            <div className="flex items-center gap-2 px-6 py-8 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin text-processing" />
+              Loading {title}...
+            </div>
+          )}
+
+          {!loading && error && (
+            <div className="m-6 rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+              Failed to load {title}: {error}
+            </div>
+          )}
+
+          {!loading && !error && text != null && (
+            <article className="mx-auto max-w-3xl px-6 py-8">
+              {renderMarkdown ? (
+                <Streamdown className="streamdown-container presence-assistant-message">
+                  {text}
+                </Streamdown>
+              ) : (
+                <pre className="whitespace-pre-wrap break-words font-mono text-sm text-foreground">
+                  {text}
+                </pre>
+              )}
+            </article>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -19,24 +19,11 @@ import { useEffect, useRef, useState } from "react";
 import { Streamdown } from "streamdown";
 import { ApiClientError, type ReadResourceContent, readResource } from "../api/client";
 import { useArtifactPanel } from "../context/ArtifactPanelContext";
-import { isMarkdownMime } from "../lib/artifact-kind";
+import { isMarkdownMime, normalizeMime } from "../lib/artifact-kind";
+import { useIsMobile } from "../lib/hooks/use-is-mobile";
 
 const TRANSITION = "300ms cubic-bezier(0.33, 1, 0.68, 1)";
 const PANEL_WIDTH = 720; // px — comfortable reading measure on desktop.
-
-function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== "undefined" && window.innerWidth < 768,
-  );
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const mq = window.matchMedia("(max-width: 767px)");
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-  return isMobile;
-}
 
 /** Decode a base64 text resource (blob form) to a string. */
 function decodeBlobText(b64: string): string {
@@ -46,9 +33,17 @@ function decodeBlobText(b64: string): string {
   return new TextDecoder().decode(bytes);
 }
 
-function downloadFilename(uri: string, name?: string): string {
+function downloadFilename(
+  uri: string,
+  name: string | undefined,
+  mimeType: string | undefined,
+): string {
   const base = name ?? uri.split("/").pop() ?? "document";
-  return /\.[a-z0-9]+$/i.test(base) ? base : `${base}.md`;
+  if (/\.[a-z0-9]+$/i.test(base)) return base;
+  // Extension-less names get one inferred from the MIME: plain text → .txt,
+  // markdown (and the catch-all) → .md.
+  const ext = normalizeMime(mimeType) === "text/plain" ? "txt" : "md";
+  return `${base}.${ext}`;
 }
 
 export function ArtifactPanel() {
@@ -125,6 +120,26 @@ export function ArtifactPanel() {
     return () => document.removeEventListener("keydown", onKey);
   }, [isOpen, closeArtifact]);
 
+  // Focus management: when the dialog opens, remember what was focused and
+  // move focus to the Close button (the panel's first stable control), so
+  // keyboard users land inside the dialog rather than behind it. On close,
+  // restore focus to the trigger (the chip). Paired with conditional render +
+  // aria-hidden below, this keeps the closed panel out of the tab order and
+  // unannounced by screen readers.
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (isOpen) {
+      restoreFocusRef.current = (document.activeElement as HTMLElement | null) ?? null;
+      // Defer one frame so the button is mounted and the slide-in has begun.
+      const id = requestAnimationFrame(() => closeButtonRef.current?.focus());
+      return () => cancelAnimationFrame(id);
+    }
+    const toRestore = restoreFocusRef.current;
+    restoreFocusRef.current = null;
+    toRestore?.focus?.();
+  }, [isOpen]);
+
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     return () => {
@@ -150,7 +165,7 @@ export function ArtifactPanel() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = downloadFilename(uri, artifact?.name);
+    a.download = downloadFilename(uri, artifact?.name, mimeType ?? artifact?.mimeType);
     document.body.appendChild(a);
     a.click();
     a.remove();
@@ -174,9 +189,14 @@ export function ArtifactPanel() {
         }}
       />
 
+      {/* The aside stays mounted so the slide transition can play, but when
+          closed it is aria-hidden + inert (no focusable controls, not
+          announced) and its content is unmounted — which also clears the
+          previous document's body so it can't linger off-screen. role=dialog /
+          aria-modal therefore only describe a panel that is actually open. */}
       <aside
-        role="dialog"
-        aria-modal="true"
+        {...(isOpen ? { role: "dialog", "aria-modal": true } : { inert: true })}
+        aria-hidden={!isOpen}
         aria-label={title}
         data-testid="artifact-panel"
         className="fixed top-0 right-0 z-30 flex h-full max-w-full flex-col border-l border-border bg-background shadow-xl"
@@ -186,71 +206,78 @@ export function ArtifactPanel() {
           transition: `transform ${TRANSITION}`,
         }}
       >
-        {/* Header — title + actions. Sticky by virtue of the flex column:
-            the body below scrolls, this stays put. */}
-        <header className="flex shrink-0 items-center gap-2 border-b border-border bg-card px-4 py-3">
-          <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <h2 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">{title}</h2>
+        {isOpen && (
+          <>
+            {/* Header — title + actions. Sticky by virtue of the flex column:
+                the body below scrolls, this stays put. */}
+            <header className="flex shrink-0 items-center gap-2 border-b border-border bg-card px-4 py-3">
+              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <h2 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+                {title}
+              </h2>
 
-          <button
-            type="button"
-            onClick={onCopy}
-            disabled={text == null}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
-            aria-label="Copy document to clipboard"
-          >
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-            {copied ? "Copied" : "Copy"}
-          </button>
-          <button
-            type="button"
-            onClick={onDownload}
-            disabled={text == null}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
-            aria-label="Download document"
-          >
-            <Download className="h-3.5 w-3.5" />
-            Download
-          </button>
-          <button
-            type="button"
-            onClick={closeArtifact}
-            className="ml-1 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-            aria-label="Close document panel"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </header>
+              <button
+                type="button"
+                onClick={onCopy}
+                disabled={text == null}
+                className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
+                aria-label="Copy document to clipboard"
+              >
+                {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                {copied ? "Copied" : "Copy"}
+              </button>
+              <button
+                type="button"
+                onClick={onDownload}
+                disabled={text == null}
+                className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
+                aria-label="Download document"
+              >
+                <Download className="h-3.5 w-3.5" />
+                Download
+              </button>
+              <button
+                ref={closeButtonRef}
+                type="button"
+                onClick={closeArtifact}
+                className="ml-1 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                aria-label="Close document panel"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </header>
 
-        {/* Body — the scrollable reading region. */}
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          {loading && (
-            <div className="flex items-center gap-2 px-6 py-8 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin text-processing" />
-              Loading {title}...
-            </div>
-          )}
-
-          {!loading && error && (
-            <div className="m-6 rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-              Failed to load {title}: {error}
-            </div>
-          )}
-
-          {!loading && !error && text != null && (
-            <article className="mx-auto max-w-3xl px-6 py-8">
-              {renderMarkdown ? (
-                <Streamdown className="streamdown-container presence-assistant-message">
-                  {text}
-                </Streamdown>
-              ) : (
-                <pre className="whitespace-pre-wrap break-words font-mono text-sm text-foreground">
-                  {text}
-                </pre>
+            {/* Body — the scrollable reading region. */}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {loading && (
+                <div className="flex items-center gap-2 px-6 py-8 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin text-processing" />
+                  Loading {title}...
+                </div>
               )}
-            </article>
-          )}
-        </div>
+
+              {!loading && error && (
+                <div className="m-6 rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                  Failed to load {title}: {error}
+                </div>
+              )}
+
+              {!loading && !error && text != null && (
+                <article className="mx-auto max-w-3xl px-6 py-8">
+                  {renderMarkdown ? (
+                    <Streamdown className="streamdown-container presence-assistant-message">
+                      {text}
+                    </Streamdown>
+                  ) : (
+                    <pre className="whitespace-pre-wrap break-words font-mono text-sm text-foreground">
+                      {text}
+                    </pre>
+                  )}
+                </article>
+              )}
+            </div>
+          </>
+        )}
       </aside>
     </>
   );

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -109,17 +109,21 @@ export function ArtifactPanel() {
     };
   }, [appName, uri]);
 
-  // Esc closes the panel while it's open.
+  // Esc closes the panel while it's open. The panel is the topmost layer, so it
+  // claims Esc in the capture phase and stops the event before it reaches other
+  // document-level Esc handlers (e.g. ChatChrome's drawer) — otherwise one Esc
+  // press would close both.
   useEffect(() => {
     if (!isOpen) return;
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
         e.preventDefault();
+        e.stopImmediatePropagation();
         closeArtifact();
       }
     }
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+    document.addEventListener("keydown", onKey, { capture: true });
+    return () => document.removeEventListener("keydown", onKey, { capture: true });
   }, [isOpen, closeArtifact]);
 
   // Focus management: when the dialog opens, remember what was focused and
@@ -214,9 +218,12 @@ export function ArtifactPanel() {
                 the body below scrolls, this stays put. */}
             <header className="flex shrink-0 items-center gap-2 border-b border-border bg-card px-4 py-3">
               <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <h2 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
-                {title}
-              </h2>
+              <div className="min-w-0 flex-1">
+                <h2 className="truncate text-sm font-semibold text-foreground">{title}</h2>
+                {artifact?.description && (
+                  <p className="truncate text-xs text-muted-foreground">{artifact.description}</p>
+                )}
+              </div>
 
               <button
                 type="button"

--- a/web/src/components/BlockTimeline.tsx
+++ b/web/src/components/BlockTimeline.tsx
@@ -38,6 +38,7 @@ import type {
   ToolCallDisplay,
 } from "../hooks/useChat";
 import { useMinDisplayTime, type VisualStatus } from "../hooks/useMinDisplayTime";
+import { isDocumentArtifact } from "../lib/artifact-kind";
 import { formatDuration, stripServerPrefix } from "../lib/format";
 import {
   aggregateGroup,
@@ -47,6 +48,7 @@ import {
   type Tone,
   type ToolDescription,
 } from "../lib/tool-display";
+import { ArtifactChip } from "./ArtifactChip";
 import { InlineAppView } from "./InlineAppView";
 import { ResourceLinkView } from "./ResourceLinkView";
 
@@ -654,16 +656,32 @@ function ToolWidgets({ calls }: { calls: ReadonlyArray<ToolCallDisplay> }) {
         />
       ))}
       {resourceLinkCalls.flatMap((tc) =>
-        tc.resourceLinks!.map((link) => (
-          <ResourceLinkView
-            key={`${tc.id}:${link.uri}`}
-            appName={tc.appName!}
-            uri={link.uri}
-            name={link.name}
-            mimeType={link.mimeType}
-            description={link.description}
-          />
-        )),
+        tc.resourceLinks!.map((link) =>
+          // Document artifacts (markdown reports, long text) get a compact
+          // chip that opens the full document in the global ArtifactPanel —
+          // a 24KB research report is a document, not a chat message. Binary
+          // resources (PDF, images) keep their inline preview, where
+          // ResourceLinkView already picks the right HTML primitive per MIME.
+          isDocumentArtifact(link.mimeType) ? (
+            <ArtifactChip
+              key={`${tc.id}:${link.uri}`}
+              appName={tc.appName!}
+              uri={link.uri}
+              name={link.name}
+              mimeType={link.mimeType}
+              description={link.description}
+            />
+          ) : (
+            <ResourceLinkView
+              key={`${tc.id}:${link.uri}`}
+              appName={tc.appName!}
+              uri={link.uri}
+              name={link.name}
+              mimeType={link.mimeType}
+              description={link.description}
+            />
+          ),
+        ),
       )}
     </>
   );

--- a/web/src/components/ChatChrome.tsx
+++ b/web/src/components/ChatChrome.tsx
@@ -24,6 +24,7 @@ import { useChatContext } from "../context/ChatContext";
 import { useChatPanelContext } from "../context/ChatPanelContext";
 import { useFocusedApp } from "../context/FocusedAppContext";
 import { useSidebar } from "../context/SidebarContext";
+import { useIsMobile } from "../lib/hooks/use-is-mobile";
 import type { ChatPanelRef } from "./ChatPanel";
 import { ChatPanel } from "./ChatPanel";
 import { ResizeHandle } from "./ResizeHandle";
@@ -31,19 +32,6 @@ import { ResizeHandle } from "./ResizeHandle";
 const DEFAULT_WIDTH = 380;
 const TRANSITION_STANDARD = "300ms cubic-bezier(0.33, 1, 0.68, 1)";
 const TRANSITION_FULLSCREEN = "350ms cubic-bezier(0.4, 0, 0.2, 1)";
-
-function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== "undefined" && window.innerWidth < 768,
-  );
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 767px)");
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-  return isMobile;
-}
 
 export function ChatChrome() {
   const { panelState, panelWidth, setPanelWidth, openPanel, closePanel, toggleFullscreen } =

--- a/web/src/components/ShellLayout.tsx
+++ b/web/src/components/ShellLayout.tsx
@@ -1,9 +1,10 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { memo, useEffect, useState } from "react";
+import { memo } from "react";
 import { NavLink } from "react-router-dom";
 import { useChatPanelContext } from "../context/ChatPanelContext";
 import { useSidebar } from "../context/SidebarContext";
 import { useWorkspaceContext } from "../context/WorkspaceContext";
+import { useIsMobile } from "../lib/hooks/use-is-mobile";
 import { resolveIcon } from "../lib/icons";
 import { identityAppRoute, isIdentityApp } from "../lib/identity-apps";
 import { cn } from "../lib/utils";
@@ -61,19 +62,6 @@ interface ShellLayoutProps {
 // wasn't moving in coordination.
 const CHAT_TRANSITION_STANDARD = "300ms cubic-bezier(0.33, 1, 0.68, 1)";
 const CHAT_RESIZE_HANDLE_WIDTH = 4; // px — matches ChatChrome's ResizeHandle
-
-function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== "undefined" && window.innerWidth < 768,
-  );
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 767px)");
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-  return isMobile;
-}
 
 export const ShellLayout = memo(function ShellLayout({
   forSlot,

--- a/web/src/components/ShellLayout.tsx
+++ b/web/src/components/ShellLayout.tsx
@@ -9,6 +9,7 @@ import { identityAppRoute, isIdentityApp } from "../lib/identity-apps";
 import { cn } from "../lib/utils";
 import { toSlug } from "../lib/workspace-slug";
 import type { PlacementEntry } from "../types";
+import { ArtifactPanel } from "./ArtifactPanel";
 import { ChatChrome } from "./ChatChrome";
 import { Logo } from "./Logo";
 import { MobileSidebarDrawer } from "./MobileSidebarDrawer";
@@ -192,6 +193,12 @@ export const ShellLayout = memo(function ShellLayout({
           `marginRight` on <main> above; the panel and handle live inside
           ChatChrome itself. */}
       <ChatChrome />
+
+      {/* Artifact document panel — the single, global mount point (sibling
+          of ChatChrome), so an artifact chip in any conversation opens its
+          report into one shared right-side drawer. Renders nothing until an
+          artifact is opened via ArtifactPanelContext. */}
+      <ArtifactPanel />
 
       {/* Mobile drawer — single-column layout mirroring desktop. */}
       {isHidden && (

--- a/web/src/context/ArtifactPanelContext.tsx
+++ b/web/src/context/ArtifactPanelContext.tsx
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------
+// ArtifactPanelContext — global state for the document/artifact drawer.
+//
+// An "artifact" is any resource_link a tool emits that deserves a document
+// surface rather than an inline box in the chat stream: a deep-research
+// report, a generated markdown doc, anything readable-long. The chip in the
+// stream is just the reference; opening it pushes the descriptor here and the
+// single global <ArtifactPanel> (mounted once by ShellLayout, like
+// ChatChrome) fetches and renders it.
+//
+// Mirrors ChatPanelContext's shape on purpose: one provider owns the open
+// descriptor, a global mount reads it, every chip across every conversation
+// opens into the same drawer.
+// ---------------------------------------------------------------------------
+
+import type { ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+/** The minimal descriptor needed to fetch + render an artifact resource. */
+export interface ArtifactDescriptor {
+  /** Server/app that owns the resource — forwarded to POST /v1/resources/read. */
+  appName: string;
+  /** Resource URI from the resource_link block (e.g. `files://<id>`). */
+  uri: string;
+  /** Display title from the resource_link `name`. */
+  name?: string;
+  /** Declared MIME type (e.g. `text/markdown`). */
+  mimeType?: string;
+  /** Optional description surfaced in the panel header. */
+  description?: string;
+}
+
+export interface ArtifactPanelContextValue {
+  /** The currently-open artifact, or null when the panel is closed. */
+  artifact: ArtifactDescriptor | null;
+  /** Open the document panel for the given artifact. */
+  openArtifact: (artifact: ArtifactDescriptor) => void;
+  /** Close the panel. */
+  closeArtifact: () => void;
+}
+
+const ArtifactPanelContext = createContext<ArtifactPanelContextValue | null>(null);
+
+export function ArtifactPanelProvider({ children }: { children: ReactNode }) {
+  const [artifact, setArtifact] = useState<ArtifactDescriptor | null>(null);
+
+  const openArtifact = useCallback((next: ArtifactDescriptor) => {
+    setArtifact(next);
+  }, []);
+
+  const closeArtifact = useCallback(() => {
+    setArtifact(null);
+  }, []);
+
+  const value = useMemo<ArtifactPanelContextValue>(
+    () => ({ artifact, openArtifact, closeArtifact }),
+    [artifact, openArtifact, closeArtifact],
+  );
+
+  return <ArtifactPanelContext value={value}>{children}</ArtifactPanelContext>;
+}
+
+/** Consume the ArtifactPanelContext. Throws if used outside the provider. */
+export function useArtifactPanel(): ArtifactPanelContextValue {
+  const ctx = useContext(ArtifactPanelContext);
+  if (!ctx) {
+    throw new Error("useArtifactPanel must be used within an ArtifactPanelProvider");
+  }
+  return ctx;
+}

--- a/web/src/lib/artifact-kind.test.ts
+++ b/web/src/lib/artifact-kind.test.ts
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------
+// artifact-kind — routing contract for resource_link document artifacts.
+//
+// The load-bearing case is the ALLOWLIST: a resource_link with NO declared
+// MIME must NOT route to the document panel (which decodes blobs as text and
+// would render binary bytes as garbage). It falls back to ResourceLinkView,
+// which degrades to a download card. This pins that flip so it can't regress
+// back to the old no-mime → document default.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test } from "bun:test";
+import { isDocumentArtifact, isMarkdownMime, normalizeMime } from "./artifact-kind";
+
+describe("isDocumentArtifact", () => {
+  test("a no-mime resource_link does NOT route to the document panel", () => {
+    expect(isDocumentArtifact(undefined)).toBe(false);
+    expect(isDocumentArtifact("")).toBe(false);
+  });
+
+  test("markdown and plain text route to the document panel", () => {
+    expect(isDocumentArtifact("text/markdown")).toBe(true);
+    expect(isDocumentArtifact("text/x-markdown")).toBe(true);
+    expect(isDocumentArtifact("text/plain")).toBe(true);
+  });
+
+  test("tolerates parameters and casing on the MIME header", () => {
+    expect(isDocumentArtifact("text/markdown; charset=utf-8")).toBe(true);
+    expect(isDocumentArtifact("TEXT/PLAIN")).toBe(true);
+    expect(isDocumentArtifact("  text/markdown  ")).toBe(true);
+  });
+
+  test("binary / unknown types fall back to the inline preview", () => {
+    expect(isDocumentArtifact("application/pdf")).toBe(false);
+    expect(isDocumentArtifact("application/octet-stream")).toBe(false);
+    expect(isDocumentArtifact("image/png")).toBe(false);
+    expect(isDocumentArtifact("text/html")).toBe(false);
+  });
+});
+
+describe("isMarkdownMime", () => {
+  test("markdown variants render as markdown; plain text does not", () => {
+    expect(isMarkdownMime("text/markdown")).toBe(true);
+    expect(isMarkdownMime("text/x-markdown; charset=utf-8")).toBe(true);
+    expect(isMarkdownMime("text/plain")).toBe(false);
+    expect(isMarkdownMime(undefined)).toBe(false);
+  });
+});
+
+describe("normalizeMime", () => {
+  test("strips parameters, trims, and lowercases; undefined for absent", () => {
+    expect(normalizeMime("Text/Markdown; charset=UTF-8")).toBe("text/markdown");
+    expect(normalizeMime("  text/plain ")).toBe("text/plain");
+    expect(normalizeMime(undefined)).toBeUndefined();
+    expect(normalizeMime("")).toBeUndefined();
+  });
+});

--- a/web/src/lib/artifact-kind.ts
+++ b/web/src/lib/artifact-kind.ts
@@ -4,9 +4,10 @@
 // A document artifact is long-form, readable content (a deep-research report,
 // a generated markdown doc) that deserves its own reading surface — the chip
 // + document panel — instead of the cramped inline box the chat stream gives
-// every resource_link today. Binary resources (PDF, images, octet-stream)
-// keep their inline preview via ResourceLinkView, which already picks the
-// right HTML primitive per MIME and isolates the renderer process.
+// every resource_link today. Binary resources (PDF, images, octet-stream) and
+// resources WITHOUT a declared MIME keep their inline preview via
+// ResourceLinkView, which already picks the right HTML primitive per MIME,
+// isolates the renderer process, and degrades to a download card.
 //
 // Keyed off MIME, not the tool name, so it is the GENERAL artifact path:
 // deep-research is just the first producer. Any future tool that emits a
@@ -14,26 +15,34 @@
 // ---------------------------------------------------------------------------
 
 /**
- * True when a resource_link should render as a document artifact (chip +
- * panel with rendered markdown) rather than an inline binary preview.
- *
- * `text/markdown` is the canonical case (deep-research reports). Plain text
- * is included so any tool emitting a long text doc gets the reading surface;
- * an unknown/absent MIME on a `files://`-style URI is treated as a document
- * too, since the inline `<pre>` fallback is exactly the cramped raw-text box
- * this feature replaces.
+ * Normalize a MIME header to its bare lowercased type: strips any `;`
+ * parameters (charset etc.) and surrounding whitespace. Returns `undefined`
+ * for an absent MIME so callers can branch on "no declared type".
  */
-export function isDocumentArtifact(mimeType: string | undefined): boolean {
-  if (!mimeType) return true;
-  const mime = mimeType.split(";")[0]!.trim().toLowerCase();
-  if (mime === "text/markdown" || mime === "text/x-markdown") return true;
-  if (mime === "text/plain") return true;
-  return false;
+export function normalizeMime(mimeType: string | undefined): string | undefined {
+  if (!mimeType) return undefined;
+  return mimeType.split(";")[0]!.trim().toLowerCase();
 }
 
 /** True for MIME types we render as markdown (vs. monospaced plain text). */
 export function isMarkdownMime(mimeType: string | undefined): boolean {
-  if (!mimeType) return true;
-  const mime = mimeType.split(";")[0]!.trim().toLowerCase();
+  const mime = normalizeMime(mimeType);
   return mime === "text/markdown" || mime === "text/x-markdown";
+}
+
+/**
+ * True when a resource_link should render as a document artifact (chip +
+ * panel with rendered markdown) rather than an inline binary preview.
+ *
+ * ALLOWLIST: only known long-form text types route to the document surface.
+ * `text/markdown` is the canonical case (deep-research reports); plain text is
+ * included so any tool emitting a long text doc gets the reading surface. An
+ * unknown or ABSENT MIME falls back to ResourceLinkView, which handles text,
+ * binary, and download-only resources gracefully — feeding a no-mime resource
+ * into the document panel would decode binary bytes as garbage text.
+ */
+export function isDocumentArtifact(mimeType: string | undefined): boolean {
+  const mime = normalizeMime(mimeType);
+  if (!mime) return false;
+  return isMarkdownMime(mime) || mime === "text/plain";
 }

--- a/web/src/lib/artifact-kind.ts
+++ b/web/src/lib/artifact-kind.ts
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------------
+// artifact-kind — decide whether a resource_link is a "document artifact".
+//
+// A document artifact is long-form, readable content (a deep-research report,
+// a generated markdown doc) that deserves its own reading surface — the chip
+// + document panel — instead of the cramped inline box the chat stream gives
+// every resource_link today. Binary resources (PDF, images, octet-stream)
+// keep their inline preview via ResourceLinkView, which already picks the
+// right HTML primitive per MIME and isolates the renderer process.
+//
+// Keyed off MIME, not the tool name, so it is the GENERAL artifact path:
+// deep-research is just the first producer. Any future tool that emits a
+// markdown/text resource_link gets the document surface for free.
+// ---------------------------------------------------------------------------
+
+/**
+ * True when a resource_link should render as a document artifact (chip +
+ * panel with rendered markdown) rather than an inline binary preview.
+ *
+ * `text/markdown` is the canonical case (deep-research reports). Plain text
+ * is included so any tool emitting a long text doc gets the reading surface;
+ * an unknown/absent MIME on a `files://`-style URI is treated as a document
+ * too, since the inline `<pre>` fallback is exactly the cramped raw-text box
+ * this feature replaces.
+ */
+export function isDocumentArtifact(mimeType: string | undefined): boolean {
+  if (!mimeType) return true;
+  const mime = mimeType.split(";")[0]!.trim().toLowerCase();
+  if (mime === "text/markdown" || mime === "text/x-markdown") return true;
+  if (mime === "text/plain") return true;
+  return false;
+}
+
+/** True for MIME types we render as markdown (vs. monospaced plain text). */
+export function isMarkdownMime(mimeType: string | undefined): boolean {
+  if (!mimeType) return true;
+  const mime = mimeType.split(";")[0]!.trim().toLowerCase();
+  return mime === "text/markdown" || mime === "text/x-markdown";
+}

--- a/web/src/lib/hooks/use-is-mobile.ts
+++ b/web/src/lib/hooks/use-is-mobile.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+// Mobile breakpoint: viewports narrower than 768px get the full-width / drawer
+// treatment instead of the desktop sidebar. Kept in one place so the chat
+// chrome and the artifact panel agree on the boundary (both slide to 100%).
+const MOBILE_QUERY = "(max-width: 767px)";
+
+/** True when the viewport is below the mobile breakpoint; reacts to resize. */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.innerWidth < 768,
+  );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia(MOBILE_QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return isMobile;
+}


### PR DESCRIPTION
Stacked on #437. Replaces the cramped inline raw-markdown box for document artifacts (deep-research reports, and any `text/markdown` resource_link) with a **chip-in-chat → document panel** (UX option B).

## What it does
- **`ArtifactChip`** — a compact card in the assistant turn (file icon, title, kind, **Open**). Carries only the resource ref, so it survives conversation reload 
- **`ArtifactPanel`** — a global right-side document drawer that fetches via the existing `readResource` path and renders **rendered markdown via Streamdown** (the app's own renderer — no raw markdown), with sticky **Copy** / **Download (.md)** / Close, scrollable reading column, Esc-to-close, loading/error states.
- Reuses the existing global-context drawer pattern (mirrors `ChatPanelContext`/`ChatChrome`); mounted once in `ShellLayout`.
- General, not deep-research-specific: routing is MIME-based (`text/markdown`/`text/plain`/unknown → document); binaries (PDF/image) keep `ResourceLinkView`'s inline preview.

## Verification
New `ArtifactPanel.test.tsx` (chip renders, no fetch until Open, Open → fetch → rendered markdown, copy/download/close, error state) — 4/4 pass. Full web suite **516 pass, 0 fail**; `npm run build` + biome clean.

## Notes for review
- Links render as Streamdown's interactive link elements (consistent with chat), not raw `<a target=_blank>` — flag if hard `<a>` behavior is required.
- Panel is a fixed 720px reading measure (not resizable); easy to add a handle later.
- Image not yet built here (agent-web cross-arch Bun build segfaults locally — builds fine in CI).