### PR TITLE
feat(metrics): label tool promotions used=true|false (promoted-but-never-called)

### DIFF
--- a/src/adapters/metrics-events.ts
+++ b/src/adapters/metrics-events.ts
@@ -7,7 +7,7 @@ import type { TokenUsage } from "../usage/types.ts";
  * is dropped on its `run.done`/`run.error`; this only bounds the leak from a
  * run whose terminator never fires (e.g. process death mid-run).
  */
-const MAX_TRACKED_RUNS = 1000;
+export const MAX_TRACKED_RUNS = 1000;
 
 /**
  * Translates engine events into Prometheus counters (see `api/metrics.ts`).
@@ -68,7 +68,16 @@ export class MetricsEventSink implements EventSink {
       this.runs.set(runId, r);
       if (this.runs.size > MAX_TRACKED_RUNS) {
         const oldest = this.runs.keys().next().value;
-        if (oldest !== undefined) this.runs.delete(oldest);
+        if (oldest !== undefined) {
+          this.runs.delete(oldest);
+          // Should be unreachable in practice (run terminators always fire, so
+          // tracked runs drain). Surface it rather than dropping the evicted
+          // run's promotion samples silently — a leak this big means a
+          // regressed terminator, not normal load.
+          console.warn(
+            `[metrics] tracked-run cap (${MAX_TRACKED_RUNS}) exceeded; dropping run ${oldest} — its promotion metrics are lost. A run terminator (run.done/run.error) likely failed to fire.`,
+          );
+        }
       }
     }
     return r;

--- a/src/adapters/metrics-events.ts
+++ b/src/adapters/metrics-events.ts
@@ -3,6 +3,13 @@ import type { EngineEvent, EventSink } from "../engine/types.ts";
 import type { TokenUsage } from "../usage/types.ts";
 
 /**
+ * Defensive cap on in-flight runs tracked for promoted-but-never-called. A run
+ * is dropped on its `run.done`/`run.error`; this only bounds the leak from a
+ * run whose terminator never fires (e.g. process death mid-run).
+ */
+const MAX_TRACKED_RUNS = 1000;
+
+/**
  * Translates engine events into Prometheus counters (see `api/metrics.ts`).
  *
  * Observe-only and process-local: it only increments in-memory counters, so it
@@ -14,8 +21,14 @@ import type { TokenUsage } from "../usage/types.ts";
  * summarizer, auto-title, briefing) run outside the engine and emit no
  * `llm.done`, so their usage is recorded at their own call sites via
  * `recordLlmUsage(source, ...)`.
+ *
+ * Promotions are counted at run end, not at promote time, so each is labeled by
+ * whether the model actually called the promoted tool — the wasted-promotion
+ * signal. State is keyed by `runId` and dropped on the run terminator.
  */
 export class MetricsEventSink implements EventSink {
+  private readonly runs = new Map<string, { promoted: Set<string>; called: Set<string> }>();
+
   emit(event: EngineEvent): void {
     const { type, data } = event;
     switch (type) {
@@ -26,14 +39,49 @@ export class MetricsEventSink implements EventSink {
       }
       case "tool.done": {
         toolCallsTotal.inc({ ok: data.ok === false ? "false" : "true" });
+        const runId = data.runId as string | undefined;
+        const name = data.name as string | undefined;
+        if (runId && name) this.run(runId).called.add(name);
         break;
       }
       case "tool.promoted": {
-        toolPromotionsTotal.inc();
+        const runId = data.runId as string | undefined;
+        const toolName = data.toolName as string | undefined;
+        if (runId && toolName) this.run(runId).promoted.add(toolName);
+        break;
+      }
+      case "run.done":
+      case "run.error": {
+        this.finalizeRun(data.runId as string | undefined);
         break;
       }
       default:
         break;
     }
+  }
+
+  /** Get (or lazily create) the per-run promoted/called tracking state. */
+  private run(runId: string): { promoted: Set<string>; called: Set<string> } {
+    let r = this.runs.get(runId);
+    if (!r) {
+      r = { promoted: new Set(), called: new Set() };
+      this.runs.set(runId, r);
+      if (this.runs.size > MAX_TRACKED_RUNS) {
+        const oldest = this.runs.keys().next().value;
+        if (oldest !== undefined) this.runs.delete(oldest);
+      }
+    }
+    return r;
+  }
+
+  /** Emit one promotion sample per promoted tool, labeled used=true|false. */
+  private finalizeRun(runId: string | undefined): void {
+    if (!runId) return;
+    const r = this.runs.get(runId);
+    if (!r) return;
+    for (const tool of r.promoted) {
+      toolPromotionsTotal.inc({ used: r.called.has(tool) ? "true" : "false" });
+    }
+    this.runs.delete(runId);
   }
 }

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -99,10 +99,18 @@ export const toolCallsTotal = new Counter({
   registers: [metricsRegistry],
 });
 
