### PR TITLE
Artifact rehydration fix + read_artifact/list_artifacts retrieval tools

### DIFF
--- a/src/conversation/event-sourced-store.ts
+++ b/src/conversation/event-sourced-store.ts
@@ -9,6 +9,7 @@
 import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import type { ResourceLinkInfo } from "../engine/content-helpers.ts";
 import type { EngineEvent, EventSink } from "../engine/types.ts";
 import { ConversationCorruptedError } from "../runtime/errors.ts";
 import { assertNoBinaryPayloads } from "./binary-guard.ts";
@@ -553,6 +554,15 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
         // model-context bound. Replay uses it verbatim so the replayed prompt
         // matches what the model saw live. See boundToolResultForModel.
         const modelOutput = typeof d.modelOutput === "string" ? d.modelOutput : undefined;
+        // UI-binding resource references. The engine emits these on the live
+        // tool.done; persist them so a reopened conversation rehydrates its
+        // artifact viewers (the panel a tool's `artifact://` resource link renders into).
+        // They are small references, not bytes — the body is fetched on view.
+        const resourceUri = typeof d.resourceUri === "string" ? d.resourceUri : undefined;
+        const resourceLinks =
+          Array.isArray(d.resourceLinks) && d.resourceLinks.length > 0
+            ? (d.resourceLinks as ResourceLinkInfo[])
+            : undefined;
         const e: ToolDoneEvent = {
           ts,
           type: "tool.done",
@@ -563,6 +573,8 @@ export class EventSourcedConversationStore implements ConversationStore, EventSi
           ms: (d.ms as number) ?? 0,
           ...(output !== undefined ? { output } : {}),
           ...(modelOutput !== undefined ? { modelOutput } : {}),
+          ...(resourceUri !== undefined ? { resourceUri } : {}),
+          ...(resourceLinks !== undefined ? { resourceLinks } : {}),
         };
         return e;
       }

--- a/src/conversation/types.ts
+++ b/src/conversation/types.ts
@@ -5,6 +5,7 @@ import type {
   LanguageModelV3TextPart,
   SharedV3ProviderOptions,
 } from "@ai-sdk/provider";
+import type { ResourceLinkInfo } from "../engine/content-helpers.ts";
 import type { ContextAssembledSource, SkillsLoadedEntry } from "../engine/types.ts";
 import type { TokenUsage } from "../usage/types.ts";
 
