### PR TITLE
feat(observability): OTel tracing + structured logs across the runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,17 @@ Reload after setting. Namespaces (`web/src/lib/debug.ts`):
 
 Namespaces are shared convention between server and browser: `NB_DEBUG=sync` plus `localStorage.nb_debug=sync` together trace the entire data.changed flow.
 
+## Observability (OTel tracing + structured logs)
+
+Vendor-neutral OpenTelemetry lives in `src/observability/`. The runtime depends only on `@opentelemetry/*` and the W3C tracecontext + OTLP wire formats — **never** a branded observability library. The wire is the interface.
+
+- **Spans:** wrap work with `withSpan(name, attrs, fn)` (active-context, nests automatically) — never call the OTel API directly from feature code. Today's spans: `agent.turn` (engine run), `llm.call` (model stream), `tool.dispatch` (MCP dispatch), and the outer HTTP span (Hono middleware, continues an inbound `traceparent`). Add `requestIdentityAttrs()` to span attrs to stamp the verified identity.
+- **Propagation:** `injectTraceparent(headers)` on outbound calls that should extend the trace (service-token mint, authenticated remote-MCP fetch). No-op outside a span.
+- **Logs:** use `log.*(msg, fields?)`. With `NB_LOG_FORMAT=json` (set by the chart) lines are structured JSON auto-enriched with `service`, `tenant_id`, `correlation_id` (the active trace id), and identity. Pretty dev output is unchanged.
+- **Trust rule — what may be stamped:** `tenant_id` is a boot-time Resource attribute from `NB_TENANT_ID`, never a request header. `user_id` / `workspace_id` / `conversation_id` come from the verified request context. **Never** stamp the display name, email, secrets, prompts, tool args/results, or file contents.
+- **Config:** `OTEL_EXPORTER_OTLP_ENDPOINT` enables export (unset = nothing exported, ids still exist for log correlation — so local dev and OSS checkouts need no infra). `NB_SERVICE_NAME` overrides the service name.
+- **OTel deps are exact-pinned to one release train** (stable `sdk-trace-*`/`resources` + the matching experimental exporter). Bump them together or export serialization breaks; the version-coherence test in `test/unit/observability.test.ts` guards it.
+
 ## Long-Running Tools (MCP Tasks)
 
 Any MCP tool whose work exceeds the stock MCP request timeout (~60 s) must be written as a **task-augmented tool**. The engine implements the client side of the MCP draft 2025-11-25 `tasks` utility end-to-end; bundle authors only have to opt in.

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,12 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@nimblebrain/mpak-sdk": "0.8.0",
         "@nimblebrain/synapse": "^0.8.0",
+        "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0",
+        "@opentelemetry/sdk-trace-node": "2.8.0",
+        "@opentelemetry/semantic-conventions": "1.41.1",
         "@sinclair/typebox": "^0.34.49",
         "@workos-inc/node": "^8.12.1",
         "ai": "^6.0.138",
