### PR TITLE
fix(oauth): make DCR redirect_uri durable; stop crash-looping remote OAuth connectors

### DIFF
--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1287,6 +1287,13 @@ export class BundleLifecycleManager {
       source,
     });
 
+    // Arm interactive OAuth for THIS user-initiated start only. The provider is
+    // long-lived (HealthMonitor reuses it for liveness reconnects on the same
+    // source); leaving it armed would let a background reconnect drive a browser
+    // flow that blocks for the full flow TTL and times out. Disarm once this
+    // start settles (`.finally` below).
+    provider.setInteractiveAuthAllowed(true);
+
     // Background start. The provider's callback resolves `authUrlPromise`
     // when interactive auth is required. If start() succeeds without ever
     // hitting interactive (headless / pre-authenticated), we transition to
@@ -1331,6 +1338,11 @@ export class BundleLifecycleManager {
         if (!capturedAuthUrl) {
           rejectAuthUrl(err instanceof Error ? err : new Error(msg));
         }
+      })
+      .finally(() => {
+        // Disarm interactive auth — subsequent (background) reconnects of this
+        // long-lived source must NOT drive a browser flow.
+        provider.setInteractiveAuthAllowed(false);
       });
 
     // Race the auth URL signal against a hard timeout. 15s is generous —

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1287,11 +1287,14 @@ export class BundleLifecycleManager {
       source,
     });
 
-    // Arm interactive OAuth for THIS user-initiated start only. The provider is
-    // long-lived (HealthMonitor reuses it for liveness reconnects on the same
-    // source); leaving it armed would let a background reconnect drive a browser
-    // flow that blocks for the full flow TTL and times out. Disarm once this
-    // start settles (`.finally` below).
+    // Arm interactive OAuth for THIS user-initiated start only. The
+    // `interactiveAuthAllowed` flag gates whether a start may drive a browser
+    // flow vs. fail fast to `reauth_required`; only a user-initiated reconnect
+    // (a human is waiting) should arm it. Disarm once this start settles
+    // (`.finally` below) so the flag never leaks into a later background start
+    // on the same provider — defensive hygiene: this fresh source isn't in the
+    // HealthMonitor boot snapshot, but a provider that ever is must never carry
+    // a stale armed flag into a liveness reconnect.
     provider.setInteractiveAuthAllowed(true);
 
     // Background start. The provider's callback resolves `authUrlPromise`

--- a/src/oauth/public-origin.ts
+++ b/src/oauth/public-origin.ts
@@ -26,11 +26,12 @@
  *      `https://{NB_PLATFORM_HOST}`. This is the normal path — the chart
  *      forwards these as facts; the policy ("custom domain wins") lives here,
  *      not in Helm templating.
- *   3. `NB_API_URL` — legacy migration fallback. Older deployments set only
- *      this. Centralizing the read here (and nowhere else — see
- *      `scripts/check-public-origin.ts`) lets us delete it cleanly once every
- *      tenant ships the facts.
- *   4. `http://localhost:27247` — dev default (no auth gate, `dev:worktree`).
+ *   3. `http://localhost:27247` — dev default (no auth gate, `dev:worktree`).
+ *
+ * The former `NB_API_URL` legacy fallback has been removed: the chart always
+ * forwards `NB_PLATFORM_HOST` (from `ingress.host`), so step 2 always resolves
+ * for any deployed tenant. `scripts/check-public-origin.ts` keeps `NB_API_URL`
+ * (and `NB_WEB_URL`) from creeping back as ad-hoc origin reads elsewhere.
  *
  * **Why config-derived, never request-derived.** The origin must NOT come from
  * the inbound `Host` / `X-Forwarded-Host` header. A header-derived `redirect_uri`
@@ -52,19 +53,14 @@ const PUBLIC_ORIGIN_ENV = "NB_PUBLIC_ORIGIN";
 const PLATFORM_HOST_ENV = "NB_PLATFORM_HOST";
 const CUSTOM_DOMAIN_ENV = "NB_CUSTOM_DOMAIN";
 const CUSTOM_DOMAIN_CANONICAL_ENV = "NB_CUSTOM_DOMAIN_CANONICAL";
-/**
- * Legacy origin var. This module is the ONLY sanctioned reader —
- * `check:public-origin` rejects `process.env.NB_API_URL` / `NB_WEB_URL`
- * anywhere else so the derivation can't re-fragment.
- */
-const LEGACY_API_URL_ENV = "NB_API_URL";
 
 /**
  * User-facing SPA origin for post-callback returns. In production the API and
  * the SPA share one origin (Caddy proxies `/v1/*` to the API), so this equals
  * `publicOrigin()`. In dev they split — API on :27247, SPA on :27246 — and
  * `src/cli/dev.ts` sets `NB_WEB_URL` so a connector return lands on the SPA,
- * not a JSON error page on the API port. Sanctioned reader, same as above.
+ * not a JSON error page on the API port. This module is the only sanctioned
+ * reader of `NB_WEB_URL` — `check:public-origin` rejects it elsewhere.
  */
 const WEB_URL_ENV = "NB_WEB_URL";
 
@@ -147,11 +143,9 @@ function computePublicOrigin(): string {
   const derivedHost = customDomain && canonical ? customDomain : platformHost;
   if (derivedHost) return assertOrigin(`https://${derivedHost}`, "derived");
 
-  // 3. Legacy fallback during migration (older deploys set only NB_API_URL).
-  const legacy = process.env[LEGACY_API_URL_ENV]?.trim();
-  if (legacy) return assertOrigin(legacy, LEGACY_API_URL_ENV);
-
-  // 4. Dev default.
+  // 3. Dev default. (The former `NB_API_URL` legacy fallback was removed — the
+  // chart always forwards `NB_PLATFORM_HOST`, so step 2 always resolves for any
+  // deployed tenant.)
   return DEV_ORIGIN;
 }
 

--- a/src/oauth/public-origin.ts
+++ b/src/oauth/public-origin.ts
@@ -53,6 +53,13 @@ const PUBLIC_ORIGIN_ENV = "NB_PUBLIC_ORIGIN";
 const PLATFORM_HOST_ENV = "NB_PLATFORM_HOST";
 const CUSTOM_DOMAIN_ENV = "NB_CUSTOM_DOMAIN";
 const CUSTOM_DOMAIN_CANONICAL_ENV = "NB_CUSTOM_DOMAIN_CANONICAL";
+/**
+ * The chart sets this on every deployed tenant pod (from `tenant.id`) and it is
+ * never set in local dev — the same deployment signal `composio/sdk.ts` keys on.
+ * Used only to decide whether falling through to the localhost dev default is a
+ * legitimate dev run or a misconfigured deploy that must fail closed.
+ */
+const TENANT_ID_ENV = "NB_TENANT_ID";
 
 /**
  * User-facing SPA origin for post-callback returns. In production the API and
@@ -143,9 +150,19 @@ function computePublicOrigin(): string {
   const derivedHost = customDomain && canonical ? customDomain : platformHost;
   if (derivedHost) return assertOrigin(`https://${derivedHost}`, "derived");
 
-  // 3. Dev default. (The former `NB_API_URL` legacy fallback was removed — the
-  // chart always forwards `NB_PLATFORM_HOST`, so step 2 always resolves for any
-  // deployed tenant.)
+  // 3. Dev default — local only. The chart always forwards `NB_PLATFORM_HOST`,
+  // so a DEPLOYED tenant resolves at step 2 and never reaches here. If it does
+  // reach here in a deployed context (host facts missing), fail closed: minting
+  // a localhost callback would silently break every OAuth flow. `NB_TENANT_ID`
+  // is the chart's deployment marker (set on every tenant pod, never in local
+  // dev), so its presence here means a real misconfiguration, not a dev run.
+  if (process.env[TENANT_ID_ENV]?.trim()) {
+    throw new Error(
+      `[public-origin] no origin facts set (${PLATFORM_HOST_ENV} / ${CUSTOM_DOMAIN_ENV} / ${PUBLIC_ORIGIN_ENV}) ` +
+        `but ${TENANT_ID_ENV} is present — refusing to default to ${DEV_ORIGIN} in a deployed context. ` +
+        `Set ingress.host in the tenant's Helm values so the chart forwards ${PLATFORM_HOST_ENV}.`,
+    );
+  }
   return DEV_ORIGIN;
 }
 

--- a/src/tools/health-monitor.ts
+++ b/src/tools/health-monitor.ts
@@ -106,6 +106,22 @@ export class HealthMonitor {
       return;
     }
 
+    // A source that was deliberately stopped via `stop()` (a teardown /
+    // disconnect — e.g. a user-initiated `startAuth` tears the boot source out
+    // of the registry and builds a fresh provider+source) is terminal for the
+    // monitor. This `records` set is a one-time boot snapshot and is never
+    // re-seeded, so the stopped instance lingers here as an orphan. Reconnecting
+    // it would run its STALE provider's refresh, whose failure makes the SDK
+    // delete the SHARED on-disk credentials (tokens/client/identity in the same
+    // wsId/serverName dir) the fresh flow depends on, and flip the connection to
+    // `reauth_required` over a live `pending_auth`. Mark it dead and leave it
+    // alone. A self-dropped transport (idle close, network blip) leaves
+    // `isStopped()` false and still reconnects below.
+    if (record.source.isStopped()) {
+      record.state = "dead";
+      return;
+    }
+
     const remote = isRemoteSource(record.source);
 
     // Source is down — emit crashed event

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -289,6 +289,15 @@ export class McpSource implements ToolSource {
    * graceful stops would surface as spurious crash events to listeners.
    */
   private stopping = false;