@@ -366,6 +367,16 @@ export interface ToolDoneEvent {
    * `output` at read time. See boundToolResultForModel.
    */
   modelOutput?: string;
+  /**
+   * Static inline-binding resource annotation (`resourceUri`) and the MCP
+   * `resource_link` blocks (`resourceLinks`) surfaced from the tool result.
+   * Persisted so a reopened conversation rehydrates its `artifact://` viewer
+   * panels — the engine emits these on the live event, and the reader/UI already
+   * consume them, but without persisting them a reloaded conversation loses the
+   * references.
+   */
+  resourceUri?: string;
+  resourceLinks?: ResourceLinkInfo[];
 }
 
 export interface ToolProgressEvent {

--- a/src/host-resources/artifacts/artifact-resolver.ts
+++ b/src/host-resources/artifacts/artifact-resolver.ts
@@ -3,6 +3,8 @@ import { log } from "../../cli/log.ts";
 import { isTextMime } from "../../files/mime.ts";
 import { isArtifactUri, uriToArtifactId } from "./artifact-uri.ts";
 import {
+  type ArtifactListOptions,
+  type ArtifactListResult,
   ArtifactNotFoundError,
   type ArtifactReadClient,
   type ArtifactReadResult,
@@ -99,6 +101,17 @@ export class ArtifactResolver {
     );
 
     return { contents };
+  }
+
+  /**
+   * List artifacts in a workspace (discovery for retrieval), reading as the
+   * viewing user. Delegates to the read client — the same workspace-scoped
+   * `artifacts:read` token gates it and RLS fences the rows. The resolver is the
+   * host's single artifact-access seam (resolve + list); no bundle is ever in
+   * the artifacts read path.
+   */
+  list(workspaceId: string, opts: ArtifactListOptions = {}): Promise<ArtifactListResult> {
+    return this.client.list(workspaceId, opts);
   }
 
   /**

--- a/src/host-resources/artifacts/data-plane-read-client.ts
+++ b/src/host-resources/artifacts/data-plane-read-client.ts
@@ -156,8 +156,6 @@ export interface ArtifactListResult {
 export interface ArtifactListOptions {
   /** Semantic type filter — the producing capability's artifact type. */
   type?: string;
-  /** Writer/source filter. */
-  source?: string;
   /** Page size (data-plane-capped). */
   limit?: number;
   /** Keyset cursor from a prior call's `nextCursor`. */
@@ -343,7 +341,6 @@ export class ArtifactReadClient {
     const root = this.config.baseUrl.replace(/\/+$/, "");
     const params = new URLSearchParams();
     if (opts.type) params.set("type", opts.type);
-    if (opts.source) params.set("source", opts.source);
     if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {
       params.set("limit", String(Math.trunc(opts.limit)));
     }

--- a/src/host-resources/artifacts/data-plane-read-client.ts
+++ b/src/host-resources/artifacts/data-plane-read-client.ts
@@ -323,7 +323,8 @@ export class ArtifactReadClient {
    * scopes the minted read token and is the RLS dimension — the page only ever
    * contains the caller's own workspace's rows. Metadata only (no bytes); read a
    * row's body with {@link read}. Filters/pagination map straight onto
-   * `GET /v1/artifacts`.
+   * `GET /v1/artifacts`, which orders newest-first (`created_at` descending) and
+   * keysets on `created_at` — the order the `list_artifacts` tool surfaces.
    */
   async list(workspaceId: string, opts: ArtifactListOptions = {}): Promise<ArtifactListResult> {
     if (!workspaceId) {
@@ -341,7 +342,10 @@ export class ArtifactReadClient {
     const root = this.config.baseUrl.replace(/\/+$/, "");
     const params = new URLSearchParams();
     if (opts.type) params.set("type", opts.type);
-    if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {
+    // Only forward a positive limit. A negative/zero is a caller error; drop it
+    // (the data plane applies its default page size) rather than forwarding a
+    // value the wire would reject or mishandle.
+    if (typeof opts.limit === "number" && Number.isFinite(opts.limit) && opts.limit >= 1) {
       params.set("limit", String(Math.trunc(opts.limit)));
     }
     if (opts.cursor) params.set("cursor", opts.cursor);

--- a/src/host-resources/artifacts/data-plane-read-client.ts
+++ b/src/host-resources/artifacts/data-plane-read-client.ts
@@ -133,6 +133,59 @@ function firstString(...vals: unknown[]): string | undefined {
   return undefined;
 }
 
+/** A row from `GET /v1/artifacts` — metadata only, no bytes. */
+export interface ArtifactListItem {
+  artifactId: string;
+  uri: string;
+  type: string;
+  mimeType: string;
+  title?: string;
+  source: string;
+  sizeBytes?: number;
+  status: string;
+  createdAt: string;
+}
+
+/** Result of {@link ArtifactReadClient.list} — a page + an opaque keyset cursor. */
+export interface ArtifactListResult {
+  items: ArtifactListItem[];
+  nextCursor?: string;
+}
+
+/** Filters for {@link ArtifactReadClient.list}. */
+export interface ArtifactListOptions {
+  /** Semantic type filter — the producing capability's artifact type. */
+  type?: string;
+  /** Writer/source filter. */
+  source?: string;
+  /** Page size (data-plane-capped). */
+  limit?: number;
+  /** Keyset cursor from a prior call's `nextCursor`. */
+  cursor?: string;
+}
+
+/** The list wire envelope; snake_case mirrors the data plane, camelCase accepted defensively. */
+interface ArtifactListRowEnvelope {
+  artifact_id?: unknown;
+  artifactId?: unknown;
+  uri?: unknown;
+  type?: unknown;
+  mime_type?: unknown;
+  mimeType?: unknown;
+  title?: unknown;
+  source?: unknown;
+  size_bytes?: unknown;
+  sizeBytes?: unknown;
+  status?: unknown;
+  created_at?: unknown;
+  createdAt?: unknown;
+}
+interface ArtifactListEnvelope {
+  artifacts?: ArtifactListRowEnvelope[];
+  next_cursor?: unknown;
+  nextCursor?: unknown;
+}
+
 export class ArtifactReadClient {
   private readonly config: ArtifactDataPlaneConfig;
   private readonly cache: ServiceTokenCache;
@@ -265,5 +318,78 @@ export class ArtifactReadClient {
     // 200 → small inline body, streamed as raw bytes.
     const body = new Uint8Array(await contentRes.arrayBuffer());
     return { mimeType, body, title, sizeBytes };
+  }
+
+  /**
+   * List artifacts as the viewing user (discovery for retrieval). `workspaceId`
+   * scopes the minted read token and is the RLS dimension — the page only ever
+   * contains the caller's own workspace's rows. Metadata only (no bytes); read a
+   * row's body with {@link read}. Filters/pagination map straight onto
+   * `GET /v1/artifacts`.
+   */
+  async list(workspaceId: string, opts: ArtifactListOptions = {}): Promise<ArtifactListResult> {
+    if (!workspaceId) {
+      throw new ArtifactReadError("artifact list requires a workspace (the viewing user's)");
+    }
+    const authedFetch = createMintingFetch({
+      cache: this.cache,
+      issuer: this.config.issuer,
+      workspace: workspaceId,
+      audience: ARTIFACTS_AUDIENCE,
+      scope: ARTIFACTS_READ_SCOPE,
+      baseFetch: this.fetchImpl,
+    });
+
+    const root = this.config.baseUrl.replace(/\/+$/, "");
+    const params = new URLSearchParams();
+    if (opts.type) params.set("type", opts.type);
+    if (opts.source) params.set("source", opts.source);
+    if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {
+      params.set("limit", String(Math.trunc(opts.limit)));
+    }
+    if (opts.cursor) params.set("cursor", opts.cursor);
+    const qs = params.toString();
+    const url = `${root}/v1/artifacts${qs ? `?${qs}` : ""}`;
+
+    let res: Response;
+    try {
+      res = await authedFetch(url, { method: "GET", headers: { Accept: "application/json" } });
+    } catch (cause) {
+      throw new ArtifactReadError(
+        `artifact list request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      );
+    }
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new ArtifactReadError(
+        `artifact list failed ${res.status}: ${detail.slice(0, 300)}`,
+        res.status,
+      );
+    }
+
+    let data: ArtifactListEnvelope;
+    try {
+      data = (await res.json()) as ArtifactListEnvelope;
+    } catch {
+      throw new ArtifactReadError("artifact list response was not JSON");
+    }
+
+    const rows = Array.isArray(data.artifacts) ? data.artifacts : [];
+    const items: ArtifactListItem[] = rows.map((r) => {
+      const sizeRaw = r.size_bytes ?? r.sizeBytes;
+      return {
+        artifactId: firstString(r.artifact_id, r.artifactId) ?? "",
+        uri: firstString(r.uri) ?? "",
+        type: firstString(r.type) ?? "",
+        mimeType: firstString(r.mime_type, r.mimeType) ?? "application/octet-stream",
+        ...(firstString(r.title) ? { title: firstString(r.title) } : {}),
+        source: firstString(r.source) ?? "",
+        ...(typeof sizeRaw === "number" && Number.isFinite(sizeRaw) ? { sizeBytes: sizeRaw } : {}),
+        status: firstString(r.status) ?? "",
+        createdAt: firstString(r.created_at, r.createdAt) ?? "",
+      };
+    });
+    const nextCursor = firstString(data.next_cursor, data.nextCursor);
+    return { items, ...(nextCursor ? { nextCursor } : {}) };
   }
 }

--- a/src/host-resources/artifacts/index.ts
+++ b/src/host-resources/artifacts/index.ts
@@ -10,6 +10,9 @@ export {
   uriToArtifactId,
 } from "./artifact-uri.ts";
 export {
+  type ArtifactListItem,
+  type ArtifactListOptions,
+  type ArtifactListResult,
   ArtifactNotFoundError,
   ArtifactReadClient,
   ArtifactReadError,

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -5,6 +5,11 @@ import { recordLlmUsage } from "../api/metrics.ts";
 import { log } from "../cli/log.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
+import {
+  type ArtifactListOptions,
+  ArtifactNotFoundError,
+  getArtifactResolver,
+} from "../host-resources/artifacts/index.ts";
 import { ORG_ADMIN_ROLES } from "../identity/types.ts";
 import { getAvailableModels, isModelAllowed } from "../model/catalog.ts";
 import {
@@ -722,6 +727,108 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
           },
           isError: false,
         };
+      },
+    },
+    {
+      name: "list_artifacts",
+      description:
+        "List stored artifacts in this workspace (anything a capability has saved to the artifact store), newest first. Optionally filter by `type`. Returns each artifact's id, title, type, and created_at; read one's content with read_artifact. Workspace-scoped — only this workspace's artifacts are returned.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          type: {
+            type: "string",
+            description: "Filter by artifact type (the producing capability's semantic type).",
+          },
+          cursor: {
+            type: "string",
+            description: "Pagination cursor from a prior call's next_cursor.",
+          },
+          limit: { type: "number", description: "Max rows to return (data-plane-capped)." },
+        },
+      },
+      handler: async (input): Promise<ToolResult> => {
+        try {
+          const wsId = runtime.requireWorkspaceId();
+          const opts: ArtifactListOptions = {};
+          if (typeof input.type === "string" && input.type.trim()) opts.type = input.type.trim();
+          if (typeof input.cursor === "string" && input.cursor.trim())
+            opts.cursor = input.cursor.trim();
+          if (typeof input.limit === "number" && Number.isFinite(input.limit))
+            opts.limit = input.limit;
+          const { items, nextCursor } = await getArtifactResolver().list(wsId, opts);
+          const lines = items.map(
+            (a) => `- ${a.title ?? a.artifactId} — ${a.type} (${a.createdAt}) → ${a.uri}`,
+          );
+          const text = items.length
+            ? `${items.length} artifact(s):\n${lines.join("\n")}${
+                nextCursor ? "\n\n(more available — pass cursor to continue)" : ""
+              }`
+            : "No artifacts found in this workspace.";
+          return {
+            content: textContent(text),
+            structuredContent: { artifacts: items, ...(nextCursor ? { nextCursor } : {}) },
+            isError: false,
+          };
+        } catch (err) {
+          return {
+            content: textContent(
+              `Failed to list artifacts: ${err instanceof Error ? err.message : String(err)}`,
+            ),
+            isError: true,
+          };
+        }
+      },
+    },
+    {
+      name: "read_artifact",
+      description:
+        "Read a stored artifact's content by its `artifact://` URI (or bare id), scoped to this workspace. Use this to retrieve an artifact referenced in this or a past conversation (a tool result's resource link), or an id from list_artifacts. Returns the artifact text.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          uri: {
+            type: "string",
+            description: "The artifact URI (artifact://art_...) or bare artifact id.",
+          },
+        },
+        required: ["uri"],
+      },
+      handler: async (input): Promise<ToolResult> => {
+        const raw = typeof input.uri === "string" ? input.uri.trim() : "";
+        if (!raw) {
+          return { content: textContent("uri is required"), isError: true };
+        }
+        const uri = raw.startsWith("artifact://") ? raw : `artifact://${raw}`;
+        try {
+          const wsId = runtime.requireWorkspaceId();
+          const result = await getArtifactResolver().read(uri, wsId);
+          const text = result.contents
+            .map((c) =>
+              typeof c.text === "string"
+                ? c.text
+                : c.blob
+                  ? `[binary artifact, mimeType=${c.mimeType ?? "unknown"}]`
+                  : "",
+            )
+            .join("");
+          return { content: textContent(text || "[empty artifact]"), isError: false };
+        } catch (err) {
+          if (err instanceof ArtifactNotFoundError) {
+            return {
+              content: textContent(
+                `Artifact "${uri}" not found in this workspace (it may not exist, or belong to another workspace).`,
+              ),
+              isError: true,
+            };
+          }
+          return {
+            content: textContent(
+              `Failed to read artifact: ${err instanceof Error ? err.message : String(err)}`,
+            ),
+            isError: true,
+          };
+        }
       },
     },
     // --- Briefing tool (in-process, uses runtime model resolver) ---

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -805,9 +805,9 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
           const result = await getArtifactResolver().read(uri, wsId);
           const text = result.contents
             .map((c) =>
-              typeof c.text === "string"
+              "text" in c && typeof c.text === "string"
                 ? c.text
-                : c.blob
+                : "blob" in c
                   ? `[binary artifact, mimeType=${c.mimeType ?? "unknown"}]`
                   : "",
             )

--- a/test/integration/core-source.test.ts
+++ b/test/integration/core-source.test.ts
@@ -56,12 +56,12 @@ async function makeRuntime(): Promise<Runtime> {
 }
 
 describe("Core Source", () => {
-	it("tools() returns 8 tools with nb__ prefix", async () => {
+	it("tools() returns 10 tools with nb__ prefix", async () => {
 		const runtime = await makeRuntime();
 		try {
 			const source = await makeInProcessSource("nb", createCoreToolDefs(runtime));
 			const tools = await source.tools();
-			expect(tools).toHaveLength(8);
+			expect(tools).toHaveLength(10);
 			for (const tool of tools) {
 				expect(tool.name).toMatch(/^nb__/);
 			}
@@ -70,7 +70,9 @@ describe("Core Source", () => {
 				"nb__briefing",
 				"nb__get_config",
 				"nb__list_apps",
+				"nb__list_artifacts",
 				"nb__manage_identity",
+				"nb__read_artifact",
 				"nb__set_model_config",
 				"nb__set_preferences",
 				"nb__version",

--- a/test/unit/artifact-resolver.test.ts
+++ b/test/unit/artifact-resolver.test.ts
@@ -443,4 +443,49 @@ describe("ArtifactReadClient.list — discovery as the viewing user", () => {
   it("fails closed without a workspace", async () => {
     await expect(makeListClient(rows).list("")).rejects.toThrow(/workspace/);
   });
+
+  it("forwards a positive limit but drops a non-positive one", async () => {
+    const urls: string[] = [];
+    const fetchImpl = ((input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === `${ISSUER}/token`) {
+        const body = new URLSearchParams(String(init?.body ?? ""));
+        const payloadB64 = (body.get("tenant_assertion") ?? "").split(".")[1] ?? "";
+        const payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as {
+          workspace: string;
+        };
+        const token = Buffer.from(JSON.stringify({ workspace: payload.workspace })).toString(
+          "base64url",
+        );
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: token, expires_in: 300 }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+      urls.push(url);
+      return Promise.resolve(
+        new Response(JSON.stringify({ artifacts: [], next_cursor: null }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
+    const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl });
+    const client = new ArtifactReadClient({
+      config: { baseUrl: DATA_PLANE, issuer: ISSUER },
+      cache,
+      fetchImpl,
+    });
+
+    await client.list(WS_A, { limit: 5 });
+    expect(urls.at(-1)).toContain("limit=5");
+
+    await client.list(WS_A, { limit: 0 });
+    expect(urls.at(-1)).not.toContain("limit=");
+
+    await client.list(WS_A, { limit: -3 });
+    expect(urls.at(-1)).not.toContain("limit=");
+  });
 });

--- a/test/unit/artifact-resolver.test.ts
+++ b/test/unit/artifact-resolver.test.ts
@@ -316,3 +316,131 @@ describe("ArtifactReadClient — reads the data plane's actual response shape", 
     expect(result.presignedUrl).toBe("https://presigned.test/art_spilled");
   });
 });
+
+// ---------------------------------------------------------------------------
+// ArtifactReadClient.list — discovery (read_artifact / list_artifacts backing).
+// Same identity plumbing as read: the workspace scopes the minted read token and
+// the data plane's RLS fences the page. We model the LIST endpoint
+// (GET /v1/artifacts?type=...) with a fake that echoes the bearer's workspace.
+// ---------------------------------------------------------------------------
+
+interface ListRow {
+  artifact_id: string;
+  uri: string;
+  type: string;
+  mime_type: string;
+  title?: string;
+  source: string;
+  status: string;
+  created_at: string;
+}
+
+function makeListFetch(byWorkspace: Record<string, ListRow[]>): typeof fetch {
+  return (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    // Token mint — echo the requested workspace into the bearer (as in read).
+    if (url === `${ISSUER}/token`) {
+      const body = new URLSearchParams(String(init?.body ?? ""));
+      const payloadB64 = (body.get("tenant_assertion") ?? "").split(".")[1] ?? "";
+      const payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as {
+        workspace: string;
+        audience: string;
+        scope: string;
+      };
+      const token = Buffer.from(
+        JSON.stringify({ workspace: payload.workspace, aud: payload.audience, scope: payload.scope }),
+      ).toString("base64url");
+      return new Response(JSON.stringify({ access_token: token, expires_in: 300 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    // LIST endpoint: GET /v1/artifacts (no /{id}). Fence by the bearer's workspace,
+    // apply the type filter the client threaded as a query param.
+    if (url.startsWith(`${DATA_PLANE}/v1/artifacts`)) {
+      const u = new URL(url);
+      if (u.pathname !== "/v1/artifacts") return new Response("not list", { status: 500 });
+      const bearer = (new Headers(init?.headers).get("Authorization") ?? "").replace(/^Bearer\s+/, "");
+      const claims = JSON.parse(Buffer.from(bearer, "base64url").toString("utf8")) as {
+        workspace: string;
+      };
+      let rows = byWorkspace[claims.workspace] ?? [];
+      const type = u.searchParams.get("type");
+      if (type) rows = rows.filter((r) => r.type === type);
+      return new Response(JSON.stringify({ artifacts: rows, next_cursor: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response("unexpected url: " + url, { status: 500 });
+  }) as typeof fetch;
+}
+
+function makeListClient(byWorkspace: Record<string, ListRow[]>): ArtifactReadClient {
+  const fetchImpl = makeListFetch(byWorkspace);
+  const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl });
+  return new ArtifactReadClient({ config: { baseUrl: DATA_PLANE, issuer: ISSUER }, cache, fetchImpl });
+}
+
+describe("ArtifactReadClient.list — discovery as the viewing user", () => {
+  const rows: Record<string, ListRow[]> = {
+    [WS_A]: [
+      {
+        artifact_id: "art_1",
+        uri: "artifact://art_1",
+        type: "research.report",
+        mime_type: "text/markdown",
+        title: "Matthew Gerard",
+        source: "task",
+        status: "ready",
+        created_at: "2026-06-16T00:00:00Z",
+      },
+      {
+        artifact_id: "art_2",
+        uri: "artifact://art_2",
+        type: "other",
+        mime_type: "text/plain",
+        source: "task",
+        status: "ready",
+        created_at: "2026-06-15T00:00:00Z",
+      },
+    ],
+    [WS_B]: [
+      {
+        artifact_id: "art_9",
+        uri: "artifact://art_9",
+        type: "research.report",
+        mime_type: "text/markdown",
+        title: "Other workspace",
+        source: "task",
+        status: "ready",
+        created_at: "2026-06-16T00:00:00Z",
+      },
+    ],
+  };
+
+  it("lists the caller's workspace rows and maps snake_case metadata", async () => {
+    const res = await makeListClient(rows).list(WS_A);
+    expect(res.items.map((i) => i.artifactId)).toEqual(["art_1", "art_2"]);
+    expect(res.items[0].title).toBe("Matthew Gerard");
+    expect(res.items[0].uri).toBe("artifact://art_1");
+    expect(res.items[0].type).toBe("research.report");
+  });
+
+  it("threads the type filter through as a query param", async () => {
+    const res = await makeListClient(rows).list(WS_A, { type: "research.report" });
+    expect(res.items.map((i) => i.artifactId)).toEqual(["art_1"]);
+  });
+
+  it("fences by RLS — a workspace never sees another's rows", async () => {
+    const res = await makeListClient(rows).list(WS_B);
+    expect(res.items.map((i) => i.artifactId)).toEqual(["art_9"]);
+  });
+
+  it("fails closed without a workspace", async () => {
+    await expect(makeListClient(rows).list("")).rejects.toThrow(/workspace/);
+  });
+});

--- a/test/unit/event-sourced-store.test.ts
+++ b/test/unit/event-sourced-store.test.ts
@@ -75,6 +75,40 @@ describe("EventSourcedConversationStore", () => {
     expect(events[2].type).toBe("run.done");
   });
 
+  it("persists resourceLinks + resourceUri on tool.done (artifact rehydration)", async () => {
+    // Regression: the engine emits resource references on tool.done, but they
+    // were dropped on persist — so a reopened conversation lost its artifact://
+    // viewers (e.g. the deep_research report panel). They must round-trip.
+    const conv = await store.create({ ownerId: "user_test" });
+    store.setActiveConversation(conv.id);
+
+    store.emit({
+      type: "tool.done",
+      data: {
+        runId: "r1",
+        name: "web__deep_research",
+        id: "tc_1",
+        ok: true,
+        ms: 1234,
+        output: "digest text",
+        resourceUri: "artifact://art_abc",
+        resourceLinks: [{ uri: "artifact://art_abc", name: "report", mimeType: "text/markdown" }],
+      },
+    });
+
+    const lines = readLines(join(dirs.dir, `${conv.id}.jsonl`));
+    const done = lines
+      .slice(1)
+      .map((l) => JSON.parse(l))
+      .find((e) => e.type === "tool.done");
+    expect(done).toBeDefined();
+    expect(done.output).toBe("digest text");
+    expect(done.resourceUri).toBe("artifact://art_abc");
+    expect(done.resourceLinks).toEqual([
+      { uri: "artifact://art_abc", name: "report", mimeType: "text/markdown" },
+    ]);
+  });
+
   it("history() reconstructs messages from events", async () => {
     const conv = await store.create({ ownerId: "user_test" });
 

--- a/test/unit/tools/core-artifact-tools.test.ts
+++ b/test/unit/tools/core-artifact-tools.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { ArtifactResolver } from "../../../src/host-resources/artifacts/artifact-resolver.ts";
+import {
+  ArtifactNotFoundError,
+  setArtifactResolver,
+} from "../../../src/host-resources/artifacts/index.ts";
+import type { Runtime } from "../../../src/runtime/runtime.ts";
+import { createCoreToolDefs } from "../../../src/tools/core-source.ts";
+
+// Behavioral tests for the read_artifact / list_artifacts core tool HANDLERS
+// (the client + persistence are covered in artifact-resolver.test.ts and
+// event-sourced-store.test.ts). We drive the real handlers with a minimal mock
+// runtime (only requireWorkspaceId is exercised) and a fake resolver injected
+// through the setArtifactResolver test seam — so the uri normalization, the
+// contents→text extraction, the not-found mapping, and the list formatting are
+// all under test, not just the data-plane plumbing.
+
+const WS = "ws_test";
+const runtime = { requireWorkspaceId: () => WS } as unknown as Runtime;
+
+function handlerFor(name: string): (input: Record<string, unknown>) => Promise<{
+  content: Array<{ text?: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}> {
+  const tool = createCoreToolDefs(runtime).find((d) => d.name === name);
+  if (!tool) throw new Error(`tool ${name} not registered`);
+  return tool.handler as never;
+}
+
+function firstText(res: { content: Array<{ text?: string }> }): string {
+  return res.content[0]?.text ?? "";
+}
+
+afterEach(() => setArtifactResolver(undefined));
+
+describe("read_artifact tool handler", () => {
+  it("reads a text artifact, normalizing a bare id to artifact://", async () => {
+    let seen: { uri: string; ws: string } | undefined;
+    setArtifactResolver({
+      read: async (uri: string, ws: string) => {
+        seen = { uri, ws };
+        return { contents: [{ uri, mimeType: "text/markdown", text: "# Report\nbody" }] };
+      },
+    } as unknown as ArtifactResolver);
+
+    const res = await handlerFor("read_artifact")({ uri: "art_1" });
+    expect(res.isError).toBeFalsy();
+    expect(firstText(res)).toBe("# Report\nbody");
+    // bare id was normalized to an artifact:// URI, and the verified ws passed through
+    expect(seen).toEqual({ uri: "artifact://art_1", ws: WS });
+  });
+
+  it("passes an explicit artifact:// uri through unchanged", async () => {
+    let seenUri = "";
+    setArtifactResolver({
+      read: async (uri: string) => {
+        seenUri = uri;
+        return { contents: [{ uri, mimeType: "text/markdown", text: "x" }] };
+      },
+    } as unknown as ArtifactResolver);
+    await handlerFor("read_artifact")({ uri: "artifact://art_9" });
+    expect(seenUri).toBe("artifact://art_9");
+  });
+
+  it("renders a binary placeholder for non-text contents", async () => {
+    setArtifactResolver({
+      read: async (uri: string) => ({
+        contents: [{ uri, mimeType: "application/pdf", blob: "AAAA" }],
+      }),
+    } as unknown as ArtifactResolver);
+    const res = await handlerFor("read_artifact")({ uri: "art_pdf" });
+    expect(firstText(res)).toMatch(/binary artifact/);
+    expect(firstText(res)).toMatch(/application\/pdf/);
+  });
+
+  it("maps ArtifactNotFoundError to a clean not-found result", async () => {
+    setArtifactResolver({
+      read: async () => {
+        throw new ArtifactNotFoundError("art_x");
+      },
+    } as unknown as ArtifactResolver);
+    const res = await handlerFor("read_artifact")({ uri: "artifact://art_x" });
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toMatch(/not found in this workspace/i);
+  });
+
+  it("requires a uri", async () => {
+    const res = await handlerFor("read_artifact")({});
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toMatch(/uri is required/i);
+  });
+});
+
+describe("list_artifacts tool handler", () => {
+  it("lists, threads the type filter, and formats rows", async () => {
+    let seenOpts: { type?: string } | undefined;
+    setArtifactResolver({
+      list: async (ws: string, opts: { type?: string }) => {
+        expect(ws).toBe(WS);
+        seenOpts = opts;
+        return {
+          items: [
+            {
+              artifactId: "art_1",
+              uri: "artifact://art_1",
+              type: "demo.kind",
+              mimeType: "text/markdown",
+              title: "Title One",
+              source: "task",
+              status: "ready",
+              createdAt: "2026-06-16T00:00:00Z",
+            },
+          ],
+        };
+      },
+    } as unknown as ArtifactResolver);
+
+    const res = await handlerFor("list_artifacts")({ type: "demo.kind" });
+    expect(res.isError).toBeFalsy();
+    expect(seenOpts?.type).toBe("demo.kind");
+    expect(firstText(res)).toMatch(/Title One/);
+    expect(firstText(res)).toMatch(/artifact:\/\/art_1/);
+    expect((res.structuredContent as { artifacts: unknown[] }).artifacts).toHaveLength(1);
+  });
+
+  it("handles the empty case", async () => {
+    setArtifactResolver({
+      list: async () => ({ items: [] }),
+    } as unknown as ArtifactResolver);
+    const res = await handlerFor("list_artifacts")({});
+    expect(res.isError).toBeFalsy();
+    expect(firstText(res)).toMatch(/no artifacts/i);
+  });
+});


### PR DESCRIPTION
Two related changes on the host artifact read path (first-principles MVP).

## 1. Fix: artifact rehydration on conversation re-open
A deep_research report rendered in the sidebar on first run but vanished when the conversation was reopened (observed: hq prod `conv_08c471e37b464b0a`). Root cause: the engine emits `resourceUri` + `resourceLinks` on `tool.done`, but `event-sourced-store.mapEngineEvent` dropped them on persist — while the jsonl-reader + UI already *read* them. Fix persists them (small references, not bytes) and declares them on `ToolDoneEvent`. Regression test added. (Fixes conversations created *after* this lands; the dropped link can't be recovered for older ones, though their bytes are still in `artifacts`.)

## 2. Feature: read_artifact + list_artifacts host tools
Generic artifact retrieval so an agent can find + read artifacts a prior turn or past conversation produced:
- `list_artifacts(type?, cursor?)` — discovery over the existing `GET /v1/artifacts` (filter + keyset), workspace-scoped, RLS-fenced.
- `read_artifact(uri|id)` — reuses the host `artifact://` resolver.

**Placement:** the trust model forbids a bundle in the artifacts read path (the host reads as the viewing user), so these are **host system tools** (kernel), not a fleet bundle — zero new trust surface, reuses `ArtifactReadClient`. The kernel stays domain-agnostic (passes the `runtime-domain-clean` grep gate). Free-text search (vs type filter) is a tracked follow-on.

## Verification
`bun test test/unit/` → 3658 pass / 0 fail; pinned tsc + biome clean. New tests: `ArtifactReadClient.list` (parsing, type filter, RLS-fence, fail-closed) + the tool.done resource-link persistence regression.