### PR TITLE
feat(connectors): unified credential-provider model (A+B+C)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -44,7 +44,7 @@ export interface ServerHandle {
   sseManager: SseEventManager;
   /** Shorthand for server.port */
   port: number;
-  /** Scoped internal token for protected default bundles. Rotated on every restart. */
+  /** Scoped internal-API auth token (the internal-API bearer). Rotated on every restart. */
   internalToken: string;
   /** Stop the server and health monitor. */
   stop(closeConnections?: boolean): void;

--- a/src/bundles/bundle-auth.ts
+++ b/src/bundles/bundle-auth.ts
@@ -5,17 +5,17 @@ import type { BundleRef } from "./types.ts";
  * mints a token on demand. Allowlist (not `!== "none"`) so a future interactive
  * auth type defaults to the OAuth path instead of silently boot-starting.
  */
-const STATIC_AUTH_TYPES: readonly string[] = ["bearer", "header", "tenant-key"];
+const STATIC_AUTH_TYPES: readonly string[] = ["bearer", "header", "provider"];
 
 /**
- * A url bundle has STATIC transport auth (`bearer` / `header` / `tenant-key`)
+ * A url bundle has STATIC transport auth (`bearer` / `header` / `provider`)
  * when it carries its own credential: it presents or mints a token on demand and
  * needs no persisted OAuth tokens and no interactive "Connect". `none` (or no
  * auth) means the bundle authenticates through the workspace OAuth provider.
  *
  * Gate boot-start and connection-state decisions on this so a static-auth source
- * is not mistaken for an un-authenticated OAuth bundle. Without it, a tenant-key
- * fleet source (artifacts / nimbletasks / web-search) is skipped at boot for
+ * is not mistaken for an un-authenticated OAuth bundle. Without it, a provider-
+ * auth fleet source (artifacts / nimbletasks / web-search) is skipped at boot for
  * "no tokens" — tools never surface — and seeded `not_authenticated`, which the
  * UI renders as a "Connect" button that would spin a bogus OAuth flow against a
  * server that has no OAuth.

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -460,7 +460,6 @@ export class BundleLifecycleManager {
       trustScore: trustScore ?? null,
       ui: ui ?? null,
       briefing: null,
-      protected: false,
       type: "plain",
       wsId,
     };
@@ -579,12 +578,8 @@ export class BundleLifecycleManager {
       }
     }
 
-    // Step 1 — Protected check
-    if (instance?.protected) {
-      throw new Error(`Cannot uninstall "${serverName}": bundle is protected`);
-    }
-
-    // Step 2+3 — Stop server, remove from registry
+    // Stop server, remove from registry. Every connector is user-removable
+    // (no `protected` guard — install/uninstall is symmetric for all classes).
     if (registry.hasSource(serverName)) {
       await registry.removeSource(serverName);
     }
@@ -1921,7 +1916,6 @@ export class BundleLifecycleManager {
       trustScore: ref.trustScore ?? null,
       ui: ref.ui ?? manifestMeta?.ui ?? null,
       briefing: manifestMeta?.briefing ?? null,
-      protected: ref.protected ?? false,
       type: manifestMeta?.type ?? "plain",
       wsId,
       // Derive the install channel from the persisted ref shape so both the
@@ -1966,7 +1960,7 @@ export class BundleLifecycleManager {
         // local; we don't need the catalog to derive the path.
         // Composio bundles carry header auth but STILL need a per-user connect,
         // so they route to the composio probe (check FIRST). Other static-auth
-        // sources (tenant-key / bearer / header) carry their own credential and
+        // sources (provider / bearer / header) carry their own credential and
         // auto-connect — no interactive Connect step — so they must not seed
         // `not_authenticated` (which the UI renders as a "Connect" button that
         // would spin a bogus OAuth flow). A surviving entry here means boot-start
@@ -2039,7 +2033,6 @@ function createInstance(
     trustScore: null,
     ui: null,
     briefing: null,
-    protected: false,
     type: isUpjack ? "upjack" : "plain",
     wsId,
     ...(namespace ? { entityDataRoot: join(dataDir, namespace, "data") } : {}),

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -553,14 +553,14 @@ export class BundleLifecycleManager {
   // ---- Uninstall ---------------------------------------------------------
 
   /**
-   * Uninstall a bundle (PRODUCT_SPEC ss3.4).
+   * Uninstall a bundle (PRODUCT_SPEC ss3.4). Every connector is user-removable —
+   * there is no `protected` guard.
    *
-   * 1. Check protected flag — reject if protected
-   * 2. Stop MCP server
-   * 3. Remove source from ToolRegistry
-   * 4. Remove entry from nimblebrain.json
-   * 5. Emit bundle.uninstalled
-   * 6. Data is NOT deleted
+   * 1. Stop MCP server
+   * 2. Remove source from ToolRegistry
+   * 3. Remove entry from nimblebrain.json
+   * 4. Emit bundle.uninstalled
+   * 5. Data is NOT deleted
    */
   async uninstall(nameOrPath: string, registry: ToolRegistry, wsId: string): Promise<void> {
     // Resolve by (serverName, wsId) first; fall back to bundleName match within

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -257,13 +257,14 @@ export async function startBundleSource(
     const serverName = ref.serverName ?? deriveServerName(ref.url);
     validateServerName(serverName);
     const sourceName = serverName;
-    // SSRF protection: validate URL before connecting. Tenant-key sources are the
-    // operator-provisioned fleet rail (tenant-key auth cannot be set by a tenant),
-    // so they may reach in-cluster `.svc` services over plain HTTP — see
-    // `validateBundleUrl`'s `fleetInternal` path.
+    // SSRF protection: validate URL before connecting. Provider-auth sources are
+    // the operator-provisioned fleet rail (a `provider` auth config can't be set
+    // from tenant input — it comes from the vetted catalog entry), so they may
+    // reach in-cluster `.svc` services over plain HTTP — see `validateBundleUrl`'s
+    // `fleetInternal` path.
     validateBundleUrl(new URL(ref.url), {
       allowInsecure: opts?.allowInsecureRemotes,
-      fleetInternal: ref.transport?.auth?.type === "tenant-key",
+      fleetInternal: ref.transport?.auth?.type === "provider",
     });
     log.info(`[bundles] Starting remote bundle ${ref.url} as ${sourceName}...`);
 
@@ -695,7 +696,10 @@ export async function startBundleSource(
       composeBundleMcpContext(opts?.bundleMcp, sourceName),
     );
   } else {
-    const internalEnv = ref.protected && opts?.internalEnv ? opts.internalEnv : undefined;
+    // Internal host env for trusted local bundles. Formerly gated on `protected`
+    // (now removed); no caller supplies `opts.internalEnv` today, so this stays
+    // dormant. A future internal/default-bundle path wires it deliberately.
+    const internalEnv = opts?.internalEnv;
     const result = buildLocalSource(
       ref,
       configDir,

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -38,12 +38,7 @@ import {
 } from "./paths.ts";
 import { notifyConnectionRunning } from "./pending-auth-buffer.ts";
 import { resolveLocalBundle } from "./resolve.ts";
-import type {
-  BundleManifest,
-  BundleRef,
-  LocalBundleMeta,
-  StartBundleResult,
-} from "./types.ts";
+import type { BundleManifest, BundleRef, LocalBundleMeta, StartBundleResult } from "./types.ts";
 import { validateBundleUrl } from "./url-validator.ts";
 
 /**

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -250,6 +250,18 @@ export async function startBundleSource(
     const serverName = ref.serverName ?? deriveServerName(ref.url);
     validateServerName(serverName);
     const sourceName = serverName;
+    // Diagnostic (NOT back-compat): name the cause when a url source declares a
+    // transport.auth.type the runtime doesn't recognize — otherwise it silently
+    // gets no credential and 401s. The likeliest case is a config that predates
+    // the provider-auth migration (e.g. the retired `tenant-key`).
+    const declaredAuthType = ref.transport?.auth?.type;
+    if (declaredAuthType && !["bearer", "header", "none", "provider"].includes(declaredAuthType)) {
+      log.warn(
+        `[bundles] source "${serverName}" declares an unrecognized transport.auth.type="${declaredAuthType}" ` +
+          "(known: bearer, header, none, provider). No credential will be attached and the source will likely 401 — " +
+          "if this config predates the provider-auth migration, re-register the source.",
+      );
+    }
     // SSRF protection: validate URL before connecting. Provider-auth sources are
     // the operator-provisioned fleet rail (a `provider` auth config can't be set
     // from tenant input — it comes from the vetted catalog entry), so they may

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -41,7 +41,6 @@ import { resolveLocalBundle } from "./resolve.ts";
 import type {
   BundleManifest,
   BundleRef,
-  InternalBundleEnv,
   LocalBundleMeta,
   StartBundleResult,
 } from "./types.ts";
@@ -190,7 +189,6 @@ export async function startBundleSource(
   configDir?: string,
   opts?: {
     allowInsecureRemotes?: boolean;
-    internalEnv?: InternalBundleEnv;
     dataDir?: string;
     /**
      * Workspace context for credential resolution and on-disk path
@@ -696,14 +694,9 @@ export async function startBundleSource(
       composeBundleMcpContext(opts?.bundleMcp, sourceName),
     );
   } else {
-    // Internal host env for trusted local bundles. Formerly gated on `protected`
-    // (now removed); no caller supplies `opts.internalEnv` today, so this stays
-    // dormant. A future internal/default-bundle path wires it deliberately.
-    const internalEnv = opts?.internalEnv;
     const result = buildLocalSource(
       ref,
       configDir,
-      internalEnv,
       opts?.dataDir,
       eventSink,
       wsContext?.workspaceId,
@@ -750,7 +743,6 @@ function buildLocalSource(
     serverName?: string;
   },
   configDir: string | undefined,
-  internalEnv: InternalBundleEnv | undefined,
   dataDirOverride: string | undefined,
   eventSink: EventSink,
   wsId: string | undefined,
@@ -798,12 +790,6 @@ function buildLocalSource(
     ...filterEnvForBundle(process.env as Record<string, string>, resolvedMcpEnv, ref.allowedEnv),
     ...(ref.env ?? {}),
   };
-
-  // Inject internal auth env for protected default bundles
-  if (internalEnv) {
-    spawnEnv.NB_INTERNAL_TOKEN = internalEnv.NB_INTERNAL_TOKEN;
-    spawnEnv.NB_HOST_URL = internalEnv.NB_HOST_URL;
-  }
 
   // Per-bundle data isolation. Callers (lifecycle install*, workspace-ops,
   // buildProcessInventory) always pass `dataDir` via

--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -51,14 +51,16 @@ export interface RemoteTransportConfig {
     | { type: "header"; name: string; value: string }
     | { type: "none" }
     /**
-     * Machine-plane auth for platform data-plane services (artifacts,
-     * nimbletasks, web-search). The runtime mints a short-lived,
-     * workspace-scoped service token on demand via the tenant-key grant
-     * (`NB_MCP_AUTHORIZER_TENANT_KEY` + `NB_FLEET_AUTHORIZER_ISSUER`), naming
-     * this `audience`/`scope`, and re-mints on expiry. No interactive OAuth, no
-     * static secret. The workspace dimension is the connection's own workspace.
+     * Non-interactive machine-plane auth produced by a named credential
+     * PROVIDER (see `src/tools/credential-provider.ts`). The provider name +
+     * its `config` are opaque to the kernel — for a catalog connector they come
+     * from the operator-published catalog entry, never tenant input. The
+     * built-in `"minted"` provider mints a short-lived, workspace-scoped service
+     * token against the fleet authorizer (config: `{ audience, scope, issuer? }`)
+     * and re-mints on expiry. No interactive OAuth, no static secret. The
+     * workspace dimension is the connection's own workspace.
      */
-    | { type: "tenant-key"; audience: string; scope: string };
+    | { type: "provider"; provider: string; config: Record<string, unknown> };
   headers?: Record<string, string>;
   reconnection?: {
     maxReconnectionDelay?: number;
@@ -82,7 +84,6 @@ export type BundleRef =
       serverName?: string;
       env?: Record<string, string>;
       allowedEnv?: string[];
-      protected?: boolean;
       trustScore?: number | null;
       ui?: BundleUiMeta | null;
     }
@@ -91,7 +92,6 @@ export type BundleRef =
       serverName?: string;
       env?: Record<string, string>;
       allowedEnv?: string[];
-      protected?: boolean;
       trustScore?: number | null;
       ui?: BundleUiMeta | null;
     }
@@ -99,7 +99,6 @@ export type BundleRef =
       url: string;
       serverName?: string;
       transport?: RemoteTransportConfig;
-      protected?: boolean;
       trustScore?: number | null;
       ui?: BundleUiMeta | null;
       /**
@@ -355,8 +354,6 @@ export interface BundleInstance {
   ui: BundleUiMeta | null;
   /** Briefing metadata from _meta["ai.nimblebrain/host"].briefing. */
   briefing: BriefingBlock | null;
-  /** Whether the bundle is protected from uninstall. */
-  protected: boolean;
   /** Whether this is an Upjack app or plain MCP server. */
   type: "upjack" | "plain";
   /**

--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -411,12 +411,6 @@ export interface LocalBundleMeta {
   upjackNamespace?: string;
 }
 
-/** Env vars injected into protected default bundles for internal host communication. */
-export interface InternalBundleEnv {
-  NB_INTERNAL_TOKEN: string;
-  NB_HOST_URL: string;
-}
-
 /** Result from starting a bundle source — includes the actual registered source name. */
 export interface StartBundleResult {
   meta: LocalBundleMeta | null;

--- a/src/bundles/url-validator.ts
+++ b/src/bundles/url-validator.ts
@@ -150,11 +150,12 @@ export function validateBundleUrl(
   }
 
   if (url.protocol === "http:") {
-    // Operator-provisioned fleet sources (tenant-key auth) may reach in-cluster
+    // Operator-provisioned fleet sources (provider auth) may reach in-cluster
     // services over plain HTTP — the fleet's trust boundary is NetworkPolicy +
     // the verified token (ARCHITECTURE P4), not TLS. This is a production posture
     // scoped to the cluster DNS suffix, NOT the dev-only `allowInsecure` flag, and
-    // it cannot be self-selected by a tenant (tenant-key auth is operator-only).
+    // it cannot be self-selected by a tenant (a `provider` auth config comes from
+    // the vetted catalog entry, never tenant input).
     if (fleetInternal && isInClusterHostname(url.hostname)) {
       return;
     }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -5,6 +5,7 @@ import { ConsoleEventSink } from "../../adapters/console-events.ts";
 import { DebugEventSink } from "../../adapters/debug-events.ts";
 import { startServerWithShutdown } from "../../api/server.ts";
 import { createSessionRegistry, resolveSessionStoreConfig } from "../../api/session-store/index.ts";
+import { registerBuiltinCredentialProviders } from "../../oauth/minted-credential-provider.ts";
 import { Runtime } from "../../runtime/runtime.ts";
 import type { TelemetryManager } from "../../telemetry/manager.ts";
 import { loadConfig } from "../config.ts";
@@ -24,6 +25,10 @@ export function createServeCommand(telemetry: TelemetryManager): Command {
       });
 
       config.events = [globals.debug ? new DebugEventSink() : new ConsoleEventSink()];
+
+      // Register built-in transport credential providers (e.g. the `minted`
+      // fleet provider) before any source starts and tries to resolve one.
+      registerBuiltinCredentialProviders();
 
       log.info("[nimblebrain] Starting runtime...");
       const startupTime = performance.now();

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -5,7 +5,6 @@ import { ConsoleEventSink } from "../../adapters/console-events.ts";
 import { DebugEventSink } from "../../adapters/debug-events.ts";
 import { startServerWithShutdown } from "../../api/server.ts";
 import { createSessionRegistry, resolveSessionStoreConfig } from "../../api/session-store/index.ts";
-import { registerBuiltinCredentialProviders } from "../../oauth/minted-credential-provider.ts";
 import { Runtime } from "../../runtime/runtime.ts";
 import type { TelemetryManager } from "../../telemetry/manager.ts";
 import { loadConfig } from "../config.ts";
@@ -25,10 +24,6 @@ export function createServeCommand(telemetry: TelemetryManager): Command {
       });
 
       config.events = [globals.debug ? new DebugEventSink() : new ConsoleEventSink()];
-
-      // Register built-in transport credential providers (e.g. the `minted`
-      // fleet provider) before any source starts and tries to resolve one.
-      registerBuiltinCredentialProviders();
 
       log.info("[nimblebrain] Starting runtime...");
       const startupTime = performance.now();

--- a/src/config/nimblebrain-config.schema.json
+++ b/src/config/nimblebrain-config.schema.json
@@ -104,10 +104,6 @@
             "items": { "type": "string" },
             "description": "Host env vars this bundle may access."
           },
-          "protected": {
-            "type": "boolean",
-            "description": "Prevents uninstall via nb__manage_app."
-          },
           "trustScore": { "type": ["number", "null"], "description": "MTF trust score (0-100)." },
           "transport": {
             "type": "object",
@@ -117,10 +113,12 @@
               "auth": {
                 "type": "object",
                 "properties": {
-                  "type": { "type": "string", "enum": ["bearer", "header", "none"] },
+                  "type": { "type": "string", "enum": ["bearer", "header", "none", "provider"] },
                   "token": { "type": "string" },
                   "name": { "type": "string" },
-                  "value": { "type": "string" }
+                  "value": { "type": "string" },
+                  "provider": { "type": "string", "description": "Credential provider name (auth.type=provider), e.g. \"minted\"." },
+                  "config": { "type": "object", "description": "Opaque provider config (e.g. { audience, scope } for \"minted\")." }
                 },
                 "required": ["type"]
               },

--- a/src/config/nimblebrain-config.schema.json
+++ b/src/config/nimblebrain-config.schema.json
@@ -117,8 +117,14 @@
                   "token": { "type": "string" },
                   "name": { "type": "string" },
                   "value": { "type": "string" },
-                  "provider": { "type": "string", "description": "Credential provider name (auth.type=provider), e.g. \"minted\"." },
-                  "config": { "type": "object", "description": "Opaque provider config (e.g. { audience, scope } for \"minted\")." }
+                  "provider": {
+                    "type": "string",
+                    "description": "Credential provider name (auth.type=provider), e.g. \"minted\"."
+                  },
+                  "config": {
+                    "type": "object",
+                    "description": "Opaque provider config (e.g. { audience, scope } for \"minted\")."
+                  }
                 },
                 "required": ["type"]
               },

--- a/src/connectors/server-detail.ts
+++ b/src/connectors/server-detail.ts
@@ -115,8 +115,11 @@ export interface NimbleBrainConnectorMeta {
    * - `composio`: Composio aggregator holds the vendor's tokens.
    *   Platform persists only an opaque `connectedAccountId` per
    *   workspace. Required: the `composio` block below.
+   * - `provider`: a platform-managed connector whose credential is produced
+   *   server-side by a named credential provider (no user/operator OAuth, no
+   *   per-user secret). Required: the `providerAuth` block below.
    */
-  auth?: "dcr" | "static" | "composio";
+  auth?: "dcr" | "static" | "composio" | "provider";
   /** Required for `auth: "static"`: where the operator creates the OAuth app. */
   operatorSetup?: {
     portalUrl: string;
@@ -153,6 +156,13 @@ export interface NimbleBrainConnectorMeta {
     authConfigEnv: string;
     tools?: string[];
   };
+  /**
+   * Required for `auth: "provider"`. Names the credential provider and its
+   * opaque config — e.g. `{ provider: "minted", config: { audience, scope } }`.
+   * Operator-authored; the install path copies it verbatim into the BundleRef
+   * `transport.auth`. NEVER derived from tenant input.
+   */
+  providerAuth?: { provider: string; config: Record<string, unknown> };
   /** Optional OAuth scopes the bundle requests. */
   requiredScopes?: string[];
   /** Optional extra authorize-URL params (e.g. Google's access_type=offline). */

--- a/src/oauth/minted-credential-provider.ts
+++ b/src/oauth/minted-credential-provider.ts
@@ -33,6 +33,11 @@ export const mintedCredentialProvider: TransportCredentialProvider = {
         "minted transport credential requires a workspaceId (the connection's workspace dimension)",
       );
     }
+    if (config === null || typeof config !== "object") {
+      throw new Error(
+        'minted transport credential requires a config object ({ audience, scope }); got a `provider` auth with no `config`',
+      );
+    }
     const issuer =
       (typeof config.issuer === "string" && config.issuer) ||
       process.env.NB_FLEET_AUTHORIZER_ISSUER;

--- a/src/oauth/minted-credential-provider.ts
+++ b/src/oauth/minted-credential-provider.ts
@@ -35,7 +35,7 @@ export const mintedCredentialProvider: TransportCredentialProvider = {
     }
     if (config === null || typeof config !== "object") {
       throw new Error(
-        'minted transport credential requires a config object ({ audience, scope }); got a `provider` auth with no `config`',
+        "minted transport credential requires a config object ({ audience, scope }); got a `provider` auth with no `config`",
       );
     }
     const issuer =

--- a/src/oauth/minted-credential-provider.ts
+++ b/src/oauth/minted-credential-provider.ts
@@ -1,0 +1,68 @@
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  registerCredentialProvider,
+  type TransportCredential,
+  type TransportCredentialProvider,
+} from "../tools/credential-provider.ts";
+import { createMintingFetch, getDefaultServiceTokenCache } from "./tenant-key-mint.ts";
+
+/** The provider name a catalog/source auth config selects: `{ type: "provider";
+ *  provider: "minted"; config: { audience, scope, issuer? } }`. */
+export const MINTED_PROVIDER = "minted";
+
+/**
+ * The platform minting provider. Mints a short-lived, workspace-scoped service
+ * token against the fleet authorizer and attaches it as the transport's `fetch`
+ * (re-minted on expiry / 401). This is the thin adapter that keeps the kernel's
+ * generic transport seam ignorant of the NimbleBrain mint protocol — the mint
+ * machinery (`tenant-key-mint.ts`) stays a kernel capability (the host artifact
+ * read path uses it too), but `remote-transport.ts` reaches it only through this
+ * registered provider, never by import.
+ *
+ * `config`: `{ audience: string; scope: string; issuer?: string }`. `issuer`
+ * defaults to `NB_FLEET_AUTHORIZER_ISSUER`. Workspace comes from the connection
+ * (the dimension the token is scoped to), NOT from config.
+ */
+export const mintedCredentialProvider: TransportCredentialProvider = {
+  credentialFor(
+    workspaceId: string | undefined,
+    config: Record<string, unknown>,
+  ): TransportCredential {
+    if (!workspaceId) {
+      throw new Error(
+        "minted transport credential requires a workspaceId (the connection's workspace dimension)",
+      );
+    }
+    const issuer =
+      (typeof config.issuer === "string" && config.issuer) ||
+      process.env.NB_FLEET_AUTHORIZER_ISSUER;
+    if (!issuer) {
+      throw new Error(
+        "minted transport credential requires NB_FLEET_AUTHORIZER_ISSUER (the mcp-authorizer issuer)",
+      );
+    }
+    const { audience, scope } = config;
+    if (typeof audience !== "string" || audience.length === 0) {
+      throw new Error("minted transport credential requires a string `audience` in config");
+    }
+    if (typeof scope !== "string" || scope.length === 0) {
+      throw new Error("minted transport credential requires a string `scope` in config");
+    }
+    const fetch = createMintingFetch({
+      cache: getDefaultServiceTokenCache(),
+      issuer,
+      workspace: workspaceId,
+      audience,
+      scope,
+    }) as FetchLike;
+    return { fetch };
+  },
+};
+
+/**
+ * Register the built-in credential providers. Called once at the composition
+ * root (the `serve` command, and any embedder boot). Idempotent.
+ */
+export function registerBuiltinCredentialProviders(): void {
+  registerCredentialProvider(MINTED_PROVIDER, mintedCredentialProvider);
+}

--- a/src/registries/projection.ts
+++ b/src/registries/projection.ts
@@ -88,6 +88,7 @@ function deriveInstall(s: ServerDetail): DirectoryEntry["install"] | null {
         : {}),
       ...(meta?.operatorSetup ? { operatorSetup: meta.operatorSetup } : {}),
       ...(meta?.composio ? { composio: meta.composio } : {}),
+      ...(meta?.providerAuth ? { providerAuth: meta.providerAuth } : {}),
     };
   }
   return null;
