### PR TITLE
feat(metrics): nb_bundle_crashed_total — counter for MCP connector crashes

### DIFF
--- a/src/adapters/metrics-events.ts
+++ b/src/adapters/metrics-events.ts
@@ -1,4 +1,9 @@
-import { recordLlmUsage, toolCallsTotal, toolPromotionsTotal } from "../api/metrics.ts";
+import {
+  recordBundleCrash,
+  recordLlmUsage,
+  toolCallsTotal,
+  toolPromotionsTotal,
+} from "../api/metrics.ts";
 import { log } from "../cli/log.ts";
 import type { EngineEvent, EventSink } from "../engine/types.ts";
 import type { TokenUsage } from "../usage/types.ts";
@@ -53,6 +58,18 @@ export class MetricsEventSink implements EventSink {
       }
       case "run.done":
       case "run.error": {
+        // The HealthMonitor reports bundle/connector liveness via `run.error`
+        // with a nested `event` discriminator (bundle.crashed / restarting /
+        // dead / recovered) and no runId. `bundle.crashed` is the canonical
+        // crash signal: the lifecycle's own `bundle.crashed` event *type* is
+        // emitted only by `recordCrash`, which currently has no callers, so
+        // counting here is 1:1 with a real detection and can't double-count.
+        // (If `recordCrash` is ever wired as the canonical emit, move the count
+        // there and drop it here.) Counts once per HealthMonitor sweep a source
+        // is found down — the per-sweep cadence the alert thresholds on.
+        if (type === "run.error" && data.event === "bundle.crashed") {
+          recordBundleCrash(data.source as string | undefined, data.remote === true);
+        }
         this.finalizeRun(data.runId as string | undefined);
         break;
       }

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -134,6 +134,49 @@ export const artifactResolutionsTotal = new Counter({
   registers: [metricsRegistry],
 });
 
