### PR TITLE
feat(workspace): scope tool composition to focused + personal (crossWorkspaceTools flag)

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -29,6 +29,18 @@ export interface FeatureFlags {
    * `conversation/compaction.ts`.
    */
   compaction?: boolean;
+  /**
+   * Default true (the Stage-2 ambient behavior). When `false`, a session's
+   * tool composition AND invocation are locked to the FOCUSED workspace plus
+   * the user's personal workspace (and the bare identity sources) — the
+   * cross-workspace membership union is no longer surfaced (`nb__search`
+   * corpus, the engine's promotable set) or callable (`routeToolCall`'s
+   * focus-gate). Cross-workspace reach becomes a sequential focus-switch, not
+   * an ambient union. Identity authorizes which workspaces may be focused;
+   * focus composes the tools. Flip per-tenant to lock down; the default moves
+   * once validated. See the workspace-lockdown design.
+   */
+  crossWorkspaceTools?: boolean;
 }
 
 /** Resolved feature flags — all required booleans (no optionals). */
@@ -44,6 +56,7 @@ const DEFAULTS: ResolvedFeatures = {
   userManagement: true,
   workspaceManagement: true,
   compaction: false,
+  crossWorkspaceTools: true,
 };
 
 /** Resolve partial feature flags to a complete set. Missing keys default to true. */
@@ -59,6 +72,7 @@ export function resolveFeatures(config?: FeatureFlags): ResolvedFeatures {
     userManagement: config.userManagement ?? true,
     workspaceManagement: config.workspaceManagement ?? true,
     compaction: config.compaction ?? false,
+    crossWorkspaceTools: config.crossWorkspaceTools ?? true,
   };
 }
 

