### PR TITLE
fix(oauth): use workspace name, not raw wsId, in DCR client_name

### DIFF
--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -13,6 +13,7 @@ import type { ToolRegistry } from "../tools/registry.ts";
 import { WorkspaceOAuthProvider } from "../tools/workspace-oauth-provider.ts";
 import { validateAdditionalAuthorizationParams } from "../util/oauth-params.ts";
 import { WorkspaceContext } from "../workspace/context.ts";
+import { resolveWorkspaceDisplayName } from "../workspace/workspace-store.ts";
 import type { AutomationDomainContext } from "./automations/src/domain.ts";
 import { createAutomation, deleteAutomation } from "./automations/src/domain.ts";
 import { connectorSlug, hasPersistedComposioConnection } from "./composio-connection.ts";
@@ -1227,8 +1228,13 @@ export class BundleLifecycleManager {
     // to the caller.
     const providerAbort = new AbortController();
 
+    // Human-readable workspace name for the vendor's consent screen, in
+    // place of the opaque wsId. Best-effort — falls back to the id.
+    const ownerDisplayName = await resolveWorkspaceDisplayName(opts.workDir, wsId);
+
     const provider = new WorkspaceOAuthProvider({
       owner: { type: "workspace", wsId },
+      ...(ownerDisplayName ? { ownerDisplayName } : {}),
       serverName,
       workDir: opts.workDir,
       // Workspace-scoped tokens route the credential directory through

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -24,6 +24,7 @@ import {
   type WorkspaceOAuthProviderOptions,
 } from "../tools/workspace-oauth-provider.ts";
 import { WorkspaceContext } from "../workspace/context.ts";
+import { resolveWorkspaceDisplayName } from "../workspace/workspace-store.ts";
 import { extractBundleMeta } from "./defaults.ts";
 import { filterEnvForBundle } from "./env-filter.ts";
 import { validateManifest } from "./manifest.ts";
@@ -369,8 +370,12 @@ export async function startBundleSource(
       // Boot path is workspace-scope only — user-scope bundles aren't
       // started at boot (they're loaded into a workspace's registry
       // on-demand when their user enters the workspace, see lifecycle).
+      // Human-readable workspace name for the vendor consent screen in
+      // place of the opaque wsId; best-effort, falls back to the id.
+      const ownerDisplayName = await resolveWorkspaceDisplayName(workDir, wsId);
       authProvider = new WorkspaceOAuthProvider({
         owner: { type: "workspace", wsId },
+        ...(ownerDisplayName ? { ownerDisplayName } : {}),
         serverName,
         workDir,
         workspaceContext: wsContext,

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -74,6 +74,18 @@ export interface WorkspaceOAuthProviderOptions {
    * path and the principal id used in connection state tracking.
    */
   owner: OAuthOwnerContext;
+  /**
+   * Human-readable label for the owner, used verbatim in the OAuth
+   * `client_name` the vendor renders on its consent screen ("NimbleBrain
+   * (<ownerDisplayName>) would like access…"). When omitted, the provider
+   * falls back to the raw owner id (`owner.wsId` / `user:<userId>`), which
+   * is an opaque token the end user can't read and a tenant identifier we'd
+   * rather not hand a third party. Callers resolve this from the
+   * workspace's `name` (see `resolveWorkspaceDisplayName`); it's purely
+   * cosmetic — the vendor mints a distinct `client_id` per registration
+   * regardless — so a missing name degrades gracefully to the id.
+   */
+  ownerDisplayName?: string;
   serverName: string;
   workDir: string;
   /**
@@ -516,6 +528,7 @@ function deferred<T>(): Deferred<T> {
  */
 export class WorkspaceOAuthProvider implements OAuthClientProvider {
   private readonly owner: OAuthOwnerContext;
+  private readonly ownerDisplayName?: string;
   private readonly serverName: string;
   /**
    * Single root directory for all credential files for this (owner,
@@ -611,6 +624,7 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
 
   constructor(opts: WorkspaceOAuthProviderOptions) {
     this.owner = opts.owner;
+    this.ownerDisplayName = opts.ownerDisplayName;
     this.serverName = opts.serverName;
     this.callbackUrl = opts.callbackUrl;
     this.canonicalCallback = canonicalEndpoint(new URL(opts.callbackUrl));
@@ -706,7 +720,8 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
 
   get clientMetadata(): OAuthClientMetadata {
     const ownerLabel =
-      this.owner.type === "workspace" ? this.owner.wsId : `user:${this.owner.userId}`;
+      this.ownerDisplayName ??
+      (this.owner.type === "workspace" ? this.owner.wsId : `user:${this.owner.userId}`);
     const meta: OAuthClientMetadata = {
       client_name: `NimbleBrain (${ownerLabel})`,
       redirect_uris: [this.callbackUrl],

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -501,6 +501,22 @@ function deferred<T>(): Deferred<T> {
 }
 
 /**
+ * Brand metadata sent in the DCR registration so vendors that honor RFC 7591
+ * `client_uri` / `logo_uri` render NimbleBrain's homepage link and logo on
+ * their consent screen instead of a bare name. Hardcoded to match the
+ * likewise-hardcoded "NimbleBrain" in `client_name`; a future white-label
+ * effort would make all three configurable together. The logo is the
+ * NimbleBrain brand mark from the platform's public asset CDN
+ * (`static.nimblebrain.ai`), built by the logos pipeline into the canonical
+ * per-brand path. We point at the 128px raster rather than the SVG variant
+ * because several OAuth/identity providers refuse to render an SVG `logo_uri`
+ * (scriptable-image hardening); the mark is transparent and reads on both
+ * light and dark consent screens.
+ */
+const NIMBLEBRAIN_CLIENT_URI = "https://nimblebrain.ai";
+const NIMBLEBRAIN_LOGO_URI = "https://static.nimblebrain.ai/logos/nimblebrain/light-128.png";
+
+/**
  * File-backed OAuthClientProvider scoped to a `(workspace, serverName)`
  * pair. Persistence layout:
  *
@@ -526,22 +542,6 @@ function deferred<T>(): Deferred<T> {
  * no HTTP round-trip, no browser. For all other interactive flows, we
  * throw `InteractiveOAuthNotSupportedError` and fail fast.
  */
-/**
- * Brand metadata sent in the DCR registration so vendors that honor RFC 7591
- * `client_uri` / `logo_uri` render NimbleBrain's homepage link and logo on
- * their consent screen instead of a bare name. Hardcoded to match the
- * likewise-hardcoded "NimbleBrain" in `client_name`; a future white-label
- * effort would make all three configurable together. The logo is the
- * NimbleBrain brand mark from the platform's public asset CDN
- * (`static.nimblebrain.ai`), built by the logos pipeline into the canonical
- * per-brand path. We point at the 128px raster rather than the SVG variant
- * because several OAuth/identity providers refuse to render an SVG `logo_uri`
- * (scriptable-image hardening); the mark is transparent and reads on both
- * light and dark consent screens.
- */
-const NIMBLEBRAIN_CLIENT_URI = "https://nimblebrain.ai";
-const NIMBLEBRAIN_LOGO_URI = "https://static.nimblebrain.ai/logos/nimblebrain/light-128.png";
-
 export class WorkspaceOAuthProvider implements OAuthClientProvider {
   private readonly owner: OAuthOwnerContext;
   private readonly ownerDisplayName?: string;

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -526,6 +526,18 @@ function deferred<T>(): Deferred<T> {
  * no HTTP round-trip, no browser. For all other interactive flows, we
  * throw `InteractiveOAuthNotSupportedError` and fail fast.
  */
+/**
+ * Brand metadata sent in the DCR registration so vendors that honor RFC 7591
+ * `client_uri` / `logo_uri` render NimbleBrain's homepage link and logo on
+ * their consent screen instead of a bare name. Hardcoded to match the
+ * likewise-hardcoded "NimbleBrain" in `client_name`; a future white-label
+ * effort would make all three configurable together. The logo is the square
+ * brand mark on `static.nimblebrain.ai` (the platform's public asset CDN) —
+ * a transparent PNG that reads on both light and dark consent screens.
+ */
+const NIMBLEBRAIN_CLIENT_URI = "https://nimblebrain.ai";
+const NIMBLEBRAIN_LOGO_URI = "https://static.nimblebrain.ai/logos/nimblebrain.png";
+
 export class WorkspaceOAuthProvider implements OAuthClientProvider {
   private readonly owner: OAuthOwnerContext;
   private readonly ownerDisplayName?: string;
@@ -724,6 +736,8 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
       (this.owner.type === "workspace" ? this.owner.wsId : `user:${this.owner.userId}`);
     const meta: OAuthClientMetadata = {
       client_name: `NimbleBrain (${ownerLabel})`,
+      client_uri: NIMBLEBRAIN_CLIENT_URI,
+      logo_uri: NIMBLEBRAIN_LOGO_URI,
       redirect_uris: [this.callbackUrl],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -531,12 +531,16 @@ function deferred<T>(): Deferred<T> {
  * `client_uri` / `logo_uri` render NimbleBrain's homepage link and logo on
  * their consent screen instead of a bare name. Hardcoded to match the
  * likewise-hardcoded "NimbleBrain" in `client_name`; a future white-label
- * effort would make all three configurable together. The logo is the square
- * brand mark on `static.nimblebrain.ai` (the platform's public asset CDN) —
- * a transparent PNG that reads on both light and dark consent screens.
+ * effort would make all three configurable together. The logo is the
+ * NimbleBrain brand mark from the platform's public asset CDN
+ * (`static.nimblebrain.ai`), built by the logos pipeline into the canonical
+ * per-brand path. We point at the 128px raster rather than the SVG variant
+ * because several OAuth/identity providers refuse to render an SVG `logo_uri`
+ * (scriptable-image hardening); the mark is transparent and reads on both
+ * light and dark consent screens.
  */
 const NIMBLEBRAIN_CLIENT_URI = "https://nimblebrain.ai";
-const NIMBLEBRAIN_LOGO_URI = "https://static.nimblebrain.ai/logos/nimblebrain.png";
+const NIMBLEBRAIN_LOGO_URI = "https://static.nimblebrain.ai/logos/nimblebrain/light-128.png";
 
 export class WorkspaceOAuthProvider implements OAuthClientProvider {
   private readonly owner: OAuthOwnerContext;

--- a/src/workspace/workspace-store.ts
+++ b/src/workspace/workspace-store.ts
@@ -140,6 +140,29 @@ export function personalWorkspaceSlugFor(userId: string): string {
   return personalWorkspaceIdFor(userId).slice(3);
 }
 
+/**
+ * Best-effort lookup of a workspace's human-readable `name` for display to
+ * a third party — currently the OAuth `client_name` a remote vendor renders
+ * on its consent screen (see `WorkspaceOAuthProvider.ownerDisplayName`).
+ *
+ * Returns `undefined` when the workspace can't be read or has no name, so
+ * the caller cleanly falls back to the opaque id. Deliberately non-throwing:
+ * a cosmetic label must never block an auth flow. Constructs a throwaway
+ * store from `workDir` — cheap, and these are infrequent (interactive auth
+ * start / bundle boot) paths, not hot loops.
+ */
+export async function resolveWorkspaceDisplayName(
+  workDir: string,
+  wsId: string,
+): Promise<string | undefined> {
+  try {
+    const ws = await new WorkspaceStore(workDir).get(wsId);
+    return ws?.name || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // ── WorkspaceStore ─────────────────────────────────────────────────
 
 export class WorkspaceStore {

--- a/test/unit/resolve-workspace-display-name.test.ts
+++ b/test/unit/resolve-workspace-display-name.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+  resolveWorkspaceDisplayName,
+  WorkspaceStore,
+} from "../../src/workspace/workspace-store.ts";
+
+// `resolveWorkspaceDisplayName` is the best-effort disk read that turns an
+// opaque wsId into the human-readable name shown on a vendor's OAuth consent
+// screen. File-IO only (no Runtime/server/spawn) → unit tier.
+
+describe("resolveWorkspaceDisplayName", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "nb-ws-name-test-"));
+  });
+
+  it("returns the workspace's human-readable name", async () => {
+    const store = new WorkspaceStore(workDir);
+    const ws = await store.create("Engineering Team");
+    expect(await resolveWorkspaceDisplayName(workDir, ws.id)).toBe("Engineering Team");
+  });
+
+  it("returns undefined for an unknown workspace (caller falls back to the id)", async () => {
+    expect(await resolveWorkspaceDisplayName(workDir, "ws_does_not_exist")).toBeUndefined();
+  });
+
+  it("returns undefined for a malformed workspace id rather than throwing", async () => {
+    expect(await resolveWorkspaceDisplayName(workDir, "not-a-ws-id")).toBeUndefined();
+  });
+});

--- a/test/unit/workspace-oauth-provider.test.ts
+++ b/test/unit/workspace-oauth-provider.test.ts
@@ -367,6 +367,38 @@ describe("WorkspaceOAuthProvider — Track A: pre-registered client + scopes + e
     );
   });
 
+  it("clientMetadata.client_name uses ownerDisplayName when provided (not the opaque wsId)", () => {
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_user_user_01ABCDEF" },
+      ownerDisplayName: "Engineering Team",
+      serverName: "granola",
+      workDir,
+      callbackUrl: CALLBACK,
+    });
+    expect(p.clientMetadata.client_name).toBe("NimbleBrain (Engineering Team)");
+  });
+
+  it("clientMetadata.client_name falls back to the raw wsId when no ownerDisplayName", () => {
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_user_user_01ABCDEF" },
+      serverName: "granola",
+      workDir,
+      callbackUrl: CALLBACK,
+    });
+    expect(p.clientMetadata.client_name).toBe("NimbleBrain (ws_user_user_01ABCDEF)");
+  });
+
+  it("clientMetadata.client_name uses ownerDisplayName for user-scoped owners too", () => {
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "user", userId: "user_01ABCDEF" },
+      ownerDisplayName: "Mat's Workspace",
+      serverName: "granola",
+      workDir,
+      callbackUrl: CALLBACK,
+    });
+    expect(p.clientMetadata.client_name).toBe("NimbleBrain (Mat's Workspace)");
+  });
+
   it("clientMetadata default token_endpoint_auth_method = 'none' (DCR PKCE-only) when no staticClient", () => {
     const p = new WorkspaceOAuthProvider({
       owner: { type: "workspace", wsId: "ws_test" },

--- a/test/unit/workspace-oauth-provider.test.ts
+++ b/test/unit/workspace-oauth-provider.test.ts
@@ -407,7 +407,9 @@ describe("WorkspaceOAuthProvider — Track A: pre-registered client + scopes + e
       callbackUrl: CALLBACK,
     });
     expect(p.clientMetadata.client_uri).toBe("https://nimblebrain.ai");
-    expect(p.clientMetadata.logo_uri).toBe("https://static.nimblebrain.ai/logos/nimblebrain.png");
+    expect(p.clientMetadata.logo_uri).toBe(
+      "https://static.nimblebrain.ai/logos/nimblebrain/light-128.png",
+    );
   });
 
   it("clientMetadata default token_endpoint_auth_method = 'none' (DCR PKCE-only) when no staticClient", () => {

--- a/test/unit/workspace-oauth-provider.test.ts
+++ b/test/unit/workspace-oauth-provider.test.ts
@@ -399,6 +399,17 @@ describe("WorkspaceOAuthProvider — Track A: pre-registered client + scopes + e
     expect(p.clientMetadata.client_name).toBe("NimbleBrain (Mat's Workspace)");
   });
 
+  it("clientMetadata carries NimbleBrain client_uri + logo_uri for consent-screen branding", () => {
+    const p = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: "ws_test" },
+      serverName: "granola",
+      workDir,
+      callbackUrl: CALLBACK,
+    });
+    expect(p.clientMetadata.client_uri).toBe("https://nimblebrain.ai");
+    expect(p.clientMetadata.logo_uri).toBe("https://static.nimblebrain.ai/logos/nimblebrain.png");
+  });
+
   it("clientMetadata default token_endpoint_auth_method = 'none' (DCR PKCE-only) when no staticClient", () => {
     const p = new WorkspaceOAuthProvider({
       owner: { type: "workspace", wsId: "ws_test" },


### PR DESCRIPTION
## Problem

When the platform dynamically registers an OAuth client (RFC 7591 DCR) with a remote MCP vendor that requires OAuth (Granola, Notion, HubSpot, …), the consent screen was bare and ugly:

> **NimbleBrain (ws_user_user_01KP730NHBCJ3CK2HFHE3HMNF6) would like access to your account**

The opaque workspace id is meaningless to the end user, needlessly hands a tenant identifier to a third party, and there's no logo or homepage link to anchor trust.

## Fix

Two parts:

**1. Human-readable name instead of the raw wsId.** Thread the workspace's `name` into the provider as `ownerDisplayName`; `client_name` uses it, falling back to the id when no name is available:

> **NimbleBrain (Engineering Team) would like access to your account**

**2. Branding metadata.** Add RFC 7591 `client_uri` (`https://nimblebrain.ai`) and `logo_uri` (`https://static.nimblebrain.ai/logos/nimblebrain/light-128.png`) so vendors that honor them render the NimbleBrain logo + homepage link on the consent screen.

Both `client_name` and the brand URLs are cosmetic to the flow — the vendor mints a distinct `client_id` per registration regardless.

## Changes

- **`workspace-oauth-provider.ts`** — optional `ownerDisplayName` on the options; `clientMetadata` prefers it over the opaque owner id, and now also emits hardcoded NimbleBrain `client_uri` + `logo_uri` (matching the already-hardcoded "NimbleBrain" in `client_name`; a future white-label effort makes all three configurable together). `logo_uri` points at the 128px raster rather than the SVG variant because several OAuth/identity providers refuse to render an SVG logo.
- **`workspace-store.ts`** — new best-effort, non-throwing `resolveWorkspaceDisplayName(workDir, wsId)` helper. A cosmetic label must never block an auth flow, so a missing/unreadable workspace degrades to the id.
- **`lifecycle.ts`** (interactive auth start) and **`startup.ts`** (bundle boot) — both provider construction sites resolve and pass the name.

## Dependency (already shipped)

The `logo_uri` points at a brand mark added to the `nimblebrain-static` repo via its canonical logos pipeline (`logos.yaml` entry + `sources/nimblebrain/light.svg` → built `logos/nimblebrain/{light,dark}.svg` + 128px raster). Deployed to the CDN and **live now**: https://static.nimblebrain.ai/logos/nimblebrain/light-128.png (200, image/png). No action needed for this PR to work.

## Tests

- `workspace-oauth-provider.test.ts`: `client_name` uses `ownerDisplayName` / falls back to wsId / works for user-scoped owners; `client_uri` + `logo_uri` present.
- New `resolve-workspace-display-name.test.ts`: happy path, unknown workspace → `undefined`, malformed id → `undefined` (no throw).
- `bun run verify:static` + full unit tier (3600 tests) green.