+/**
+ * Remote/local MCP bundle (connector) crashes detected by the HealthMonitor
+ * liveness loop, by connector and transport kind. A "crash" here is one
+ * HealthMonitor sweep finding a source down (transport gone) that was NOT
+ * deliberately stopped — so a connector that stays down increments once per
+ * sweep (~30s) until it recovers or escalates to dead. That per-sweep cadence
+ * is exactly the alertable signal: a sustained nonzero rate for one connector
+ * is a real liveness problem the host would otherwise only learn about from a
+ * user noticing failed tool calls.
+ *
+ * `connector` is the source name, sanitized to a bounded charset (see
+ * recordBundleCrash) so a malformed/unbounded name can't explode cardinality.
+ * `remote` separates remote (HTTP/SSE) connectors from local stdio bundles.
+ * No tenant/workspace label — one pod per tenant, so the scrape namespace
+ * attributes it (same rationale as nb_artifact_resolutions_total).
+ */
+export const bundleCrashedTotal = new Counter({
+  name: "nb_bundle_crashed_total",
+  help: "MCP bundle/connector crashes detected by the health monitor, by connector and transport kind.",
+  labelNames: ["connector", "remote"] as const,
+  registers: [metricsRegistry],
+});
+
+/**
+ * Connector/source names allowed through as a metric label unmodified. The
+ * curated connector ids are lower kebab/dot tokens (e.g. `com-dropbox-mcp`,
+ * `synapse-crm`), so this is generous; anything else buckets to "other" in
+ * recordBundleCrash so an unexpectedly-shaped name can't mint an unbounded
+ * series.
+ */
+const SAFE_CONNECTOR = /^[a-z0-9_.-]+$/;
+
+/**
+ * Record one health-monitor-detected bundle crash. `connector` is the source
+ * name (sanitized to a bounded label); `remote` is true for HTTP/SSE connectors
+ * and false for local stdio bundles. Defensive: a missing/empty/odd name
+ * buckets to "other".
+ */
+export function recordBundleCrash(connector: string | undefined, remote: boolean): void {
+  const safe = connector && SAFE_CONNECTOR.test(connector) ? connector : "other";
+  bundleCrashedTotal.inc({ connector: safe, remote: remote ? "true" : "false" });
+}
+
 /** Token usage subset needed for metrics — a structural slice of `TokenUsage`. */
 interface UsageForMetrics {
   inputTokens: number;

--- a/test/unit/metrics.test.ts
+++ b/test/unit/metrics.test.ts
@@ -3,8 +3,10 @@ import { log } from "../../src/cli/log.ts";
 import { MAX_TRACKED_RUNS, MetricsEventSink } from "../../src/adapters/metrics-events.ts";
 import type { Counter } from "prom-client";
 import {
+  bundleCrashedTotal,
   llmCallsTotal,
   llmTokensTotal,
+  recordBundleCrash,
   recordLlmUsage,
   toolCallsTotal,
   toolPromotionsTotal,
@@ -20,6 +22,13 @@ async function read(counter: Counter<any>, labels: Record<string, string> = {}):
     if (Object.entries(labels).every(([k, v]) => s.labels[k] === v)) return s.value;
   }
   return 0;
+}
+
+// Sum across every label-series of a counter — for asserting "nothing changed".
+// biome-ignore lint/suspicious/noExplicitAny: same as read().
+async function readTotal(counter: Counter<any>): Promise<number> {
+  const metric = await counter.get();
+  return metric.values.reduce((acc, s) => acc + s.value, 0);
 }
 
 describe("recordLlmUsage", () => {
@@ -140,5 +149,55 @@ describe("MetricsEventSink", () => {
     const sink = new MetricsEventSink();
     // Must not throw on an unrelated event.
     expect(() => sink.emit({ type: "run.start", data: { runId: "r1" } })).not.toThrow();
+  });
+});
+
+describe("bundle crash metric", () => {
+  it("test_run_error_bundle_crashed_increments_counter_with_connector_and_remote", async () => {
+    const sink = new MetricsEventSink();
+    const labels = { connector: "com-dropbox-mcp", remote: "true" };
+    const before = await read(bundleCrashedTotal, labels);
+    // Mirrors HealthMonitor's emission: run.error with a nested bundle.crashed
+    // event, a `source` name, and `remote: true`. No runId.
+    sink.emit({
+      type: "run.error",
+      data: { source: "com-dropbox-mcp", event: "bundle.crashed", remote: true },
+    });
+    expect((await read(bundleCrashedTotal, labels)) - before).toBe(1);
+  });
+
+  it("test_local_source_bundle_crashed_records_remote_false", async () => {
+    const sink = new MetricsEventSink();
+    const labels = { connector: "synapse-crm", remote: "false" };
+    const before = await read(bundleCrashedTotal, labels);
+    // A local stdio bundle: HealthMonitor omits the `remote` field entirely.
+    sink.emit({
+      type: "run.error",
+      data: { source: "synapse-crm", event: "bundle.crashed" },
+    });
+    expect((await read(bundleCrashedTotal, labels)) - before).toBe(1);
+  });
+
+  it("test_run_error_without_bundle_crashed_does_not_increment", async () => {
+    const sink = new MetricsEventSink();
+    const before = await readTotal(bundleCrashedTotal);
+    // An ordinary run error and a normal run completion must not touch the
+    // crash counter — only the nested bundle.crashed discriminator counts.
+    sink.emit({ type: "run.error", data: { runId: "r1" } });
+    sink.emit({ type: "run.done", data: { runId: "r2" } });
+    sink.emit({
+      type: "run.error",
+      data: { source: "com-dropbox-mcp", event: "bundle.restarting", remote: true },
+    });
+    expect((await readTotal(bundleCrashedTotal)) - before).toBe(0);
+  });
+
+  it("test_unsafe_connector_name_buckets_to_other", async () => {
+    const labels = { connector: "other", remote: "false" };
+    const before = await read(bundleCrashedTotal, labels);
+    recordBundleCrash("Weird Name!! /etc", false);
+    recordBundleCrash(undefined, false);
+    recordBundleCrash("", false);
+    expect((await read(bundleCrashedTotal, labels)) - before).toBe(3);
   });
 });


### PR DESCRIPTION
## What

Adds `nb_bundle_crashed_total{connector, remote}` — a Prometheus counter incremented when the HealthMonitor detects an MCP bundle/connector down. Pairs with the `BundleCrashLooping` alert (deployments).

## Why

Connector crash-loops were invisible to alerting: a user noticed failed tool calls and filed a report days later instead of the platform paging. This is the metric half of closing that gap, uniformly for all MCP servers.

## Details

- Counter + `recordBundleCrash` helper in `src/api/metrics.ts`; increment in `MetricsEventSink` (`src/adapters/metrics-events.ts`), additive to the existing `run.error` / `run.done` handling (preserves `finalizeRun`).
- **Counting point:** the HealthMonitor `run.error` with `data.event === "bundle.crashed"` — the only *live* crash emission. The lifecycle `recordCrash` (`type: "bundle.crashed"`) has no callers (dead code; noted in a comment), so this is 1:1 with a detection and cannot double-count. Increments once per ~30s sweep a source is found down, until it recovers or escalates to dead.
- **Cardinality:** `connector` = source name, sanitized to `^[a-z0-9_.-]+$` (else `"other"`). No workspace/tenant label — one pod per tenant, so the scrape namespace attributes it (same rationale as `nb_artifact_resolutions_total`). `remote` distinguishes HTTP/SSE connectors from local stdio bundles.
- Tests: increments with correct labels; remote vs local; unsafe-name bucketing; no increment on ordinary `run.error` / `run.done`.

`bun run verify` passes.

## Follow-up

`recordCrash` is dead code (uncalled) — if it's ever wired as the canonical crash emit, move the count there and drop the HealthMonitor count.
