### PR TITLE
test: standing grep-gate keeps the runtime kernel domain-clean

### DIFF
--- a/test/unit/runtime-domain-clean.test.ts
+++ b/test/unit/runtime-domain-clean.test.ts
@@ -7,11 +7,17 @@ import { spawnSync } from "bun";
  * Standing guard: the runtime kernel stays generic.
  *
  * Capability lives in MCP servers, not in `src/`. A handful of generic
- * mentions of "deep research" (an English phrase, third-party model
- * catalog names) and "artifact" (the English word, plus service names)
- * legitimately occur in the kernel and form a fixed baseline. Anything
- * above that baseline means a domain capability has leaked back into the
- * runtime — this test fails loudly so it cannot ride in unnoticed.
+ * mentions of "deep research" (third-party model catalog names) legitimately
+ * occur in the kernel and form a fixed baseline. Anything above that baseline
+ * means a domain capability has leaked back into the runtime — this test fails
+ * loudly so it cannot ride in unnoticed.
+ *
+ * The dropped output-store seam (the artifact-producing capability that was
+ * removed) is guarded precisely by the file-existence test below, so this
+ * word-gate deliberately does NOT match "artifact": the kernel uses that word
+ * pervasively for unrelated infra (a live `artifacts` data-plane service, plus
+ * build/cache/tmp/oauth artifacts), and gating on it by count would fail on
+ * benign growth while blaming a "domain capability leak."
  *
  * The ceiling is the exact count of those benign mentions today. It is a
  * ratchet: if you legitimately remove a benign hit, lower the ceiling in
@@ -20,10 +26,10 @@ import { spawnSync } from "bun";
  */
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 
-// Benign baseline in `src/`: an English phrase, a third-party model
-// catalog, the English word "artifact", and platform service names.
-// Net-new domain code would push the count above this.
-const DOMAIN_HIT_CEILING = 20;
+// Benign baseline in `src/`: third-party model catalog names
+// (`o3-deep-research`, `o4-mini-deep-research`). Net-new domain code would
+// push the count above this.
+const DOMAIN_HIT_CEILING = 8;
 
 function grepDomainHits(): string[] {
   // `--untracked` so a not-yet-committed file (the most likely way a
@@ -34,7 +40,7 @@ function grepDomainHits(): string[] {
       "grep",
       "--untracked",
       "-niE",
-      "deep.?research|artifact",
+      "deep.?research",
       "--",
       "src/*",
     ],
@@ -54,12 +60,12 @@ function grepDomainHits(): string[] {
 }
 
 describe("runtime stays domain-clean", () => {
-  test("no net-new 'deep research' / 'artifact' hits in src/", () => {
+  test("no net-new 'deep research' hits in src/", () => {
     const hits = grepDomainHits();
     if (hits.length > DOMAIN_HIT_CEILING) {
       const offenders = hits.join("\n");
       throw new Error(
-        `Found ${hits.length} 'deep research' / 'artifact' hits in src/, ` +
+        `Found ${hits.length} 'deep research' hits in src/, ` +
           `ceiling is ${DOMAIN_HIT_CEILING}. A domain capability has likely ` +
           `leaked into the runtime kernel — it belongs in an MCP server. ` +
           `Hits:\n${offenders}`,

--- a/test/unit/runtime-domain-clean.test.ts
+++ b/test/unit/runtime-domain-clean.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "bun";
+
+/**
+ * Standing guard: the runtime kernel stays generic.
+ *
+ * Capability lives in MCP servers, not in `src/`. A handful of generic
+ * mentions of "deep research" (an English phrase, third-party model
+ * catalog names) and "artifact" (the English word, plus service names)
+ * legitimately occur in the kernel and form a fixed baseline. Anything
+ * above that baseline means a domain capability has leaked back into the
+ * runtime — this test fails loudly so it cannot ride in unnoticed.
+ *
+ * The ceiling is the exact count of those benign mentions today. It is a
+ * ratchet: if you legitimately remove a benign hit, lower the ceiling in
+ * the same change. If you find yourself wanting to raise it, that is the
+ * signal that a capability is being put in the wrong place.
+ */
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+// Benign baseline in `src/`: an English phrase, a third-party model
+// catalog, the English word "artifact", and platform service names.
+// Net-new domain code would push the count above this.
+const DOMAIN_HIT_CEILING = 20;
+
+function grepDomainHits(): string[] {
+  // `--untracked` so a not-yet-committed file (the most likely way a
+  // capability lands back in the kernel) is also caught.
+  const result = spawnSync(
+    [
+      "git",
+      "grep",
+      "--untracked",
+      "-niE",
+      "deep.?research|artifact",
+      "--",
+      "src/*",
+    ],
+    { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" },
+  );
+  // `git grep` exits 1 when there are no matches; treat that as empty,
+  // anything else (e.g. exit 128 — not a work tree) as a real failure.
+  if (result.exitCode !== 0 && result.exitCode !== 1) {
+    throw new Error(
+      `git grep failed (exit ${result.exitCode}): ${result.stderr.toString()}`,
+    );
+  }
+  return result.stdout
+    .toString()
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+}
+
+describe("runtime stays domain-clean", () => {
+  test("no net-new 'deep research' / 'artifact' hits in src/", () => {
+    const hits = grepDomainHits();
+    if (hits.length > DOMAIN_HIT_CEILING) {
+      const offenders = hits.join("\n");
+      throw new Error(
+        `Found ${hits.length} 'deep research' / 'artifact' hits in src/, ` +
+          `ceiling is ${DOMAIN_HIT_CEILING}. A domain capability has likely ` +
+          `leaked into the runtime kernel — it belongs in an MCP server. ` +
+          `Hits:\n${offenders}`,
+      );
+    }
+    expect(hits.length).toBeLessThanOrEqual(DOMAIN_HIT_CEILING);
+  });
+
+  test("output-store and get-output never reappear in the kernel", () => {
+    expect(existsSync(join(REPO_ROOT, "src", "files", "output-store.ts"))).toBe(
+      false,
+    );
+    expect(existsSync(join(REPO_ROOT, "src", "tools", "get-output.ts"))).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a standing unit test (`test/unit/runtime-domain-clean.test.ts`) that guards the runtime kernel against domain capability creeping back into `src/`.

The test:
- Runs `git grep --untracked -niE 'deep.?research' -- 'src/*'` and asserts the hit count stays at or below the current benign baseline (**8**: third-party model catalog names — `o3-deep-research`, `o4-mini-deep-research`). Any net-new domain hit pushes it over the ceiling and the test fails loudly, listing the offending lines. `--untracked` ensures a not-yet-committed file is caught too.
- Asserts `src/files/output-store.ts` and `src/tools/get-output.ts` do **not** exist, so the dropped output-store seam cannot reappear.

The word-gate deliberately does **not** match `artifact`: the kernel uses that word pervasively for unrelated infra (a live `artifacts` data-plane service, plus build/cache/tmp/oauth artifacts), so gating on it by count would fail on benign growth while blaming a "domain capability leak." The removed output-store seam — the actual artifact-producing capability — is guarded precisely by the file-existence test instead.

## Why

Capability comes from MCP servers; the kernel stays generic. This is a ratchet test — if you legitimately remove a benign hit, lower the ceiling in the same change. Wanting to raise it is the signal that a capability is being put in the wrong place.

## Verification

- `bun test test/unit/runtime-domain-clean.test.ts` — 2 pass.
- Verified the guard fails (9 > 8, offender listed) when a domain hit is injected, and passes again once removed.
- No production code changes.