--- a/src/orchestrator/route.ts
+++ b/src/orchestrator/route.ts
@@ -250,6 +250,18 @@ export async function routeToolCall(opts: {
   identityId: string;
   namespacedName: string;
   runtime: OrchestratorRuntime;
+  /**
+   * Optional focus-gate (workspace lockdown). When supplied, a workspace tool
+   * is callable ONLY if its workspace is in this set — the session's focused
+   * workspace plus the user's personal workspace — even when the caller is a
+   * member of the tool's workspace. Membership authorizes which workspaces may
+   * be focused; this set is which ones currently ARE. Absent (the default,
+   * `features.crossWorkspaceTools` on), membership alone gates and the ambient
+   * cross-workspace behavior is preserved. Routing stays pure: this is an
+   * explicit caller input (the caller resolves it from the feature flag), never
+   * ambient state.
+   */
+  allowedWsIds?: readonly string[];
 }): Promise<RoutedToolCall> {
   const { identityId, namespacedName, runtime } = opts;
 
@@ -303,6 +315,17 @@ export async function routeToolCall(opts: {
   const accessible = await workspaceStore.getWorkspacesForUser(identityId);
   const isMember = accessible.some((w) => w.id === wsId);
   if (!isMember) {
+    throw new WorkspaceAccessDenied(identityId, wsId);
+  }
+
+  // Step 3b — focus gate (workspace lockdown). A member can still be denied if
+  // the tool's workspace is outside the session's allowed-set (focused ∪
+  // personal). This is what makes the workspace a real wall rather than a soft
+  // suggestion: a directly-named `ws_<other>-tool` cannot be invoked unless that
+  // workspace is currently focused, even though list-narrowing already hides it.
+  // (#474 may later distinguish this from a true non-member denial to drive the
+  // "want me to switch?" elicitation; today it collapses to the same denial.)
+  if (opts.allowedWsIds && !opts.allowedWsIds.includes(wsId)) {
     throw new WorkspaceAccessDenied(identityId, wsId);
   }
 

--- a/src/orchestrator/tool-list-aggregator.ts
+++ b/src/orchestrator/tool-list-aggregator.ts
@@ -104,6 +104,18 @@ export interface ToolListAggregatorOptions {
 export interface ToolListAggregator {
   aggregateToolList(identityId: string): Promise<readonly NamespacedToolDescriptor[]>;
   /**
+   * Like {@link aggregateToolList}, but composed over an EXPLICIT workspace set
+   * (the session's focused ∪ personal, under workspace lockdown) instead of the
+   * identity's full membership union. The set is intersected with membership
+   * first, so it can only ever NARROW the identity's reach, never widen it.
+   * Identity sources are still prepended. Memo-free (the focus set varies per
+   * turn) — see {@link ToolListCache.composeUnion}.
+   */
+  aggregateScopedToolList(
+    identityId: string,
+    scopeWsIds: readonly string[],
+  ): Promise<readonly NamespacedToolDescriptor[]>;
+  /**
    * Drop the cached union for `identityId`. The aggregator calls this
    * automatically when the workspace membership for the identity
    * changes (`getWorkspacesForUser` returns a different set than the
@@ -247,6 +259,28 @@ export function createToolListAggregator(options: ToolListAggregatorOptions): To
     return identityTools.length === 0 ? wsUnion : [...identityTools, ...wsUnion];
   };
 
+  const aggregateScopedToolList = async (
+    identityId: string,
+    scopeWsIds: readonly string[],
+  ): Promise<readonly NamespacedToolDescriptor[]> => {
+    if (typeof identityId !== "string" || identityId.length === 0) {
+      throw new Error("[tool-list-aggregator] aggregateScopedToolList: identityId is required");
+    }
+    // Intersect the requested scope with actual membership: the focus-scoped
+    // set can only NARROW the identity's reach, never widen it. (The focused ws
+    // is already membership-gated upstream at `resolveWorkspace`, and the
+    // personal ws is a member by construction — this is belt-and-suspenders
+    // against a stale or wrong id reaching here.)
+    const member = await options.workspaceStore.getWorkspacesForUser(identityId);
+    const memberIds = new Set(member.map((ws) => ws.id));
+    const wsIds = [...new Set(scopeWsIds)].filter((id) => memberIds.has(id));
+    const [identityTools, wsUnion] = await Promise.all([
+      getIdentityDescriptors(),
+      cache.composeUnion(wsIds, namespacedToolName),
+    ]);
+    return identityTools.length === 0 ? wsUnion : [...identityTools, ...wsUnion];
+  };
+
   const invalidateIdentity = (identityId: string): void => {
     cache.invalidateIdentity(identityId);
     identityMembershipStamp.delete(identityId);
@@ -265,6 +299,7 @@ export function createToolListAggregator(options: ToolListAggregatorOptions): To
 
   return {
     aggregateToolList,
+    aggregateScopedToolList,
     invalidateIdentity,
     invalidateWorkspace,
     activeWatcherCount,

--- a/src/orchestrator/tool-list-cache.ts
+++ b/src/orchestrator/tool-list-cache.ts
@@ -382,6 +382,53 @@ export class ToolListCache {
   }
 
   /**
+   * Compose a union over an EXPLICIT workspace set, with NO identity-level
+   * memo. Used by the focus-scoped path (workspace lockdown): the set is
+   * `{focused, personal}`, which varies per turn, so the `identityId`-keyed
+   * memo in {@link getUnionForIdentity} would serve a stale union for a
+   * different focus. The per-WORKSPACE listings this fans out over ARE cached +
+   * FS-watched (`getWorkspaceListing`), so recomposing a 2-element union per
+   * call is cheap and always fresh — no second cache to invalidate. A rejected
+   * whole-workspace listing is dropped (degrade gracefully), mirroring
+   * {@link getUnionForIdentity}. No `subscribedIdentities` tracking: there is no
+   * memoized union here to invalidate.
+   */
+  async composeUnion(
+    wsIds: readonly string[],
+    namespace: (wsId: string, toolName: string) => string,
+  ): Promise<readonly NamespacedToolDescriptor[]> {
+    this.assertOpen();
+    const settled = await Promise.allSettled(
+      wsIds.map(async (wsId) => ({ wsId, listing: await this.getWorkspaceListing(wsId) })),
+    );
+    const out: NamespacedToolDescriptor[] = [];
+    for (const result of settled) {
+      if (result.status === "rejected") {
+        log.debug(
+          "mcp",
+          `[tool-list-cache] composeUnion dropping a workspace: ${
+            result.reason instanceof Error ? result.reason.message : String(result.reason)
+          }`,
+        );
+        continue;
+      }
+      const { wsId, listing } = result.value;
+      for (const t of listing.tools) {
+        out.push({
+          name: namespace(wsId, t.name),
+          wsId,
+          toolName: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+          ...(t.annotations !== undefined ? { annotations: t.annotations } : {}),
+          ...(t.execution !== undefined ? { execution: t.execution } : {}),
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
    * Drop the cached union for `identityId` (e.g. after a membership
    * change the FS watcher can't see). Idempotent. Also unsubscribes
    * this identity from every workspace's invalidation list so a stale

--- a/src/runtime/identity-tool-router.ts
+++ b/src/runtime/identity-tool-router.ts
@@ -64,7 +64,10 @@ export type WorkspaceDispatchHook = (callId: string, wsId: string) => void;
  * unit tests can stub with a tiny in-memory aggregator that doesn't need
  * a workspace store or FS watcher.
  */
-export type IdentityToolRouterAggregator = Pick<ToolListAggregator, "aggregateToolList">;
+export type IdentityToolRouterAggregator = Pick<
+  ToolListAggregator,
+  "aggregateToolList" | "aggregateScopedToolList"
+>;
 
 export interface IdentityToolRouterOptions {
   /**
@@ -83,6 +86,16 @@ export interface IdentityToolRouterOptions {
   aggregator: IdentityToolRouterAggregator;
   /** Optional audit-attribution hook. See `WorkspaceDispatchHook`. */
   onWorkspaceDispatch?: WorkspaceDispatchHook;
+  /**
+   * Workspace lockdown (`features.crossWorkspaceTools === false`). When set,
+   * the router's REACHABLE set and its INVOCATION gate are both scoped to this
+   * workspace set — the session's focused workspace plus the user's personal
+   * workspace — instead of the identity's full membership union. The caller
+   * resolves it from the feature flag and the focused workspace; the router
+   * stays a pure composition. Absent (the default), the ambient cross-workspace
+   * union is preserved unchanged.
+   */
+  allowedWsIds?: readonly string[];
 }
 
 export class IdentityToolRouter implements ToolRouter {
@@ -90,6 +103,7 @@ export class IdentityToolRouter implements ToolRouter {
   private readonly runtime: OrchestratorRuntime;
   private readonly aggregator: IdentityToolRouterAggregator;
   private readonly onWorkspaceDispatch?: WorkspaceDispatchHook;
+  private readonly allowedWsIds?: readonly string[];
 
   constructor(opts: IdentityToolRouterOptions) {
     // The type system already pins the shape; we only need to catch the
@@ -103,6 +117,7 @@ export class IdentityToolRouter implements ToolRouter {
     this.runtime = opts.runtime;
     this.aggregator = opts.aggregator;
     if (opts.onWorkspaceDispatch) this.onWorkspaceDispatch = opts.onWorkspaceDispatch;
+    if (opts.allowedWsIds) this.allowedWsIds = opts.allowedWsIds;
   }
 
   /**
@@ -114,7 +129,11 @@ export class IdentityToolRouter implements ToolRouter {
    * pick up fields it has no contract for.
    */
   async availableTools(): Promise<ToolSchema[]> {
-    const aggregated = await this.aggregator.aggregateToolList(this.identityId);
+    // Under workspace lockdown the reachable set is scoped to {focused ∪
+    // personal}; otherwise it's the identity's full cross-workspace union.
+    const aggregated = this.allowedWsIds
+      ? await this.aggregator.aggregateScopedToolList(this.identityId, this.allowedWsIds)
+      : await this.aggregator.aggregateToolList(this.identityId);
     return aggregated.map((t) => ({
       name: t.name,
       description: t.description,
@@ -145,6 +164,9 @@ export class IdentityToolRouter implements ToolRouter {
         identityId: this.identityId,
         namespacedName: call.name,
         runtime: this.runtime,
+        // Focus-gate: under lockdown a member can still be denied a tool whose
+        // workspace isn't in {focused ∪ personal}. Undefined preserves ambient.
+        ...(this.allowedWsIds ? { allowedWsIds: this.allowedWsIds } : {}),
       });
     } catch (err) {
       return mapOrchestratorErrorToToolResult(err, call.name);

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -550,10 +550,12 @@ export class Runtime {
         if (!rtHolder.rt) throw new Error("Runtime not initialized");
         const identity = getRequestContext()?.identity;
         if (!identity) return rtHolder.rt.getRegistryForCurrentWorkspace();
+        const allowedWsIds = rtHolder.rt._lockdownAllowedWsIds(identity.id);
         return new IdentityToolRouter({
           identityId: identity.id,
           runtime: rtHolder.rt,
           aggregator: rtHolder.rt.getToolListAggregator(),
+          ...(allowedWsIds ? { allowedWsIds } : {}),
         });
       },
       // Default initial active set: focused-workspace tools (namespaced
@@ -2337,11 +2339,29 @@ export class Runtime {
    * session's focused workspace — so cross-workspace dispatches attribute
    * correctly in audit logs.
    */
+  /**
+   * Workspace lockdown (`features.crossWorkspaceTools === false`): the set a
+   * session may compose tools from and invoke into — its FOCUSED workspace plus
+   * the caller's personal workspace. Returns `undefined` when lockdown is off
+   * (the ambient cross-workspace union is preserved) or no workspace is focused
+   * (CLI/dev — only identity-owned tools contribute). Read by every
+   * `IdentityToolRouter` construction and by `listDiscoverableTools`, so the
+   * reachable set, the search corpus, and the invocation gate all derive from
+   * one source.
+   */
+  _lockdownAllowedWsIds(identityId: string): readonly string[] | undefined {
+    if (this._features.crossWorkspaceTools) return undefined;
+    const focused = this._currentWorkspaceId?.() ?? null;
+    const personal = personalWorkspaceIdFor(identityId);
+    return [...new Set(focused ? [focused, personal] : [personal])];
+  }
+
   private _buildIdentityToolRouter(opts: {
     identityId: string;
     perCallWorkspaceMap: Map<string, string>;
   }): ToolRouter {
     const { identityId, perCallWorkspaceMap } = opts;
+    const allowedWsIds = this._lockdownAllowedWsIds(identityId);
     return new IdentityToolRouter({
       identityId,
       runtime: this,
@@ -2349,6 +2369,7 @@ export class Runtime {
       onWorkspaceDispatch: (callId, wsId) => {
         perCallWorkspaceMap.set(callId, wsId);
       },
+      ...(allowedWsIds ? { allowedWsIds } : {}),
     });
   }
 
@@ -2901,7 +2922,12 @@ export class Runtime {
       // NamespacedToolDescriptor carries every ToolSchema field (name,
       // description, inputSchema, annotations) plus wsId/toolName — so the
       // union is assignable to ToolSchema[] for the search/eligibility path.
-      return this._toolListAggregator.aggregateToolList(identity.id);
+      // Under workspace lockdown the search corpus is scoped to {focused ∪
+      // personal}; otherwise it's the identity's full cross-workspace union.
+      const allowedWsIds = this._lockdownAllowedWsIds(identity.id);
+      return allowedWsIds
+        ? this._toolListAggregator.aggregateScopedToolList(identity.id, allowedWsIds)
+        : this._toolListAggregator.aggregateToolList(identity.id);
     }
     return this.getRegistryForCurrentWorkspace().availableTools();
   }

--- a/test/unit/orchestrator/route.test.ts
+++ b/test/unit/orchestrator/route.test.ts
@@ -200,6 +200,54 @@ describe("routeToolCall — happy path", () => {
   });
 });
 
+describe("routeToolCall — focus gate (workspace lockdown)", () => {
+  // Pins: a MEMBER of a workspace is still denied a tool there when the
+  // workspace is outside the session's allowed-set (focused ∪ personal).
+  // Membership authorizes which workspaces MAY be focused; the allowed-set is
+  // which ones currently ARE. Without this gate, narrowing the tool LISTS would
+  // not stop a directly-named cross-workspace tool from being dispatched.
+  test("denies a member workspace that is outside allowedWsIds", async () => {
+    const runtime = buildHappyRuntime();
+    let thrown: unknown = null;
+    try {
+      await routeToolCall({
+        identityId: USER_ID,
+        namespacedName: `${SHARED_WS}-crm__search`,
+        runtime,
+        allowedWsIds: [PERSONAL_WS], // focused on personal; ws_helix is in scope no longer
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(WorkspaceAccessDenied);
+    // Fails closed BEFORE constructing a workspace context.
+    expect(runtime.contextCallCount()).toBe(0);
+  });
+
+  test("allows a member workspace that IS in allowedWsIds", async () => {
+    const runtime = buildHappyRuntime();
+    const routed = await routeToolCall({
+      identityId: USER_ID,
+      namespacedName: `${SHARED_WS}-crm__search`,
+      runtime,
+      allowedWsIds: [SHARED_WS, PERSONAL_WS],
+    });
+    expect(routed.context.workspaceId).toBe(SHARED_WS);
+    expect(routed.source.name).toBe("crm");
+  });
+
+  test("omitting allowedWsIds preserves ambient cross-workspace (membership-only gate)", async () => {
+    const runtime = buildHappyRuntime();
+    // No allowedWsIds → the default flag-on behavior: membership alone gates.
+    const routed = await routeToolCall({
+      identityId: USER_ID,
+      namespacedName: `${SHARED_WS}-crm__search`,
+      runtime,
+    });
+    expect(routed.context.workspaceId).toBe(SHARED_WS);
+  });
+});
+
 describe("routeToolCall — strict invariant (Stage 1 lesson 3)", () => {
   // Pins: un-namespaced names MUST throw rather than silently fall
   // back to "the user's personal workspace." A defensive default

--- a/test/unit/orchestrator/tool-list-aggregator.test.ts
+++ b/test/unit/orchestrator/tool-list-aggregator.test.ts
@@ -233,6 +233,46 @@ describe("aggregateToolList — happy path", () => {
   });
 });
 
+// ── 1b. Scoped aggregation (workspace lockdown) ────────────────────
+
+describe("aggregateScopedToolList — focus-scoped composition", () => {
+  test("composes ONLY the requested workspaces, not the full membership union", async () => {
+    const wsA = "ws_a";
+    const wsB = "ws_b";
+    const workDir = trackDir(makeWorkDir([wsA, wsB]));
+    const { lister } = spyingLister(async (wsId) =>
+      wsId === wsA ? buildTools(["alpha", "beta", "gamma"], "src_a") : buildTools(["delta"], "src_b"),
+    );
+    const store = buildStore({ user_1: [wsA, wsB] }); // member of BOTH
+    const agg = track(
+      createToolListAggregator({ workDir, workspaceStore: store, listToolsForWorkspace: lister }),
+    );
+
+    // Scope to wsA only → wsB's tools are excluded even though the user is a member.
+    const out = await agg.aggregateScopedToolList("user_1", [wsA]);
+    const parsed = out.map((d) => parseWs(d.name));
+    expect(parsed.every((p) => p.wsId === wsA)).toBe(true);
+    expect(parsed.map((p) => p.toolName).sort()).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  test("intersects the scope with membership — a non-member id in the set is dropped, never widens", async () => {
+    const wsA = "ws_a";
+    const workDir = trackDir(makeWorkDir([wsA]));
+    const { lister } = spyingLister(async () => buildTools(["alpha"], "src_a"));
+    const store = buildStore({ user_1: [wsA] }); // member of wsA only
+    const agg = track(
+      createToolListAggregator({ workDir, workspaceStore: store, listToolsForWorkspace: lister }),
+    );
+
+    // Caller passes a workspace the user is NOT a member of — it must be dropped,
+    // not composed (the scope can only narrow, never widen past membership).
+    const out = await agg.aggregateScopedToolList("user_1", [wsA, "ws_not_a_member"]);
+    const parsed = out.map((d) => parseWs(d.name));
+    expect(parsed.every((p) => p.wsId === wsA)).toBe(true);
+    expect(parsed).toHaveLength(1);
+  });
+});
+
 // ── 2. Collision ───────────────────────────────────────────────────
 
 describe("aggregateToolList — collision across workspaces", () => {

--- a/test/unit/runtime/identity-tool-router.test.ts
+++ b/test/unit/runtime/identity-tool-router.test.ts
@@ -129,6 +129,11 @@ function makeStubAggregator(
     async aggregateToolList(identityId: string) {
       return byIdentity.get(identityId) ?? [];
     },
+    async aggregateScopedToolList(identityId: string, scopeWsIds: readonly string[]) {
+      const scope = new Set(scopeWsIds);
+      // Identity tools (wsId null) always included; workspace tools filtered to scope.
+      return (byIdentity.get(identityId) ?? []).filter((d) => d.wsId === null || scope.has(d.wsId));
+    },
   };
 }
 
@@ -508,5 +513,79 @@ describe("IdentityToolRouter — orchestrator errors", () => {
 
     expect(result.isError).toBe(true);
     expect(result.structuredContent).toMatchObject({ error: "orchestrator_error" });
+  });
+});
+
+describe("IdentityToolRouter — workspace lockdown (allowedWsIds)", () => {
+  const OTHER_WS = "ws_other";
+
+  test("availableTools uses the scoped path — out-of-scope workspace tools excluded, identity tools kept", async () => {
+    const aggregator = makeStubAggregator(
+      new Map([
+        [
+          USER_ID,
+          [
+            {
+              name: namespacedToolName(SHARED_WS, "crm__search"),
+              description: "d",
+              inputSchema: { type: "object", properties: {} },
+              wsId: SHARED_WS,
+              toolName: "crm__search",
+            },
+            {
+              name: namespacedToolName(OTHER_WS, "x__run"),
+              description: "d",
+              inputSchema: { type: "object", properties: {} },
+              wsId: OTHER_WS,
+              toolName: "x__run",
+            },
+            {
+              name: "conversations__list",
+              description: "d",
+              inputSchema: { type: "object", properties: {} },
+              wsId: null,
+              toolName: "conversations__list",
+            },
+          ],
+        ],
+      ]),
+    );
+    const router = new IdentityToolRouter({
+      identityId: USER_ID,
+      runtime: makeStubRuntime({
+        registries: new Map(),
+        memberships: new Map(),
+        existingWorkspaces: new Set(),
+        workDir,
+      }),
+      aggregator,
+      allowedWsIds: [SHARED_WS, PERSONAL_WS], // OTHER_WS is not focused
+    });
+
+    const names = (await router.availableTools()).map((t) => t.name);
+    expect(names).toContain(`${SHARED_WS}-crm__search`);
+    expect(names).toContain("conversations__list"); // identity tools always reachable
+    expect(names).not.toContain(`${OTHER_WS}-x__run`); // out-of-scope → excluded
+  });
+
+  test("execute denies a directly-named out-of-scope tool even when the caller is a member (focus gate)", async () => {
+    const otherSource = makeSpySource("x");
+    const runtime = makeStubRuntime({
+      registries: new Map([[OTHER_WS, [otherSource]]]),
+      // The user IS a member of OTHER_WS — only the focus gate stops the call.
+      memberships: new Map([[USER_ID, [SHARED_WS, PERSONAL_WS, OTHER_WS]]]),
+      existingWorkspaces: new Set([SHARED_WS, PERSONAL_WS, OTHER_WS]),
+      workDir,
+    });
+    const router = new IdentityToolRouter({
+      identityId: USER_ID,
+      runtime,
+      aggregator: makeStubAggregator(new Map()),
+      allowedWsIds: [SHARED_WS, PERSONAL_WS], // OTHER_WS not in scope
+    });
+
+    const res = await router.execute({ id: "c1", name: `${OTHER_WS}-x__run`, input: {} });
+    expect(res.isError).toBe(true); // WorkspaceAccessDenied → mapped to an error result
+    expect(otherSource.calls).toHaveLength(0); // the out-of-scope source never ran
   });
 });


### PR DESCRIPTION
Implements the foundational half of #465 (workspace lockdown): the composition inversion.

## What
A session's tool **composition** and **invocation** scope to `{focused workspace} ∪ {personal workspace} ∪ {identity sources}` instead of the ambient union of every workspace the identity belongs to. *Identity authorizes which workspaces may be focused; focus composes the tools.*

**Gated behind a new feature flag `crossWorkspaceTools` (default `true` = current Stage-2 behavior)** — this lands with **zero behavior change** until a tenant flips it to `false`. Flip per-tenant to lock down; move the default once validated.

## Three enforcement points, one source
All derive from `Runtime._lockdownAllowedWsIds(identityId)` → `{focused ∪ personal}` (or `undefined` when the flag is on, preserving ambient):

1. **Reachable set + `nb__search` corpus** — `IdentityToolRouter.availableTools` and `Runtime.listDiscoverableTools` use a new **memo-free** scoped aggregation (`ToolListAggregator.aggregateScopedToolList` → `ToolListCache.composeUnion`). The existing `getUnionForIdentity` memo is keyed on identity alone, so it can't serve a focus-varying set — hence a sibling compose path over the (already cached + FS-watched) per-workspace listings.
2. **Invocation — the security floor** — `routeToolCall` gains an optional `allowedWsIds` focus-gate applied **after** the membership check. A directly-named `ws_<other>-tool` is denied **even when the caller is a member**. This is the load-bearing finding: invocation is membership-gated, not focus-gated, so narrowing the *lists* alone would not stop a model from calling a cross-workspace tool by name.

The scoped set is always **intersected with membership** → it can only NARROW reach, never widen it. `routeToolCall` stays pure: `allowedWsIds` is an explicit caller input (resolved from the flag), never ambient state.

## Safety / scope
- Active set was already focus-scoped; untouched.
- Default-flag-on ⇒ existing cross-workspace tests pass unchanged (delegate, surfacing, smoke).
- **Deferred (tracked):** `/mcp` tools/list + CallTool scoping — the `/mcp`-contract item; no external clients today, and the `routeToolCall` gate is already in place, the `/mcp` session just needs to supply `allowedWsIds`. Names-only directory + elicitation → #474. Automation whitelist → #475.

## Verification
`bunx tsc --noEmit` clean · `verify:static` exit 0 (format/lint/cycles/code-style/codegen) · full backend unit+integration suite **`failures="0"` / 4254 tests** (JUnit-confirmed; transient network/`rpds` flakes are pre-existing and env-dependent).

New tests: route focus-gate deny/allow + ambient-preserved; `aggregateScopedToolList` narrowing + membership-intersection; router scoped `availableTools` + `execute` focus-gate.
