### PR TITLE
fix(web): recover from stale lazy-chunk 404s after deploy (white screen)

### DIFF
--- a/web/src/__tests__/stale-chunk-recovery.test.ts
+++ b/web/src/__tests__/stale-chunk-recovery.test.ts
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------
+// shouldReloadForStaleChunk — the loop guard
+//
+// The only real branch logic in the stale-chunk recovery: a reload fires at
+// most once per debounce window. A regression here (reload loop) would hammer
+// the asset server and trap the user on a blank page, so it's the one piece
+// worth pinning. Pure over an injected clock + Storage — no DOM needed.
+// ---------------------------------------------------------------------------
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { shouldReloadForStaleChunk } from "../lib/stale-chunk-recovery";
+
+/** Minimal in-memory Storage stub (only the two methods under test). */
+function fakeStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => m.get(k) ?? null,
+    setItem: (k, v) => {
+      m.set(k, v);
+    },
+    removeItem: (k) => {
+      m.delete(k);
+    },
+    clear: () => m.clear(),
+    key: () => null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+}
+
+describe("shouldReloadForStaleChunk", () => {
+  let storage: Storage;
+  beforeEach(() => {
+    storage = fakeStorage();
+  });
+
+  test("reloads on the first stale-chunk failure", () => {
+    expect(shouldReloadForStaleChunk(1_000_000, storage)).toBe(true);
+  });
+
+  test("suppresses a second failure inside the debounce window (no reload loop)", () => {
+    const t0 = 1_000_000;
+    expect(shouldReloadForStaleChunk(t0, storage)).toBe(true);
+    expect(shouldReloadForStaleChunk(t0 + 1, storage)).toBe(false);
+    expect(shouldReloadForStaleChunk(t0 + 9_999, storage)).toBe(false);
+  });
+
+  test("reloads again once the debounce window has elapsed (recovers from a later deploy)", () => {
+    const t0 = 1_000_000;
+    expect(shouldReloadForStaleChunk(t0, storage)).toBe(true);
+    expect(shouldReloadForStaleChunk(t0 + 10_000, storage)).toBe(true);
+    // ...and the fresh attempt re-arms the guard.
+    expect(shouldReloadForStaleChunk(t0 + 10_001, storage)).toBe(false);
+  });
+});

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -34,7 +34,7 @@ export class ErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       if (this.props.fallback) return this.props.fallback;
       return (
-        <div className="flex flex-col items-center justify-center h-full gap-4 p-8 text-center">
+        <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-8 text-center">
           <p className="text-lg font-medium">Something went wrong</p>
           <p className="text-sm text-muted-foreground">
             An unexpected error occurred while rendering this page.

--- a/web/src/lib/stale-chunk-recovery.ts
+++ b/web/src/lib/stale-chunk-recovery.ts
@@ -1,0 +1,40 @@
+import { captureEvent } from "../telemetry";
+
+const RELOAD_KEY = "nb:last-chunk-reload";
+const RELOAD_DEBOUNCE_MS = 10_000;
+
+/**
+ * Decide whether a stale-chunk reload should fire now, recording the attempt
+ * when it returns true. A second failure within {@link RELOAD_DEBOUNCE_MS} is
+ * suppressed — the guard that prevents a reload loop when the asset is
+ * genuinely unreachable (offline, or a deploy still mid-flight with no pod
+ * serving assets yet). Pure aside from the storage read/write, so the
+ * loop-guard logic is unit-testable without a DOM (see stale-chunk-recovery.test.ts).
+ */
+export function shouldReloadForStaleChunk(now: number, storage: Storage): boolean {
+  const last = Number(storage.getItem(RELOAD_KEY) ?? "0");
+  if (now - last < RELOAD_DEBOUNCE_MS) return false;
+  storage.setItem(RELOAD_KEY, String(now));
+  return true;
+}
+
+/**
+ * Wire up Vite's stale-chunk recovery. A tab open across a deploy 404s on its
+ * next dynamic import (the hashed chunk — e.g. the streamdown/Shiki
+ * `highlighted-body` code-block module — was deleted by the new build) and
+ * throws "Failed to fetch dynamically imported module", an unhandled rejection
+ * that white-screens the app. Vite dispatches `vite:preloadError` for exactly
+ * this; reload once to pick up the new index.html + current chunk hashes,
+ * guarded against a loop. Call once at startup.
+ */
+export function registerStaleChunkRecovery(): void {
+  window.addEventListener("vite:preloadError", (event) => {
+    if (!shouldReloadForStaleChunk(Date.now(), sessionStorage)) return;
+    event.preventDefault(); // we're handling it via reload; suppress the throw
+    // PostHog persists queued events to storage and flushes on the next load,
+    // so this survives the reload. Sizes the deferred asset-retention work
+    // (how often tabs actually hit a deploy boundary).
+    captureEvent("stale_chunk_reload", { reason: event.payload?.message });
+    window.location.reload();
+  });
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,35 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+
+// Stale-chunk recovery. Hashed lazy chunks (e.g. the streamdown/Shiki
+// `highlighted-body` code-block module, loaded on demand when a message
+// contains a code block) are deleted when a new build deploys. A tab that
+// outlived a deploy 404s on its next dynamic import and throws "Failed to
+// fetch dynamically imported module" — an unhandled rejection that white-
+// screens the app. Vite dispatches `vite:preloadError` for exactly this:
+// reload once to pick up the new index.html + current chunk hashes. A short
+// time guard prevents a reload loop when the asset is genuinely unreachable
+// (offline, or a deploy still mid-flight with no pod serving assets yet).
+window.addEventListener("vite:preloadError", (event) => {
+  const KEY = "nb:last-chunk-reload";
+  const now = Date.now();
+  const last = Number(sessionStorage.getItem(KEY) ?? "0");
+  if (now - last < 10_000) return; // already reloaded recently — don't loop
+  event.preventDefault(); // we're handling it via reload; suppress the throw
+  sessionStorage.setItem(KEY, String(now));
+  window.location.reload();
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    {/* Root catch-all: a render-time throw that escapes the inner route-level
+        boundary (shell/bootstrap layer, or a chunk error surfaced during
+        render rather than as vite:preloadError) degrades to the fallback card
+        instead of a blank white page. */}
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,25 +2,11 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { registerStaleChunkRecovery } from "./lib/stale-chunk-recovery";
 
-// Stale-chunk recovery. Hashed lazy chunks (e.g. the streamdown/Shiki
-// `highlighted-body` code-block module, loaded on demand when a message
-// contains a code block) are deleted when a new build deploys. A tab that
-// outlived a deploy 404s on its next dynamic import and throws "Failed to
-// fetch dynamically imported module" — an unhandled rejection that white-
-// screens the app. Vite dispatches `vite:preloadError` for exactly this:
-// reload once to pick up the new index.html + current chunk hashes. A short
-// time guard prevents a reload loop when the asset is genuinely unreachable
-// (offline, or a deploy still mid-flight with no pod serving assets yet).
-window.addEventListener("vite:preloadError", (event) => {
-  const KEY = "nb:last-chunk-reload";
-  const now = Date.now();
-  const last = Number(sessionStorage.getItem(KEY) ?? "0");
-  if (now - last < 10_000) return; // already reloaded recently — don't loop
-  event.preventDefault(); // we're handling it via reload; suppress the throw
-  sessionStorage.setItem(KEY, String(now));
-  window.location.reload();
-});
+// Recover a tab that outlived a deploy: a 404 on a stale hashed lazy chunk
+// would otherwise white-screen the app. See stale-chunk-recovery.ts.
+registerStaleChunkRecovery();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
## Problem

A browser tab open across a deploy holds the **previous** build's module graph. Its hashed lazy chunks (e.g. the `streamdown`/Shiki code-block module — `highlighted-body-<hash>.js` — loaded on demand when a message contains a code block) are gone from the server after a new build ships. The next dynamic import 404s:

```
Uncaught TypeError: Failed to fetch dynamically imported module: /assets/highlighted-body-<hash>.js
```

This is an unhandled rejection, and `main.tsx` rendered `<App/>` with no top-level boundary and no `vite:preloadError` handler — so the page goes **fully white** instead of recovering or degrading gracefully. (The only `ErrorBoundary` wraps `<Routes>`, leaving the shell/bootstrap layer above it unprotected too.)

## Fix (`web/src/main.tsx`)

- Listen for Vite's `vite:preloadError` and **reload once** to pick up the new `index.html` + current chunk hashes. A 10s `sessionStorage` time guard prevents a reload loop when the asset is genuinely unreachable (offline, or a deploy still mid-flight).
- Wrap the app root in `ErrorBoundary` so any render-time throw that escapes the inner route-level boundary degrades to the fallback card rather than a blank page.

Verified: `tsc --noEmit` clean, Biome clean.

## Follow-ups (tracked, not in this PR)

- Explicit "backend unavailable / reconnecting" UI for API/SSE failures instead of bounce-to-Login; auto-retry bootstrap on transient failure.
- Retain prior builds' `/assets/` chunks across a deploy (grace window) so an in-flight tab can still fetch its old chunk.
