### PR TITLE
refactor(connectors): consolidate connector meta-projection into one helper

### DIFF
--- a/src/registries/projection.ts
+++ b/src/registries/projection.ts
@@ -16,7 +16,11 @@
  * never invoke these directly.
  */
 
-import { getNimbleBrainConnectorMeta, type ServerDetail } from "../connectors/server-detail.ts";
+import {
+  getNimbleBrainConnectorMeta,
+  type NimbleBrainConnectorMeta,
+  type ServerDetail,
+} from "../connectors/server-detail.ts";
 import { validateAdditionalAuthorizationParams } from "../util/oauth-params.ts";
 import { isHttpUrl } from "../util/url.ts";
 import type { DirectoryEntry, RegistryType } from "./types.ts";
@@ -24,6 +28,47 @@ import type { DirectoryEntry, RegistryType } from "./types.ts";
 export interface ProjectionContext {
   registryId: string;
   registryType: RegistryType;
+}
+
+/**
+ * The auth/connection fields the directory (`deriveInstall`'s remote-oauth
+ * action) and the catalog (`serverDetailToCatalogEntry`) BOTH derive from
+ * the `_meta["ai.nimblebrain/connector"]` extension, derived exactly once.
+ *
+ * These two projections render the same `ServerDetail` for different
+ * surfaces (Browse/install vs. Configure) and MUST agree on these fields —
+ * they diverged once (#462) and nothing structural stopped it. Spreading
+ * this single result into both call sites makes drift impossible: there is
+ * one derivation, so the directory and the catalog can never disagree on
+ * `auth` / scopes / params / operatorSetup / composio / providerAuth.
+ *
+ * The catalog-only fields (`tags`, `interactive`, `docsUrl`) are NOT here:
+ * they don't belong on the directory entry's `install` action (the
+ * directory carries `tags` at the row's top level, not inside `install`),
+ * so they stay inline at the catalog call site.
+ *
+ * `auth` always resolves (defaulting to `"dcr"`); the rest are present only
+ * when the meta carries them, matching the `...(meta?.X ? { X } : {})`
+ * shape both sites previously inlined.
+ */
+function connectorMetaAuthFields(meta: NimbleBrainConnectorMeta | undefined): {
+  auth: "dcr" | "static" | "composio" | "provider";
+  requiredScopes?: string[];
+  additionalAuthorizationParams?: Record<string, string>;
+  operatorSetup?: { portalUrl: string; hint: string; clientSecretKey: string };
+  composio?: { toolkit: string; authConfigEnv: string; tools?: string[] };
+  providerAuth?: { provider: string; config: Record<string, unknown> };
+} {
+  return {
+    auth: meta?.auth ?? "dcr",
+    ...(meta?.requiredScopes ? { requiredScopes: meta.requiredScopes } : {}),
+    ...(meta?.additionalAuthorizationParams
+      ? { additionalAuthorizationParams: meta.additionalAuthorizationParams }
+      : {}),
+    ...(meta?.operatorSetup ? { operatorSetup: meta.operatorSetup } : {}),
+    ...(meta?.composio ? { composio: meta.composio } : {}),
+    ...(meta?.providerAuth ? { providerAuth: meta.providerAuth } : {}),
+  };
 }
 
 /**
@@ -76,19 +121,11 @@ function deriveInstall(s: ServerDetail): DirectoryEntry["install"] | null {
   }
   const remote = s.remotes?.[0];
   if (remote && (remote.type === "streamable-http" || remote.type === "sse")) {
-    const meta = getNimbleBrainConnectorMeta(s);
     return {
       kind: "remote-oauth",
       url: remote.url,
       transportType: remote.type,
-      auth: meta?.auth ?? "dcr",
-      ...(meta?.requiredScopes ? { requiredScopes: meta.requiredScopes } : {}),
-      ...(meta?.additionalAuthorizationParams
-        ? { additionalAuthorizationParams: meta.additionalAuthorizationParams }
-        : {}),
-      ...(meta?.operatorSetup ? { operatorSetup: meta.operatorSetup } : {}),
-      ...(meta?.composio ? { composio: meta.composio } : {}),
-      ...(meta?.providerAuth ? { providerAuth: meta.providerAuth } : {}),
+      ...connectorMetaAuthFields(getNimbleBrainConnectorMeta(s)),
     };
   }
   return null;
@@ -155,14 +192,7 @@ export function serverDetailToCatalogEntry(s: ServerDetail): ConnectorCatalogEnt
     description: s.description,
     ...(iconUrl ? { iconUrl } : {}),
     url: remote.url,
-    auth: meta?.auth ?? "dcr",
-    ...(meta?.requiredScopes ? { requiredScopes: meta.requiredScopes } : {}),
-    ...(meta?.additionalAuthorizationParams
-      ? { additionalAuthorizationParams: meta.additionalAuthorizationParams }
-      : {}),
-    ...(meta?.operatorSetup ? { operatorSetup: meta.operatorSetup } : {}),
-    ...(meta?.composio ? { composio: meta.composio } : {}),
-    ...(meta?.providerAuth ? { providerAuth: meta.providerAuth } : {}),
+    ...connectorMetaAuthFields(meta),
     ...(meta?.tags ? { tags: meta.tags } : {}),
     ...(typeof meta?.interactive === "boolean" ? { interactive: meta.interactive } : {}),
     ...(meta?.docsUrl ? { docsUrl: meta.docsUrl } : {}),

--- a/test/unit/directory-entry-projection.test.ts
+++ b/test/unit/directory-entry-projection.test.ts
@@ -285,3 +285,128 @@ describe("serverDetailToCatalogEntry", () => {
     expect(e?.providerAuth).toEqual({ provider: "minted", config: { audience: "mcp-fleet" } });
   });
 });
+
+describe("directory and catalog projections agree on shared meta auth fields", () => {
+  // Regression guard for #464 (and the #462 divergence it prevents): the
+  // Browse/install path (`projectServerDetailToDirectoryEntry(...).install`)
+  // and the Configure/catalog path (`serverDetailToCatalogEntry(...)`)
+  // derive the SAME `_meta`-sourced auth fields. They are now a single
+  // helper; if a future change re-forks the derivation, these assertions
+  // fail in CI before the surfaces can drift.
+
+  test("a static-auth entry yields identical auth/scopes/params/operatorSetup on both paths", () => {
+    const s = detail({
+      remotes: [{ type: "streamable-http", url: "https://example.com/mcp" }],
+      _meta: {
+        "ai.nimblebrain/connector": {
+          auth: "static",
+          requiredScopes: ["read", "write"],
+          additionalAuthorizationParams: { access_type: "offline", prompt: "consent" },
+          operatorSetup: {
+            portalUrl: "https://example.com/portal",
+            hint: "Create app",
+            clientSecretKey: "x.client_secret",
+          },
+        },
+      },
+    });
+
+    const dir = projectServerDetailToDirectoryEntry(s, CTX);
+    const cat = serverDetailToCatalogEntry(s);
+    expect(dir?.install.kind).toBe("remote-oauth");
+    expect(cat).not.toBeNull();
+    if (dir?.install.kind !== "remote-oauth" || !cat) {
+      throw new Error("expected a remote-oauth directory install and a catalog entry");
+    }
+
+    expect(dir.install.auth).toBe(cat.auth);
+    expect(dir.install.requiredScopes).toEqual(cat.requiredScopes);
+    expect(dir.install.additionalAuthorizationParams).toEqual(cat.additionalAuthorizationParams);
+    expect(dir.install.operatorSetup).toEqual(cat.operatorSetup);
+    // Concrete values, so the assertion fails loudly if BOTH paths regress together.
+    expect(cat.auth).toBe("static");
+    expect(cat.requiredScopes).toEqual(["read", "write"]);
+    expect(cat.additionalAuthorizationParams).toEqual({
+      access_type: "offline",
+      prompt: "consent",
+    });
+    expect(cat.operatorSetup?.clientSecretKey).toBe("x.client_secret");
+  });
+
+  test("a provider-auth entry carries identical providerAuth on both paths", () => {
+    const s = detail({
+      remotes: [{ type: "streamable-http", url: "http://mcp-web.mcp-shared.svc/mcp" }],
+      _meta: {
+        "ai.nimblebrain/connector": {
+          auth: "provider",
+          requiredScopes: ["mcp:invoke"],
+          providerAuth: {
+            provider: "minted",
+            config: { audience: "mcp-fleet", scope: "mcp:invoke" },
+          },
+        },
+      },
+    });
+
+    const dir = projectServerDetailToDirectoryEntry(s, CTX);
+    const cat = serverDetailToCatalogEntry(s);
+    if (dir?.install.kind !== "remote-oauth" || !cat) {
+      throw new Error("expected a remote-oauth directory install and a catalog entry");
+    }
+
+    expect(dir.install.auth).toBe(cat.auth);
+    expect(dir.install.providerAuth).toEqual(cat.providerAuth);
+    expect(dir.install.requiredScopes).toEqual(cat.requiredScopes);
+    expect(cat.auth).toBe("provider");
+    expect(cat.providerAuth).toEqual({
+      provider: "minted",
+      config: { audience: "mcp-fleet", scope: "mcp:invoke" },
+    });
+  });
+
+  test("a composio entry carries identical composio config on both paths", () => {
+    const s = detail({
+      remotes: [{ type: "streamable-http", url: "https://example.com/mcp" }],
+      _meta: {
+        "ai.nimblebrain/connector": {
+          auth: "composio",
+          composio: { toolkit: "gmail", authConfigEnv: "GMAIL_AC", tools: ["send", "list"] },
+        },
+      },
+    });
+
+    const dir = projectServerDetailToDirectoryEntry(s, CTX);
+    const cat = serverDetailToCatalogEntry(s);
+    if (dir?.install.kind !== "remote-oauth" || !cat) {
+      throw new Error("expected a remote-oauth directory install and a catalog entry");
+    }
+
+    expect(dir.install.auth).toBe(cat.auth);
+    expect(dir.install.composio).toEqual(cat.composio);
+    expect(cat.auth).toBe("composio");
+    expect(cat.composio).toEqual({
+      toolkit: "gmail",
+      authConfigEnv: "GMAIL_AC",
+      tools: ["send", "list"],
+    });
+  });
+
+  test("absent meta defaults both paths to dcr with no auth extras", () => {
+    const s = detail({
+      remotes: [{ type: "streamable-http", url: "https://example.com/mcp" }],
+    });
+
+    const dir = projectServerDetailToDirectoryEntry(s, CTX);
+    const cat = serverDetailToCatalogEntry(s);
+    if (dir?.install.kind !== "remote-oauth" || !cat) {
+      throw new Error("expected a remote-oauth directory install and a catalog entry");
+    }
+
+    expect(dir.install.auth).toBe("dcr");
+    expect(cat.auth).toBe("dcr");
+    expect(dir.install.requiredScopes).toBeUndefined();
+    expect(cat.requiredScopes).toBeUndefined();
+    expect(dir.install.providerAuth).toBeUndefined();
+    expect(cat.providerAuth).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #464.

## Problem

`src/registries/projection.ts` had the directory (browse/install) path (`deriveInstall`) and the catalog (Configure) path (`serverDetailToCatalogEntry`) each independently re-derive the same `_meta` auth fields from `getNimbleBrainConnectorMeta`. They diverged once already — #462: the catalog path dropped icon-less entries while the directory path didn't, so a connector browsed but couldn't install. Nothing enforced that the two stay in sync.

## Fix (pure refactor, no behavior change)

- Extract `connectorMetaAuthFields(meta)` deriving the **6 shared fields once**: `auth` (default `"dcr"`), `requiredScopes`, `additionalAuthorizationParams`, `operatorSetup`, `composio`, `providerAuth` — same presence guards as before.
- `deriveInstall` and `serverDetailToCatalogEntry` now spread the helper.
- **Byte-identical output.** Path-specific logic untouched: the catalog-only `tags`/`interactive`/`docsUrl` stay inline (they don't belong on the directory entry's `install`), and the two drop rules (missing-`remote` / missing-`install`) and the differing `id`/`url`/`iconUrl?` shapes are unchanged.

## Regression guard

New test: for the same `ServerDetail`, the directory and catalog projections must **agree** on the shared meta fields (`auth`/`providerAuth`/`requiredScopes`/`additionalAuthorizationParams`/`operatorSetup`/`composio`). A future re-fork fails CI — which is the whole point.

`bun run verify` green (3662 unit + 558 web + 613 integration + smoke).