-/** Tools promoted into the active set (progressive-disclosure discovery). */
+/**
+ * Tools promoted into the active set (progressive-disclosure discovery),
+ * labeled by whether the promoted tool was actually called later in the same
+ * run. `used="false"` is the wasted-promotion signal — a cache-prefix re-write
+ * for a tool the model never used — that validates the auto-promote policy:
+ * `used="false" / total` is the promoted-but-never-called rate. Counted at run
+ * end (not at promote time) so the correlation is known.
+ */
 export const toolPromotionsTotal = new Counter({
   name: "nb_tool_promotions_total",
-  help: "Tools promoted into the active set (progressive disclosure).",
+  help: "Tools promoted into the active set, by whether the tool was used in the run.",
+  labelNames: ["used"] as const,
   registers: [metricsRegistry],
 });
 

--- a/test/unit/metrics.test.ts
+++ b/test/unit/metrics.test.ts
@@ -62,7 +62,6 @@ describe("MetricsEventSink", () => {
       fresh: await read(llmTokensTotal, fresh),
       okTrue: await read(toolCallsTotal, { ok: "true" }),
       okFalse: await read(toolCallsTotal, { ok: "false" }),
-      promo: await read(toolPromotionsTotal),
     };
 
     sink.emit({
@@ -72,14 +71,44 @@ describe("MetricsEventSink", () => {
         usage: { inputTokens: 200, outputTokens: 10, cacheReadTokens: 0, cacheWriteTokens: 0 },
       },
     });
-    sink.emit({ type: "tool.done", data: { ok: true } });
-    sink.emit({ type: "tool.done", data: { ok: false } });
-    sink.emit({ type: "tool.promoted", data: { toolName: "x" } });
+    sink.emit({ type: "tool.done", data: { runId: "r-sink", name: "a", ok: true } });
+    sink.emit({ type: "tool.done", data: { runId: "r-sink", name: "b", ok: false } });
 
     expect((await read(llmTokensTotal, fresh)) - before.fresh).toBe(200);
     expect((await read(toolCallsTotal, { ok: "true" })) - before.okTrue).toBe(1);
     expect((await read(toolCallsTotal, { ok: "false" })) - before.okFalse).toBe(1);
-    expect((await read(toolPromotionsTotal)) - before.promo).toBe(1);
+  });
+
+  it("labels promotions used=true when the promoted tool is called, false otherwise", async () => {
+    const sink = new MetricsEventSink();
+    const beforeTrue = await read(toolPromotionsTotal, { used: "true" });
+    const beforeFalse = await read(toolPromotionsTotal, { used: "false" });
+
+    // Run 1: promote two tools, call only one, then finish.
+    sink.emit({ type: "tool.promoted", data: { runId: "r1", toolName: "used-tool" } });
+    sink.emit({ type: "tool.promoted", data: { runId: "r1", toolName: "unused-tool" } });
+    sink.emit({ type: "tool.done", data: { runId: "r1", name: "used-tool", ok: true } });
+    // Nothing should be counted until the run terminates.
+    expect((await read(toolPromotionsTotal, { used: "true" })) - beforeTrue).toBe(0);
+    sink.emit({ type: "run.done", data: { runId: "r1" } });
+
+    expect((await read(toolPromotionsTotal, { used: "true" })) - beforeTrue).toBe(1);
+    expect((await read(toolPromotionsTotal, { used: "false" })) - beforeFalse).toBe(1);
+  });
+
+  it("does not double-count or leak across interleaved runs; run.error finalizes too", async () => {
+    const sink = new MetricsEventSink();
+    const beforeFalse = await read(toolPromotionsTotal, { used: "false" });
+
+    // Interleaved runs, neither tool called; one ends via run.error.
+    sink.emit({ type: "tool.promoted", data: { runId: "rA", toolName: "tA" } });
+    sink.emit({ type: "tool.promoted", data: { runId: "rB", toolName: "tB" } });
+    sink.emit({ type: "run.done", data: { runId: "rA" } });
+    sink.emit({ type: "run.error", data: { runId: "rB" } });
+    // A second terminator for an already-finalized run is a no-op.
+    sink.emit({ type: "run.done", data: { runId: "rA" } });
+
+    expect((await read(toolPromotionsTotal, { used: "false" })) - beforeFalse).toBe(2);
   });
 
   it("ignores events it doesn't track", async () => {

--- a/test/unit/metrics.test.ts
+++ b/test/unit/metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { MetricsEventSink } from "../../src/adapters/metrics-events.ts";
+import { MAX_TRACKED_RUNS, MetricsEventSink } from "../../src/adapters/metrics-events.ts";
 import type { Counter } from "prom-client";
 import {
   llmCallsTotal,
@@ -109,6 +109,31 @@ describe("MetricsEventSink", () => {
     sink.emit({ type: "run.done", data: { runId: "rA" } });
 
     expect((await read(toolPromotionsTotal, { used: "false" })) - beforeFalse).toBe(2);
+  });
+
+  it("warns (not silently) and drops the oldest run when the tracked-run cap is exceeded", async () => {
+    const sink = new MetricsEventSink();
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg?: unknown) => {
+      warnings.push(String(msg));
+    };
+    try {
+      const before = await read(toolPromotionsTotal, { used: "false" });
+      // The first run is the oldest, so it's evicted once the cap is exceeded.
+      sink.emit({ type: "tool.promoted", data: { runId: "evict-me", toolName: "t" } });
+      for (let i = 0; i <= MAX_TRACKED_RUNS; i++) {
+        sink.emit({ type: "tool.promoted", data: { runId: `filler-${i}`, toolName: "t" } });
+      }
+      // Its terminator now finds no state → no sample recorded (the loss the
+      // warn surfaces).
+      sink.emit({ type: "run.done", data: { runId: "evict-me" } });
+
+      expect((await read(toolPromotionsTotal, { used: "false" })) - before).toBe(0);
+      expect(warnings.some((w) => w.includes("evict-me"))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
   it("ignores events it doesn't track", async () => {


### PR DESCRIPTION
## Why

Validates #426's **aggressive** `nb__search` auto-promote (top-3 matches promoted on every search). The QA on #426 raised the right concern: on a *browse* search the model never calls those tools, so each is a wasted prefix cache re-write. This turns that from a guess into a Grafana number.

## What changed

`nb_tool_promotions_total` gains a **`used`** label. The `MetricsEventSink` correlates per run:

- track promoted tool names (`tool.promoted`) and called tool names (`tool.done`), keyed by `runId`;
- at the run terminator (`run.done` / `run.error`), emit one sample per promoted tool, `used="true"` if it was called that run, else `"false"`;
- drop the run's state.

So the **promoted-but-never-called rate** is `sum(rate(nb_tool_promotions_total{used="false"}[…])) / sum(rate(nb_tool_promotions_total[…]))`. High → dial #426 back to conservative; low → aggressive is paying off.

## Notes

- **Counted at run end, not at promote time**, so the call correlation is known. The *total* is unchanged — every promotion is still counted once per (run, tool), now sliceable by `used`.
- Per-run state is keyed by `runId` and dropped on the terminator, with a defensive `MAX_TRACKED_RUNS` cap so a run whose terminator never fires (process death mid-run) can't leak.
- Only genuine promotions emit `tool.promoted` (the engine's `addTool` is idempotent — re-promoting an already-active tool is a no-op), so an already-active tool isn't miscounted.

## Tradeoff / follow-up

`tool.promoted` doesn't carry *who* promoted (search-auto vs explicit `manage_tools`), so this is the **aggregate** used-rate — which is dominated by #426 (every search promotes 3), so it still implicates the aggressive policy. Slicing by source needs threading a `source` through `addTool` → the event; tracked separately.

## Tests

`used=true` when the promoted tool is called and `false` otherwise; nothing counts until the run terminates; interleaved runs don't cross-contaminate; `run.error` finalizes; a duplicate terminator is a no-op. `verify:static` clean, `test:unit` 3562 pass.

> Depends on infra PR #58 (ServiceMonitor → `/metrics`) for this to actually reach Prometheus.
