### PR TITLE
observability: count artifact:// resolutions (nb_artifact_resolutions_total)

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -42,6 +42,7 @@ import { PersonalWorkspaceInvariantError } from "../workspace/errors.ts";
 import type { WorkspaceStore } from "../workspace/workspace-store.ts";
 import type { ConversationEventManager } from "./conversation-events.ts";
 import type { SseEventManager } from "./events.ts";
+import { artifactResolutionsTotal } from "./metrics.ts";
 import { ChatRequestBody, ToolCallRequestEnvelope } from "./schemas/rest.ts";
 import { validateAgainst } from "./schemas/validate.ts";
 import { startSseHeartbeat } from "./sse-heartbeat.ts";
@@ -887,20 +888,28 @@ export async function handleReadResource(
     const resolver = getArtifactResolver();
     try {
       const result = await resolver.read(uri, ws);
+      artifactResolutionsTotal.inc({ result: "ok" });
       return json(result as Record<string, unknown>);
     } catch (err) {
       // A malformed `artifact://` id is client input, not a server fault: 400,
       // and never warn-log it — a hostile/typo'd URI must not spam the logs.
       if (err instanceof InvalidArtifactUriError) {
+        artifactResolutionsTotal.inc({ result: "malformed" });
         log.debug("host-resources", `[artifact] rejected malformed URI ${uri}: ${err.message}`);
         return apiError(400, "bad_request", "Malformed artifact:// URI", { uri });
       }
       if (err instanceof ArtifactNotFoundError) {
+        // High-signal: the host emitted this link and now can't resolve it —
+        // most often a cross-workspace reference RLS-denied at the data plane.
+        // The 404 is otherwise silent; this counter is the fleet-level signal.
+        artifactResolutionsTotal.inc({ result: "not_found" });
         return apiError(404, "resource_not_found", `Resource "${uri}" not found`, { uri });
       }
       if (err instanceof ArtifactTooLargeError) {
+        artifactResolutionsTotal.inc({ result: "too_large" });
         return apiError(413, "resource_too_large", err.message, { uri });
       }
+      artifactResolutionsTotal.inc({ result: "error" });
       log.warn(
         `[artifact] read ${uri} (ws=${ws}) failed: ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -114,6 +114,26 @@ export const toolPromotionsTotal = new Counter({
   registers: [metricsRegistry],
 });
 
+/**
+ * Host resolutions of `artifact://` resource links, by outcome. `result` is a
+ * closed set: `ok` | `not_found` | `too_large` | `malformed` | `error`.
+ *
+ * The `not_found` rate is the high-signal detector: the host emitted a
+ * `resource_link` and then could not resolve it — most often a cross-workspace
+ * reference whose artifact lives in a workspace the viewing read token can't
+ * reach (RLS-denied, collapsed to 404). That failure is otherwise silent (the
+ * data plane returns a deliberate 404, the host renders a benign banner), so
+ * this counter is the only fleet-level signal it happened. No tenant/workspace
+ * label — one pod per tenant, so the scrape namespace attributes it, and a
+ * workspace label would be client-unbounded.
+ */
+export const artifactResolutionsTotal = new Counter({
+  name: "nb_artifact_resolutions_total",
+  help: "Host artifact:// resolutions, by result.",
+  labelNames: ["result"] as const,
+  registers: [metricsRegistry],
+});
+
 /** Token usage subset needed for metrics — a structural slice of `TokenUsage`. */
 interface UsageForMetrics {
   inputTokens: number;

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { readFile, rename, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import { recordLlmUsage } from "../api/metrics.ts";
+import { artifactResolutionsTotal, recordLlmUsage } from "../api/metrics.ts";
 import { log } from "../cli/log.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
@@ -812,9 +812,11 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
                   : "",
             )
             .join("");
+          artifactResolutionsTotal.inc({ result: "ok" });
           return { content: textContent(text || "[empty artifact]"), isError: false };
         } catch (err) {
           if (err instanceof ArtifactNotFoundError) {
+            artifactResolutionsTotal.inc({ result: "not_found" });
             return {
               content: textContent(
                 `Artifact "${uri}" not found in this workspace (it may not exist, or belong to another workspace).`,
@@ -822,6 +824,7 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               isError: true,
             };
           }
+          artifactResolutionsTotal.inc({ result: "error" });
           return {
             content: textContent(
               `Failed to read artifact: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/tools/core-source.ts
+++ b/src/tools/core-source.ts
@@ -8,7 +8,9 @@ import type { ToolResult } from "../engine/types.ts";
 import {
   type ArtifactListOptions,
   ArtifactNotFoundError,
+  ArtifactTooLargeError,
   getArtifactResolver,
+  InvalidArtifactUriError,
 } from "../host-resources/artifacts/index.ts";
 import { ORG_ADMIN_ROLES } from "../identity/types.ts";
 import { getAvailableModels, isModelAllowed } from "../model/catalog.ts";
@@ -815,6 +817,14 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
           artifactResolutionsTotal.inc({ result: "ok" });
           return { content: textContent(text || "[empty artifact]"), isError: false };
         } catch (err) {
+          // Same label granularity as the UI read path (handlers.ts) so
+          // `nb_artifact_resolutions_total{result}` means one thing across both
+          // resolution sites: a malformed id (client/model input) and an
+          // over-cap body are not server errors and must not inflate `error`.
+          if (err instanceof InvalidArtifactUriError) {
+            artifactResolutionsTotal.inc({ result: "malformed" });
+            return { content: textContent(`Malformed artifact URI "${uri}".`), isError: true };
+          }
           if (err instanceof ArtifactNotFoundError) {
             artifactResolutionsTotal.inc({ result: "not_found" });
             return {
@@ -823,6 +833,10 @@ export function createCoreToolDefs(runtime: Runtime): InProcessTool[] {
               ),
               isError: true,
             };
+          }
+          if (err instanceof ArtifactTooLargeError) {
+            artifactResolutionsTotal.inc({ result: "too_large" });
+            return { content: textContent(err.message), isError: true };
           }
           artifactResolutionsTotal.inc({ result: "error" });
           return {

--- a/test/unit/api/read-resource-handler.test.ts
+++ b/test/unit/api/read-resource-handler.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { handleReadResource } from "../../../src/api/handlers.ts";
+import { artifactResolutionsTotal } from "../../../src/api/metrics.ts";
 import {
   ArtifactNotFoundError,
   type ArtifactResolver,
@@ -348,6 +349,35 @@ describe("handleReadResource — artifact:// branch", () => {
     ]);
     // Read as the viewing user's verified workspace.
     expect(calls).toEqual([{ uri: "artifact://abc123", ws: "w1" }]);
+  });
+
+  // The counter is the only fleet-level signal that the host emitted a link it
+  // then couldn't resolve — assert the not_found and ok branches record it.
+  // Deltas, not absolutes: the counter is a process-global singleton other
+  // cases in this file also touch.
+  async function resolutionCount(result: string): Promise<number> {
+    const metric = await artifactResolutionsTotal.get();
+    return metric.values.find((v) => v.labels.result === result)?.value ?? 0;
+  }
+
+  it("counts a not_found resolution as result=not_found", async () => {
+    const before = await resolutionCount("not_found");
+    const runtime = makeStubRuntime();
+    stubArtifactResolver(() => {
+      throw new ArtifactNotFoundError("abc123");
+    });
+    await handleReadResource(req({ uri: "artifact://abc123" }), runtime, { workspaceId: "w1" });
+    expect(await resolutionCount("not_found")).toBe(before + 1);
+  });
+
+  it("counts a successful resolution as result=ok", async () => {
+    const before = await resolutionCount("ok");
+    const runtime = makeStubRuntime();
+    stubArtifactResolver((uri) => ({
+      contents: [{ uri, mimeType: "text/plain", text: "x" }],
+    }));
+    await handleReadResource(req({ uri: "artifact://abc123" }), runtime, { workspaceId: "w1" });
+    expect(await resolutionCount("ok")).toBe(before + 1);
   });
 });
 

--- a/test/unit/tools/core-artifact-tools.test.ts
+++ b/test/unit/tools/core-artifact-tools.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { artifactResolutionsTotal } from "../../../src/api/metrics.ts";
 import type { ArtifactResolver } from "../../../src/host-resources/artifacts/artifact-resolver.ts";
 import {
   ArtifactNotFoundError,
+  ArtifactTooLargeError,
+  InvalidArtifactUriError,
   setArtifactResolver,
 } from "../../../src/host-resources/artifacts/index.ts";
 import type { Runtime } from "../../../src/runtime/runtime.ts";
@@ -83,6 +86,42 @@ describe("read_artifact tool handler", () => {
     const res = await handlerFor("read_artifact")({ uri: "artifact://art_x" });
     expect(res.isError).toBe(true);
     expect(firstText(res)).toMatch(/not found in this workspace/i);
+  });
+
+  // The tool path mirrors the UI read path's metric label granularity: malformed
+  // (client/model input) and too_large (over-cap body) are distinct outcomes,
+  // not `error`. Deltas, since the counter is a process-global singleton.
+  async function resolutionCount(result: string): Promise<number> {
+    const metric = await artifactResolutionsTotal.get();
+    return metric.values.find((v) => v.labels.result === result)?.value ?? 0;
+  }
+
+  it("maps a malformed uri to result=malformed (not error)", async () => {
+    const before = await resolutionCount("malformed");
+    const errBefore = await resolutionCount("error");
+    setArtifactResolver({
+      read: async (uri: string) => {
+        throw new InvalidArtifactUriError(uri, "id must match the safe-id grammar");
+      },
+    } as unknown as ArtifactResolver);
+    const res = await handlerFor("read_artifact")({ uri: "artifact://bad id" });
+    expect(res.isError).toBe(true);
+    expect(await resolutionCount("malformed")).toBe(before + 1);
+    expect(await resolutionCount("error")).toBe(errBefore); // not folded into error
+  });
+
+  it("maps an over-cap body to result=too_large (not error)", async () => {
+    const before = await resolutionCount("too_large");
+    const errBefore = await resolutionCount("error");
+    setArtifactResolver({
+      read: async () => {
+        throw new ArtifactTooLargeError(99, 8);
+      },
+    } as unknown as ArtifactResolver);
+    const res = await handlerFor("read_artifact")({ uri: "artifact://art_big" });
+    expect(res.isError).toBe(true);
+    expect(await resolutionCount("too_large")).toBe(before + 1);
+    expect(await resolutionCount("error")).toBe(errBefore);
   });
 
   it("requires a uri", async () => {


### PR DESCRIPTION
Closes #468.

## What
Adds `nb_artifact_resolutions_total{result}` (prom-client) and increments it at both host artifact-resolution sites, with **identical** label granularity on each so one series means one thing:
- UI read path — `handleReadResource` (`src/api/handlers.ts`): `ok` / `malformed` / `not_found` / `too_large` / `error`.
- `read_artifact` tool path (`src/tools/core-source.ts`): `ok` / `malformed` / `not_found` / `too_large` / `error`.

(The tool path's `malformed` and `too_large` branches were added in `60e555b` after QA flagged a label asymmetry — both errors are reachable from `resolver.read`, so folding them into `error` would have polluted the error series the moment anyone alerts on it.)

## Why
A cross-workspace `artifact://` reference (artifact lives in a workspace the viewing read token can't reach → RLS-denied → collapsed `404`) surfaces as a benign "Resource not found" banner with **no exception, no 5xx, no metric**. That's how a real user-facing failure ran undiagnosed for hours. The `not_found` rate is the high-signal "the host emitted a link it then couldn't resolve" detector — the one place this class is cheaply observable.

## Notes
- Bounded labels only; **no** tenant/workspace label (one pod per tenant, so the scrape namespace already attributes it — a workspace label would be client-unbounded). Matches the convention of the existing `nb_*` counters.
- `src/tools/core-source.ts` already imported from `../api/metrics.ts` (`recordLlmUsage`), so the increment adds no new layering.
- Regression tests (4 new assertions across two files):
  - `test/unit/api/read-resource-handler.test.ts` — UI path records `ok` and `not_found`.
  - `test/unit/tools/core-artifact-tools.test.ts` — tool path records `malformed` and `too_large` and does **not** fold them into `error`.
  - All delta-based, since the counter is a process-global singleton.

## Verification
`bunx tsc --noEmit` clean · `biome check` clean · `verify:static` exit 0 · full backend unit + integration suite green (0 fail), including the 4 new assertions above (+2 test cases over the prior commit).

## Context
Prerequisite **deployments#48** (merged) enabled the tenant ServiceMonitor, so this counter is now actually scraped. Part of the observability cluster: NimbleBrainInc/platform#60 (instrument the artifacts data plane) + NimbleBrainInc/infra#90 (shared data-plane alert rules, incl. the `ArtifactLinkUnresolvable` alert that consumes this metric). UX pair: #467 (don't surface unresolvable links).