+  /**
+   * Set true ONLY by a deliberate `stop()` (teardown / disconnect), reset by
+   * `start()`. Distinct from `stopping`, which `cleanupOnStartFailure()` also
+   * sets to suppress crash noise on a failed start: a failed start is
+   * retryable, a deliberate teardown is not. `HealthMonitor` reads this (via
+   * {@link isStopped}) to leave a deliberately-stopped, registry-removed source
+   * terminal instead of reconnecting an orphaned instance.
+   */
+  private stopped = false;
 
   /**
    * Listeners notified when this source's enumerable tool set may have
@@ -341,10 +350,11 @@ export class McpSource implements ToolSource {
     // a dead instance's tail into the new instance's crash report.
     this.stderrTail = [];
     this.stderrLineBuf = "";
-    // Clear deliberate-teardown flag so a restart re-enables crash detection
+    // Clear deliberate-teardown flags so a restart re-enables crash detection
     // on the new transport. Set in `stop()` to suppress onclose-emitted
     // `source.crashed` events during graceful teardown.
     this.stopping = false;
+    this.stopped = false;
 
     if (this.mode.type === "stdio") {
       const stdioTransport = new StdioClientTransport({
@@ -860,6 +870,17 @@ export class McpSource implements ToolSource {
     return this.transport !== null && this.client !== null && !this.dead;
   }
 
+  /**
+   * Whether this source was deliberately stopped via `stop()` (teardown /
+   * disconnect) and not since restarted. `HealthMonitor` uses this to avoid
+   * reconnecting an orphaned, registry-removed instance — see the field doc on
+   * {@link stopped}. A self-dropped transport (idle close, network blip) leaves
+   * this false, so it still reconnects.
+   */
+  isStopped(): boolean {
+    return this.stopped;
+  }
+
   /** Time (ms) since the source was last started, or null if never started. */
   uptime(): number | null {
     if (this.startedAt === null) return null;
@@ -876,6 +897,9 @@ export class McpSource implements ToolSource {
     // `stopping` field. Without this, every graceful stop would emit a
     // `source.crashed` event when `transport.close()` triggers onclose.
     this.stopping = true;
+    // Distinct durable marker for "deliberately stopped" (vs the failed-start
+    // `stopping` that `cleanupOnStartFailure` also sets). Cleared by `start()`.
+    this.stopped = true;
     // Abort any in-flight streams so their drainers unblock and the handle
     // map can be cleared without leaking outstanding `awaitToolTaskResult`
     // callers. Each drainer will reject its terminalDeferred, which is

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -1717,12 +1717,17 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
     // Always clear local state regardless of upstream revocation result.
     // `all` is broader than the literal "tokens" the method name implies,
     // and intentional: leaving the cached DCR `client.json` behind across
-    // a disconnect/reconnect is the well-trodden bug path. If `NB_API_URL`
-    // changes between a disconnect and the next reconnect, the AS still
-    // has the old `redirect_uri` registered to the cached `client_id`,
-    // and the next /authorize comes back as `Invalid redirect_uri`.
-    // Re-registering on reconnect costs one DCR roundtrip — cheap insurance
-    // against a confusing prod failure mode.
+    // a deliberate disconnect/reconnect is the well-trodden bug path. If the
+    // tenant's canonical origin changes between a disconnect and the next
+    // reconnect (e.g. a custom domain is added so `publicOrigin()` /
+    // `NB_PLATFORM_HOST` resolves to a different host), the AS still has the
+    // old `redirect_uri` registered to the cached `client_id`, and the next
+    // /authorize comes back as `Invalid redirect_uri`. Re-registering on the
+    // next reconnect costs one DCR roundtrip — cheap insurance against a
+    // confusing prod failure mode. (Note: this is the *deliberate disconnect*
+    // path; a passive host drift does NOT discard the client — see
+    // `clientInformation`, which honors the stored registration on the
+    // silent/background path and only re-registers on user-initiated reauth.)
     await this.invalidateCredentials("all");
     result.deletedLocal = true;
     return result;

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -46,13 +46,14 @@ export class InteractiveOAuthNotSupportedError extends Error {
 /**
  * Thrown by `redirectToAuthorization` when the authorization server demands an
  * INTERACTIVE (browser) round-trip but this start attempt is NOT user-initiated
- * — i.e. boot auto-start or a `HealthMonitor` liveness reconnect. No human is
+ * — i.e. a boot source's auto-start or one of its `HealthMonitor` liveness
+ * reconnects (both reuse the boot provider with the flag unarmed). No human is
  * waiting, so registering an `oauth-flow-registry` flow would only block
  * `start()` on `awaitPendingFlow()` for the full 15-minute flow TTL and then
  * fail — the headless-reconnect crash loop this fix removes. The provider
  * instead flips the connection to `reauth_required` (via `notifyAuthLost`) and
- * throws this so `start()` fails fast. The UI's Reconnect button runs
- * `startAuth`, which arms interactive auth for that one attempt.
+ * throws this so `start()` fails fast. The UI's Reconnect runs `startAuth`,
+ * which builds a fresh provider and arms interactive auth for that one attempt.
  */
 export class BackgroundReauthRequiredError extends Error {
   constructor(public readonly serverName: string) {
@@ -589,15 +590,21 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
   private authLostNotified = false;
   /**
    * Whether this provider may drive an INTERACTIVE (browser) OAuth flow on the
-   * current start attempt. The provider is long-lived — the same instance backs
-   * the initial connect AND every later `HealthMonitor` liveness reconnect — so
-   * this is a per-attempt signal, not a construction-time one. The lifecycle
-   * arms it (via {@link setInteractiveAuthAllowed}) only for a user-initiated
-   * `startAuth` and disarms it when that start settles. Background starts (boot
-   * auto-start, liveness reconnect) leave it false: if they hit an interactive
-   * requirement they flip to `reauth_required` and fail fast (see
-   * {@link BackgroundReauthRequiredError}) rather than blocking on a flow no
-   * human will complete.
+   * current start attempt — a per-attempt signal, not construction-time.
+   *
+   * Two provider lifecycles exist, and the flag's default (false) is the safe
+   * one for both:
+   *   - A BOOT source reuses one provider instance across its initial
+   *     auto-start AND every later `HealthMonitor` liveness reconnect. All of
+   *     those are background — the flag is never armed — so an interactive
+   *     requirement flips to `reauth_required` and fails fast instead of
+   *     blocking on a browser flow no one will complete.
+   *   - A USER-INITIATED `startAuth` builds a FRESH provider+source (teardown +
+   *     rebuild) and arms the flag (via {@link setInteractiveAuthAllowed}) for
+   *     that one start only, disarming when it settles.
+   *
+   * So the only path that ever drives interactive auth is an explicit user
+   * reconnect; see {@link BackgroundReauthRequiredError}.
    */
   private interactiveAuthAllowed = false;
   private readonly staticClient?: WorkspaceOAuthProviderOptions["staticClient"];
@@ -858,23 +865,25 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
       };
       return info;
     }
-    if (this.cachedClientInfo) {
-      // Reuse a structurally-valid cached client. We do NOT discard on a
-      // redirect_uri host mismatch (drift) — a registered DCR client is durable
-      // identity, and silent refresh reuses its `client_id` without sending any
-      // redirect_uri. Discarding here orphaned the refresh token and forced a
-      // headless interactive flow that timed out (the crash loop). Only a
-      // structurally-corrupt entry is dropped.
-      if (this.hasUsableRedirectUris(this.cachedClientInfo)) return this.cachedClientInfo;
-      this.cachedClientInfo = null;
-      await this.unlinkIfExists(this.dataDir, "client.json");
-    }
-    // DCR client info is workspace-shared regardless of scope — every
-    // member of the workspace authenticates as the same NimbleBrain
-    // OAuth client.
-    const data = await this.readJson<OAuthClientInformationFull>(this.dataDir, "client.json");
-    if (data && this.hasUsableRedirectUris(data)) {
-      if (this.redirectUriMatchesCurrent(data) || !this.interactiveAuthAllowed) {
+    // Candidate registration: prefer the in-memory cache, else read disk. The
+    // SAME decision applies to both — a cached client can itself be a
+    // previously-honored DRIFTED client (set on the silent/background path
+    // below), so the cached path must run the drift/interactive decision too,
+    // not blindly return it. (DCR client info is workspace-shared regardless of
+    // scope: every member authenticates as the same NimbleBrain OAuth client.)
+    const data =
+      this.cachedClientInfo ??
+      (await this.readJson<OAuthClientInformationFull>(this.dataDir, "client.json"));
+    if (data) {
+      if (!this.hasUsableRedirectUris(data)) {
+        // Structurally corrupt (missing / empty / non-array redirect_uris):
+        // unusable at /authorize. Drop it so the SDK re-registers.
+        log.warn(
+          `[oauth] ${this.serverName} stored client has no usable redirect_uris — discarding so the next flow re-registers`,
+        );
+        this.cachedClientInfo = null;
+        await this.unlinkIfExists(this.dataDir, "client.json");
+      } else if (this.redirectUriMatchesCurrent(data) || !this.interactiveAuthAllowed) {
         // The registration matches the current host, OR this is a background /
         // silent context (refresh, boot, liveness reconnect). Honor the stored
         // registration — it's immutable identity, and refresh reuses the
@@ -890,28 +899,22 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
         }
         this.cachedClientInfo = data;
         return data;
+      } else {
+        // Drift on a USER-INITIATED interactive flow: a human is reconnecting
+        // and the canonical host changed since this client was registered.
+        // Re-register against the current host so the next /authorize's
+        // redirect_uri matches the NEW registration AND the session cookie (set
+        // on the current host) travels back on the callback leg. The deliberate,
+        // consented re-registration the architecture calls for — not the silent
+        // discard-on-every-read that caused the crash loop.
+        log.warn(
+          `[oauth] ${this.serverName} redirect_uri drift on user-initiated reauth (registered=${
+            data.redirect_uris?.[0] ?? "<none>"
+          }, current=${this.callbackUrl}) — re-registering for the current host`,
+        );
+        this.cachedClientInfo = null;
+        await this.unlinkIfExists(this.dataDir, "client.json");
       }
-      // Drift on a USER-INITIATED interactive flow: a human is reconnecting and
-      // the canonical host changed since this client was registered. Re-register
-      // against the current host so the next /authorize's redirect_uri matches
-      // the NEW registration AND the session cookie (set on the current host)
-      // travels back on the callback leg. This is the deliberate, consented
-      // re-registration the architecture calls for — not the silent
-      // discard-on-every-read that caused the crash loop.
-      log.warn(
-        `[oauth] ${this.serverName} redirect_uri drift on user-initiated reauth (registered=${
-          data.redirect_uris?.[0] ?? "<none>"
-        }, current=${this.callbackUrl}) — re-registering for the current host`,
-      );
-      this.cachedClientInfo = null;
-      await this.unlinkIfExists(this.dataDir, "client.json");
-    } else if (data && !this.hasUsableRedirectUris(data)) {
-      // Structurally corrupt on-disk record (missing / empty / non-array
-      // redirect_uris): unusable at /authorize. Drop it so the SDK re-registers.
-      log.warn(
-        `[oauth] ${this.serverName} stored client.json has no usable redirect_uris — discarding so the next flow re-registers`,
-      );
-      await this.unlinkIfExists(this.dataDir, "client.json");
     }
     // No usable client info on disk → SDK will DCR. Coalesce concurrent
     // callers so only ONE DCR happens; second caller awaits the first's

--- a/src/tools/workspace-oauth-provider.ts
+++ b/src/tools/workspace-oauth-provider.ts
@@ -44,6 +44,28 @@ export class InteractiveOAuthNotSupportedError extends Error {
 }
 
 /**
+ * Thrown by `redirectToAuthorization` when the authorization server demands an
+ * INTERACTIVE (browser) round-trip but this start attempt is NOT user-initiated
+ * — i.e. boot auto-start or a `HealthMonitor` liveness reconnect. No human is
+ * waiting, so registering an `oauth-flow-registry` flow would only block
+ * `start()` on `awaitPendingFlow()` for the full 15-minute flow TTL and then
+ * fail — the headless-reconnect crash loop this fix removes. The provider
+ * instead flips the connection to `reauth_required` (via `notifyAuthLost`) and
+ * throws this so `start()` fails fast. The UI's Reconnect button runs
+ * `startAuth`, which arms interactive auth for that one attempt.
+ */
+export class BackgroundReauthRequiredError extends Error {
+  constructor(public readonly serverName: string) {
+    super(
+      `[workspace-oauth-provider] ${serverName} needs interactive reauthorization, but no ` +
+        `user-initiated flow is active — surfacing reauth_required instead of blocking a ` +
+        `background start on a browser flow no one will complete.`,
+    );
+    this.name = "BackgroundReauthRequiredError";
+  }
+}
+
+/**
  * Discriminated union identifying who "owns" an OAuth connection — the
  * thing whose tokens these are. Two top-level shapes:
  *
@@ -565,6 +587,19 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
   /** De-dupe guard: a flurry of in-flight tool calls can each throw
    *  UnauthorizedError; the connection should flip to reauth_required once. */
   private authLostNotified = false;
+  /**
+   * Whether this provider may drive an INTERACTIVE (browser) OAuth flow on the
+   * current start attempt. The provider is long-lived — the same instance backs
+   * the initial connect AND every later `HealthMonitor` liveness reconnect — so
+   * this is a per-attempt signal, not a construction-time one. The lifecycle
+   * arms it (via {@link setInteractiveAuthAllowed}) only for a user-initiated
+   * `startAuth` and disarms it when that start settles. Background starts (boot
+   * auto-start, liveness reconnect) leave it false: if they hit an interactive
+   * requirement they flip to `reauth_required` and fail fast (see
+   * {@link BackgroundReauthRequiredError}) rather than blocking on a flow no
+   * human will complete.
+   */
+  private interactiveAuthAllowed = false;
   private readonly staticClient?: WorkspaceOAuthProviderOptions["staticClient"];
   private readonly scopes?: string[];
   private readonly additionalAuthorizationParams?: Record<string, string>;
@@ -730,8 +765,26 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
 
   // ── OAuthClientProvider interface ─────────────────────────────────
 
+  /**
+   * Arm/disarm interactive (browser) OAuth for the NEXT start attempt. Called
+   * by the lifecycle: armed for a user-initiated `startAuth`, disarmed once that
+   * start settles. See {@link interactiveAuthAllowed}.
+   */
+  setInteractiveAuthAllowed(allowed: boolean): void {
+    this.interactiveAuthAllowed = allowed;
+  }
+
   get redirectUrl(): string {
-    return this.callbackUrl;
+    // A registered DCR client is bound to the redirect_uri it was registered
+    // with — the AS rejects any other value at /authorize. Honor the stored
+    // registration (durable identity) and fall back to the freshly-computed
+    // callback only when there is no stored client yet (a fresh DCR registers
+    // the current host). Refresh-token grants don't send a redirect_uri at all,
+    // so this only matters on the interactive authorization_code path — where,
+    // for the cases that actually reach it, the stored value equals callbackUrl
+    // (a host-drifted client is re-registered for the current host before its
+    // interactive flow runs; see `clientInformation`).
+    return this.cachedClientInfo?.redirect_uris?.[0] ?? this.callbackUrl;
   }
 
   get clientMetadata(): OAuthClientMetadata {
@@ -806,10 +859,13 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
       return info;
     }
     if (this.cachedClientInfo) {
-      if (this.isClientInfoUsable(this.cachedClientInfo)) return this.cachedClientInfo;
-      // Cached entry has stale redirect_uri (e.g. NB_API_URL changed
-      // between registration and now). Drop it so we re-register fresh
-      // below, then on disk so future reads agree.
+      // Reuse a structurally-valid cached client. We do NOT discard on a
+      // redirect_uri host mismatch (drift) — a registered DCR client is durable
+      // identity, and silent refresh reuses its `client_id` without sending any
+      // redirect_uri. Discarding here orphaned the refresh token and forced a
+      // headless interactive flow that timed out (the crash loop). Only a
+      // structurally-corrupt entry is dropped.
+      if (this.hasUsableRedirectUris(this.cachedClientInfo)) return this.cachedClientInfo;
       this.cachedClientInfo = null;
       await this.unlinkIfExists(this.dataDir, "client.json");
     }
@@ -817,22 +873,43 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
     // member of the workspace authenticates as the same NimbleBrain
     // OAuth client.
     const data = await this.readJson<OAuthClientInformationFull>(this.dataDir, "client.json");
-    if (data && this.isClientInfoUsable(data)) {
-      this.cachedClientInfo = data;
-      return data;
-    }
-    if (data && !this.isClientInfoUsable(data)) {
-      // Drift detection: the platform's redirect_uri (derived from
-      // NB_API_URL) doesn't match what was registered with the
-      // authorization server when this client was DCR'd. Returning the
-      // stale entry here means the next /authorize sends a redirect_uri
-      // the AS doesn't recognize, surfacing as `invalid_redirect_uri`
-      // long after the user has clicked Connect. Drop the entry and
-      // let the SDK trigger a fresh DCR call with the current URI.
+    if (data && this.hasUsableRedirectUris(data)) {
+      if (this.redirectUriMatchesCurrent(data) || !this.interactiveAuthAllowed) {
+        // The registration matches the current host, OR this is a background /
+        // silent context (refresh, boot, liveness reconnect). Honor the stored
+        // registration — it's immutable identity, and refresh reuses the
+        // `client_id` without a redirect_uri, so a host that has since drifted
+        // is irrelevant to keeping the connection alive.
+        if (!this.redirectUriMatchesCurrent(data)) {
+          log.debug(
+            "mcp",
+            `[oauth] ${this.serverName} honoring registered redirect_uri ${
+              data.redirect_uris?.[0]
+            } (current callback ${this.callbackUrl}) — registration is immutable; refresh reuses client_id`,
+          );
+        }
+        this.cachedClientInfo = data;
+        return data;
+      }
+      // Drift on a USER-INITIATED interactive flow: a human is reconnecting and
+      // the canonical host changed since this client was registered. Re-register
+      // against the current host so the next /authorize's redirect_uri matches
+      // the NEW registration AND the session cookie (set on the current host)
+      // travels back on the callback leg. This is the deliberate, consented
+      // re-registration the architecture calls for — not the silent
+      // discard-on-every-read that caused the crash loop.
       log.warn(
-        `[oauth] ${this.serverName} cached DCR client redirect_uri drift detected (registered=${
+        `[oauth] ${this.serverName} redirect_uri drift on user-initiated reauth (registered=${
           data.redirect_uris?.[0] ?? "<none>"
-        }, current=${this.callbackUrl}) — discarding cached client.json so the next flow re-registers`,
+        }, current=${this.callbackUrl}) — re-registering for the current host`,
+      );
+      this.cachedClientInfo = null;
+      await this.unlinkIfExists(this.dataDir, "client.json");
+    } else if (data && !this.hasUsableRedirectUris(data)) {
+      // Structurally corrupt on-disk record (missing / empty / non-array
+      // redirect_uris): unusable at /authorize. Drop it so the SDK re-registers.
+      log.warn(
+        `[oauth] ${this.serverName} stored client.json has no usable redirect_uris — discarding so the next flow re-registers`,
       );
       await this.unlinkIfExists(this.dataDir, "client.json");
     }
@@ -884,21 +961,40 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
   }
 
   /**
-   * Drift check for a DCR `client.json`. Returns true when the
-   * registered `redirect_uris` includes the current callbackUrl —
-   * i.e. the AS will accept what we send at /authorize and /token.
-   * Returns false when the registration is stale (the canonical
-   * NB_API_URL-changed-between-deploys case), so callers know to
-   * re-register rather than serve a doomed flow.
+   * Structural validity of a stored DCR `client.json`: it must carry at least
+   * one `redirect_uri` to be usable at /authorize. A missing / empty / non-array
+   * value is corrupt on-disk state — unusable, so the caller re-registers.
    *
-   * Conservative: a missing or non-array `redirect_uris` is treated
-   * as drift (force re-register). That handles broken on-disk state
-   * the same as known drift.
+   * This intentionally does NOT compare against the current `callbackUrl`: a
+   * host that drifted from the registered value is NOT a reason to discard a
+   * valid registration. Silent refresh reuses the `client_id` without sending a
+   * redirect_uri, so a drifted client stays fully usable for keeping the
+   * connection alive. Host-drift handling lives in `clientInformation` (honor on
+   * the silent/background path; re-register only on a user-initiated interactive
+   * reauth). See {@link redirectUriMatchesCurrent}.
    */
-  private isClientInfoUsable(info: OAuthClientInformationFull): boolean {
+  private hasUsableRedirectUris(info: OAuthClientInformationFull): boolean {
+    const uris = info.redirect_uris;
+    return Array.isArray(uris) && uris.length > 0;
+  }
+
+  /**
+   * Whether the stored client's registered `redirect_uri` matches this
+   * provider's current `callbackUrl`, compared canonically (trailing slash,
+   * default port, host case tolerated). Detects host drift — used for logging
+   * and to decide whether a USER-INITIATED interactive reauth must re-register
+   * against the current host.
+   */
+  private redirectUriMatchesCurrent(info: OAuthClientInformationFull): boolean {
     const uris = info.redirect_uris;
     if (!Array.isArray(uris) || uris.length === 0) return false;
-    return uris.includes(this.callbackUrl);
+    return uris.some((u) => {
+      try {
+        return canonicalEndpoint(new URL(u)) === this.canonicalCallback;
+      } catch {
+        return false;
+      }
+    });
   }
 
   async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
@@ -1305,6 +1401,30 @@ export class WorkspaceOAuthProvider implements OAuthClientProvider {
         }
         log.debug("mcp", `[oauth] ${this.serverName} redirect probe failed: ${String(probeErr)}`);
       }
+    }
+
+    // Background/liveness gate. If this start attempt is NOT user-initiated
+    // (boot auto-start or a HealthMonitor liveness reconnect), there is no user
+    // to complete a browser flow. Registering an `oauth-flow-registry` flow here
+    // would block `start()` on `awaitPendingFlow()` for the full 15-minute flow
+    // TTL and then fail — the headless-reconnect crash loop. Flip the connection
+    // to `reauth_required` (one-shot via `notifyAuthLost`) and fail fast; the
+    // UI's Reconnect runs `startAuth`, which arms interactive for that attempt.
+    if (!this.interactiveAuthAllowed) {
+      log.debug(
+        "mcp",
+        `[oauth] ${this.serverName} interactive auth required but no user-initiated flow active — surfacing reauth_required (no headless block)`,
+      );
+      this.notifyAuthLost();
+      const err = new BackgroundReauthRequiredError(this.serverName);
+      // Settle the pending flow so any concurrently-coalesced auth() chain
+      // awaiting `awaitPendingFlow()` rejects too instead of hanging. The extra
+      // `.catch` swallows the no-awaiter case (the common one: start() fails
+      // fast on this error and never calls awaitPendingFlow), so the deliberate
+      // rejection can't surface as an unhandled rejection.
+      this.pendingFlow.promise.catch(() => {});
+      d?.reject(err);
+      throw err;
     }
 
     // Interactive branch: real browser redirect required. Register the

--- a/test/integration/workspace-oauth-provider.test.ts
+++ b/test/integration/workspace-oauth-provider.test.ts
@@ -194,6 +194,8 @@ describe("WorkspaceOAuthProvider — authorize redirect probe (interactive)", ()
         headlessAuthProbe: true,
         onInteractiveAuthRequired: (url) => callbackUrls.push(url),
       });
+      // Interactive branch is gated to user-initiated flows; arm it here.
+      p.setInteractiveAuthAllowed(true);
       const state = p.state();
       authUrl.searchParams.set("state", state);
 
@@ -241,6 +243,8 @@ describe("WorkspaceOAuthProvider — authorize redirect probe (interactive)", ()
           captured = url;
         },
       });
