### PR TITLE
fix(conversations): orphaned run no longer swallows later turns in chat UI

### DIFF
--- a/src/bundles/conversations/src/jsonl-reader.ts
+++ b/src/bundles/conversations/src/jsonl-reader.ts
@@ -486,9 +486,11 @@ function collectRun(
   let endTs = events[start]?.ts ?? "";
   let stopReason: string | undefined;
   // A run is "terminated" only when we see its run.done/run.error. If the loop
-  // runs out of events first, the turn was still in flight when the file was
-  // read → mark the message pending.
+  // runs off the END of the array first, the turn was still in flight when the
+  // file was read → mark the message pending. A run cut short by a LATER turn
+  // (foreign user.message / run.start) is `abandoned`, not pending — see below.
   let terminated = false;
+  let abandoned = false;
 
   let i = start + 1;
   while (i < events.length) {
@@ -505,6 +507,21 @@ function collectRun(
       stopReason = "error";
       terminated = true;
       i++;
+      break;
+    }
+    // Implicit run end: a foreign user.message or a different run's run.start
+    // means this run never closed cleanly (process death / deploy bounce
+    // mid-turn before a terminal event). Stop here WITHOUT consuming the event
+    // (`i` stays put) so the outer loop renders it as its own turn. Mirrors the
+    // sibling LLM-replay projection's guard in src/conversation/
+    // event-reconstructor.ts. Without this, an orphaned run swallows every
+    // subsequent turn and the transcript appears to lose everything after the
+    // bounce (NimbleBrain prod incident: a deploy-killed turn hid the next hour
+    // of an actively-used conversation on reload). The loop begins at start + 1,
+    // so any run.start seen here is by construction a foreign run.
+    if (isUserMessage(inner) || isRunStart(inner)) {
+      abandoned = true;
+      stopReason = "interrupted";
       break;
     }
     if (isLlmResponse(inner) && inner.runId === runId) {
@@ -627,7 +644,12 @@ function collectRun(
     ...(flatToolCalls.length > 0 ? { toolCalls: flatToolCalls } : {}),
     usage,
     ...(stopReason && stopReason !== "complete" ? { stopReason } : {}),
-    ...(terminated ? {} : { pending: true }),
+    // `pending` only for a TRULY trailing in-flight run (ran off the end of the
+    // array). An `abandoned` run has a later turn after it, so it can never be
+    // in flight — stamping it pending would show a perpetual "still thinking"
+    // spinner on an old turn (and chat-store's trailing-pending trim doesn't
+    // apply to an interior turn anyway). It carries stopReason "interrupted".
+    ...(terminated || abandoned ? {} : { pending: true }),
   };
   return [msg, i];
 }

--- a/test/unit/bundles/conversations/jsonl-reader.test.ts
+++ b/test/unit/bundles/conversations/jsonl-reader.test.ts
@@ -338,6 +338,68 @@ describe("readConversation (event format)", () => {
 		expect(result!.messages.at(-1)!.pending).toBeUndefined();
 	});
 
+	test("an orphaned mid-transcript run does not swallow later turns", async () => {
+		// Regression: a run killed mid-turn (process death / deploy bounce) has
+		// no run.done. Before the fix, collectRun consumed the rest of the event
+		// array, dropping every later turn from the rendered transcript — the
+		// user perceived "I lost the last hour of conversation" even though the
+		// data was fully persisted. The orphaned run must end at the next turn's
+		// boundary, and subsequent turns must still render.
+		const lines = [
+			JSON.stringify(eventMeta("conv_orphan01")),
+			// Turn 1 — complete.
+			JSON.stringify({ ts: "2025-06-01T00:00:00.000Z", type: "user.message", content: [{ type: "text", text: "first question" }] }),
+			JSON.stringify({ ts: "2025-06-01T00:00:01.000Z", type: "run.start", runId: "run_1" }),
+			JSON.stringify({ ts: "2025-06-01T00:00:02.000Z", type: "llm.response", runId: "run_1", model: "m1", content: [{ type: "text", text: "first answer" }], usage: { inputTokens: 5, outputTokens: 2 }, llmMs: 10 }),
+			JSON.stringify({ ts: "2025-06-01T00:00:03.000Z", type: "run.done", runId: "run_1", stopReason: "complete" }),
+			// Turn 2 — ORPHANED: user message + a run that never closes (no run.done).
+			JSON.stringify({ ts: "2025-06-01T00:00:04.000Z", type: "user.message", content: [{ type: "text", text: "second question" }] }),
+			JSON.stringify({ ts: "2025-06-01T00:00:05.000Z", type: "run.start", runId: "run_2" }),
+			JSON.stringify({ ts: "2025-06-01T00:00:06.000Z", type: "llm.response", runId: "run_2", model: "m1", content: [{ type: "text", text: "partial work before the bounce" }], usage: { inputTokens: 5, outputTokens: 2 }, llmMs: 10 }),
+			// <-- pod killed here; no run.done for run_2.
+			// Turn 3 — complete (came after the restart).
+			JSON.stringify({ ts: "2025-06-01T00:00:07.000Z", type: "user.message", content: [{ type: "text", text: "third question" }] }),
+			JSON.stringify({ ts: "2025-06-01T00:00:08.000Z", type: "run.start", runId: "run_3" }),
+			JSON.stringify({ ts: "2025-06-01T00:00:09.000Z", type: "llm.response", runId: "run_3", model: "m1", content: [{ type: "text", text: "third answer" }], usage: { inputTokens: 5, outputTokens: 2 }, llmMs: 10 }),
+			JSON.stringify({ ts: "2025-06-01T00:00:10.000Z", type: "run.done", runId: "run_3", stopReason: "complete" }),
+		];
+		const path = writeTmpFile("conv_orphan01.jsonl", lines);
+
+		const result = await readConversation(path);
+		expect(result).not.toBeNull();
+		// All 6 turns render (3 user + 3 assistant) — nothing swallowed.
+		const roles = result!.messages.map((m) => m.role);
+		expect(roles).toEqual(["user", "assistant", "user", "assistant", "user", "assistant"]);
+		// The post-bounce turns survive.
+		expect(result!.messages[4]!.content).toBe("third question");
+		expect(result!.messages[5]!.content).toBe("third answer");
+		// The orphaned turn rendered its partial work...
+		const orphaned = result!.messages[3]!;
+		expect(orphaned.content).toBe("partial work before the bounce");
+		// ...but is ABANDONED, not pending — no perpetual "still thinking" spinner.
+		expect(orphaned.pending).toBeUndefined();
+		expect(orphaned.stopReason).toBe("interrupted");
+	});
+
+	test("a trailing in-flight run (no later turn) is still pending, not abandoned", async () => {
+		// Guard against over-correction: only a run with a LATER turn after it is
+		// abandoned. A genuinely trailing incomplete run is the live turn and must
+		// stay pending so chat-store's resume path reconciles it.
+		const lines = [
+			JSON.stringify(eventMeta("conv_orphan02")),
+			JSON.stringify({ ts: "2025-06-01T00:00:00.000Z", type: "user.message", content: [{ type: "text", text: "q" }] }),
+			JSON.stringify({ ts: "2025-06-01T00:00:01.000Z", type: "run.start", runId: "run_live" }),
+			JSON.stringify({ ts: "2025-06-01T00:00:02.000Z", type: "llm.response", runId: "run_live", model: "m1", content: [{ type: "text", text: "streaming..." }], usage: { inputTokens: 5, outputTokens: 2 }, llmMs: 10 }),
+			// No run.done and no later turn — genuinely in flight.
+		];
+		const path = writeTmpFile("conv_orphan02.jsonl", lines);
+
+		const result = await readConversation(path);
+		const asst = result!.messages.at(-1)!;
+		expect(asst.pending).toBe(true);
+		expect(asst.stopReason).toBeUndefined();
+	});
+
 	test("sets status='error' and isError=true for a failed tool call", async () => {
 		const runId = "run_b";
 		const lines = [


### PR DESCRIPTION
## Problem

A run killed mid-turn (process death, e.g. a pod restart/deploy bounce) emits no `run.done`/`run.error`. In the chat-UI JSONL projection (`src/bundles/conversations/src/jsonl-reader.ts`), `collectRun()` only breaks its event loop on a terminator matching the **same** runId. With no terminator, an orphaned run consumes the **rest of the event array** and the outer loop ends — so **every turn after the orphaned run is silently dropped from the rendered transcript on reload**, even though all turns are fully persisted on disk. Users perceive losing the tail of an actively-used conversation.

The sibling LLM-replay projection (`src/conversation/event-reconstructor.ts:227-229`) already guards exactly this case (the "implicit run end" break) — the two projections had drifted.

## Fix

- Port the implicit-run-end guard into `collectRun`: break **without consuming the event** on a foreign `user.message` / `run.start`, so the outer loop renders subsequent turns.
- Distinguish an **abandoned** run (a later turn follows — it can never complete) from a **trailing in-flight** run (ran off the end of the array). The former is stamped `stopReason: "interrupted"` and is **not** `pending`, avoiding a perpetual "still thinking" spinner on an old turn. The latter stays `pending` for the resume path to reconcile.

## Tests

Two regression tests in `test/unit/bundles/conversations/jsonl-reader.test.ts`:
- a mid-transcript orphaned run preserves all later turns and is marked `interrupted`;
- a genuinely trailing in-flight run stays `pending`.

Verified the first test **fails without the guard** and passes with it. `bun test` (25/25), `tsc`, lint, format all clean.

## Follow-ups (tracked, not in this PR)

- Extract a shared run-segmentation primitive so the two projections can't drift again.
- Emit a terminal event for abandoned runs at the source (graceful shutdown and/or a startup reaper) so orphaned runs never reach disk.
