### PR TITLE
fix(connectors): don't drop catalog entries without an icon

### DIFF
--- a/src/registries/directory.ts
+++ b/src/registries/directory.ts
@@ -138,8 +138,9 @@ export class ConnectorDirectory {
 
   /**
    * Flat `ConnectorCatalogEntry[]` — the shape the catalog tool surface
-   * + Configure page consume. Drops servers without remotes / icons
-   * (those don't have a renderable Configure-page identity).
+   * + Configure page consume. Drops only servers without remotes (those
+   * have no installable identity). A missing icon is cosmetic and never
+   * drops the entry — the UI falls back to a letter-avatar.
    */
   async catalogEntries(): Promise<ConnectorCatalogEntry[]> {
     const { servers } = await this.servers();

--- a/src/registries/projection.ts
+++ b/src/registries/projection.ts
@@ -106,8 +106,12 @@ export interface ConnectorCatalogEntry {
   /** Display name from `title` (falling back to `name`). */
   name: string;
   description: string;
-  /** First icon src; the platform-bundled catalog ships at least one. */
-  iconUrl: string;
+  /**
+   * First icon src, when the entry ships one. Optional — a missing icon is
+   * cosmetic: the UI falls back to a deterministic letter-avatar. Never gate
+   * installability on this.
+   */
+  iconUrl?: string;
   /** Remote MCP server URL — the value that goes into the bundle `url`. */
   url: string;
   auth: "dcr" | "static" | "composio" | "provider";
@@ -135,23 +139,21 @@ export interface ConnectorCatalogEntry {
 
 /**
  * Project one `ServerDetail` into the flat catalog entry shape.
- * Returns null when the entry isn't a remote OAuth service (no
- * `remotes[]`) or doesn't carry a renderable icon — those are the
- * minimum fields the Configure page assumes, and surfacing a
- * partial-shape catalog entry would break the call sites that
- * dereference `cat.url` or `cat.iconUrl` unconditionally.
+ * Returns null only when the entry isn't a remote OAuth service (no
+ * `remotes[]`) — that's a genuinely non-functional entry. A missing icon
+ * is cosmetic and never gates projection: `iconUrl` is omitted and the UI
+ * falls back to a letter-avatar.
  */
 export function serverDetailToCatalogEntry(s: ServerDetail): ConnectorCatalogEntry | null {
   const remote = s.remotes?.[0];
   if (!remote) return null;
   const iconUrl = s.icons?.[0]?.src;
-  if (!iconUrl) return null;
   const meta = getNimbleBrainConnectorMeta(s);
   return {
     id: s.name,
     name: s.title ?? s.name,
     description: s.description,
-    iconUrl,
+    ...(iconUrl ? { iconUrl } : {}),
     url: remote.url,
     auth: meta?.auth ?? "dcr",
     ...(meta?.requiredScopes ? { requiredScopes: meta.requiredScopes } : {}),

--- a/test/unit/connector-directory.test.ts
+++ b/test/unit/connector-directory.test.ts
@@ -383,6 +383,40 @@ describe("ConnectorDirectory lookup tables", () => {
     expect(calls).toBe(1);
   });
 
+  test("catalogById finds an icon-less provider entry — the path that refused the install", async () => {
+    // Regression for the catalog projection foot-gun: an icon-less
+    // `provider`-auth connector used to be dropped at projection time, so
+    // catalogById returned null and the provider-auth install failed with
+    // "not a recognized platform connector". Icons are cosmetic — a missing
+    // icon must never make a connector non-functional.
+    const store = freshStore();
+    const path = writeStaticCatalog([
+      {
+        name: "ai.nimblebrain/web",
+        description: "Web tools",
+        version: "1.0.0",
+        // NOTE: no `icons` field.
+        remotes: [{ type: "streamable-http", url: "http://mcp-web.mcp-shared.svc/mcp" }],
+        _meta: {
+          "ai.nimblebrain/connector": {
+            auth: "provider",
+            providerAuth: { provider: "minted", config: { audience: "mcp-fleet" } },
+          },
+        },
+      },
+    ]);
+    await configureRegistries(store, [
+      { id: "static", name: "Static", type: "static", enabled: true, url: path },
+    ]);
+
+    const entry = await new ConnectorDirectory(store).catalogById("ai.nimblebrain/web");
+    expect(entry).not.toBeNull();
+    expect(entry?.id).toBe("ai.nimblebrain/web");
+    expect(entry?.iconUrl).toBeUndefined();
+    expect(entry?.auth).toBe("provider");
+    expect(entry?.providerAuth).toEqual({ provider: "minted", config: { audience: "mcp-fleet" } });
+  });
+
   test("iconByPackage maps npm-scoped package identifier → icon src", async () => {
     const store = freshStore();
     await configureRegistries(store, [

--- a/test/unit/directory-entry-projection.test.ts
+++ b/test/unit/directory-entry-projection.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { ServerDetail } from "../../src/connectors/server-detail.ts";
-import { projectServerDetailToDirectoryEntry } from "../../src/registries/projection.ts";
+import {
+  projectServerDetailToDirectoryEntry,
+  serverDetailToCatalogEntry,
+} from "../../src/registries/projection.ts";
 
 const CTX = { registryId: "test", registryType: "static" as const };
 
@@ -216,5 +219,69 @@ describe("projectServerDetailToDirectoryEntry", () => {
     if (e?.install.kind === "remote-oauth") {
       expect(e.install.url).toBe("https://example.com/sse");
     }
+  });
+});
+
+describe("serverDetailToCatalogEntry", () => {
+  test("projects an icon-less entry that has a remote (icon is cosmetic, never gates install)", () => {
+    // The foot-gun this fixes: a missing icon must NOT make a connector
+    // un-installable. The entry projects; iconUrl is omitted so the UI
+    // falls back to a letter-avatar.
+    const e = serverDetailToCatalogEntry(
+      detail({
+        remotes: [{ type: "streamable-http", url: "https://example.com/mcp" }],
+      }),
+    );
+    expect(e).not.toBeNull();
+    expect(e?.id).toBe("io.example/test");
+    expect(e?.url).toBe("https://example.com/mcp");
+    expect(e?.iconUrl).toBeUndefined();
+  });
+
+  test("carries iconUrl through when an icon is present", () => {
+    const e = serverDetailToCatalogEntry(
+      detail({
+        icons: [{ src: "https://a.svg", sizes: ["any"] }],
+        remotes: [{ type: "streamable-http", url: "https://example.com/mcp" }],
+      }),
+    );
+    expect(e?.iconUrl).toBe("https://a.svg");
+  });
+
+  test("returns null without a remote — that drop stays (genuinely non-functional)", () => {
+    // No remote URL = nothing to install/connect to. This is the only
+    // legitimate reason to drop a catalog entry.
+    const e = serverDetailToCatalogEntry(detail());
+    expect(e).toBeNull();
+  });
+
+  test("returns null without a remote even when icons are present", () => {
+    const e = serverDetailToCatalogEntry(
+      detail({
+        icons: [{ src: "https://a.svg", sizes: ["any"] }],
+      }),
+    );
+    expect(e).toBeNull();
+  });
+
+  test("projects an icon-less provider-auth entry with providerAuth verbatim", () => {
+    // The exact class that hit the bug: a platform `provider` connector with
+    // no icon. Pre-fix the projection dropped it, so catalogById returned null
+    // and the install failed with "not a recognized platform connector".
+    const e = serverDetailToCatalogEntry(
+      detail({
+        remotes: [{ type: "streamable-http", url: "http://mcp-web.mcp-shared.svc/mcp" }],
+        _meta: {
+          "ai.nimblebrain/connector": {
+            auth: "provider",
+            providerAuth: { provider: "minted", config: { audience: "mcp-fleet" } },
+          },
+        },
+      }),
+    );
+    expect(e).not.toBeNull();
+    expect(e?.iconUrl).toBeUndefined();
+    expect(e?.auth).toBe("provider");
+    expect(e?.providerAuth).toEqual({ provider: "minted", config: { audience: "mcp-fleet" } });
   });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -569,7 +569,8 @@ export interface ConnectorCatalogEntry {
   id: string;
   name: string;
   description: string;
-  iconUrl: string;
+  /** Optional brand icon URL — omitted when the entry ships no icon; the UI falls back to a letter-avatar. */
+  iconUrl?: string;
   url: string;
   auth: "dcr" | "static" | "composio" | "provider";
   requiredScopes?: string[];


### PR DESCRIPTION
## Problem

`serverDetailToCatalogEntry` dropped any catalog entry whose `ServerDetail` had no icon (`if (!iconUrl) return null`), so the entry never reached `catalogById`. A **provider-auth install** re-resolves the entry by id from the trusted catalog before minting a fleet token, so an icon-less connector was refused as *"not a recognized platform connector"* — even though it browsed fine. A missing **cosmetic** field silently made the connector un-installable, with a misleading error.

Inconsistent with the rest of the codebase: `types.ts` already had `iconUrl?` optional and the UI (`ConnectorIcon`) already degrades to a letter-avatar. Only the projection disagreed.

## Fix

- `ConnectorCatalogEntry.iconUrl` → optional; omit it when absent.
- **Keep** the missing-`remotes` drop (no URL = genuinely non-functional); remove the missing-icon drop.
- Mirror the optional type in the web API client. Browse card / Configure page / list already route through the letter-avatar fallback — no raw `<img>`.

A missing icon → letter-avatar, never an un-installable connector.

## Tests
- `serverDetailToCatalogEntry`: icon-less + remote → projects; no remote → `null`.
- `catalogById` finds an icon-less provider entry (the path that refused the install), `providerAuth` intact.

`bun run verify` green (unit + web + integration + smoke).