+      // Interactive branch is gated to user-initiated flows; arm it here.
+      p.setInteractiveAuthAllowed(true);
       const state = p.state();
       authUrl.searchParams.set("state", state);
 

--- a/test/unit/api/connectors-redirect.test.ts
+++ b/test/unit/api/connectors-redirect.test.ts
@@ -37,8 +37,8 @@ describe("workspaceConnectorsUrl", () => {
   });
 
   it("uses webOrigin: NB_WEB_URL wins over the derived/legacy origin", () => {
-    // No NB_WEB_URL → webOrigin() falls through to publicOrigin() (legacy NB_API_URL here).
-    process.env.NB_API_URL = "https://api.example.com";
+    // No NB_WEB_URL → webOrigin() falls through to publicOrigin() (derived host).
+    process.env.NB_PLATFORM_HOST = "api.example.com";
     expect(workspaceConnectorsUrl("ws_x")).toBe("https://api.example.com/w/x/settings/connectors");
     // NB_WEB_URL set → the user-facing SPA origin wins (the dev API/SPA-port split).
     process.env.NB_WEB_URL = "https://web.example.com";

--- a/test/unit/api/mcp-auth-routes.test.ts
+++ b/test/unit/api/mcp-auth-routes.test.ts
@@ -387,6 +387,7 @@ describe("bouncer mode: state envelope wrap on initiate / unwrap on callback", (
     "NB_OAUTH_BOUNCER_CALLBACK_URL",
     "NB_OAUTH_BOUNCER_TENANT_KEY",
     "NB_TENANT_ID",
+    "NB_PLATFORM_HOST",
   ] as const;
 
   let savedEnv: Record<string, string | undefined>;
@@ -398,6 +399,11 @@ describe("bouncer mode: state envelope wrap on initiate / unwrap on callback", (
     process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = BOUNCER_CALLBACK;
     process.env.NB_OAUTH_BOUNCER_TENANT_KEY = TENANT_KEY_B64;
     process.env.NB_TENANT_ID = TID;
+    // A real bouncer-mode tenant always carries a public-origin fact too: the
+    // bouncer 302s the callback back to this tenant's `publicOrigin()` (the
+    // return leg). Set it so the callback handler can build the return URL —
+    // without it, `publicOrigin()` fails closed (NB_TENANT_ID set, no host facts).
+    process.env.NB_PLATFORM_HOST = `${TID}.platform.nimblebrain.ai`;
     const { _resetBouncerModeForTest } = await import("../../../src/oauth/bouncer-config.ts");
     _resetBouncerModeForTest();
     lifecycle = makeStubLifecycle();

--- a/test/unit/composio-auth.test.ts
+++ b/test/unit/composio-auth.test.ts
@@ -181,28 +181,45 @@ describe("composioUserId", () => {
 });
 
 describe("composioCallbackUrl", () => {
-  const origApi = process.env.NB_API_URL;
+  const ENV_KEYS = [
+    "NB_PUBLIC_ORIGIN",
+    "NB_PLATFORM_HOST",
+    "NB_CUSTOM_DOMAIN",
+    "NB_CUSTOM_DOMAIN_CANONICAL",
+    "NB_API_URL",
+  ] as const;
+  let savedEnv: Record<string, string | undefined>;
+  beforeEach(() => {
+    savedEnv = {};
+    for (const k of ENV_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
   afterEach(() => {
-    if (origApi === undefined) delete process.env.NB_API_URL;
-    else process.env.NB_API_URL = origApi;
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
   });
 
-  test("uses NB_API_URL when set", () => {
+  test("derives from the tenant public origin (platform host)", () => {
+    process.env.NB_PLATFORM_HOST = "platform.example.test";
+    expect(composioCallbackUrl()).toBe("https://platform.example.test/v1/composio-auth/callback");
+  });
+
+  test("derives from the custom domain when canonical", () => {
+    process.env.NB_PLATFORM_HOST = "platform.example.test";
+    process.env.NB_CUSTOM_DOMAIN = "brain.example.test";
+    expect(composioCallbackUrl()).toBe("https://brain.example.test/v1/composio-auth/callback");
+  });
+
+  test("ignores legacy NB_API_URL (fallback removed) — falls back to localhost", () => {
     process.env.NB_API_URL = "https://platform.example.test";
-    expect(composioCallbackUrl()).toBe(
-      "https://platform.example.test/v1/composio-auth/callback",
-    );
-  });
-
-  test("trims trailing slashes", () => {
-    process.env.NB_API_URL = "https://platform.example.test//";
-    expect(composioCallbackUrl()).toBe(
-      "https://platform.example.test/v1/composio-auth/callback",
-    );
+    expect(composioCallbackUrl()).toBe("http://localhost:27247/v1/composio-auth/callback");
   });
 
   test("falls back to localhost when unset", () => {
-    delete process.env.NB_API_URL;
     expect(composioCallbackUrl()).toBe("http://localhost:27247/v1/composio-auth/callback");
   });
 });

--- a/test/unit/health-monitor-remote.test.ts
+++ b/test/unit/health-monitor-remote.test.ts
@@ -8,6 +8,7 @@ function makeMockRemoteSource(
   name: string,
 ): McpSource & {
   alive: boolean;
+  stopped: boolean;
   startResult: boolean;
   stopCalls: number;
   startCalls: number;
@@ -16,6 +17,7 @@ function makeMockRemoteSource(
   const mock = {
     name,
     alive: true,
+    stopped: false,
     startResult: true,
     stopCalls: 0,
     startCalls: 0,
@@ -24,6 +26,9 @@ function makeMockRemoteSource(
     },
     isAlive() {
       return mock.alive;
+    },
+    isStopped() {
+      return mock.stopped;
     },
     uptime() {
       return startedAt !== null ? Date.now() - startedAt : null;
@@ -46,6 +51,7 @@ function makeMockRemoteSource(
     },
   } as unknown as McpSource & {
     alive: boolean;
+    stopped: boolean;
     startResult: boolean;
     stopCalls: number;
     startCalls: number;
@@ -56,15 +62,19 @@ function makeMockRemoteSource(
 /** Mock stdio source — no isRemote() method (or returns false). */
 function makeMockStdioSource(
   name: string,
-): McpSource & { alive: boolean; restartResult: boolean; restartCalls: number } {
+): McpSource & { alive: boolean; stopped: boolean; restartResult: boolean; restartCalls: number } {
   let startedAt: number | null = Date.now();
   const mock = {
     name,
     alive: true,
+    stopped: false,
     restartResult: true,
     restartCalls: 0,
     isAlive() {
       return mock.alive;
+    },
+    isStopped() {
+      return mock.stopped;
     },
     uptime() {
       return startedAt !== null ? Date.now() - startedAt : null;
@@ -77,7 +87,12 @@ function makeMockStdioSource(
       }
       return mock.restartResult;
     },
-  } as unknown as McpSource & { alive: boolean; restartResult: boolean; restartCalls: number };
+  } as unknown as McpSource & {
+    alive: boolean;
+    stopped: boolean;
+    restartResult: boolean;
+    restartCalls: number;
+  };
   return mock;
 }
 
@@ -289,6 +304,55 @@ describe("HealthMonitor — remote sources", () => {
     expect(remote.stopCalls).toBe(1);
     expect(remote.startCalls).toBe(1);
     expect(stdio.restartCalls).toBe(1);
+
+    monitor.stop();
+  });
+
+  it("test_deliberately_stopped_source_not_reconnected_marked_dead", async () => {
+    // A source torn down via stop() (teardown / user-initiated startAuth rebuild)
+    // lingers in the boot snapshot. The monitor must NOT reconnect this orphan —
+    // doing so runs its stale provider's refresh, which can delete shared creds
+    // and clobber a live pending_auth. It must go terminal (dead) silently.
+    const source = makeMockRemoteSource("stopped-remote");
+    const sink = makeEventCollector();
+    const monitor = new HealthMonitor([source], sink, { checkIntervalMs: 60_000, baseDelayMs: 1 });
+
+    source.alive = false;
+    source.stopped = true; // deliberate stop()
+
+    await monitor.check();
+
+    // No reconnect attempt, no crash/restart noise.
+    expect(source.stopCalls).toBe(0);
+    expect(source.startCalls).toBe(0);
+    const events = eventNames(sink);
+    expect(events).not.toContain("bundle.crashed");
+    expect(events).not.toContain("bundle.restarting");
+    expect(events).not.toContain("bundle.recovered");
+
+    // Terminal: marked dead and stays dead on subsequent checks.
+    expect(monitor.getStatus()[0]!.state).toBe("dead");
+    await monitor.check();
+    expect(source.startCalls).toBe(0);
+
+    monitor.stop();
+  });
+
+  it("test_self_dropped_source_not_stopped_still_reconnects", async () => {
+    // A transport that dropped on its own (idle close / network blip) leaves
+    // isStopped() false — it must STILL reconnect, unchanged from before.
+    const source = makeMockRemoteSource("self-dropped-remote");
+    const sink = makeEventCollector();
+    const monitor = new HealthMonitor([source], sink, { checkIntervalMs: 60_000, baseDelayMs: 1 });
+
+    source.alive = false; // dropped, but NOT via stop()
+    expect(source.stopped).toBe(false);
+
+    await monitor.check();
+
+    expect(source.stopCalls).toBe(1);
+    expect(source.startCalls).toBe(1);
+    expect(monitor.getStatus()[0]!.state).toBe("healthy");
 
     monitor.stop();
   });

--- a/test/unit/health-monitor.test.ts
+++ b/test/unit/health-monitor.test.ts
@@ -8,6 +8,7 @@ function makeMockSource(
   name: string,
 ): McpSource & {
   alive: boolean;
+  stopped: boolean;
   restartResult: boolean;
   restartCalls: number;
   setUptime: (ms: number) => void;
@@ -16,10 +17,14 @@ function makeMockSource(
   const mock = {
     name,
     alive: true,
+    stopped: false,
     restartResult: true,
     restartCalls: 0,
     isAlive() {
       return mock.alive;
+    },
+    isStopped() {
+      return mock.stopped;
     },
     uptime() {
       return startedAt !== null ? Date.now() - startedAt : null;
@@ -38,6 +43,7 @@ function makeMockSource(
     },
   } as unknown as McpSource & {
     alive: boolean;
+    stopped: boolean;
     restartResult: boolean;
     restartCalls: number;
     setUptime: (ms: number) => void;

--- a/test/unit/oauth/mcp-callback-url.test.ts
+++ b/test/unit/oauth/mcp-callback-url.test.ts
@@ -4,14 +4,18 @@ import { _resetBouncerModeForTest } from "../../../src/oauth/bouncer-config.ts";
 import { mcpAuthCallbackUrl } from "../../../src/oauth/mcp-callback-url.ts";
 
 // The single source of truth for the OAuth redirect_uri. Every provider
-// path (initiate, boot-start, revocation) resolves through this, so the
-// DCR drift check never fires on our own inconsistency. These cases pin
-// that contract: bouncer mode wins; otherwise NB_API_URL; otherwise the
-// localhost dev default.
+// path (initiate, boot-start, revocation) resolves through this. These cases
+// pin that contract: bouncer mode wins; otherwise the tenant public origin
+// (`publicOrigin()`, derived from the host facts); otherwise the localhost
+// dev default.
 const ENV_KEYS = [
   "NB_OAUTH_BOUNCER_CALLBACK_URL",
   "NB_OAUTH_BOUNCER_TENANT_KEY",
   "NB_TENANT_ID",
+  "NB_PUBLIC_ORIGIN",
+  "NB_PLATFORM_HOST",
+  "NB_CUSTOM_DOMAIN",
+  "NB_CUSTOM_DOMAIN_CANONICAL",
   "NB_API_URL",
 ] as const;
 
@@ -38,25 +42,26 @@ describe("mcpAuthCallbackUrl — single callback-URL authority", () => {
     process.env.NB_OAUTH_BOUNCER_CALLBACK_URL = bouncerCallback;
     process.env.NB_OAUTH_BOUNCER_TENANT_KEY = randomBytes(32).toString("base64");
     process.env.NB_TENANT_ID = "tenant-a";
-    // Even with a tenant-direct NB_API_URL set, bouncer wins — this is the
-    // exact prod config where boot-start used to diverge onto NB_API_URL.
-    process.env.NB_API_URL = "https://hq.platform.nimblebrain.ai";
+    // Even with a tenant-direct public origin set, bouncer wins — this is the
+    // exact prod config where boot-start used to diverge onto the tenant host.
+    process.env.NB_PLATFORM_HOST = "hq.platform.nimblebrain.ai";
     _resetBouncerModeForTest();
 
     expect(mcpAuthCallbackUrl()).toBe(bouncerCallback);
   });
 
-  it("falls back to NB_API_URL when not in bouncer mode", () => {
-    process.env.NB_API_URL = "https://hq.platform.nimblebrain.ai";
+  it("falls back to the tenant public origin when not in bouncer mode", () => {
+    process.env.NB_PLATFORM_HOST = "hq.platform.nimblebrain.ai";
     expect(mcpAuthCallbackUrl()).toBe("https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback");
   });
 
-  it("trims a trailing slash on NB_API_URL so the path isn't doubled", () => {
-    process.env.NB_API_URL = "https://hq.platform.nimblebrain.ai/";
-    expect(mcpAuthCallbackUrl()).toBe("https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback");
+  it("derives from the custom domain when canonical, even outside bouncer mode", () => {
+    process.env.NB_PLATFORM_HOST = "hq.platform.nimblebrain.ai";
+    process.env.NB_CUSTOM_DOMAIN = "brain.hq.com";
+    expect(mcpAuthCallbackUrl()).toBe("https://brain.hq.com/v1/mcp-auth/callback");
   });
 
-  it("defaults to the localhost dev callback when neither bouncer nor NB_API_URL is set", () => {
+  it("defaults to the localhost dev callback when neither bouncer nor host facts are set", () => {
     expect(mcpAuthCallbackUrl()).toBe("http://localhost:27247/v1/mcp-auth/callback");
   });
 });

--- a/test/unit/public-origin.test.ts
+++ b/test/unit/public-origin.test.ts
@@ -12,6 +12,7 @@ const ENV_KEYS = [
   "NB_CUSTOM_DOMAIN",
   "NB_CUSTOM_DOMAIN_CANONICAL",
   "NB_API_URL",
+  "NB_TENANT_ID",
 ] as const;
 
 let saved: Record<string, string | undefined>;
@@ -77,6 +78,20 @@ describe("publicOrigin — derivation policy", () => {
   });
 
   it("returns the dev origin when nothing is configured", () => {
+    expect(publicOrigin()).toBe("http://localhost:27247");
+  });
+
+  it("test_publicOrigin_no_facts_with_tenant_id_fails_closed", () => {
+    // A deployed pod always carries NB_TENANT_ID. If it reaches the dev fallback
+    // (host facts missing), that's a misconfigured deploy — fail closed rather
+    // than mint a localhost callback that silently breaks every OAuth flow.
+    process.env.NB_TENANT_ID = "acme";
+    expect(() => publicOrigin()).toThrow(/refusing to default to .* in a deployed context/);
+  });
+
+  it("test_publicOrigin_no_facts_no_tenant_id_returns_dev_origin", () => {
+    // Local dev (no NB_TENANT_ID) keeps working with no host facts.
+    delete process.env.NB_TENANT_ID;
     expect(publicOrigin()).toBe("http://localhost:27247");
   });
 });

--- a/test/unit/public-origin.test.ts
+++ b/test/unit/public-origin.test.ts
@@ -64,12 +64,12 @@ describe("publicOrigin — derivation policy", () => {
     expect(publicOrigin()).toBe("https://auth.customer.com");
   });
 
-  it("falls back to legacy NB_API_URL when no host facts are present", () => {
+  it("ignores legacy NB_API_URL — the fallback was removed (no host facts → dev origin)", () => {
     process.env.NB_API_URL = "https://legacy.platform.nimblebrain.ai";
-    expect(publicOrigin()).toBe("https://legacy.platform.nimblebrain.ai");
+    expect(publicOrigin()).toBe("http://localhost:27247");
   });
 
-  it("prefers derived host facts over a legacy NB_API_URL", () => {
+  it("ignores NB_API_URL even when set alongside host facts (derived host wins)", () => {
     process.env.NB_PLATFORM_HOST = "acme.platform.nimblebrain.ai";
     process.env.NB_CUSTOM_DOMAIN = "ai.acme.com";
     process.env.NB_API_URL = "https://stale.platform.nimblebrain.ai";
@@ -112,9 +112,9 @@ describe("publicOrigin — fail-closed assertions", () => {
     expect(publicOrigin()).toBe("https://brain.acme.com");
   });
 
-  it("tolerates sloppy trailing slashes from legacy NB_API_URL", () => {
-    process.env.NB_API_URL = "https://legacy.platform.nimblebrain.ai//";
-    expect(publicOrigin()).toBe("https://legacy.platform.nimblebrain.ai");
+  it("tolerates sloppy trailing slashes on an explicit NB_PUBLIC_ORIGIN", () => {
+    process.env.NB_PUBLIC_ORIGIN = "https://brain.acme.com//";
+    expect(publicOrigin()).toBe("https://brain.acme.com");
   });
 });
 

--- a/test/unit/tools/workspace-oauth-provider-client-info.test.ts
+++ b/test/unit/tools/workspace-oauth-provider-client-info.test.ts
@@ -107,6 +107,40 @@ describe("WorkspaceOAuthProvider.clientInformation — redirect_uri drift", () =
     const provider = makeProvider();
     expect(provider.redirectUrl).toBe(CURRENT_CALLBACK);
   });
+
+  it("test_clientInformation_cached_drift_reregisters_when_interactive_armed", async () => {
+    // Reused-provider path: a first background read HONORS the drifted client and
+    // caches it. A later read with interactive armed must NOT blindly return the
+    // cached drifted client — it must apply the same re-register decision the
+    // disk branch does (otherwise the authorize leg sends a redirect_uri the AS
+    // rejects). Guards against the cached-branch short-circuit.
+    await writeClientJson([DRIFTED_REDIRECT]);
+    const provider = makeProvider();
+
+    // 1. Background read → honor + cache the drifted client.
+    const honored = await provider.clientInformation();
+    expect(honored?.client_id).toBe("cid-stored");
+    expect(existsSync(join(dataDir, "client.json"))).toBe(true);
+
+    // 2. User-initiated interactive re-read → re-register, do NOT return cached.
+    provider.setInteractiveAuthAllowed(true);
+    const reread = await provider.clientInformation();
+    expect(reread).toBeUndefined();
+    expect(existsSync(join(dataDir, "client.json"))).toBe(false);
+  });
+
+  it("test_clientInformation_cached_drift_honored_when_background", async () => {
+    // Same reused-provider, but background (flag false) on the second read: the
+    // cached drifted client stays honored (silent refresh keeps working).
+    await writeClientJson([DRIFTED_REDIRECT]);
+    const provider = makeProvider();
+
+    await provider.clientInformation(); // cache the drifted client
+    const reread = await provider.clientInformation(); // still background
+
+    expect(reread?.client_id).toBe("cid-stored");
+    expect(existsSync(join(dataDir, "client.json"))).toBe(true);
+  });
 });
 
 describe("WorkspaceOAuthProvider.redirectToAuthorization — background gate", () => {

--- a/test/unit/tools/workspace-oauth-provider-client-info.test.ts
+++ b/test/unit/tools/workspace-oauth-provider-client-info.test.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  BackgroundReauthRequiredError,
+  WorkspaceOAuthProvider,
+} from "../../../src/tools/workspace-oauth-provider.ts";
+
+/**
+ * Regression coverage for the OAuth redirect_uri-drift fix:
+ *
+ *   - A stored DCR client whose registered redirect_uri has drifted from the
+ *     current callback is HONORED on the silent/background path (not discarded)
+ *     — discarding it orphaned the refresh token and forced a headless
+ *     interactive flow that timed out (the bundle.crashed loop).
+ *   - A structurally-corrupt client (no usable redirect_uris) is still dropped.
+ *   - A user-initiated interactive flow on a drifted host DOES re-register.
+ *   - A background start that hits an interactive requirement flips to
+ *     reauth_required and fails fast instead of blocking on a browser flow.
+ */
+
+const WS_ID = "ws_abc123";
+const SERVER = "com-test-mcp";
+const CURRENT_CALLBACK = "https://new.example.com/v1/mcp-auth/callback";
+const DRIFTED_REDIRECT = "https://old.example.com/v1/mcp-auth/callback";
+
+let workDir: string;
+let dataDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "nb-oauth-provider-"));
+  // Mirror the provider's legacy dataDir layout.
+  dataDir = join(workDir, "workspaces", WS_ID, "credentials", "mcp-oauth", SERVER);
+  await mkdir(dataDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+function makeProvider(): WorkspaceOAuthProvider {
+  return new WorkspaceOAuthProvider({
+    owner: { type: "workspace", wsId: WS_ID },
+    serverName: SERVER,
+    workDir,
+    callbackUrl: CURRENT_CALLBACK,
+  });
+}
+
+async function writeClientJson(redirectUris: unknown): Promise<void> {
+  await writeFile(
+    join(dataDir, "client.json"),
+    JSON.stringify({ client_id: "cid-stored", redirect_uris: redirectUris }),
+  );
+}
+
+describe("WorkspaceOAuthProvider.clientInformation — redirect_uri drift", () => {
+  it("test_clientInformation_drifted_redirect_is_honored_not_discarded", async () => {
+    await writeClientJson([DRIFTED_REDIRECT]);
+    const provider = makeProvider();
+
+    const info = await provider.clientInformation();
+
+    // Stored client is returned (refresh reuses its client_id) ...
+    expect(info?.client_id).toBe("cid-stored");
+    // ... and the on-disk registration is preserved, not orphaned.
+    expect(existsSync(join(dataDir, "client.json"))).toBe(true);
+  });
+
+  it("test_clientInformation_corrupt_redirect_uris_is_discarded", async () => {
+    await writeClientJson([]); // empty array → structurally unusable
+    const provider = makeProvider();
+
+    const info = await provider.clientInformation();
+
+    expect(info).toBeUndefined(); // forces a fresh DCR
+    expect(existsSync(join(dataDir, "client.json"))).toBe(false);
+  });
+
+  it("test_clientInformation_drift_with_interactive_armed_reregisters", async () => {
+    await writeClientJson([DRIFTED_REDIRECT]);
+    const provider = makeProvider();
+    provider.setInteractiveAuthAllowed(true); // user-initiated reauth
+
+    const info = await provider.clientInformation();
+
+    // Re-register against the current host: drop the stale client, return
+    // undefined so the SDK runs a fresh DCR.
+    expect(info).toBeUndefined();
+    expect(existsSync(join(dataDir, "client.json"))).toBe(false);
+  });
+
+  it("test_redirectUrl_honors_stored_registration_after_load", async () => {
+    await writeClientJson([DRIFTED_REDIRECT]);
+    const provider = makeProvider();
+
+    await provider.clientInformation(); // loads + caches the stored client
+
+    // The redirect_uri presented to the AS is the registered one, not the
+    // recomputed callback.
+    expect(provider.redirectUrl).toBe(DRIFTED_REDIRECT);
+  });
+
+  it("test_redirectUrl_falls_back_to_callback_without_stored_client", () => {
+    const provider = makeProvider();
+    expect(provider.redirectUrl).toBe(CURRENT_CALLBACK);
+  });
+});
+
+describe("WorkspaceOAuthProvider.redirectToAuthorization — background gate", () => {
+  it("test_redirectToAuthorization_background_flips_reauth_and_fails_fast", async () => {
+    let authLostFired = false;
+    const provider = new WorkspaceOAuthProvider({
+      owner: { type: "workspace", wsId: WS_ID },
+      serverName: SERVER,
+      workDir,
+      callbackUrl: CURRENT_CALLBACK,
+      onAuthLost: () => {
+        authLostFired = true;
+      },
+      // interactiveAuthAllowed defaults false (background / liveness context);
+      // headlessAuthProbe false so we reach the interactive branch directly.
+    });
+
+    provider.state(); // establish the pending flow
+
+    await expect(
+      provider.redirectToAuthorization(new URL("https://vendor.example.com/authorize?state=abc")),
+    ).rejects.toBeInstanceOf(BackgroundReauthRequiredError);
+
+    // The connection is flagged for reauth instead of blocking a browser flow.
+    expect(authLostFired).toBe(true);
+  });
+});

--- a/test/unit/workspace-oauth-provider-concurrency.test.ts
+++ b/test/unit/workspace-oauth-provider-concurrency.test.ts
@@ -37,13 +37,17 @@ function makeProvider(
   workDir: string,
   onInteractiveAuthRequired?: (url: string) => void,
 ): WorkspaceOAuthProvider {
-  return new WorkspaceOAuthProvider({
+  const provider = new WorkspaceOAuthProvider({
     owner: { type: "workspace", wsId: "ws_test" },
     serverName: "test-srv",
     workDir,
     callbackUrl: CALLBACK,
     ...(onInteractiveAuthRequired ? { onInteractiveAuthRequired } : {}),
   });
+  // The redirectToAuthorization coalesce tests exercise the interactive branch,
+  // now gated to user-initiated flows. Arm it so the branch is reachable.
+  provider.setInteractiveAuthAllowed(true);
+  return provider;
 }
 
 function pkceChallenge(verifier: string): string {

--- a/test/unit/workspace-oauth-provider-headless-probe.test.ts
+++ b/test/unit/workspace-oauth-provider-headless-probe.test.ts
@@ -21,7 +21,7 @@ function makeProvider(
   headlessAuthProbe: boolean,
   onInteractiveAuthRequired: (url: string) => void,
 ): WorkspaceOAuthProvider {
-  return new WorkspaceOAuthProvider({
+  const provider = new WorkspaceOAuthProvider({
     owner: { type: "workspace", wsId: "ws_test" },
     serverName: "granola-test",
     workDir,
@@ -30,6 +30,11 @@ function makeProvider(
     headlessAuthProbe,
     onInteractiveAuthRequired,
   });
+  // These tests exercise the probe / interactive branch, which is now gated to
+  // user-initiated flows. Arm it so the branch is reachable (background starts
+  // short-circuit to reauth_required — covered separately).
+  provider.setInteractiveAuthAllowed(true);
+  return provider;
 }
 
 describe("WorkspaceOAuthProvider — redirect-probe is gated on headlessAuthProbe", () => {

--- a/test/unit/workspace-oauth-provider.test.ts
+++ b/test/unit/workspace-oauth-provider.test.ts
@@ -89,18 +89,17 @@ describe("WorkspaceOAuthProvider — file I/O roundtrips", () => {
     expect(await p2.clientInformation()).toBeDefined();
   });
 
-  it("clientInformation discards a cached client whose redirect_uri doesn't match the current callback", async () => {
-    // Simulate the operational case: a DCR client was registered when
-    // NB_API_URL was the dev default (or wrong), then the operator set
-    // NB_API_URL on the deploy and the provider's callbackUrl flipped.
-    // Returning the stale client.json would send the AS a redirect_uri
-    // the registered client doesn't allow, surfacing as
-    // `Invalid redirect_uri for OAuth client` after the user has
-    // already clicked Connect.
+  it("clientInformation honors a drifted client on the silent path, re-registers only on user-initiated reauth", async () => {
+    // A DCR client was registered when the callback host was X; the canonical
+    // host later drifted to Y. The registration is durable identity — silent
+    // refresh reuses its client_id (no redirect_uri sent) — so a BACKGROUND read
+    // must NOT discard it. Discarding orphaned the refresh token and forced a
+    // headless interactive flow that timed out (the bundle.crashed loop). Only a
+    // user-initiated interactive reauth re-registers against the current host.
     const stalePath = "http://localhost:27247/v1/mcp-auth/callback";
     const livePath = "https://hq.platform.nimblebrain.ai/v1/mcp-auth/callback";
 
-    // Provider 1 writes a client with the stale redirect_uri.
+    // Provider 1 registers a client against the (soon-to-be-stale) redirect_uri.
     const p1 = new WorkspaceOAuthProvider({
       owner: { type: "workspace", wsId: "ws_test" },
       serverName: "drift-srv",
@@ -110,26 +109,27 @@ describe("WorkspaceOAuthProvider — file I/O roundtrips", () => {
     await p1.saveClientInformation({ client_id: "cid-stale", redirect_uris: [stalePath] });
     expect(await p1.clientInformation()).toBeDefined();
 
-    // Provider 2 (fresh process, current deploy) reads the same dir
-    // but with the live callback URL. The cached client is stale —
-    // expect undefined so the SDK re-registers.
+    // Provider 2 (fresh process, current deploy, BACKGROUND/silent context): the
+    // host drifted, but the stored client is HONORED so refresh keeps working —
+    // returned, and left on disk.
     const p2 = new WorkspaceOAuthProvider({
       owner: { type: "workspace", wsId: "ws_test" },
       serverName: "drift-srv",
       workDir,
       callbackUrl: livePath,
     });
-    expect(await p2.clientInformation()).toBeUndefined();
+    expect((await p2.clientInformation())?.client_id).toBe("cid-stale");
 
-    // And the on-disk client.json should be gone — drift detection
-    // unlinks it so a subsequent saveClientInformation writes a fresh
-    // record matching the current redirect URI.
+    // Provider 3 with interactive armed (a user clicked Reconnect): the drift IS
+    // resolved by re-registering against the current host — drop the stale client
+    // and return undefined so the SDK runs a fresh DCR.
     const p3 = new WorkspaceOAuthProvider({
       owner: { type: "workspace", wsId: "ws_test" },
       serverName: "drift-srv",
       workDir,
       callbackUrl: livePath,
     });
+    p3.setInteractiveAuthAllowed(true);
     expect(await p3.clientInformation()).toBeUndefined();
   });
 

--- a/test/unit/workspace-oauth-provider.test.ts
+++ b/test/unit/workspace-oauth-provider.test.ts
@@ -505,7 +505,9 @@ describe("WorkspaceOAuthProvider — Track A: pre-registered client + scopes + e
       try {
         await p.redirectToAuthorization(authUrl);
       } catch {
-        // expected — UnauthorizedError on interactive branch
+        // expected to throw — with interactiveAuthAllowed defaulting false this
+        // is BackgroundReauthRequiredError; either way our params are appended
+        // to the fetched URL before the gate, which is what this asserts below.
       }
       // The URL passed to fetch (after our params were appended) should
       // contain access_type and prompt.


### PR DESCRIPTION
## Problem

Remote OAuth MCP connectors that use Dynamic Client Registration (DCR) could fall into a crash loop. When the OAuth `redirect_uri` the runtime computes for a connector diverges from the value its DCR client was originally registered with (for example, a workspace gains a custom domain, so `publicOrigin()` resolves to a different host), `clientInformation()` discarded the stored `client.json` — orphaning the registered client and its refresh token. Silent refresh then failed, and the reconnect path launched a full interactive OAuth flow on the background/liveness loop. No user is there to complete it, so it blocked (~15 min flow TTL), failed, and looped. The connector showed as connected in the UI while every tool call failed.

## Root cause

The `redirect_uri` was treated as a value to recompute from current request/policy on every connect, when it is properly part of a connector's **durable registration identity**: the authorization server binds a DCR client to the `redirect_uri` it registered with. Recomputing it retroactively invalidated valid registrations.

## Fix

- **Honor the stored registration.** `clientInformation()` no longer discards a structurally valid stored DCR client on a `redirect_uri` host mismatch. The stored client is reused, so silent refresh keeps working (the `refresh_token` grant reuses `client_id` and sends no `redirect_uri`). Only a structurally corrupt record (missing/empty `redirect_uris`) is dropped. `isClientInfoUsable` is split into `hasUsableRedirectUris` (structural) and `redirectUriMatchesCurrent` (canonical drift check).
- **Re-register only on user-initiated interactive reauth.** When the canonical host genuinely changed and a user is reconnecting, the client is re-registered against the current host so the new `/authorize` `redirect_uri` matches the new registration and the session cookie travels back on the callback leg.
- **No interactive auth on the liveness loop.** A new per-attempt `interactiveAuthAllowed` gate is armed only by a user-initiated `startAuth`. A background start that hits an interactive requirement flips the connection to the existing `reauth_required` state and fails fast (`BackgroundReauthRequiredError`) instead of blocking on a browser flow no one will complete.
- **Remove the legacy `NB_API_URL` origin fallback** in `public-origin.ts`, with a fail-closed guard: a deployed context (`NB_TENANT_ID` set) with no host facts now throws at boot rather than minting a `localhost` callback. Local dev is unchanged.

## Hardening (from adversarial review)

- **Orphaned boot-source reconnect.** `HealthMonitor`'s record set is a one-time boot snapshot that teardown never prunes, so a user-initiated reconnect left the old, deliberately stopped source instance to be reconnected by the liveness loop — which could delete shared on-disk credentials and clobber a live `pending_auth`. `McpSource` now carries a `stopped` flag (set only by `stop()`, reset by `start()`, distinct from the failed-start `stopping`), and `HealthMonitor.checkOne` marks a deliberately stopped source terminal instead of reconnecting it. Self-dropped transports (idle close, network blip) leave `stopped` false and still reconnect.
- **Unified cached + disk decision** in `clientInformation()` so a reused provider can't return a drifted client on interactive reauth and skip re-registration. Corrected the provider doc-comments to the actual lifecycle (boot sources reuse one provider across background reconnects; user `startAuth` builds a fresh one and arms interactive).

## Tests

- `test_deliberately_stopped_source_not_reconnected_marked_dead`
- `test_self_dropped_source_not_stopped_still_reconnects`
- `test_clientInformation_cached_drift_reregisters_when_interactive_armed`
- `test_clientInformation_cached_drift_honored_when_background`
- `test_publicOrigin_no_facts_with_tenant_id_fails_closed`
- `test_publicOrigin_no_facts_no_tenant_id_returns_dev_origin`
- plus the `client-info` regression suite (drift honored / corrupt dropped / re-register on armed interactive).

`bun run verify` passes (static + unit + web + bundles + integration + smoke).

## Follow-ups (out of scope here)

- `HealthMonitor` only watches the boot snapshot; a fresh source built by `startAuth` after a reconnect isn't health-monitored until restart (pre-existing — will track separately).
- The chart-side half of the `NB_API_URL` removal lands in the infra repo.
- Per-connector redirect strategy (some vendors require a single controlled callback; others can register per-host) is a follow-up.
