### PR TITLE
feat(metrics): nb_bundle_unhealthy gauge for connector-down alerting; align bundle label on source

### DIFF
--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -15,7 +15,8 @@
  * timing-sensitive tests). Default process metrics are opt-in via
  * enableDefaultMetrics(), called once at server start.
  */
-import { Counter, collectDefaultMetrics, Histogram, Registry } from "prom-client";
+import { Counter, collectDefaultMetrics, Gauge, Histogram, Registry } from "prom-client";
+import type { BundleHealth } from "../tools/health-monitor.ts";
 
 export const metricsRegistry = new Registry();
 
@@ -144,37 +145,98 @@ export const artifactResolutionsTotal = new Counter({
  * is a real liveness problem the host would otherwise only learn about from a
  * user noticing failed tool calls.
  *
- * `connector` is the source name, sanitized to a bounded charset (see
+ * `source` is the MCP source name, sanitized to a bounded charset (see
  * recordBundleCrash) so a malformed/unbounded name can't explode cardinality.
  * `remote` separates remote (HTTP/SSE) connectors from local stdio bundles.
  * No tenant/workspace label — one pod per tenant, so the scrape namespace
  * attributes it (same rationale as nb_artifact_resolutions_total).
+ *
+ * This is a crash-RATE signal (good for dashboards / spotting active
+ * crash-looping). It is NOT the right primitive for "is this connector down
+ * right now": the HealthMonitor stops emitting once a source exhausts its
+ * restarts and is marked dead-terminal, so the counter goes flat while the
+ * connector stays down. Use `nb_bundle_unhealthy` (below) for down-alerting.
  */
 export const bundleCrashedTotal = new Counter({
   name: "nb_bundle_crashed_total",
-  help: "MCP bundle/connector crashes detected by the health monitor, by connector and transport kind.",
-  labelNames: ["connector", "remote"] as const,
+  help: "MCP bundle/connector crashes detected by the health monitor, by source and transport kind.",
+  labelNames: ["source", "remote"] as const,
   registers: [metricsRegistry],
 });
 
 /**
- * Connector/source names allowed through as a metric label unmodified. The
- * curated connector ids are lower kebab/dot tokens (e.g. `com-dropbox-mcp`,
- * `synapse-crm`), so this is generous; anything else buckets to "other" in
- * recordBundleCrash so an unexpectedly-shaped name can't mint an unbounded
- * series.
+ * MCP source names allowed through as a metric label unmodified. The curated
+ * connector ids are lower kebab/dot tokens (e.g. `com-dropbox-mcp`,
+ * `synapse-crm`), so this is generous; anything else buckets to "other" so an
+ * unexpectedly-shaped name can't mint an unbounded series.
  */
-const SAFE_CONNECTOR = /^[a-z0-9_.-]+$/;
+const SAFE_SOURCE = /^[a-z0-9_.-]+$/;
 
 /**
- * Record one health-monitor-detected bundle crash. `connector` is the source
+ * Record one health-monitor-detected bundle crash. `source` is the MCP source
  * name (sanitized to a bounded label); `remote` is true for HTTP/SSE connectors
  * and false for local stdio bundles. Defensive: a missing/empty/odd name
  * buckets to "other".
  */
-export function recordBundleCrash(connector: string | undefined, remote: boolean): void {
-  const safe = connector && SAFE_CONNECTOR.test(connector) ? connector : "other";
-  bundleCrashedTotal.inc({ connector: safe, remote: remote ? "true" : "false" });
+export function recordBundleCrash(source: string | undefined, remote: boolean): void {
+  const safe = source && SAFE_SOURCE.test(source) ? source : "other";
+  bundleCrashedTotal.inc({ source: safe, remote: remote ? "true" : "false" });
+}
+
+/**
+ * Gauge: which MCP bundles/connectors are currently DOWN — HealthMonitor state
+ * `dead` — by source. `1` = down.
+ *
+ * Why a gauge, not the `nb_bundle_crashed_total` counter: a down source emits a
+ * crash event each ~30s HealthMonitor sweep only until it exhausts its restarts
+ * (`MAX_RESTARTS`), at which point it's marked `dead` and the monitor stops
+ * touching it ("dead is terminal"). So the counter records a short burst then
+ * goes flat — an `increase()`-based alert would auto-resolve minutes into a
+ * multi-day outage. This gauge instead stays asserted for the entire outage and
+ * clears only when the source recovers, so `== 1 for: Nm` is a correct
+ * "connector has been down for N minutes" signal.
+ *
+ * Excludes `restarting` (transient: at most `MAX_RESTARTS` attempts over a few
+ * minutes before the source is either healthy again or `dead`). Driven at
+ * scrape time from the live HealthMonitor via {@link registerBundleHealthGauge};
+ * the collect callback resets first, so a recovered source's series disappears.
+ *
+ * No tenant/workspace label — one pod per tenant, scrape namespace attributes it.
+ */
+export const bundleUnhealthy = new Gauge({
+  name: "nb_bundle_unhealthy",
+  help: 'MCP bundles currently down (HealthMonitor state "dead"), by source. 1 = down.',
+  labelNames: ["source"] as const,
+  registers: [metricsRegistry],
+  collect() {
+    // Runs at scrape time (prom-client invokes this in `.get()`). Reset so a
+    // source that has since recovered drops out of the series entirely (the
+    // gauge is absent for healthy sources), letting the alert resolve.
+    this.reset();
+    const status = healthStatusProvider?.() ?? [];
+    for (const b of status) {
+      if (b.state !== "dead") continue;
+      const safe = b.name && SAFE_SOURCE.test(b.name) ? b.name : "other";
+      this.set({ source: safe }, 1);
+    }
+  },
+});
+
+/**
+ * Live HealthMonitor status provider read by the `nb_bundle_unhealthy` gauge's
+ * collect callback. `null` until wired (e.g. local dev with no server start, or
+ * a test that hasn't registered one), in which case the gauge reports nothing.
+ */
+let healthStatusProvider: (() => BundleHealth[]) | null = null;
+
+/**
+ * Wire the `nb_bundle_unhealthy` gauge to a live HealthMonitor. Call once at
+ * server start, right after the HealthMonitor is constructed, with
+ * `() => healthMonitor.getStatus()`. Last registration wins (so tests can swap
+ * in a stub); the gauge reads through this provider at every scrape.
+ */
+export function registerBundleHealthGauge(getStatus: () => BundleHealth[]): void {
+  healthStatusProvider = getStatus;
 }
 
 /** Token usage subset needed for metrics — a structural slice of `TokenUsage`. */

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -20,6 +20,7 @@ import { resolveAuthMode } from "./auth-middleware.ts";
 import { ConversationEventManager } from "./conversation-events.ts";
 import { deriveDataChangedTarget, SseEventManager } from "./events.ts";
 import { McpServerHost } from "./mcp-server.ts";
+import { registerBundleHealthGauge } from "./metrics.ts";
 import { LoginRateLimiter, RequestRateLimiter } from "./rate-limiter.ts";
 import { InMemorySessionRegistry, type SessionRegistry } from "./session-store/index.ts";
 import type { AppContext } from "./types.ts";
@@ -87,6 +88,11 @@ export function startServer(options: ServerOptions): ServerHandle {
   const mcpSources = runtime.mcpSources();
   const healthMonitor = new HealthMonitor(mcpSources, runtime.getEventSink());
   healthMonitor.start();
+  // Expose currently-down bundles as the `nb_bundle_unhealthy` gauge (read
+  // through this provider at scrape time). The gauge stays asserted for the
+  // whole outage, unlike the crash counter which goes flat once a source is
+  // dead-terminal — so the down-alert resolves only on recovery.
+  registerBundleHealthGauge(() => healthMonitor.getStatus());
 
   // Connection credential re-validation (a disjoint concern from HealthMonitor's
   // transport liveness): poll providers whose upstream account can lapse without

--- a/test/unit/metrics.test.ts
+++ b/test/unit/metrics.test.ts
@@ -1,16 +1,19 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { afterAll, describe, expect, it, spyOn } from "bun:test";
 import { log } from "../../src/cli/log.ts";
 import { MAX_TRACKED_RUNS, MetricsEventSink } from "../../src/adapters/metrics-events.ts";
 import type { Counter } from "prom-client";
 import {
   bundleCrashedTotal,
+  bundleUnhealthy,
   llmCallsTotal,
   llmTokensTotal,
   recordBundleCrash,
   recordLlmUsage,
+  registerBundleHealthGauge,
   toolCallsTotal,
   toolPromotionsTotal,
 } from "../../src/api/metrics.ts";
+import type { BundleHealth } from "../../src/tools/health-monitor.ts";
 
 // Read one label-series value off a counter. Tests use deltas (read → act →
 // read) rather than reset(), so they're robust to the shared process-global
@@ -153,9 +156,9 @@ describe("MetricsEventSink", () => {
 });
 
 describe("bundle crash metric", () => {
-  it("test_run_error_bundle_crashed_increments_counter_with_connector_and_remote", async () => {
+  it("test_run_error_bundle_crashed_increments_counter_with_source_and_remote", async () => {
     const sink = new MetricsEventSink();
-    const labels = { connector: "com-dropbox-mcp", remote: "true" };
+    const labels = { source: "com-dropbox-mcp", remote: "true" };
     const before = await read(bundleCrashedTotal, labels);
     // Mirrors HealthMonitor's emission: run.error with a nested bundle.crashed
     // event, a `source` name, and `remote: true`. No runId.
@@ -168,7 +171,7 @@ describe("bundle crash metric", () => {
 
   it("test_local_source_bundle_crashed_records_remote_false", async () => {
     const sink = new MetricsEventSink();
-    const labels = { connector: "synapse-crm", remote: "false" };
+    const labels = { source: "synapse-crm", remote: "false" };
     const before = await read(bundleCrashedTotal, labels);
     // A local stdio bundle: HealthMonitor omits the `remote` field entirely.
     sink.emit({
@@ -192,12 +195,76 @@ describe("bundle crash metric", () => {
     expect((await readTotal(bundleCrashedTotal)) - before).toBe(0);
   });
 
-  it("test_unsafe_connector_name_buckets_to_other", async () => {
-    const labels = { connector: "other", remote: "false" };
+  it("test_unsafe_source_name_buckets_to_other", async () => {
+    const labels = { source: "other", remote: "false" };
     const before = await read(bundleCrashedTotal, labels);
     recordBundleCrash("Weird Name!! /etc", false);
     recordBundleCrash(undefined, false);
     recordBundleCrash("", false);
     expect((await read(bundleCrashedTotal, labels)) - before).toBe(3);
+  });
+});
+
+describe("bundle unhealthy gauge", () => {
+  // Read one `nb_bundle_unhealthy` series; `.get()` triggers the collect
+  // callback. Returns undefined when the series is absent (collect resets each
+  // scrape, so a recovered source disappears entirely rather than going to 0).
+  async function readGauge(source: string): Promise<number | undefined> {
+    const metric = await bundleUnhealthy.get();
+    for (const s of metric.values) {
+      if (s.labels.source === source) return s.value;
+    }
+    return undefined;
+  }
+
+  const status = (...records: Array<Partial<BundleHealth> & { name: string; state: BundleHealth["state"] }>): BundleHealth[] =>
+    records.map((r) => ({ uptime: null, restartCount: 0, ...r }));
+
+  // Leave the gauge inert for other test files sharing the process-global
+  // registry (a full-registry scrape elsewhere would otherwise invoke our
+  // collect with a stale provider).
+  afterAll(() => registerBundleHealthGauge(() => []));
+
+  it("test_bundle_unhealthy_gauge_reports_1_for_dead_source", async () => {
+    registerBundleHealthGauge(() => status({ name: "com-dropbox-mcp", state: "dead" }));
+    expect(await readGauge("com-dropbox-mcp")).toBe(1);
+  });
+
+  it("test_bundle_unhealthy_gauge_absent_for_healthy_source", async () => {
+    registerBundleHealthGauge(() => status({ name: "synapse-crm", state: "healthy" }));
+    expect(await readGauge("synapse-crm")).toBeUndefined();
+  });
+
+  it("test_bundle_unhealthy_gauge_excludes_restarting_source", async () => {
+    // `restarting` is transient (≤ MAX_RESTARTS attempts) — only terminal `dead`
+    // should assert the down signal.
+    registerBundleHealthGauge(() => status({ name: "ai-granola-mcp", state: "restarting" }));
+    expect(await readGauge("ai-granola-mcp")).toBeUndefined();
+  });
+
+  it("test_bundle_unhealthy_gauge_resolves_when_source_recovers", async () => {
+    registerBundleHealthGauge(() => status({ name: "com-dropbox-mcp", state: "dead" }));
+    expect(await readGauge("com-dropbox-mcp")).toBe(1);
+    // Source recovers → collect resets → series disappears → alert can resolve.
+    registerBundleHealthGauge(() => status({ name: "com-dropbox-mcp", state: "healthy" }));
+    expect(await readGauge("com-dropbox-mcp")).toBeUndefined();
+  });
+
+  it("test_bundle_unhealthy_gauge_separate_series_per_source", async () => {
+    registerBundleHealthGauge(() =>
+      status(
+        { name: "com-dropbox-mcp", state: "dead" },
+        { name: "ai-granola-mcp", state: "dead" },
+        { name: "synapse-crm", state: "healthy" },
+      ),
+    );
+    expect(await readGauge("com-dropbox-mcp")).toBe(1);
+    expect(await readGauge("ai-granola-mcp")).toBe(1);
+    expect(await readGauge("synapse-crm")).toBeUndefined();
+  });
+
+  it("test_bundle_unhealthy_gauge_unsafe_source_buckets_to_other", async () => {
+    registerBundleHealthGauge(() => status({ name: "Weird Name!! /etc", state: "dead" }));
+    expect(await readGauge("other")).toBe(1);
   });
 });


### PR DESCRIPTION
## What

- Adds `nb_bundle_unhealthy{source}` **gauge** — set at scrape time from `HealthMonitor.getStatus()`, `1` for each bundle in terminal `dead` state, absent otherwise. Stays asserted for the whole outage and resolves on recovery.
- Renames the `nb_bundle_crashed_total` label `connector` → `source` to match the registry convention (`nb_llm_*`, `nb_tool_*`).

## Why

The crash counter (#496) is the wrong primitive for "is this connector down right now." The HealthMonitor stops emitting once a source exhausts `MAX_RESTARTS` and is marked dead-terminal, so an `increase()`-based alert spikes then decays to 0 and **auto-resolves ~18 min into a multi-day outage** — exactly the "silent for days, nobody paged" incident. A gauge driven by live health state stays lit until recovery. (Surfaced by QA review of the alert PR.)

## Details

- Gauge uses a prom-client `collect()` callback that `reset()`s then `set({source}, 1)` for dead bundles; wired via `registerBundleHealthGauge(() => healthMonitor.getStatus())` in `server.ts`. `dead`-only (excludes transient `restarting`). Source sanitized to a bounded charset (else `"other"`); no tenant/workspace label (one pod per tenant → scrape namespace attributes it).
- Pairs with the `TenantConnectorDown` alert (deployments). The `nb_bundle_crashed_total` counter is retained as a crash-rate signal for dashboards.
- Tests: gauge reports `1` for dead / absent for healthy / excludes restarting / resolves on recovery / per-source series / unsafe-name bucketing; counter tests updated to the `source` label.

`bun run verify` passes.
