### PR TITLE
fix(api/auth): 503 (not 401) when token refresh can't reach a verdict

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -16,6 +16,7 @@ import {
   isArtifactUri,
 } from "../host-resources/artifacts/index.ts";
 import type { IdentityProvider, UserIdentity } from "../identity/provider.ts";
+import { RefreshTokenError } from "../identity/provider.ts";
 import { DEV_IDENTITY } from "../identity/providers/dev.ts";
 import {
   ConversationAccessDeniedError,
@@ -1639,23 +1640,33 @@ export async function handleOidcRefresh(
 
     return res;
   } catch (err) {
-    // invalid_grant = refresh token expired/revoked (e.g. session ended due to
-    // inactivity). Expected; the client re-authenticates. Log terse, no stack.
-    // Anything else is unexpected — log the message (still no bundled-source dump).
-    const expired =
-      typeof err === "object" &&
-      err !== null &&
-      "error" in err &&
-      (err as { error?: unknown }).error === "invalid_grant";
-    if (expired) {
+    // The provider classifies the failure (it owns its SDK's error shapes); we
+    // only map that verdict to a status. A `rejected` refresh means the session
+    // is genuinely dead → 401, the client logs out and re-authenticates. Any
+    // other failure is transient/infrastructural → 503 `refresh_unavailable`,
+    // which the client treats as "keep the session and retry" rather than
+    // logging a valid user out over a network blip or a deploy-time 5xx. (This
+    // is the server-side half of the same fix as fetch-with-refresh.ts.)
+    if (err instanceof RefreshTokenError && err.kind === "rejected") {
+      // Expected (session expired/revoked). Log terse, no stack.
       log.warn(
         "[nimblebrain] Token refresh rejected (session expired) — client will re-authenticate",
       );
-    } else {
-      const reason = err instanceof Error ? err.message : String(err);
-      log.error("[nimblebrain] Token refresh failed", { reason });
+      return apiError(401, "refresh_failed", "Token refresh failed");
     }
-    return apiError(401, "refresh_failed", "Token refresh failed");
+    // Transient: log at error so a misconfig (e.g. invalid_client) or an
+    // unmapped code surfaces to an operator instead of hiding in the client's
+    // soft-retry loop. Retry-After completes the 503's HTTP semantics.
+    const reason = err instanceof Error ? err.message : String(err);
+    const code = err instanceof RefreshTokenError ? err.code : undefined;
+    log.error("[nimblebrain] Token refresh unavailable", { reason, code });
+    return apiError(
+      503,
+      "refresh_unavailable",
+      "Token refresh temporarily unavailable",
+      undefined,
+      { "Retry-After": "1" },
+    );
   }
 }
 

--- a/src/identity/provider.ts
+++ b/src/identity/provider.ts
@@ -36,6 +36,42 @@ export interface TokenResult {
   refreshToken?: string;
 }
 
+/**
+ * Why a refresh failed — the distinction the refresh handler acts on.
+ *
+ * - `rejected`    — the IdP gave a definitive verdict that this end-user's
+ *                   refresh token is no longer valid (expired/revoked/reused).
+ *                   The session is genuinely over → re-authenticate.
+ * - `unavailable` — the refresh hop failed *without* a definitive verdict: a
+ *                   thrown network error, a 5xx/429 from the IdP, a timeout, or
+ *                   a deployment misconfig (bad client credentials). The
+ *                   end-user's token is probably fine; we just couldn't reach a
+ *                   verdict this instant → keep the session and retry.
+ */
+export type RefreshFailureKind = "rejected" | "unavailable";
+
+/**
+ * Thrown by {@link IdentityProvider.refreshToken} to tell the handler which
+ * kind of failure occurred. Providers own this classification because only they
+ * understand their SDK's error shapes — the handler must stay provider-agnostic
+ * (it maps `kind` → HTTP status and never sniffs vendor error fields).
+ */
+export class RefreshTokenError extends Error {
+  readonly kind: RefreshFailureKind;
+  /** Provider-specific code for logging/triage (e.g. the OAuth error code). */
+  readonly code?: string;
+  constructor(
+    kind: RefreshFailureKind,
+    message: string,
+    options?: { code?: string; cause?: unknown },
+  ) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = "RefreshTokenError";
+    this.kind = kind;
+    this.code = options?.code;
+  }
+}
+
 // ── User management ────────────────────────────────────────────────
 
 export interface CreateUserInput {
@@ -78,7 +114,11 @@ export interface IdentityProvider {
   /** Exchange an authorization code for tokens. Accepts optional PKCE code_verifier. */
   exchangeCode?(code: string, codeVerifier?: string): Promise<TokenResult>;
 
-  /** Refresh an access token using a refresh token. */
+  /**
+   * Refresh an access token using a refresh token. On failure, throws a
+   * {@link RefreshTokenError} whose `kind` tells the handler whether the
+   * session is dead (`rejected`) or the hop was merely transient (`unavailable`).
+   */
   refreshToken?(refreshToken: string): Promise<TokenResult>;
 
   // ── User management ──────────────────────────────────────────────

--- a/src/identity/providers/workos.ts
+++ b/src/identity/providers/workos.ts
@@ -12,6 +12,7 @@ import type {
   TokenResult,
   UserIdentity,
 } from "../provider.ts";
+import { RefreshTokenError } from "../provider.ts";
 import type { OrgRole } from "../types.ts";
 import type { User, UserPreferences, UserStore } from "../user.ts";
 
@@ -323,14 +324,44 @@ export class WorkosIdentityProvider implements IdentityProvider {
   }
 
   async refreshToken(refreshToken: string): Promise<TokenResult> {
-    const result = await this.workos.userManagement.authenticateWithRefreshToken({
-      clientId: this.clientId,
-      refreshToken,
-    });
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-    };
+    try {
+      const result = await this.workos.userManagement.authenticateWithRefreshToken({
+        clientId: this.clientId,
+        refreshToken,
+      });
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+      };
+    } catch (err) {
+      // Classify the failure for the handler. The end-user's session is dead
+      // ONLY on `invalid_grant` (refresh token expired/revoked/reused — RFC
+      // 6749 §5.2), which WorkOS surfaces as an OauthException carrying that
+      // `.error` code. Everything else leaves the session intact and must NOT
+      // log the user out:
+      //   - other OAuth codes (invalid_client/unauthorized_client) = this
+      //     deployment's WorkOS credentials are wrong — a config problem, not a
+      //     dead session;
+      //   - GenericServerException / RateLimitExceededException = a 5xx/429
+      //     from WorkOS during a blip;
+      //   - a thrown fetch / TypeError = the IdP hop never completed.
+      // All of those are `unavailable`: we couldn't reach a verdict, so keep
+      // the session and let the client retry.
+      const oauthError =
+        typeof err === "object" && err !== null && "error" in err
+          ? (err as { error?: unknown }).error
+          : undefined;
+      if (oauthError === "invalid_grant") {
+        throw new RefreshTokenError("rejected", "Refresh token rejected by IdP (invalid_grant)", {
+          code: "invalid_grant",
+          cause: err,
+        });
+      }
+      throw new RefreshTokenError("unavailable", "Token refresh did not reach a verdict", {
+        code: typeof oauthError === "string" ? oauthError : undefined,
+        cause: err,
+      });
+    }
   }
 
   async listUsers(): Promise<User[]> {

--- a/test/unit/identity/oidc-refresh.test.ts
+++ b/test/unit/identity/oidc-refresh.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the OIDC token-refresh failure taxonomy.
+ *
+ * A refresh can fail two fundamentally different ways, and only one of them
+ * means the user's session is over:
+ *
+ * - `rejected`    — the IdP definitively refused the refresh token
+ *                   (`invalid_grant`: expired/revoked/reused). Session dead →
+ *                   the handler returns 401 and the client logs out.
+ * - `unavailable` — the refresh hop failed without a verdict (network throw,
+ *                   IdP 5xx/429, a misconfig like `invalid_client`). Session is
+ *                   probably fine → the handler returns 503 and the client keeps
+ *                   the session and retries.
+ *
+ * Two layers are covered:
+ *   1. WorkosIdentityProvider.refreshToken classifies SDK errors into
+ *      RefreshTokenError("rejected" | "unavailable").
+ *   2. handleOidcRefresh maps that verdict to an HTTP status (provider-agnostic).
+ */
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { handleOidcRefresh } from "../../../src/api/handlers.ts";
+import type { WorkosAuth } from "../../../src/identity/instance.ts";
+import {
+  type IdentityProvider,
+  RefreshTokenError,
+  type TokenResult,
+} from "../../../src/identity/provider.ts";
+import { WorkosIdentityProvider } from "../../../src/identity/providers/workos.ts";
+import { WorkspaceStore } from "../../../src/workspace/workspace-store.ts";
+
+// ── Layer 1: WorkOS provider classification ──────────────────────────
+
+const BASE_CONFIG: WorkosAuth = {
+  adapter: "workos",
+  clientId: "client_test_refresh",
+  redirectUri: "http://localhost/callback",
+  organizationId: "org_test_refresh",
+  apiKey: "sk_test_fake_refresh",
+};
+
+/** Build a provider whose underlying WorkOS refresh call throws `thrown`. */
+function providerThatThrows(thrown: unknown): WorkosIdentityProvider {
+  const workspaceStore = new WorkspaceStore(mkdtempSync(join(tmpdir(), "oidc-refresh-")));
+  const provider = new WorkosIdentityProvider(BASE_CONFIG, undefined, workspaceStore);
+  const sdk = (provider as unknown as { workos: { userManagement: Record<string, unknown> } })
+    .workos;
+  sdk.userManagement = {
+    authenticateWithRefreshToken: async () => {
+      throw thrown;
+    },
+  };
+  return provider;
+}
+
+describe("WorkosIdentityProvider.refreshToken classification", () => {
+  test("invalid_grant (OauthException shape) → rejected", async () => {
+    // WorkOS surfaces a refused refresh token as an OauthException with
+    // `.error === "invalid_grant"`. This is the ONLY dead-session signal.
+    const provider = providerThatThrows({
+      name: "OauthException",
+      status: 400,
+      error: "invalid_grant",
+      message: "The refresh token is invalid.",
+    });
+    try {
+      await provider.refreshToken("rt");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RefreshTokenError);
+      expect((err as RefreshTokenError).kind).toBe("rejected");
+      expect((err as RefreshTokenError).code).toBe("invalid_grant");
+    }
+  });
+
+  test("invalid_client (deployment misconfig) → unavailable, NOT a dead session", async () => {
+    // Wrong client credentials are an operator problem; the user's token is
+    // fine. Logging them out would destroy valid sessions fleet-wide on a bad
+    // deploy. Transient bucket, but the code is preserved for the error log.
+    const provider = providerThatThrows({
+      name: "OauthException",
+      status: 401,
+      error: "invalid_client",
+      message: "Client authentication failed.",
+    });
+    try {
+      await provider.refreshToken("rt");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RefreshTokenError);
+      expect((err as RefreshTokenError).kind).toBe("unavailable");
+      expect((err as RefreshTokenError).code).toBe("invalid_client");
+    }
+  });
+
+  test("GenericServerException (IdP 5xx) → unavailable", async () => {
+    const provider = providerThatThrows({
+      name: "GenericServerException",
+      status: 503,
+      message: "Service unavailable",
+    });
+    try {
+      await provider.refreshToken("rt");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as RefreshTokenError).kind).toBe("unavailable");
+      expect((err as RefreshTokenError).code).toBeUndefined();
+    }
+  });
+
+  test("thrown network error (TypeError) → unavailable", async () => {
+    const provider = providerThatThrows(new TypeError("Failed to fetch"));
+    try {
+      await provider.refreshToken("rt");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as RefreshTokenError).kind).toBe("unavailable");
+    }
+  });
+});
+
+// ── Layer 2: handler maps the verdict to an HTTP status ──────────────
+
+/** Minimal IdentityProvider that supports refresh; refreshToken is supplied. */
+function refreshProvider(
+  refreshToken: (rt: string) => Promise<TokenResult>,
+  opts?: { tokenRefresh?: boolean },
+): IdentityProvider {
+  return {
+    capabilities: {
+      authCodeFlow: true,
+      tokenRefresh: opts?.tokenRefresh ?? true,
+      managedUsers: true,
+    },
+    verifyRequest: async () => null,
+    refreshToken,
+    listUsers: async () => [],
+    createUser: async () => {
+      throw new Error("unused");
+    },
+    deleteUser: async () => false,
+  } as IdentityProvider;
+}
+
+const withCookie = (value = "rt-value") =>
+  new Request("https://app.test/v1/auth/refresh", {
+    method: "POST",
+    headers: { cookie: `nb_refresh=${value}` },
+  });
+
+describe("handleOidcRefresh status mapping", () => {
+  test("rejected → 401 refresh_failed (log out)", async () => {
+    const provider = refreshProvider(async () => {
+      throw new RefreshTokenError("rejected", "dead", { code: "invalid_grant" });
+    });
+    const res = await handleOidcRefresh(withCookie(), provider, false);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("refresh_failed");
+  });
+
+  test("unavailable → 503 refresh_unavailable + Retry-After (keep session)", async () => {
+    const provider = refreshProvider(async () => {
+      throw new RefreshTokenError("unavailable", "blip", { code: "invalid_client" });
+    });
+    const res = await handleOidcRefresh(withCookie(), provider, false);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("1");
+    expect((await res.json()).error).toBe("refresh_unavailable");
+  });
+
+  test("a non-RefreshTokenError throw still defaults to 503 (never logs out on a surprise)", async () => {
+    const provider = refreshProvider(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const res = await handleOidcRefresh(withCookie(), provider, false);
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toBe("refresh_unavailable");
+  });
+
+  test("success → 200 with a fresh nb_session cookie", async () => {
+    const provider = refreshProvider(async () => ({
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+    }));
+    const res = await handleOidcRefresh(withCookie(), provider, true);
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("nb_session=new-access");
+  });
+
+  test("no refresh cookie → 401 no_refresh_token", async () => {
+    const provider = refreshProvider(async () => {
+      throw new Error("should not be called");
+    });
+    const res = await handleOidcRefresh(
+      new Request("https://app.test/v1/auth/refresh", { method: "POST" }),
+      provider,
+      false,
+    );
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("no_refresh_token");
+  });
+
+  test("provider can't refresh → 400 not_configured", async () => {
+    const provider = refreshProvider(async () => ({ accessToken: "x" }), {
+      tokenRefresh: false,
+    });
+    const res = await handleOidcRefresh(withCookie(), provider, false);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("not_configured");
+  });
+});

--- a/test/unit/identity/oidc-refresh.test.ts
+++ b/test/unit/identity/oidc-refresh.test.ts
@@ -46,6 +46,9 @@ const BASE_CONFIG: WorkosAuth = {
 function providerThatThrows(thrown: unknown): WorkosIdentityProvider {
   const workspaceStore = new WorkspaceStore(mkdtempSync(join(tmpdir(), "oidc-refresh-")));
   const provider = new WorkosIdentityProvider(BASE_CONFIG, undefined, workspaceStore);
+  // Cast escape hatch: `workos` is a private field typed as the full WorkOS SDK;
+  // we only need to swap the one method under test, so we widen it to a bag of
+  // unknowns rather than reconstruct the SDK's type.
   const sdk = (provider as unknown as { workos: { userManagement: Record<string, unknown> } })
     .workos;
   sdk.userManagement = {

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -9,6 +9,11 @@
 }
 
 :8080 {
+	# Status-transparent passthrough: the upstream's HTTP status must reach the
+	# browser unaltered. The web client distinguishes a 401 (log out) from a 503
+	# (`/v1/auth/refresh` transient — keep session, retry), so do NOT add
+	# `handle_errors`, a friendly error page, or passive health-checks here that
+	# would rewrite or swallow upstream 5xx on /v1/*.
 	handle /v1/* {
 		reverse_proxy {$PLATFORM_URL}
 	}


### PR DESCRIPTION
## Problem

`handleOidcRefresh` (`POST /v1/auth/refresh`) collapsed **every** refresh failure into `401 refresh_failed`. But the refresh call to WorkOS can fail in ways that don't mean the user's session is over: a thrown network call, a WorkOS `5xx`/`429`, a deployment misconfig (wrong client credentials). All of those returned `401`, and the client logs out on `401`.

This is the **same bug class as #434**, one layer up. #434 taught the *browser→app* hop to distinguish a transient transport failure from a dead session; the *app→IdP* hop still collapsed everything into `401`, so a transient IdP blip bounced valid users to the sign-in screen anyway — defeating part of the fix it shipped alongside.

## Fix

Classify the failure **at the provider**, where the SDK's error shapes are actually known, and keep the handler provider-agnostic.

- **`src/identity/provider.ts`** — new typed `RefreshTokenError { kind: "rejected" | "unavailable"; code? }`. This is the error model the `refreshToken()` interface was missing.
- **`src/identity/providers/workos.ts`** — `refreshToken` now wraps the WorkOS call and throws:
  - `rejected` **only** on `invalid_grant` (refresh token expired/revoked/reused — RFC 6749 §5.2; the one OAuth code that means *this user's session is dead*).
  - `unavailable` for everything else: other OAuth codes (`invalid_client`/`unauthorized_client` = deployment misconfig, not a dead session), `GenericServerException`/`RateLimitExceededException` (5xx/429), and a thrown `TypeError` (the hop never completed).
- **`src/api/handlers.ts`** — the `catch` just maps the verdict to a status:
  - `rejected` → `401 refresh_failed` (client logs out) — logged terse at `warn`.
  - everything else → **`503 refresh_unavailable`** + `Retry-After: 1` — logged at `error` (so a misconfig or an unmapped code pages an operator instead of hiding in the client's soft-retry loop).

  The merged client (#434) already treats any non-`{400,401}` response, including `503`, as **"keep the session, retry."** Unknown errors default to `unavailable`, so an unrecognized failure can never log a valid user out.

- **`web/Caddyfile`** — comment that `/v1/*` is a **status-transparent passthrough**: the client now depends on upstream `5xx` reaching the browser unaltered, so no `handle_errors`/error-page/passive-health-check may be added there.

## Why the provider, not the handler

The kernel handler has no business sniffing a vendor SDK's `err.error` string (the previous code duck-typed `invalid_grant`). Today only WorkOS reaches this path; the next provider throws a different shape and the handler would silently misclassify all of its errors. Moving classification into the adapter keeps the handler stable and provider-agnostic — the handler gets *simpler*, and the only place importing vendor error knowledge is the WorkOS adapter.

## Platform notes (verified)

- `503` passes **ALB → Caddy → browser verbatim** — no service mesh; the ingress uses a bare `reverse_proxy` with no error handling or passive health-checks.
- Health probes hit `/` (ALB) and `/v1/health` (k8s) — **never** `/v1/auth/refresh` — so a refresh `503` cannot mark the pod unhealthy or pull it from rotation. `503` is the honest signal ("pod is up, this request couldn't complete") over `502`/`504`.

## Tests

`test/unit/identity/oidc-refresh.test.ts` (10 cases):
- **Provider classification:** `invalid_grant → rejected`; `invalid_client → unavailable`; `GenericServerException (5xx) → unavailable`; thrown `TypeError → unavailable`.
- **Handler mapping:** `rejected → 401 refresh_failed`; `unavailable → 503 refresh_unavailable + Retry-After`; non-`RefreshTokenError` throw → `503` (defaults safe, never logs out); success → `200` + `nb_session` cookie; no cookie → `401 no_refresh_token`; can't-refresh → `400 not_configured`.

Full identity suite green (126), `tsc` clean, `biome` clean.

## Follow-ups (out of scope, separate owners)

- **Graceful drain on the agent chart** — single-replica-per-tenant rollouts have a window with no Ready pod; the client's ~800ms retry budget may not outlast a cold start. Mirror `leadmagnet`'s `deregistration_delay` + `preStop`. (platform-ops)
- **Client honoring `Retry-After`** — the web client currently uses a fixed 400ms backoff. (web)