@@ -109,7 +110,7 @@ export interface ConnectorCatalogEntry {
   iconUrl: string;
   /** Remote MCP server URL — the value that goes into the bundle `url`. */
   url: string;
-  auth: "dcr" | "static" | "composio";
+  auth: "dcr" | "static" | "composio" | "provider";
   requiredScopes?: string[];
   additionalAuthorizationParams?: Record<string, string>;
   operatorSetup?: { portalUrl: string; hint: string; clientSecretKey: string };
@@ -120,6 +121,13 @@ export interface ConnectorCatalogEntry {
    * `connection.json`. Absent on dcr/static entries.
    */
   composio?: { toolkit: string; authConfigEnv: string; tools?: string[] };
+  /**
+   * Required for `auth: "provider"` entries: the credential provider name + its
+   * opaque config (e.g. `{ provider: "minted", config: { audience, scope } }`).
+   * Operator-authored; copied verbatim into the BundleRef's `transport.auth` at
+   * install, never derived from tenant input.
+   */
+  providerAuth?: { provider: string; config: Record<string, unknown> };
   tags?: string[];
   interactive?: boolean;
   docsUrl?: string;
@@ -152,6 +160,7 @@ export function serverDetailToCatalogEntry(s: ServerDetail): ConnectorCatalogEnt
       : {}),
     ...(meta?.operatorSetup ? { operatorSetup: meta.operatorSetup } : {}),
     ...(meta?.composio ? { composio: meta.composio } : {}),
+    ...(meta?.providerAuth ? { providerAuth: meta.providerAuth } : {}),
     ...(meta?.tags ? { tags: meta.tags } : {}),
     ...(typeof meta?.interactive === "boolean" ? { interactive: meta.interactive } : {}),
     ...(meta?.docsUrl ? { docsUrl: meta.docsUrl } : {}),

--- a/src/registries/types.ts
+++ b/src/registries/types.ts
@@ -126,7 +126,7 @@ export interface RemoteOAuthInstall {
    * the handshake.
    */
   transportType: "streamable-http" | "sse";
-  auth: "dcr" | "static" | "composio";
+  auth: "dcr" | "static" | "composio" | "provider";
   requiredScopes?: string[];
   additionalAuthorizationParams?: Record<string, string>;
   operatorSetup?: { portalUrl: string; hint: string; clientSecretKey: string };
@@ -136,6 +136,14 @@ export interface RemoteOAuthInstall {
    * `NimbleBrainConnectorMeta.composio` for the canonical shape.
    */
   composio?: { toolkit: string; authConfigEnv: string; tools?: string[] };
+  /**
+   * Required for `auth: "provider"`. Names the credential provider and its
+   * opaque config (e.g. `{ provider: "minted", config: { audience, scope } }`).
+   * Operator-authored in the catalog — the install path copies it verbatim into
+   * the BundleRef's `transport.auth`, NEVER taking provider/config from tenant
+   * input. That is what keeps a self-installable platform connector safe.
+   */
+  providerAuth?: { provider: string; config: Record<string, unknown> };
 }
 
 /**

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -436,8 +436,8 @@ export class Runtime {
     }
     const events: EventSink = new MultiEventSink(sinkList);
 
-    // Mint a scoped internal token for protected default bundles.
-    // Rotated on every runtime restart — never persisted.
+    // Mint the scoped internal-API auth token (the internal-API bearer checked
+    // in auth-middleware). Rotated on every runtime restart — never persisted.
     const internalToken = crypto.randomUUID();
 
     initWorkDir(config);
@@ -2530,7 +2530,7 @@ export class Runtime {
     };
   }
 
-  /** Scoped internal token for protected default bundles. Rotated on every restart. */
+  /** Scoped internal-API auth token (the internal-API bearer). Rotated on every restart. */
   getInternalToken(): string {
     return this._internalToken;
   }
@@ -2544,7 +2544,7 @@ export class Runtime {
    * would N×-multiply the request-path latency.
    *
    * `SharedSourceRef`-wrapped sources are unwrapped before the `McpSource`
-   * check; protected default bundles arrive wrapped and would otherwise be
+   * check; shared sources arrive wrapped and would otherwise be
    * silently invisible to this path.
    */
   private async getAppSkillResource(serverName: string): Promise<string | null> {
@@ -2616,8 +2616,8 @@ export class Runtime {
     const registry = this._workspaceRegistries.get(wsId);
     if (!registry) return [];
 
-    // Candidate sources: MCP-backed (unwrapping `SharedSourceRef` so protected
-    // default bundles are visible), and not the one already injected via
+    // Candidate sources: MCP-backed (unwrapping `SharedSourceRef` so shared
+    // sources are visible), and not the one already injected via
     // `<app-guide>` in `appContext` chats — otherwise the same body lands
     // twice in the prompt under two different framings.
     //

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -66,6 +66,7 @@ import { UserStore } from "../identity/user.ts";
 import { InstructionsStore } from "../instructions/index.ts";
 import { getModelByString, getProviderFromModel } from "../model/catalog.ts";
 import { buildModelResolver, resolveModelString } from "../model/registry.ts";
+import { registerBuiltinCredentialProviders } from "../oauth/minted-credential-provider.ts";
 import { installOAuthFetchDebug } from "../oauth/oauth-fetch-debug.ts";
 import { requestIdentityAttrs, withSpan } from "../observability/index.ts";
 import {
@@ -383,6 +384,14 @@ export class Runtime {
 
   /** Create and start a runtime from config. */
   static async start(config: RuntimeConfig): Promise<Runtime> {
+    // Register built-in transport credential providers (e.g. `minted`) at the
+    // ONE composition root every entry point shares — serve, the no-subcommand
+    // TUI/headless boot, and the automation runner all reach here before
+    // startWorkspaceBundles. Idempotent (last-writer-wins); doing it here instead
+    // of per-entry-point avoids a provider-auth source failing to boot under any
+    // path that forgot to register.
+    registerBuiltinCredentialProviders();
+
     // Temporary OAuth token-exchange diagnostic (no-op unless
     // NB_DEBUG_OAUTH_EXCHANGE is set). Installed before any bundle OAuth so
     // it captures the agent's /token request + the vendor's raw response.

--- a/src/runtime/workspace-runtime.ts
+++ b/src/runtime/workspace-runtime.ts
@@ -232,7 +232,7 @@ export async function startWorkspaceBundles(
       // Composio bundles carry header auth but STILL need a per-user connect, so
       // they route to the composio probe (check FIRST — they're also static-auth
       // by transport, but must not skip the connect gate). Other static-auth
-      // sources (tenant-key / bearer / header) carry their own credential and
+      // sources (provider / bearer / header) carry their own credential and
       // mint/present on demand — boot-start them. Only OAuth bundles gate on
       // persisted tokens.
       const hasAuth = entry.bundle.composio

--- a/src/tools/connector-tools.ts
+++ b/src/tools/connector-tools.ts
@@ -991,6 +991,9 @@ async function handleInstallRemoteOAuth(
   if (action.auth === "static" && !action.operatorSetup) {
     return errResult(`"${entry.name}" is static-auth but missing operatorSetup config.`);
   }
+  if (action.auth === "provider" && !action.providerAuth) {
+    return errResult(`"${entry.name}" is provider-auth but missing providerAuth config block.`);
+  }
 
   // serverName is the slugified canonical reverse-DNS form — opaque,
   // URL-safe, filesystem-safe, collision-free by construction. See
@@ -1100,8 +1103,22 @@ async function handleInstallRemoteOAuth(
       // Pin the transport class the source advertised. Default would be
       // streamable-http (createRemoteTransport's fallback), which is wrong
       // for vendors whose remote `type` is `sse` — PayPal / Cloudflare /
-      // Webflow / Wix in the bundled catalog today.
-      transport: composioWiring?.transport ?? { type: action.transportType },
+      // Webflow / Wix in the bundled catalog today. A `provider`-auth entry
+      // also carries its credential class here: provider + config are copied
+      // VERBATIM from the (operator-authored) catalog entry — never tenant
+      // input — which is what makes a self-installable platform connector safe.
+      transport:
+        composioWiring?.transport ??
+        (action.auth === "provider" && action.providerAuth
+          ? {
+              type: action.transportType,
+              auth: {
+                type: "provider",
+                provider: action.providerAuth.provider,
+                config: action.providerAuth.config,
+              },
+            }
+          : { type: action.transportType }),
       // Post-Stage-2: every ref's oauthScope is "workspace". The install
       // targets the request's active workspace (see the dispatch logic
       // above); the ref carries no per-target scope literal.
@@ -1218,15 +1235,13 @@ async function handleInstallRemoteOAuth(
   lifecycle.seedInstance(serverName, action.url, ref, undefined, wsId, undefined, wsRegistry);
   lifecycle.notifyInstalled(serverName, wsId);
 
-  // Composio-backed URL bundles authenticate via static header
-  // (x-api-key) — no MCP-side OAuth flow is needed to start the
-  // source, so kick it off here rather than waiting for the next
-  // platform boot. Tool listing works regardless of whether the
-  // user has completed Composio's OAuth dance yet; tool execution
-  // returns Composio's "not connected" errors until they do.
-  // For static / dcr bundles, source.start() is bound to
-  // `lifecycle.startAuth` (called from `/v1/mcp-auth/initiate`)
-  // and shouldn't run here.
+  // Static-credential URL bundles authenticate without an MCP-side OAuth flow,
+  // so start the source here rather than waiting for the next platform boot:
+  //  - composio: static `x-api-key` header (tool execution returns "not
+  //    connected" until the user finishes Composio's OAuth dance);
+  //  - provider: a server-side credential (e.g. minted) — no user auth at all.
+  // For static / dcr bundles, source.start() is bound to `lifecycle.startAuth`
+  // (called from `/v1/mcp-auth/initiate`) and shouldn't run here.
   //
   // Eager-start is a UX optimization (instant tool list). If it
   // fails the install itself has still succeeded — the BundleRef
@@ -1238,7 +1253,7 @@ async function handleInstallRemoteOAuth(
   // so the agent can communicate "installed, eager-start failed,
   // click Connect" cleanly.
   let startWarning: string | undefined;
-  if (action.auth === "composio") {
+  if (action.auth === "composio" || action.auth === "provider") {
     try {
       await startBundleSource(ref, wsRegistry, ctx.runtime.getEventSink(), undefined, {
         allowInsecureRemotes: ctx.runtime.getAllowInsecureRemotes(),
@@ -1249,7 +1264,7 @@ async function handleInstallRemoteOAuth(
     } catch (err) {
       startWarning = err instanceof Error ? err.message : String(err);
       log.warn(
-        `[connector-tools] composio eager-start failed for ${entry.name} in ${wsId} ` +
+        `[connector-tools] ${action.auth} eager-start failed for ${entry.name} in ${wsId} ` +
           `(install succeeded; click Connect to retry): ${startWarning}`,
       );
     }

--- a/src/tools/connector-tools.ts
+++ b/src/tools/connector-tools.ts
@@ -963,7 +963,9 @@ async function handleInstallRemoteOAuth(
   if (entry.install.kind !== "remote-oauth") {
     return errResult("invariant violated: handleInstallRemoteOAuth requires remote-oauth entry");
   }
-  const action = entry.install;
+  // Reassignable: a `provider` entry's security-critical fields are re-resolved
+  // from the server-trusted catalog below (the caller's wire values are discarded).
+  let action = entry.install;
 
   // Cheap entry-shape validation up front (fail fast, no IO). The
   // expensive remote work — Composio session create, operator
@@ -991,8 +993,23 @@ async function handleInstallRemoteOAuth(
   if (action.auth === "static" && !action.operatorSetup) {
     return errResult(`"${entry.name}" is static-auth but missing operatorSetup config.`);
   }
-  if (action.auth === "provider" && !action.providerAuth) {
-    return errResult(`"${entry.name}" is provider-auth but missing providerAuth config block.`);
+  if (action.auth === "provider") {
+    // SECURITY (trust boundary): a `provider` install mints a fleet-trusted,
+    // workspace-scoped service token (the `minted` provider) and ships it to the
+    // entry's URL. The install tool otherwise trusts the caller-supplied entry
+    // ("the registry that produced the entry is the source of truth") — but that
+    // is FALSE for this class: a workspace admin could forge an entry with an
+    // arbitrary url + audience/scope and exfiltrate a fleet token / reach an
+    // in-cluster .svc the SSRF guard protects. So re-resolve the security-critical
+    // fields (url + providerAuth) from the SERVER-trusted catalog by id, discard
+    // the caller's, and reject any provider entry that isn't a known catalog entry.
+    const trusted = await ctx.runtime.getConnectorDirectory().catalogById(entry.id);
+    if (!trusted || trusted.auth !== "provider" || !trusted.providerAuth) {
+      return errResult(
+        `"${entry.name}" is not a recognized platform connector — refusing a provider-auth install from an unverified entry.`,
+      );
+    }
+    action = { ...action, url: trusted.url, providerAuth: trusted.providerAuth };
   }
 
   // serverName is the slugified canonical reverse-DNS form — opaque,

--- a/src/tools/credential-provider.ts
+++ b/src/tools/credential-provider.ts
@@ -1,0 +1,44 @@
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+/**
+ * The credential a provider attaches to a remote MCP transport: either static
+ * headers, or a `fetch` wrapper that injects (and re-mints) a token per request.
+ */
+export interface TransportCredential {
+  headers?: Record<string, string>;
+  fetch?: FetchLike;
+}
+
+/**
+ * Produces the credential for a remote MCP connection. This is the kernel's ONE
+ * generic seam for non-interactive, preconfigured machine-plane auth — the thing
+ * `bearer`/`header`/minted-token all are, viewed as "attach a credential."
+ *
+ * `config` is OPAQUE to the kernel: it comes from the source's vetted transport
+ * auth config, which (for catalog connectors) originates from the operator-
+ * published catalog entry — NEVER from tenant input. So the kernel never learns
+ * what a provider means (issuer, audience, fleet, …); it just asks for a
+ * credential for `(workspaceId, config)` and presents it.
+ */
+export interface TransportCredentialProvider {
+  credentialFor(
+    workspaceId: string | undefined,
+    config: Record<string, unknown>,
+  ): TransportCredential;
+}
+
+const REGISTRY = new Map<string, TransportCredentialProvider>();
+
+/** Register a named credential provider. Called at the composition root (and by
+ *  tests). Re-registration overwrites — last writer wins. */
+export function registerCredentialProvider(
+  name: string,
+  provider: TransportCredentialProvider,
+): void {
+  REGISTRY.set(name, provider);
+}
+
+/** Look up a registered provider by name, or undefined if none is registered. */
+export function getCredentialProvider(name: string): TransportCredentialProvider | undefined {
+  return REGISTRY.get(name);
+}

--- a/src/tools/remote-transport.ts
+++ b/src/tools/remote-transport.ts
@@ -3,7 +3,7 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { FetchLike, Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { RemoteTransportConfig } from "../bundles/types.ts";
-import { createMintingFetch, getDefaultServiceTokenCache } from "../oauth/tenant-key-mint.ts";
+import { getCredentialProvider } from "./credential-provider.ts";
 
 /**
  * Resolve `${ENV_VAR}` placeholders against `process.env`.
@@ -51,9 +51,9 @@ export function createRemoteTransport(
   config?: RemoteTransportConfig,
   authProvider?: OAuthClientProvider,
   opts?: {
-    /** Workspace of the connection — required for `auth.type: "tenant-key"`, the
-     *  dimension the minted token is scoped to. Threaded from the McpSource's
-     *  `BundleMcpContext`. */
+    /** Workspace of the connection — passed to a credential provider (e.g. the
+     *  dimension a `provider`-auth token is scoped to). Threaded from the
+     *  McpSource's `BundleMcpContext`. */
     workspaceId?: string;
   },
 ): Transport {
@@ -71,33 +71,26 @@ export function createRemoteTransport(
     headers[k] = resolveEnvTemplate(v);
   }
 
-  // Machine-plane auth: mint a workspace-scoped service token on demand and
-  // attach it as the transport's `fetch`. This is NOT a static header (the
-  // token is short-lived and re-minted on expiry / 401) and it is NOT OAuth
-  // (no interactive flow). Fail loud here if the connection's workspace or the
-  // authorizer issuer is missing — a tenant-key bundle is unreachable without
-  // both, and a downstream 401 would not name the cause.
+  // Provider-backed machine-plane auth: a named credential provider produces a
+  // `fetch` (or headers) for this connection. NOT a static header (the built-in
+  // `minted` provider re-mints a short-lived token on expiry / 401) and NOT
+  // OAuth (no interactive flow). The provider + its `config` are opaque here;
+  // the kernel just asks for a credential. Fail loud if the named provider isn't
+  // registered — a downstream 401 would not name the cause.
   let mintingFetch: FetchLike | undefined;
-  if (config?.auth?.type === "tenant-key") {
-    const workspaceId = opts?.workspaceId;
-    if (!workspaceId) {
+  if (config?.auth?.type === "provider") {
+    const provider = getCredentialProvider(config.auth.provider);
+    if (!provider) {
       throw new Error(
-        "tenant-key transport auth requires a workspaceId (the connection's workspace dimension)",
+        `transport auth provider "${config.auth.provider}" is not registered ` +
+          "(call registerBuiltinCredentialProviders() at the composition root)",
       );
     }
-    const issuer = process.env.NB_FLEET_AUTHORIZER_ISSUER;
-    if (!issuer) {
-      throw new Error(
-        "tenant-key transport auth requires NB_FLEET_AUTHORIZER_ISSUER (the mcp-authorizer issuer)",
-      );
+    const credential = provider.credentialFor(opts?.workspaceId, config.auth.config);
+    if (credential.headers) {
+      for (const [k, v] of Object.entries(credential.headers)) headers[k] = v;
     }
-    mintingFetch = createMintingFetch({
-      cache: getDefaultServiceTokenCache(),
-      issuer,
-      workspace: workspaceId,
-      audience: config.auth.audience,
-      scope: config.auth.scope,
-    }) as FetchLike;
+    mintingFetch = credential.fetch;
   }
 
   // Only wire the OAuth provider if no static auth is configured. Static

--- a/test/integration/internal-auth-token.test.ts
+++ b/test/integration/internal-auth-token.test.ts
@@ -13,7 +13,6 @@ import {
 	INTERNAL_TOKEN_ALLOWED_PATHS,
 } from "../../src/api/auth-utils.ts";
 import { filterEnvForBundle } from "../../src/bundles/env-filter.ts";
-import { DEFAULT_BUNDLES } from "../../src/bundles/defaults.ts";
 import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
 
 let runtime: Runtime;
@@ -187,11 +186,5 @@ describe("internal auth token - env isolation", () => {
 		};
 		const result = filterEnvForBundle(env, undefined, ["NB_INTERNAL_TOKEN"]);
 		expect(result.NB_INTERNAL_TOKEN).toBeUndefined();
-	});
-
-	it("default bundles are marked as protected", () => {
-		for (const bundle of DEFAULT_BUNDLES) {
-			expect(bundle.protected).toBe(true);
-		}
 	});
 });

--- a/test/integration/lifecycle-startauth-interactive-failure.test.ts
+++ b/test/integration/lifecycle-startauth-interactive-failure.test.ts
@@ -127,7 +127,6 @@ describe("lifecycle.startAuth — interactive-flow failure is surfaced, not swal
       trustScore: null,
       ui: null,
       briefing: null,
-      protected: false,
       type: "plain",
       wsId: WS,
       oauthScope: "workspace",

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -275,40 +275,6 @@ describe("BundleLifecycleManager — uninstall", () => {
 		expect(lifecycle.getInstances().find(i => i.serverName === serverName)).toBeUndefined();
 	}, 15_000);
 
-	it("rejects uninstall of a protected bundle", async () => {
-		const bundleDir = createEchoBundleOnDisk(join(testDir, "echo-protected"));
-		const configPath = join(testDir, "nimblebrain-protected.json");
-		writeFileSync(configPath, JSON.stringify({ bundles: [] }, null, 2));
-
-		const registry = new ToolRegistry();
-		const sink = makeEventCollector();
-		const lifecycle = new BundleLifecycleManager(sink, configPath);
-
-		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
-
-		// Mark as protected
-		instance.protected = true;
-
-		// Attempt uninstall should throw
-		let error: Error | null = null;
-		try {
-			await lifecycle.uninstall(instance.serverName, registry, "ws_test");
-		} catch (e) {
-			error = e as Error;
-		}
-
-		expect(error).not.toBeNull();
-		expect(error!.message).toContain("protected");
-
-		// Source should still be registered
-		expect(registry.hasSource(instance.serverName)).toBe(true);
-
-		// No uninstalled event
-		expect(eventTypes(sink)).not.toContain("bundle.uninstalled");
-
-		await registry.removeSource(instance.serverName);
-	}, 15_000);
-
 	it("does not delete data directories on uninstall", async () => {
 		const bundleDir = createEchoBundleOnDisk(join(testDir, "echo-data-preserve"));
 		const configPath = join(testDir, "nimblebrain-data.json");
@@ -590,7 +556,6 @@ describe("BundleLifecycleManager — instance tracking", () => {
 
 		lifecycle.seedInstance("ipinfo", "@nimblebraininc/ipinfo", {
 			name: "@nimblebraininc/ipinfo",
-			protected: true,
 			trustScore: 92,
 			ui: { name: "IPInfo", icon: "globe" },
 		}, undefined, "ws_test");
@@ -598,7 +563,6 @@ describe("BundleLifecycleManager — instance tracking", () => {
 		const instance = lifecycle.getInstance("ipinfo", "ws_test")!;
 		expect(instance).toBeDefined();
 		expect(instance.state).toBe("running");
-		expect(instance.protected).toBe(true);
 		expect(instance.trustScore).toBe(92);
 		expect(instance.ui?.name).toBe("IPInfo");
 

--- a/test/unit/briefing-collector.test.ts
+++ b/test/unit/briefing-collector.test.ts
@@ -48,7 +48,6 @@ function makeInstance(overrides: Partial<BundleInstance> = {}): BundleInstance {
 				},
 			],
 		},
-		protected: false,
 		type: "upjack",
 		wsId: "ws_test",
 		...overrides,

--- a/test/unit/connector-tools.test.ts
+++ b/test/unit/connector-tools.test.ts
@@ -1414,16 +1414,10 @@ describe("manage_connectors.clear_user_config", () => {
 
 describe("deriveConnectorStatus", () => {
   test("running + no probes outstanding → ready", () => {
-    expect(deriveConnectorStatus({ state: "running" })).toEqual({ status: "ready" });
-  });
-
-  test("provider-auth fleet source (running, no operator OAuth, no user_config) → ready", () => {
-    // Regression: a `provider`-auth fleet source (e.g. deep_research `web`) is a
-    // remote bundle, so it gets NO `userConfig` probe (that gate is `!isRemote`)
-    // and has no operator OAuth client — its credential is provided server-side.
-    // It boots `running` (bundleHasStaticAuth), so it must derive `ready`: no
-    // bogus Connect, no "needs setup" for a key the server already holds. The UI
-    // hero is status-driven, so `ready` means no Connect button.
+    // This is the state a provider-auth fleet source (e.g. deep_research `web`)
+    // produces: a remote bundle gets NO userConfig probe (`!isRemote`) and has no
+    // operator OAuth client, so its inputs are bare `{ state: "running" }` → ready
+    // (no bogus Connect). Boot-side coverage: provider-source-boot.test.ts.
     expect(deriveConnectorStatus({ state: "running" })).toEqual({ status: "ready" });
   });
 

--- a/test/unit/connector-tools.test.ts
+++ b/test/unit/connector-tools.test.ts
@@ -795,6 +795,44 @@ describe("manage_connectors.install", () => {
     expect(text).toContain("not visible in this workspace");
   });
 
+  test("SECURITY: refuses a provider-auth install whose entry isn't a known catalog connector", async () => {
+    // The provider class mints a fleet-trusted, workspace-scoped service token and
+    // ships it to the entry's URL. Unlike every other install kind, its config must
+    // NOT be trusted from the caller-supplied entry — a workspace admin could forge
+    // one pointing at an in-cluster .svc with an attacker-chosen audience/scope and
+    // exfiltrate a fleet token / reach the fleet rail the SSRF guard protects. The
+    // handler must re-resolve from the server-trusted catalog by id and reject an
+    // entry that isn't there.
+    const tool = buildTool(h, ADMIN_USER);
+    const result = await tool.handler({
+      action: "install",
+      entry: {
+        id: "evil.attacker/web",
+        name: "Totally Legit",
+        registryId: "bundled-static",
+        registryType: "static",
+        install: {
+          kind: "remote-oauth",
+          url: "http://mcp-authorizer.mcp-shared.svc/token",
+          transportType: "streamable-http",
+          auth: "provider",
+          providerAuth: {
+            provider: "minted",
+            config: { audience: "artifacts", scope: "artifacts:write" },
+          },
+        },
+      },
+      wsId: h.wsId,
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content?.[0] as { text?: string } | undefined)?.text ?? "";
+    expect(text).toMatch(/not a recognized platform connector/i);
+    // Nothing forged was persisted into workspace.json.
+    const ws = await h.workspaceStore.get(h.wsId);
+    const bundles = (ws?.bundles ?? []) as Array<{ url?: string }>;
+    expect(bundles.some((b) => (b.url ?? "").includes("mcp-authorizer"))).toBe(false);
+  });
+
   test("install hard-errors when there is no workspace in context (no session, no wsId arg)", async () => {
     // Install defaults to the request's workspace (`getWorkspaceId()`),
     // but here the session workspace is explicitly null (third arg to

--- a/test/unit/connector-tools.test.ts
+++ b/test/unit/connector-tools.test.ts
@@ -1417,6 +1417,16 @@ describe("deriveConnectorStatus", () => {
     expect(deriveConnectorStatus({ state: "running" })).toEqual({ status: "ready" });
   });
 
+  test("provider-auth fleet source (running, no operator OAuth, no user_config) → ready", () => {
+    // Regression: a `provider`-auth fleet source (e.g. deep_research `web`) is a
+    // remote bundle, so it gets NO `userConfig` probe (that gate is `!isRemote`)
+    // and has no operator OAuth client — its credential is provided server-side.
+    // It boots `running` (bundleHasStaticAuth), so it must derive `ready`: no
+    // bogus Connect, no "needs setup" for a key the server already holds. The UI
+    // hero is status-driven, so `ready` means no Connect button.
+    expect(deriveConnectorStatus({ state: "running" })).toEqual({ status: "ready" });
+  });
+
   test("missingOperatorSetup wins over every other signal — admin acts first", () => {
     // Even with state=running and required user_config populated, an
     // unconfigured operator OAuth client should mark the connector as

--- a/test/unit/directory-entry-projection.test.ts
+++ b/test/unit/directory-entry-projection.test.ts
@@ -126,6 +126,31 @@ describe("projectServerDetailToDirectoryEntry", () => {
     }
   });
 
+  test("projects provider auth + providerAuth (the platform-connector class)", () => {
+    const e = projectServerDetailToDirectoryEntry(
+      detail({
+        remotes: [{ type: "streamable-http", url: "http://mcp-web.mcp-shared.svc/mcp" }],
+        _meta: {
+          "ai.nimblebrain/connector": {
+            auth: "provider",
+            providerAuth: { provider: "minted", config: { audience: "mcp-fleet", scope: "mcp:invoke" } },
+          },
+        },
+      }),
+      CTX,
+    );
+    expect(e?.install.kind).toBe("remote-oauth");
+    if (e?.install.kind === "remote-oauth") {
+      expect(e.install.auth).toBe("provider");
+      // The operator-authored provider config is carried through verbatim — this
+      // is what the install path copies into transport.auth (never tenant input).
+      expect(e.install.providerAuth).toEqual({
+        provider: "minted",
+        config: { audience: "mcp-fleet", scope: "mcp:invoke" },
+      });
+    }
+  });
+
   test("threads streamable-http transport type from remotes[0] to install action", () => {
     const e = projectServerDetailToDirectoryEntry(
       detail({

--- a/test/unit/lifecycle-connection.test.ts
+++ b/test/unit/lifecycle-connection.test.ts
@@ -25,7 +25,6 @@ function seedInstance(lifecycle: BundleLifecycleManager, serverName: string, wsI
     trustScore: null,
     ui: null,
     briefing: null,
-    protected: false,
     type: "plain",
     wsId,
   };

--- a/test/unit/lifecycle-recover-source.test.ts
+++ b/test/unit/lifecycle-recover-source.test.ts
@@ -49,7 +49,6 @@ function seedInstance(lifecycle: BundleLifecycleManager, serverName: string, ref
     trustScore: null,
     ui: null,
     briefing: null,
-    protected: false,
     type: "plain",
     wsId: WS,
     oauthScope: "workspace",

--- a/test/unit/lifecycle-startauth-coalesce.test.ts
+++ b/test/unit/lifecycle-startauth-coalesce.test.ts
@@ -44,7 +44,6 @@ function seedInstance(
     trustScore: null,
     ui: null,
     briefing: null,
-    protected: false,
     type: "plain",
     wsId,
     oauthScope: "workspace",

--- a/test/unit/lifecycle-startauth-disconnect.test.ts
+++ b/test/unit/lifecycle-startauth-disconnect.test.ts
@@ -42,7 +42,6 @@ function seedInstance(
     trustScore: null,
     ui: null,
     briefing: null,
-    protected: false,
     type: "plain",
     wsId,
     oauthScope,

--- a/test/unit/provider-source-boot.test.ts
+++ b/test/unit/provider-source-boot.test.ts
@@ -9,20 +9,20 @@ class NoopSink implements EventSink {
   emit(_event: EngineEvent): void {}
 }
 
-function tenantKeyRef(): BundleRef {
+function providerRef(): BundleRef {
   return {
     url: "https://web.svc.test/mcp",
     serverName: "web",
     transport: {
       type: "streamable-http",
-      auth: { type: "tenant-key", audience: "mcp-fleet", scope: "mcp:invoke" },
+      auth: { type: "provider", provider: "minted", config: { audience: "mcp-fleet", scope: "mcp:invoke" } },
     },
   };
 }
 
 describe("bundleHasStaticAuth", () => {
-  test("tenant-key url bundle has static auth", () => {
-    expect(bundleHasStaticAuth(tenantKeyRef())).toBe(true);
+  test("provider-auth url bundle has static auth", () => {
+    expect(bundleHasStaticAuth(providerRef())).toBe(true);
   });
 
   test("bearer and header url bundles have static auth", () => {
@@ -48,15 +48,15 @@ describe("bundleHasStaticAuth", () => {
   });
 });
 
-describe("seedInstance — tenant-key fleet source", () => {
-  // Regression: a tenant-key source mints on demand and has no persisted OAuth
+describe("seedInstance — provider-auth fleet source", () => {
+  // Regression: a provider-auth source mints on demand and has no persisted OAuth
   // tokens, so the OAuth-centric boot gate seeded it `not_authenticated` — the
   // agent never saw its tools, and the UI showed a "Connect" button that would
   // spin a bogus OAuth flow against a server with no OAuth. It must seed
   // `running` (auto-connected) instead.
   test("seeds running, not not_authenticated", () => {
     const lifecycle = new BundleLifecycleManager(new NoopSink(), undefined);
-    lifecycle.seedInstance("web", "https://web.svc.test/mcp", tenantKeyRef(), undefined, "ws_test");
+    lifecycle.seedInstance("web", "https://web.svc.test/mcp", providerRef(), undefined, "ws_test");
 
     const conn = lifecycle.getInstance("web", "ws_test")?.connections.get(WORKSPACE_PRINCIPAL_ID);
     expect(conn?.state).toBe("running");

--- a/test/unit/remote-transport-factory.test.ts
+++ b/test/unit/remote-transport-factory.test.ts
@@ -153,6 +153,20 @@ describe("createRemoteTransport — provider auth (minted)", () => {
 		).toThrow(/workspaceId/);
 	});
 
+	test("throws a clear error on a provider auth with no config (fail loud, not a cryptic undefined read)", () => {
+		process.env.NB_FLEET_AUTHORIZER_ISSUER = "https://authz.test";
+		// A malformed workspace.json `{ type: "provider", provider: "minted" }` with
+		// no `config` (the TS type requires it; JSON config can omit it).
+		const noConfig = { auth: { type: "provider" as const, provider: "minted" } } as unknown as Parameters<
+			typeof createRemoteTransport
+		>[1];
+		expect(() =>
+			createRemoteTransport(new URL("https://artifacts.test/mcp"), noConfig, undefined, {
+				workspaceId: "ws_smoke",
+			}),
+		).toThrow(/config object/);
+	});
+
 	test("throws when NB_FLEET_AUTHORIZER_ISSUER is unset", () => {
 		delete process.env.NB_FLEET_AUTHORIZER_ISSUER;
 		expect(() =>

--- a/test/unit/remote-transport-factory.test.ts
+++ b/test/unit/remote-transport-factory.test.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { afterEach, describe, expect, test } from "bun:test";
 import { createRemoteTransport } from "../../src/tools/remote-transport.ts";
+import { registerBuiltinCredentialProviders } from "../../src/oauth/minted-credential-provider.ts";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 
@@ -115,7 +116,11 @@ describe("createRemoteTransport", () => {
 	});
 });
 
-describe("createRemoteTransport — tenant-key auth", () => {
+describe("createRemoteTransport — provider auth (minted)", () => {
+	// The generic `provider` auth dispatches to a registered credential provider;
+	// register the built-in `minted` provider so the seam resolves it.
+	registerBuiltinCredentialProviders();
+
 	const saved = {
 		tid: process.env.NB_TENANT_ID,
 		key: process.env.NB_MCP_AUTHORIZER_TENANT_KEY,
@@ -133,21 +138,25 @@ describe("createRemoteTransport — tenant-key auth", () => {
 		}
 	});
 
-	const tenantKeyConfig = {
-		auth: { type: "tenant-key" as const, audience: "artifacts", scope: "artifacts:write" },
+	const mintedConfig = {
+		auth: {
+			type: "provider" as const,
+			provider: "minted",
+			config: { audience: "artifacts", scope: "artifacts:write" },
+		},
 	};
 
 	test("throws when the connection has no workspaceId (fail loud, not a silent 401)", () => {
 		process.env.NB_FLEET_AUTHORIZER_ISSUER = "https://authz.test";
 		expect(() =>
-			createRemoteTransport(new URL("https://artifacts.test/mcp"), tenantKeyConfig),
+			createRemoteTransport(new URL("https://artifacts.test/mcp"), mintedConfig),
 		).toThrow(/workspaceId/);
 	});
 
 	test("throws when NB_FLEET_AUTHORIZER_ISSUER is unset", () => {
 		delete process.env.NB_FLEET_AUTHORIZER_ISSUER;
 		expect(() =>
-			createRemoteTransport(new URL("https://artifacts.test/mcp"), tenantKeyConfig, undefined, {
+			createRemoteTransport(new URL("https://artifacts.test/mcp"), mintedConfig, undefined, {
 				workspaceId: "ws_smoke",
 			}),
 		).toThrow(/NB_FLEET_AUTHORIZER_ISSUER/);
@@ -157,7 +166,7 @@ describe("createRemoteTransport — tenant-key auth", () => {
 		process.env.NB_TENANT_ID = "hq";
 		process.env.NB_MCP_AUTHORIZER_TENANT_KEY = randomBytes(32).toString("base64");
 		process.env.NB_FLEET_AUTHORIZER_ISSUER = "https://authz.test";
-		const t = createRemoteTransport(new URL("https://artifacts.test/mcp"), tenantKeyConfig, undefined, {
+		const t = createRemoteTransport(new URL("https://artifacts.test/mcp"), mintedConfig, undefined, {
 			workspaceId: "ws_smoke",
 		});
 		expect(t).toBeInstanceOf(StreamableHTTPClientTransport);

--- a/test/unit/remote-transport-types.test.ts
+++ b/test/unit/remote-transport-types.test.ts
@@ -26,7 +26,6 @@ describe("Remote transport — TypeScript types", () => {
 				type: "streamable-http",
 				auth: { type: "bearer", token: "tok_123" },
 			},
-			protected: true,
 			trustScore: 85,
 			ui: null,
 		};

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -571,7 +571,7 @@ export interface ConnectorCatalogEntry {
   description: string;
   iconUrl: string;
   url: string;
-  auth: "dcr" | "static" | "composio";
+  auth: "dcr" | "static" | "composio" | "provider";
   requiredScopes?: string[];
   additionalAuthorizationParams?: Record<string, string>;
   operatorSetup?: { portalUrl: string; hint: string; clientSecretKey: string };
@@ -872,7 +872,7 @@ export interface DirectoryEntry {
     | {
         kind: "remote-oauth";
         url: string;
-        auth: "dcr" | "static" | "composio";
+        auth: "dcr" | "static" | "composio" | "provider";
         requiredScopes?: string[];
         additionalAuthorizationParams?: Record<string, string>;
         operatorSetup?: { portalUrl: string; hint: string; clientSecretKey: string };

--- a/web/src/pages/settings/ConnectorBrowsePage.tsx
+++ b/web/src/pages/settings/ConnectorBrowsePage.tsx
@@ -127,6 +127,15 @@ export function ConnectorBrowsePage() {
       // Stdio (mpak-bundle): install completes in-process; route to
       // Configure so the user can fill in any user_config fields.
       if (entry.install.kind === "remote-oauth") {
+        // A provider-auth (platform) source has no user/operator OAuth — its
+        // credential is minted server-side and it eager-starts `running` at
+        // install. So there's no auth flow to launch: route to Configure, which
+        // renders it `ready`. Launching initiateMcpOAuth here would spin a bogus
+        // OAuth flow against a server that has none.
+        if (entry.install.auth === "provider") {
+          navigate(`${configureBasePath}/${result.serverName}`);
+          return;
+        }
         // Composio-backed connectors route through their own initiate
         // endpoint (keyed on catalog id, not server name). Everything
         // else (dcr + static) stays on /v1/mcp-auth.


### PR DESCRIPTION
Unify the connector model: DCR / Composio / static / platform-server connectors all install and remove the same way — from the catalog, with tools available when a conversation is focused in that workspace. Removes the platform-specific `tenant-key`/`protected` leak from the kernel. Design: `hq/research/SPEC-connector-model-unification.md`.

## A — generic credential-provider transport auth
`{ type: "tenant-key" }` → `{ type: "provider"; provider; config }`. The kernel no longer knows "fleet"/"tenant-key"/"mint". The mint stays a kernel capability behind the `minted` provider (registered in `Runtime.start` — the one composition root all entry points share); `remote-transport.ts` no longer imports it. `protected` removed (it was only web's uninstall guard; `DEFAULT_BUNDLES` is `[]`, so the protected-gated internal-env path was dead).

## B — verification
The three "agent-layer" gaps were closed structurally by A (+ merged #449), not by new fix code: corpus-vs-active-set is correct focus-based behavior; a remote source gets no `userConfig` gate → running → `ready`; `protected` gone → uninstall is unconditional + `removeSource` fires invalidation. Regression test + tracked-issue resolution.

## C — catalog + install (the Install-button experience)
web → a catalog connector (`auth: provider`), installable like any other; eager-starts `running` (no OAuth), tools available immediately. Frontend skips the OAuth flow for provider and renders `ready`.

**Trust boundary — ENFORCED (not just asserted):** the `provider` class mints a fleet-trusted token, so its `url`+`providerAuth` are re-resolved server-side from the trusted catalog by id at install (`catalogById`); the caller's wire values are discarded and an unknown provider entry is rejected. Security test covers a forged entry. (This closed a critical caught in review — caller-supplied provider installs could otherwise exfiltrate a fleet token / SSRF the fleet rail.)

## Pairs with (coordinated landing)
- **deployments #39** — `platform.yaml` catalog entry for web (staging-gated until `mcp-web` is in prod); `admin-add-source` off `tenant-key`/`protected`.
- **nimblebrain-schemas #1** — `provider` auth variant (provider/config required), drop `protected`. Must publish in lockstep (else `FORCE_SCHEMA_FETCH` reverts).

**Deploy order:** #458 first (runtime must understand `provider`), then deployments #39; schemas #1 independently. No back-compat shim by decision (no tenants deployed → no live config stranded). A diagnostic `log.warn` names an unrecognized `auth.type` for operator insurance.

## Verification
tsc / biome (repo pinned gate) clean; full suite **4231 pass / 0 fail**. Survived multiple review rounds (composition-root asymmetry, dead internalEnv seam, biome/CI, the provider trust boundary).

## Pre-merge checklist
- [ ] CHANGELOG/docs entry for the config-breaking change (`tenant-key`/`protected` removal)
- [ ] schemas #1 merged + published in lockstep