@@ -98,7 +104,31 @@
 
     "@nimblebrain/synapse": ["@nimblebrain/synapse@0.8.0", "", { "peerDependencies": { "@modelcontextprotocol/ext-apps": "^1.3.1", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react"], "bin": { "synapse": "dist/codegen/cli.js" } }, "sha512-he6+9AOZFsZwnQS6IGbBrkL5OoQ1AwTpjACNQnyyqXgljZ/BhXNCSG9CzzUtS+XorYcZ4EZIEadUXFXSafZkZw=="],
 
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.8.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.219.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/otlp-exporter-base": "0.219.0", "@opentelemetry/otlp-transformer": "0.219.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/sdk-trace-base": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.219.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/otlp-transformer": "0.219.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/sdk-logs": "0.219.0", "@opentelemetry/sdk-metrics": "2.8.0", "@opentelemetry/sdk-trace-base": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.8.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.8.0", "@opentelemetry/core": "2.8.0", "@opentelemetry/sdk-trace-base": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@posthog/core": ["@posthog/core@1.24.1", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA=="],
 
@@ -540,9 +570,13 @@
 
     "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
+    "ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "ink/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "prom-client/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nimblebrain",
   "version": "0.0.0-dev",
-  "description": "Self-hosted platform for MCP Apps and agent automations — tools, interactive UIs, scheduled runs, multi-agent delegation",
+  "description": "Self-hosted platform for MCP Apps and agent automations \u2014 tools, interactive UIs, scheduled runs, multi-agent delegation",
   "license": "Apache-2.0",
   "author": "NimbleBrain, Inc. <oss@nimblebrain.ai>",
   "repository": {
@@ -101,6 +101,12 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@nimblebrain/mpak-sdk": "0.8.0",
     "@nimblebrain/synapse": "^0.8.0",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
+    "@opentelemetry/sdk-trace-node": "2.8.0",
+    "@opentelemetry/semantic-conventions": "1.41.1",
     "@sinclair/typebox": "^0.34.49",
     "@workos-inc/node": "^8.12.1",
     "ai": "^6.0.138",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nimblebrain",
   "version": "0.0.0-dev",
-  "description": "Self-hosted platform for MCP Apps and agent automations \u2014 tools, interactive UIs, scheduled runs, multi-agent delegation",
+  "description": "Self-hosted platform for MCP Apps and agent automations — tools, interactive UIs, scheduled runs, multi-agent delegation",
   "license": "Apache-2.0",
   "author": "NimbleBrain, Inc. <oss@nimblebrain.ai>",
   "repository": {

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -4,6 +4,7 @@ import { enableDefaultMetrics } from "./metrics.ts";
 import { corsMiddleware } from "./middleware/cors.ts";
 import { metricsMiddleware } from "./middleware/metrics.ts";
 import { securityHeaders } from "./middleware/security-headers.ts";
+import { tracingMiddleware } from "./middleware/tracing.ts";
 import { authRoutes } from "./routes/auth.ts";
 import { bootstrapRoutes } from "./routes/bootstrap.ts";
 import { chatRoutes } from "./routes/chat.ts";
@@ -28,6 +29,10 @@ export function createApp(
 
   // Turn on process/runtime metrics for this server (idempotent).
   enableDefaultMetrics();
+
+  // Tracing outermost so the HTTP span wraps the full chain (incl. metrics) and
+  // establishes the trace context every downstream handler/span inherits.
+  app.use("*", tracingMiddleware());
 
   // Request metrics first so it times the full handler chain.
   app.use("*", metricsMiddleware());

--- a/src/api/middleware/tracing.ts
+++ b/src/api/middleware/tracing.ts
@@ -1,0 +1,41 @@
+import { createMiddleware } from "hono/factory";
+import { withInboundSpan } from "../../observability/index.ts";
+
+// Mirror the metrics middleware: clamp the method to the standard verbs so a
+// client can't inflate span-name cardinality with arbitrary HTTP method tokens
+// (this runs before auth).
+const STANDARD_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]);
+
+/**
+ * Opens the outer HTTP span for every request, continued from an inbound W3C
+ * `traceparent` when present (e.g. the mcp-edge -> runtime hop) so the trace is
+ * one across services. The internal `agent.turn` / `llm.call` / `tool.dispatch`
+ * spans nest under it for the synchronous chat path.
+ *
+ * Identity is deliberately NOT stamped here — auth runs later in the chain, and
+ * the trust rule forbids reading identity off the raw request. The verified
+ * identity lands on `agent.turn` from the request context instead.
+ *
+ * The span name uses the matched route template (`c.req.routePath`), known only
+ * after routing, so it is refined via `setName` once `next()` resolves. The
+ * `/metrics` scrape is skipped to keep Prometheus' own polling out of traces.
+ */
+export function tracingMiddleware() {
+  return createMiddleware(async (c, next) => {
+    if (c.req.path === "/metrics") {
+      return next();
+    }
+    const method = STANDARD_METHODS.has(c.req.method) ? c.req.method : "OTHER";
+    await withInboundSpan(
+      `HTTP ${method}`,
+      c.req.raw.headers,
+      { "http.method": method },
+      async (span) => {
+        await next();
+        const route = c.req.routePath || "/*";
+        span.setName(`${method} ${route}`);
+        span.setAttrs({ "http.route": route, "http.status_code": c.res.status });
+      },
+    );
+  });
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -12,6 +12,7 @@ import { validateComposioConfig } from "../composio/sdk.ts";
 import type { IdentityProvider } from "../identity/provider.ts";
 import { DevIdentityProvider } from "../identity/providers/dev.ts";
 import { canonicalOrigins, webOrigin } from "../oauth/public-origin.ts";
+import { shutdownTracing } from "../observability/index.ts";
 import type { Runtime } from "../runtime/runtime.ts";
 import { HealthMonitor } from "../tools/health-monitor.ts";
 import { createApp } from "./app.ts";
@@ -326,6 +327,9 @@ export async function startServerWithShutdown(options: ServerOptions): Promise<v
 
     handle.stop(true);
     await runtime.shutdown();
+    // Flush any buffered spans before exit so the final window isn't dropped on
+    // pod termination (BatchSpanProcessor schedule is ~5s). No-op without export.
+    await shutdownTracing();
 
     clearTimeout(safetyTimeout);
     console.error("[nimblebrain] Shutdown complete.");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { CommanderError } from "commander";
+import { initTracing } from "../observability/index.ts";
 import { TelemetryManager } from "../telemetry/manager.ts";
 import { createAutomationCommand } from "./commands/automation.ts";
 import { createBundleCommand } from "./commands/bundle.ts";
@@ -34,6 +35,11 @@ const KNOWN_COMMANDS = new Set([
 ]);
 
 async function main() {
+  // Install vendor-neutral OTel tracing once, before any command runs. No-op
+  // (nothing exported) unless OTEL_EXPORTER_OTLP_ENDPOINT is set, so this is
+  // safe for CLI/TUI and OSS checkouts with no observability infra.
+  initTracing();
+
   // Pre-check for unknown subcommands (before Commander parses)
   const firstArg = process.argv[2];
   if (firstArg && !firstArg.startsWith("-") && !KNOWN_COMMANDS.has(firstArg)) {

--- a/src/cli/log.ts
+++ b/src/cli/log.ts
@@ -1,8 +1,19 @@
 /**
- * Startup logger — colored stderr output for CLI boot messages.
+ * Runtime logger — two output formats, one stream (stderr).
  *
- * Info messages use dim text, warnings use yellow, errors use red.
- * All output goes to stderr to keep stdout clean for JSON-RPC / pipe output.
+ * - **pretty** (default): colored/dimmed stderr lines, for CLI/TUI and local
+ *   `bun run dev`. Unchanged from the original logger so the dev loop reads the
+ *   same. stdout stays clean for JSON-RPC / pipe output.
+ * - **json**: one structured JSON object per line, opted into with
+ *   `NB_LOG_FORMAT=json` (the chart sets it for deployed pods). Each line is
+ *   auto-enriched with `service`, `tenant_id`, `correlation_id` (the active
+ *   trace id), and the verified request identity (`user_id` / `workspace_id` /
+ *   `conversation_id`) so logs pivot to traces in Grafana and are queryable by
+ *   tenant in Loki. Identity comes only from the verified request context, never
+ *   the wire, and never includes the human display name. Still on stderr —
+ *   Kubernetes captures it alongside stdout, so Promtail ingests it either way.
+ *
+ * Both formats keep stdout untouched.
  *
  * Debug messages are gated behind the `NB_DEBUG` environment variable. Set it
  * to a comma-separated list of namespaces to enable, or `*` for all:
@@ -15,7 +26,7 @@
  *   - `mcp` — McpSource construction, dispatch decisions (task-augmented vs inline)
  *   - `sse` — Runtime event sink → SSE broadcast (tool.progress, data.changed)
  *
- * Keep this list in sync with the CLAUDE.md "Debugging" section so it's
+ * Keep this list in sync with the CLAUDE.md "Debug Logging" section so it's
  * discoverable without reading source.
  *
  * `log.bundle(sourceName, line)` is intentionally NOT gated. Bundle stderr
@@ -25,10 +36,25 @@
  * a chatty bundle. Visual prefix + dim formatting makes it tunable by eye.
  */
 
+import { requestIdentityAttrs } from "../observability/identity.ts";
+import { currentTraceId } from "../observability/tracing.ts";
+
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+
+/** Structured fields attached to a log line. Never put secrets or payloads here. */
+export type LogFields = Record<string, unknown>;
+
+type Level = "debug" | "info" | "warn" | "error";
+
+// Read at call time (not module load) so the format is controllable in tests
+// and a late `NB_LOG_FORMAT` still takes effect. The comparison is trivial.
+const isJson = (): boolean => process.env.NB_LOG_FORMAT === "json";
+const SERVICE = process.env.NB_SERVICE_NAME ?? "nimblebrain-runtime";
+// Boot-time tenant of this deployment (chart -> NB_TENANT_ID). Unset in dev.
+const TENANT_ID = process.env.NB_TENANT_ID;
 
 const enabledNamespaces: Set<string> = (() => {
   const raw = process.env.NB_DEBUG ?? "";
@@ -44,10 +70,45 @@ function isDebugEnabled(ns: string): boolean {
   return allNamespacesEnabled || enabledNamespaces.has(ns);
 }
 
+/**
+ * Emit one structured JSON line. Identity + correlation are pulled from the
+ * active request context / span here, so callers never thread them manually.
+ */
+function emitJson(level: Level, message: string, fields?: LogFields, ns?: string): void {
+  const record: LogFields = {
+    timestamp: new Date().toISOString(),
+    level,
+    service: SERVICE,
+    ...(TENANT_ID ? { tenant_id: TENANT_ID } : {}),
+    ...(ns ? { ns } : {}),
+    message,
+    ...requestIdentityAttrs(),
+  };
+  const correlationId = currentTraceId();
+  if (correlationId) record.correlation_id = correlationId;
+  if (fields) Object.assign(record, fields);
+  process.stderr.write(`${JSON.stringify(record)}\n`);
+}
+
+/** Pretty-mode trailer: render extra fields compactly so dev still sees them. */
+function prettyFields(fields?: LogFields): string {
+  if (!fields || Object.keys(fields).length === 0) return "";
+  return ` ${dim(JSON.stringify(fields))}`;
+}
+
 export const log = {
-  info: (msg: string) => console.error(dim(msg)),
-  warn: (msg: string) => console.error(yellow(msg)),
-  error: (msg: string) => console.error(red(msg)),
+  info: (msg: string, fields?: LogFields) => {
+    if (isJson()) emitJson("info", msg, fields);
+    else console.error(dim(msg) + prettyFields(fields));
+  },
+  warn: (msg: string, fields?: LogFields) => {
+    if (isJson()) emitJson("warn", msg, fields);
+    else console.error(yellow(msg) + prettyFields(fields));
+  },
+  error: (msg: string, fields?: LogFields) => {
+    if (isJson()) emitJson("error", msg, fields);
+    else console.error(red(msg) + prettyFields(fields));
+  },
   /**
    * Emit a gated debug line. Use for tracing that is useful during
    * development / incident response but too noisy for normal operation.
@@ -56,17 +117,21 @@ export const log = {
    * `NB_DEBUG` (or `NB_DEBUG=*`). Cheap when disabled — the enabled check is
    * a `Set.has` on a cached Set.
    */
-  debug: (ns: string, msg: string) => {
+  debug: (ns: string, msg: string, fields?: LogFields) => {
     if (!isDebugEnabled(ns)) return;
-    console.error(`${cyan(`[${ns}]`)} ${msg}`);
+    if (isJson()) emitJson("debug", msg, fields, ns);
+    else console.error(`${cyan(`[${ns}]`)} ${msg}${prettyFields(fields)}`);
   },
   /** Check whether a namespace is enabled, e.g. to skip expensive log args. */
   debugEnabled: isDebugEnabled,
   /**
    * Emit a single line of bundle subprocess stderr output. Default-on,
    * dimmed, prefixed `[bundle:<name>]` so it's visually distinct from NB's
-   * own output. See file header for rationale.
+   * own output. In JSON mode it becomes a structured `bundle.stderr` record
+   * carrying the raw line, so it stays queryable per bundle. See file header.
    */
-  bundle: (sourceName: string, line: string) =>
-    console.error(dim(`[bundle:${sourceName}] ${line}`)),
+  bundle: (sourceName: string, line: string) => {
+    if (isJson()) emitJson("info", "bundle.stderr", { bundle: sourceName, line }, "bundle");
+    else console.error(dim(`[bundle:${sourceName}] ${line}`));
+  },
 };

--- a/src/model/stream.ts
+++ b/src/model/stream.ts
@@ -6,6 +6,7 @@ import type {
   LanguageModelV3Usage,
   SharedV3ProviderMetadata,
 } from "@ai-sdk/provider";
+import { withSpan } from "../observability/index.ts";
 
 export interface StreamResult {
   content: LanguageModelV3Content[];
@@ -13,7 +14,42 @@ export interface StreamResult {
   finishReason: LanguageModelV3FinishReason;
 }
 
+/**
+ * Trace one model call as an `llm.call` span nested under the active
+ * `agent.turn`. Attributes are operational only — model id, provider, token
+ * counts, finish reason. Prompt and completion content are NEVER recorded.
+ */
 export async function callModel(
+  model: LanguageModelV3,
+  options: LanguageModelV3CallOptions,
+  onTextDelta: (text: string) => void,
+  onReasoningDelta?: (text: string) => void,
+  onToolInputStart?: (id: string, toolName: string) => void,
+  onToolInputEnd?: (id: string) => void,
+): Promise<StreamResult> {
+  return withSpan(
+    "llm.call",
+    { "llm.model": model.modelId, "llm.provider": model.provider },
+    async (span) => {
+      const result = await callModelInner(
+        model,
+        options,
+        onTextDelta,
+        onReasoningDelta,
+        onToolInputStart,
+        onToolInputEnd,
+      );
+      span.setAttrs({
+        "llm.tokens.input": result.usage.inputTokens.total ?? 0,
+        "llm.tokens.output": result.usage.outputTokens.total ?? 0,
+        "llm.finish_reason": result.finishReason.unified,
+      });
+      return result;
+    },
+  );
+}
+
+async function callModelInner(
   model: LanguageModelV3,
   options: LanguageModelV3CallOptions,
   onTextDelta: (text: string) => void,

--- a/src/oauth/tenant-key-mint.ts
+++ b/src/oauth/tenant-key-mint.ts
@@ -1,3 +1,4 @@
+import { injectTraceparent } from "../observability/index.ts";
 import { WORKSPACE_ID_RE } from "../workspace/workspace-id-pattern.ts";
 import { ALLOWED_TID_PATTERN, EnvelopeError, signMacEnvelope } from "./envelope.ts";
 
@@ -217,7 +218,10 @@ export async function mintServiceToken(opts: MintServiceTokenOptions): Promise<S
   try {
     res = await doFetch(tokenUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      // Continue the trace into the authorizer (a traced mesh service). The
+      // traceparent is correlation only — the tenant assertion in the body is
+      // the authority. No-op when there's no active span (e.g. boot-time mint).
+      headers: injectTraceparent({ "Content-Type": "application/x-www-form-urlencoded" }),
       body: body.toString(),
     });
   } catch (cause) {
@@ -400,6 +404,9 @@ export function createMintingFetch(opts: MintingFetchOptions): typeof fetch {
       // (content-type, session id) ride through via `init`.
       const headers = new Headers(init?.headers);
       headers.set("Authorization", `Bearer ${token}`);
+      // Propagate the active trace onto the authenticated remote-MCP request so
+      // the span continues on the same hop as the verified service identity.
+      injectTraceparent(headers);
       return base(input, { ...init, headers });
     };
     const res = await send(false);

--- a/src/observability/identity.ts
+++ b/src/observability/identity.ts
@@ -1,0 +1,22 @@
+import { getRequestContext } from "../runtime/request-context.ts";
+import type { SpanAttrs } from "./tracing.ts";
+
+/**
+ * Identity attributes for a span or log line, read from the verified
+ * per-request context (AsyncLocalStorage) — NEVER from the wire. Opaque ids
+ * only: the user's id, workspace id, and conversation id. The human display
+ * name is deliberately excluded (spans/logs are operational telemetry, not a
+ * user directory). Tenant id is a process/Resource constant set in
+ * `initTracing`, so it is not repeated here.
+ *
+ * Returns an empty object outside a request scope (CLI boot, background work).
+ */
+export function requestIdentityAttrs(): SpanAttrs {
+  const ctx = getRequestContext();
+  if (!ctx) return {};
+  const attrs: SpanAttrs = {};
+  if (ctx.identity?.id) attrs.user_id = ctx.identity.id;
+  if (ctx.scope.kind === "workspace") attrs.workspace_id = ctx.scope.workspaceId;
+  if (ctx.conversationId) attrs.conversation_id = ctx.conversationId;
+  return attrs;
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Kernel observability seam — vendor-neutral OpenTelemetry tracing + the
+ * identity enrichment that rides on spans and structured logs.
+ *
+ * The runtime depends only on `@opentelemetry/*` and the W3C tracecontext /
+ * OTLP wire formats; it does not take a dependency on any vendor or
+ * platform-specific observability library. See `tracing.ts` for the rationale.
+ */
+export { requestIdentityAttrs } from "./identity.ts";
+export {
+  currentTraceId,
+  initTracing,
+  injectTraceparent,
+  type SpanAttrs,
+  type SpanHandle,
+  withInboundSpan,
+  withSpan,
+} from "./tracing.ts";

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -13,6 +13,8 @@ export {
   injectTraceparent,
   type SpanAttrs,
   type SpanHandle,
+  shutdownTracing,
+  type WithSpanOptions,
   withInboundSpan,
   withSpan,
 } from "./tracing.ts";

--- a/src/observability/tracing.ts
+++ b/src/observability/tracing.ts
@@ -1,0 +1,164 @@
+/**
+ * Vendor-neutral OpenTelemetry tracing for the runtime kernel.
+ *
+ * The kernel depends only on the open OTel + W3C tracecontext primitives — never
+ * on a vendor or platform-specific observability library. The wire is the
+ * interface: spans export over OTLP to whatever collector the operator points
+ * `OTEL_EXPORTER_OTLP_ENDPOINT` at, and a trace continues across process hops via
+ * the standard W3C `traceparent` header. With the endpoint unset — the default,
+ * including local `bun run dev` and every OSS checkout — nothing is exported.
+ * Trace ids still exist in-process so logs carry a correlation id, but NO infra
+ * is required to run the runtime.
+ *
+ * OTel JS ships **stable** packages (`api`, `sdk-trace-*`, `resources`) and
+ * **experimental** ones (the OTLP exporter, 0.x). They must come from the same
+ * release train or serialization fails at export (`instrumentationLibrary` vs
+ * `instrumentationScope`). Keep `package.json` pinned to a coherent set; the
+ * version-coherence test guards it.
+ */
+import {
+  type Attributes,
+  context,
+  propagation,
+  type Span,
+  SpanStatusCode,
+  trace,
+} from "@opentelemetry/api";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+
+const SERVICE_NAME = process.env.NB_SERVICE_NAME ?? "nimblebrain-runtime";
+const TRACER_NAME = "nimblebrain-runtime";
+const INVALID_TRACE_ID = "00000000000000000000000000000000";
+
+let configured = false;
+
+/**
+ * Install tracing for this process. Idempotent — safe to call from every entry
+ * point (serve, dev, automations, tests). Reads two operator knobs:
+ *   - `OTEL_EXPORTER_OTLP_ENDPOINT` — collector base URL; unset = no export.
+ *   - `NB_TENANT_ID` — this deployment's tenant; stamped on the Resource so
+ *     every span carries it and it cannot be spoofed by a request.
+ */
+export function initTracing(): void {
+  if (configured) return;
+  configured = true;
+
+  const attrs: Attributes = { [ATTR_SERVICE_NAME]: SERVICE_NAME };
+  // The runtime process belongs to exactly one tenant; the tenant id is a
+  // boot-time constant from the deployment (chart -> NB_TENANT_ID), never a
+  // request header. On the Resource it rides every span and is structurally
+  // unspoofable. Unset in local/dev — omit rather than fake.
+  const tenantId = process.env.NB_TENANT_ID;
+  if (tenantId) attrs.tenant_id = tenantId;
+
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes(attrs),
+    spanProcessors: process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+      ? [new BatchSpanProcessor(new OTLPTraceExporter())]
+      : [],
+  });
+  // register() installs the W3C tracecontext propagator + an AsyncLocalStorage
+  // context manager, so active-span nesting works under Bun.
+  provider.register();
+}
+
+const tracer = () => trace.getTracer(TRACER_NAME);
+
+/** Span attributes — low-cardinality string/number/boolean only. NEVER secrets,
+ *  prompts, tool arguments/results, or file contents. */
+export type SpanAttrs = Attributes;
+
+/** A minimal handle so call sites can add late attributes (token counts, etc.)
+ *  or refine the span name without importing the OTel API directly. */
+export interface SpanHandle {
+  setAttrs(attrs: SpanAttrs): void;
+  /** Rename the span once a low-cardinality label is known (e.g. an HTTP route
+   *  resolved only after routing). Pass a TEMPLATE, never a raw path with ids. */
+  setName(name: string): void;
+}
+
+class SpanHandleImpl implements SpanHandle {
+  constructor(private readonly span: Span) {}
+  setAttrs(attrs: SpanAttrs): void {
+    this.span.setAttributes(attrs);
+  }
+  setName(name: string): void {
+    this.span.updateName(name);
+  }
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Run `fn` inside a new active span. The span is the active context for the
+ * duration, so any span started inside `fn` nests under it automatically.
+ * Records the exception + ERROR status on throw, and always ends the span.
+ * Cheap when no exporter is configured (the SDK still threads context).
+ */
+export async function withSpan<T>(
+  name: string,
+  attrs: SpanAttrs,
+  fn: (span: SpanHandle) => Promise<T>,
+): Promise<T> {
+  return tracer().startActiveSpan(name, async (span: Span) => {
+    span.setAttributes(attrs);
+    try {
+      return await fn(new SpanHandleImpl(span));
+    } catch (err) {
+      span.recordException(err as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: errMessage(err) });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Run `fn` as an active span continued from an inbound `traceparent` (e.g. the
+ * mcp-edge -> runtime hop). With no inbound context present it opens a fresh
+ * root span. Used by the HTTP middleware.
+ */
+export async function withInboundSpan<T>(
+  name: string,
+  inboundHeaders: Headers,
+  attrs: SpanAttrs,
+  fn: (span: SpanHandle) => Promise<T>,
+): Promise<T> {
+  const carrier: Record<string, string> = {};
+  inboundHeaders.forEach((v, k) => {
+    carrier[k] = v;
+  });
+  const parent = propagation.extract(context.active(), carrier);
+  return context.with(parent, () => withSpan(name, attrs, fn));
+}
+
+/** The active trace id (32-hex), or undefined outside any span. For log
+ *  correlation — emit it as `correlation_id` so logs pivot to traces. */
+export function currentTraceId(): string | undefined {
+  const ctx = trace.getActiveSpan()?.spanContext();
+  if (!ctx || ctx.traceId === INVALID_TRACE_ID) return undefined;
+  return ctx.traceId;
+}
+
+/**
+ * Inject the active W3C `traceparent` into an outbound header carrier so the
+ * trace continues into the next hop (remote MCP server, service-token mint).
+ * Identity rides its own verified headers separately — traceparent is
+ * correlation, never authority. Mutates and returns the carrier.
+ */
+export function injectTraceparent<T extends Headers | Record<string, string>>(headers: T): T {
+  const carrier: Record<string, string> = {};
+  propagation.inject(context.active(), carrier);
+  for (const [k, v] of Object.entries(carrier)) {
+    if (headers instanceof Headers) headers.set(k, v);
+    else (headers as Record<string, string>)[k] = v;
+  }
+  return headers;
+}

--- a/src/observability/tracing.ts
+++ b/src/observability/tracing.ts
@@ -35,6 +35,7 @@ const TRACER_NAME = "nimblebrain-runtime";
 const INVALID_TRACE_ID = "00000000000000000000000000000000";
 
 let configured = false;
+let provider: NodeTracerProvider | undefined;
 
 /**
  * Install tracing for this process. Idempotent — safe to call from every entry
@@ -55,7 +56,7 @@ export function initTracing(): void {
   const tenantId = process.env.NB_TENANT_ID;
   if (tenantId) attrs.tenant_id = tenantId;
 
-  const provider = new NodeTracerProvider({
+  provider = new NodeTracerProvider({
     resource: resourceFromAttributes(attrs),
     spanProcessors: process.env.OTEL_EXPORTER_OTLP_ENDPOINT
       ? [new BatchSpanProcessor(new OTLPTraceExporter())]
@@ -64,6 +65,34 @@ export function initTracing(): void {
   // register() installs the W3C tracecontext propagator + an AsyncLocalStorage
   // context manager, so active-span nesting works under Bun.
   provider.register();
+}
+
+/**
+ * Flush and shut down the tracer provider. Call on SIGTERM/SIGINT so the
+ * BatchSpanProcessor exports its final buffered window instead of dropping it
+ * on pod termination (the default schedule is ~5s). No-op before init / with no
+ * exporter. Idempotent.
+ *
+ * Best-effort and bounded: an unreachable collector makes `provider.shutdown()`
+ * retry with backoff for ~8.5s and then reject — neither of which may stall or
+ * fail graceful shutdown. So the flush races a short deadline and all errors are
+ * swallowed (export failures already surface via OTel diag). A dropped final
+ * window is acceptable; a hung or crashing shutdown is not.
+ */
+export async function shutdownTracing(timeoutMs = 2000): Promise<void> {
+  const p = provider;
+  provider = undefined;
+  if (!p) return;
+  try {
+    await Promise.race([
+      p.shutdown(),
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, timeoutMs).unref?.();
+      }),
+    ]);
+  } catch {
+    // Best-effort: never let a flush failure block or break shutdown.
+  }
 }
 
 const tracer = () => trace.getTracer(TRACER_NAME);
@@ -95,16 +124,28 @@ function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+export interface WithSpanOptions {
+  /**
+   * Errors matching this predicate are recorded on the span but do NOT mark it
+   * failed — e.g. user cancellation, which is expected, not a crash. The span
+   * is annotated `cancelled=true` and its status left UNSET so a normal abort
+   * doesn't show up as ERROR telemetry.
+   */
+  isExpectedError?: (err: unknown) => boolean;
+}
+
 /**
  * Run `fn` inside a new active span. The span is the active context for the
  * duration, so any span started inside `fn` nests under it automatically.
- * Records the exception + ERROR status on throw, and always ends the span.
- * Cheap when no exporter is configured (the SDK still threads context).
+ * Records the exception on throw — ERROR status unless the error is classified
+ * expected via `opts.isExpectedError` — and always ends the span. Cheap when no
+ * exporter is configured (the SDK still threads context).
  */
 export async function withSpan<T>(
   name: string,
   attrs: SpanAttrs,
   fn: (span: SpanHandle) => Promise<T>,
+  opts?: WithSpanOptions,
 ): Promise<T> {
   return tracer().startActiveSpan(name, async (span: Span) => {
     span.setAttributes(attrs);
@@ -112,7 +153,11 @@ export async function withSpan<T>(
       return await fn(new SpanHandleImpl(span));
     } catch (err) {
       span.recordException(err as Error);
-      span.setStatus({ code: SpanStatusCode.ERROR, message: errMessage(err) });
+      if (opts?.isExpectedError?.(err)) {
+        span.setAttribute("cancelled", true);
+      } else {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: errMessage(err) });
+      }
       throw err;
     } finally {
       span.end();

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -65,6 +65,7 @@ import { InstructionsStore } from "../instructions/index.ts";
 import { getModelByString, getProviderFromModel } from "../model/catalog.ts";
 import { buildModelResolver, resolveModelString } from "../model/registry.ts";
 import { installOAuthFetchDebug } from "../oauth/oauth-fetch-debug.ts";
+import { requestIdentityAttrs, withSpan } from "../observability/index.ts";
 import {
   createToolListAggregator,
   type ToolListAggregator,
@@ -1768,8 +1769,13 @@ export class Runtime {
       }
     }
 
+    // Root span for the agent turn — the common chokepoint for both the HTTP
+    // and CLI entry points. Opened inside runWithRequestContext so the verified
+    // identity is in scope; the llm.call and tool.dispatch spans nest under it.
     const result = await runWithRequestContext(reqCtx, () =>
-      engine.run(engineConfig, systemPrompt, messages, tools),
+      withSpan("agent.turn", { "llm.model": model, ...requestIdentityAttrs() }, () =>
+        engine.run(engineConfig, systemPrompt, messages, tools),
+      ),
     );
 
     const usage: TurnUsage = {

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -1099,6 +1099,8 @@ export class McpSource implements ToolSource {
           isTaskAugmented
             ? this.callToolAsTask(toolName, dispatchArgs, signal)
             : this.callToolInline(toolName, dispatchArgs, signal),
+        // A client cancellation isn't a crash — don't mark the span failed.
+        { isExpectedError: () => signal?.aborted === true },
       );
     } catch (err) {
       // Cancellation isn't a crash — the source is healthy, the client just

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -22,6 +22,7 @@ import {
   type HostResourcesResolver,
   hostExtensions,
 } from "../host-resources/index.ts";
+import { requestIdentityAttrs, withSpan } from "../observability/index.ts";
 import { coerceInputForSchema } from "./coerce-input.ts";
 import { promoteHiddenErrors } from "./promote-hidden-errors.ts";
 import { createRemoteTransport } from "./remote-transport.ts";
@@ -1086,9 +1087,19 @@ export class McpSource implements ToolSource {
     );
 
     try {
-      return isTaskAugmented
-        ? await this.callToolAsTask(toolName, dispatchArgs, signal)
-        : await this.callToolInline(toolName, dispatchArgs, signal);
+      return await withSpan(
+        "tool.dispatch",
+        {
+          "tool.name": toolName,
+          "tool.source": this.name,
+          "tool.path": isTaskAugmented ? "task-augmented" : "inline",
+          ...requestIdentityAttrs(),
+        },
+        () =>
+          isTaskAugmented
+            ? this.callToolAsTask(toolName, dispatchArgs, signal)
+            : this.callToolInline(toolName, dispatchArgs, signal),
+      );
     } catch (err) {
       // Cancellation isn't a crash — the source is healthy, the client just
       // asked to stop. Emit a terminal tool.progress for task-augmented

--- a/test/unit/observability.test.ts
+++ b/test/unit/observability.test.ts
@@ -1,3 +1,4 @@
+import { SpanStatusCode } from "@opentelemetry/api";
 import { beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -62,14 +63,30 @@ describe("withSpan", () => {
     expect(spanNamed("agent.turn").attributes["llm.model"]).toBe("anthropic:x");
   });
 
-  it("records the exception and re-throws on error", async () => {
+  it("records the exception and marks ERROR on an unexpected error", async () => {
     await expect(
       withSpan("tool.dispatch", {}, async () => {
         throw new Error("boom");
       }),
     ).rejects.toThrow("boom");
-    // Span still ended (exported) even though the body threw.
-    expect(spanNamed("tool.dispatch")).toBeDefined();
+    // Span still ended (exported) and is marked failed.
+    expect(spanNamed("tool.dispatch").status.code).toBe(SpanStatusCode.ERROR);
+  });
+
+  it("does not mark the span failed for an expected (cancelled) error", async () => {
+    await expect(
+      withSpan(
+        "tool.dispatch",
+        {},
+        async () => {
+          throw new Error("aborted");
+        },
+        { isExpectedError: () => true },
+      ),
+    ).rejects.toThrow("aborted");
+    const span = spanNamed("tool.dispatch");
+    expect(span.status.code).toBe(SpanStatusCode.UNSET);
+    expect(span.attributes.cancelled).toBe(true);
   });
 
   it("nests child spans under the active span (same trace, parent linked)", async () => {

--- a/test/unit/observability.test.ts
+++ b/test/unit/observability.test.ts
@@ -1,0 +1,180 @@
+import { beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { log } from "../../src/cli/log.ts";
+import type { UserIdentity } from "../../src/identity/provider.ts";
+import {
+  currentTraceId,
+  injectTraceparent,
+  requestIdentityAttrs,
+  withSpan,
+} from "../../src/observability/index.ts";
+import { type RequestContext, runWithRequestContext } from "../../src/runtime/request-context.ts";
+
+const exporter = new InMemorySpanExporter();
+
+beforeAll(() => {
+  // Register a provider with an in-memory exporter so withSpan() produces real,
+  // inspectable spans. No OTLP endpoint — matches the no-export default path.
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  provider.register();
+});
+
+beforeEach(() => {
+  exporter.reset();
+});
+
+const PII_EMAIL = "secret@example.com";
+const PII_NAME = "Jane Secret";
+
+function identityCtx(): RequestContext {
+  const identity: UserIdentity = {
+    id: "user_123",
+    email: PII_EMAIL,
+    displayName: PII_NAME,
+    orgRole: "member",
+    preferences: {},
+  };
+  return {
+    identity,
+    scope: {
+      kind: "workspace",
+      workspaceId: "ws_abc123",
+      workspaceAgents: null,
+      workspaceModelOverride: null,
+    },
+    conversationId: "conv_9",
+  };
+}
+
+function spanNamed(name: string) {
+  const span = exporter.getFinishedSpans().find((s) => s.name === name);
+  if (!span) throw new Error(`span ${name} not found`);
+  return span;
+}
+
+describe("withSpan", () => {
+  it("returns the wrapped function's result and ends the span", async () => {
+    const result = await withSpan("agent.turn", { "llm.model": "anthropic:x" }, async () => 42);
+    expect(result).toBe(42);
+    expect(spanNamed("agent.turn").attributes["llm.model"]).toBe("anthropic:x");
+  });
+
+  it("records the exception and re-throws on error", async () => {
+    await expect(
+      withSpan("tool.dispatch", {}, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    // Span still ended (exported) even though the body threw.
+    expect(spanNamed("tool.dispatch")).toBeDefined();
+  });
+
+  it("nests child spans under the active span (same trace, parent linked)", async () => {
+    await withSpan("agent.turn", {}, async () => {
+      await withSpan("llm.call", {}, async () => {});
+    });
+    const turn = spanNamed("agent.turn");
+    const child = spanNamed("llm.call");
+    expect(child.spanContext().traceId).toBe(turn.spanContext().traceId);
+    expect(child.parentSpanContext?.spanId).toBe(turn.spanContext().spanId);
+  });
+});
+
+describe("currentTraceId / injectTraceparent", () => {
+  it("has no trace id and injects no traceparent outside a span", () => {
+    expect(currentTraceId()).toBeUndefined();
+    expect(injectTraceparent({} as Record<string, string>).traceparent).toBeUndefined();
+  });
+
+  it("exposes a 32-hex trace id and injects traceparent inside a span", async () => {
+    await withSpan("agent.turn", {}, async () => {
+      const id = currentTraceId();
+      expect(id).toMatch(/^[0-9a-f]{32}$/);
+      const headers = injectTraceparent({} as Record<string, string>);
+      expect(headers.traceparent).toContain(id ?? "");
+    });
+  });
+});
+
+describe("requestIdentityAttrs — trust + PII boundary", () => {
+  it("returns nothing outside a request context", () => {
+    expect(requestIdentityAttrs()).toEqual({});
+  });
+
+  it("stamps only opaque ids — never email or display name", () => {
+    runWithRequestContext(identityCtx(), () => {
+      const attrs = requestIdentityAttrs();
+      expect(attrs.user_id).toBe("user_123");
+      expect(attrs.workspace_id).toBe("ws_abc123");
+      expect(attrs.conversation_id).toBe("conv_9");
+      const serialized = JSON.stringify(attrs);
+      expect(serialized).not.toContain(PII_EMAIL);
+      expect(serialized).not.toContain(PII_NAME);
+    });
+  });
+
+  it("keeps PII off the span attributes", async () => {
+    await runWithRequestContext(identityCtx(), () =>
+      withSpan("agent.turn", requestIdentityAttrs(), async () => {}),
+    );
+    const serialized = JSON.stringify(spanNamed("agent.turn").attributes);
+    expect(serialized).toContain("user_123");
+    expect(serialized).not.toContain(PII_EMAIL);
+    expect(serialized).not.toContain(PII_NAME);
+  });
+});
+
+describe("structured logger (JSON mode)", () => {
+  it("emits enriched JSON with identity + correlation, never PII", async () => {
+    process.env.NB_LOG_FORMAT = "json";
+    const lines: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    // @ts-expect-error narrow override for capture
+    process.stderr.write = (chunk: string) => {
+      lines.push(String(chunk));
+      return true;
+    };
+    try {
+      // Inside a span so the line carries a correlation id (the trace id).
+      await runWithRequestContext(identityCtx(), () =>
+        withSpan("agent.turn", {}, async () => {
+          log.info("turn.start", { iteration: 1 });
+        }),
+      );
+    } finally {
+      process.stderr.write = orig;
+      process.env.NB_LOG_FORMAT = undefined;
+    }
+    const rec = JSON.parse(lines.join("").trim());
+    expect(rec.level).toBe("info");
+    expect(rec.service).toBe("nimblebrain-runtime");
+    expect(rec.message).toBe("turn.start");
+    expect(rec.user_id).toBe("user_123");
+    expect(rec.workspace_id).toBe("ws_abc123");
+    expect(rec.iteration).toBe(1);
+    expect(rec.correlation_id).toMatch(/^[0-9a-f]{32}$/);
+    // PII never appears anywhere in the serialized line.
+    expect(rec.displayName).toBeUndefined();
+    const joined = lines.join("");
+    expect(joined).not.toContain(PII_EMAIL);
+    expect(joined).not.toContain(PII_NAME);
+  });
+});
+
+describe("OTel dependency coherence", () => {
+  it("pins the stable + experimental packages to one release train", async () => {
+    const pkg = await Bun.file(`${import.meta.dir}/../../package.json`).json();
+    const d = pkg.dependencies as Record<string, string>;
+    expect(d["@opentelemetry/api"]).toBe("1.9.1");
+    expect(d["@opentelemetry/exporter-trace-otlp-http"]).toBe("0.219.0");
+    // The stable SDK packages must share one version; the exporter is the
+    // matching 0.2xx experimental line. Bump them together or export
+    // serialization fails (instrumentationLibrary vs instrumentationScope).
+    expect(d["@opentelemetry/sdk-trace-base"]).toBe("2.8.0");
+    expect(d["@opentelemetry/sdk-trace-node"]).toBe(d["@opentelemetry/sdk-trace-base"]);
+    expect(d["@opentelemetry/resources"]).toBe(d["@opentelemetry/sdk-trace-base"]);
+  });
+});


### PR DESCRIPTION
## What

Instruments the agent runtime with **vendor-neutral OpenTelemetry tracing** and **structured JSON logging** — the tracing pillar of the platform observability contract (logs/metrics are tracked separately). The runtime is the live chokepoint today (MCP bundles run in-process), so this is the shortest path to real tenant traces in Grafana.

## Architecture (the load-bearing decision)

The kernel depends **only** on `@opentelemetry/*` and the W3C tracecontext + OTLP wire formats — **not** on any branded/platform observability library. The wire is the interface, so the OSS runtime and the private platform services each implement it independently. This keeps the kernel's dependency set boring and standard, avoids a stability-gradient inversion (private infra upstream of the OSS kernel), and means a third party running the runtime just points `OTEL_EXPORTER_OTLP_ENDPOINT` at their own backend.

## Tracing

- New `src/observability/` seam: `initTracing`, `withSpan`, `withInboundSpan`, `injectTraceparent`, `currentTraceId`, `requestIdentityAttrs`.
- Three nested spans per request, at the common chokepoints (so both the HTTP and CLI entry points are covered):
  - `agent.turn` — the engine run
  - `llm.call` — the model stream (model, provider, token counts, finish reason)
  - `tool.dispatch` — in-process MCP dispatch (tool, source, inline vs task-augmented)
- Outer HTTP span via Hono middleware, **continued from an inbound `traceparent`** (the mcp-edge → runtime hop) so the trace is one across services.
- `traceparent` propagation on the service-token mint and the authenticated remote-MCP fetch, extending the trace into the authorizer mesh.

## Identity & trust

- `tenant_id` is a **boot-time Resource attribute** from `NB_TENANT_ID` (unspoofable), never a request header.
- `user_id` / `workspace_id` / `conversation_id` come from the **verified** request context. The human **display name and email are never** stamped on spans or logs.
- No secrets, prompts, tool args/results, or file contents on spans.

## Structured logs

- `src/cli/log.ts` gains a JSON format (`NB_LOG_FORMAT=json`, set by the chart for deployed pods) auto-enriched with `service`, `tenant_id`, `correlation_id` (the active trace id), and identity — logs pivot to traces and are queryable per tenant in Loki. Pretty dev output is unchanged; stdout stays clean.

## Safe by default

With `OTEL_EXPORTER_OTLP_ENDPOINT` unset, nothing exports — trace ids still exist in-process for log correlation — so OSS checkouts and local `bun run dev` are untouched. No observability infra required to run the runtime.

## Verification

- `bun run verify:static` (format, lint, tsc, cycles, path guards, code-style, codegen) ✅
- `bun run test:unit` — 3555 pass (incl. 10 new observability tests) ✅
- `bun run test:integration` — 590 pass / 0 fail (exercises the HTTP middleware + `agent.turn` wrap against real servers) ✅
- Live boot check under Bun: OTLP exporter + `BatchSpanProcessor` construct without throwing; nested `agent.turn` → `llm.call` share one `correlation_id` across both spans and the JSON log lines.

## Out of scope (follow-ups)

- Chart wiring of `OTEL_EXPORTER_OTLP_ENDPOINT` + `NB_LOG_FORMAT=json` into runtime pods (a `deployments/` change). The runtime ships dormant-by-default until then.
- More adopters and downstream-service tracing as the mesh matures.