### PR TITLE
feat(metrics): nb_llm_request_duration_seconds + nb_llm_errors_total

### DIFF
--- a/src/adapters/metrics-events.ts
+++ b/src/adapters/metrics-events.ts
@@ -1,4 +1,6 @@
 import {
+  llmErrorsTotal,
+  llmRequestDurationSeconds,
   recordBundleCrash,
   recordLlmUsage,
   toolCallsTotal,
@@ -39,8 +41,21 @@ export class MetricsEventSink implements EventSink {
     const { type, data } = event;
     switch (type) {
       case "llm.done": {
+        const model = (data.model as string) ?? "unknown";
         const usage = data.usage as TokenUsage | undefined;
-        if (usage) recordLlmUsage("main", (data.model as string) ?? "unknown", usage);
+        if (usage) recordLlmUsage("main", model, usage);
+        // Per-call latency for the p99 alert. `llmMs` is set on every llm.done
+        // (engine measures it around the provider call); guard the type anyway.
+        const llmMs = data.llmMs;
+        if (typeof llmMs === "number") {
+          llmRequestDurationSeconds.observe({ source: "main", model }, llmMs / 1000);
+        }
+        break;
+      }
+      case "llm.error": {
+        // Terminal provider failure after retries (aborts excluded upstream).
+        // Pairs with nb_llm_calls_total to form the error rate.
+        llmErrorsTotal.inc({ source: "main", model: (data.model as string) ?? "unknown" });
         break;
       }
       case "tool.done": {

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -101,6 +101,13 @@ export const llmCallsTotal = new Counter({
  * tail the alert cares about. Forked fast-slot calls (compaction / title /
  * briefing) are not observed here — they emit no `llm.done` and record usage at
  * their own call sites (same boundary as the token counters).
+ *
+ * Completed-calls SLI: only successful calls (`llm.done`) are sampled. A call
+ * that fails terminally records no latency sample — it bumps `nb_llm_errors_total`
+ * instead — so this is "p99 of completed calls" and the latency alert is
+ * intentionally blind to slow-then-failed calls. That degradation surfaces via
+ * the error rate, not here; keeping failures out preserves the success-latency
+ * semantics (no `outcome` label needed).
  */
 export const llmRequestDurationSeconds = new Histogram({
   name: "nb_llm_request_duration_seconds",

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -92,6 +92,41 @@ export const llmCallsTotal = new Counter({
   registers: [metricsRegistry],
 });
 
+/**
+ * LLM request latency in seconds — the wall-clock of one provider round-trip
+ * (streaming included), observed on the main agentic loop's `llm.done`. Drives
+ * the p99-latency alert. Buckets run long (to 120s): an agentic call with a
+ * large context and tool streaming sits far right of an HTTP histogram, so the
+ * 0.005–10s bucket set used for `http_request_duration_seconds` would clip the
+ * tail the alert cares about. Forked fast-slot calls (compaction / title /
+ * briefing) are not observed here — they emit no `llm.done` and record usage at
+ * their own call sites (same boundary as the token counters).
+ */
+export const llmRequestDurationSeconds = new Histogram({
+  name: "nb_llm_request_duration_seconds",
+  help: "LLM request latency in seconds, by call source and model.",
+  labelNames: ["source", "model"] as const,
+  buckets: [0.25, 0.5, 1, 2, 5, 10, 20, 30, 45, 60, 90, 120],
+  registers: [metricsRegistry],
+});
+
+/**
+ * LLM calls that failed terminally — the provider call threw and the engine's
+ * in-call retry (3 attempts with backoff) was exhausted, or a context overflow
+ * could not be recovered. User-initiated cancellations (abort signal) are NOT
+ * counted — they aren't provider failures. Pairs with `nb_llm_calls_total`
+ * (which counts successes) to form the error rate `errors / (errors + calls)`
+ * the alert thresholds on. No error dimension, to keep cardinality bounded; a
+ * bounded `kind` (rate_limit / timeout / server) can be added later if triage
+ * needs it.
+ */
+export const llmErrorsTotal = new Counter({
+  name: "nb_llm_errors_total",
+  help: "LLM calls that failed terminally (provider error after retries), by source and model.",
+  labelNames: ["source", "model"] as const,
+  registers: [metricsRegistry],
+});
+
 /** Tool executions, by outcome. */
 export const toolCallsTotal = new Counter({
   name: "nb_tool_calls_total",

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -653,6 +653,18 @@ export class AgentEngine {
               callMessages = sanitizeMessages(runTransform(overflowAttempt));
               continue;
             }
+            // Terminal LLM failure: the call threw, in-call retry is exhausted,
+            // and it's neither a recoverable overflow nor a user cancellation.
+            // Emit the observe-only error fact (for the LLM error-rate metric)
+            // before re-throwing — the error still propagates and ends the run.
+            // Aborts are excluded: a cancellation isn't a provider failure and
+            // must not inflate the error rate.
+            if (!config.signal?.aborted) {
+              this.events.emit({
+                type: "llm.error",
+                data: { runId, model: config.model },
+              });
+            }
             throw err;
           }
         }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -104,6 +104,14 @@ export type EngineEventType =
   | "tool.promoted"
   | "tool.released"
   | "llm.done"
+  /**
+   * A provider LLM call failed terminally — the call threw and the in-call
+   * retry was exhausted (or a context overflow could not be recovered).
+   * NOT emitted for user-initiated cancellations (abort). Payload: { runId,
+   * model }. Observe-only signal for the LLM error-rate metric; the error
+   * itself still propagates and ends the run as `run.error`.
+   */
+  | "llm.error"
   | "run.done"
   | "run.error"
   | "skills.loaded"

--- a/test/unit/metrics.test.ts
+++ b/test/unit/metrics.test.ts
@@ -6,6 +6,8 @@ import {
   bundleCrashedTotal,
   bundleUnhealthy,
   llmCallsTotal,
+  llmErrorsTotal,
+  llmRequestDurationSeconds,
   llmTokensTotal,
   recordBundleCrash,
   recordLlmUsage,
@@ -266,5 +268,62 @@ describe("bundle unhealthy gauge", () => {
   it("test_bundle_unhealthy_gauge_unsafe_source_buckets_to_other", async () => {
     registerBundleHealthGauge(() => status({ name: "Weird Name!! /etc", state: "dead" }));
     expect(await readGauge("other")).toBe(1);
+  });
+});
+
+describe("LLM latency + error metrics", () => {
+  // Read a histogram's _sum / _count for a label-series. prom-client emits the
+  // aggregate as sibling series named `<name>_sum` / `<name>_count`.
+  async function readHistogram(
+    suffix: "sum" | "count",
+    labels: Record<string, string>,
+  ): Promise<number> {
+    const metric = await llmRequestDurationSeconds.get();
+    const want = `nb_llm_request_duration_seconds_${suffix}`;
+    for (const s of metric.values) {
+      if (
+        // biome-ignore lint/suspicious/noExplicitAny: prom-client value shape.
+        (s as any).metricName === want &&
+        Object.entries(labels).every(([k, v]) => s.labels[k] === v)
+      ) {
+        return s.value;
+      }
+    }
+    return 0;
+  }
+
+  it("test_llm_done_observes_latency_histogram_seconds", async () => {
+    const sink = new MetricsEventSink();
+    const labels = { source: "main", model: "tm-latency" };
+    const beforeCount = await readHistogram("count", labels);
+    const beforeSum = await readHistogram("sum", labels);
+    // 2400ms call → 2.4s observed.
+    sink.emit({ type: "llm.done", data: { runId: "r1", model: "tm-latency", llmMs: 2400 } });
+    expect((await readHistogram("count", labels)) - beforeCount).toBe(1);
+    expect((await readHistogram("sum", labels)) - beforeSum).toBeCloseTo(2.4, 5);
+  });
+
+  it("test_llm_done_without_llmMs_does_not_observe", async () => {
+    const sink = new MetricsEventSink();
+    const labels = { source: "main", model: "tm-no-ms" };
+    const before = await readHistogram("count", labels);
+    // A malformed llm.done missing llmMs must not record a 0s (or NaN) sample.
+    sink.emit({ type: "llm.done", data: { runId: "r1", model: "tm-no-ms" } });
+    expect((await readHistogram("count", labels)) - before).toBe(0);
+  });
+
+  it("test_llm_error_increments_errors_counter_with_model", async () => {
+    const sink = new MetricsEventSink();
+    const labels = { source: "main", model: "tm-err" };
+    const before = await read(llmErrorsTotal, labels);
+    sink.emit({ type: "llm.error", data: { runId: "r1", model: "tm-err" } });
+    expect((await read(llmErrorsTotal, labels)) - before).toBe(1);
+  });
+
+  it("test_llm_done_does_not_increment_error_counter", async () => {
+    const sink = new MetricsEventSink();
+    const before = await readTotal(llmErrorsTotal);
+    sink.emit({ type: "llm.done", data: { runId: "r1", model: "tm-err", llmMs: 100 } });
+    expect((await readTotal(llmErrorsTotal)) - before).toBe(0);
   });
 });


### PR DESCRIPTION
## What

Adds the two LLM-call observability signals the deferred `tenant-llm` alert group needs (p99 latency, error rate):

- **`nb_llm_request_duration_seconds`** `{source, model}` — Histogram, observed on the main loop's `llm.done` from the `llmMs` the engine already measures around the provider call. Buckets run long (to 120s) — an agentic call with a large context + tool streaming sits far right of an HTTP histogram, so the `http_request_duration_seconds` bucket set would clip the tail the alert cares about.
- **`nb_llm_errors_total`** `{source, model}` — Counter, incremented on a new **`llm.error`** engine event emitted at the terminal LLM-failure throw site (after the in-call 3× retry is exhausted, or an unrecoverable context overflow). Pairs with `nb_llm_calls_total` (successes) to form `errors / (errors + calls)`.

## Why

`nb_llm_calls_total` / `nb_llm_tokens_total` carry no per-call latency or error dimension, so `TenantLLMLatencyHigh` (p99 > 30s) and `TenantLLMErrorRateHigh` (> 10%) couldn't be written. This is the metric half; the alerts land in deployments once this ships.

## Details

- **Latency** is observed in `MetricsEventSink` on `llm.done` (source `"main"`), guarded on `typeof llmMs === "number"` so a malformed event records nothing rather than a 0s/NaN sample. Forked fast-slot calls (compaction/title/briefing) aren't observed here — they emit no `llm.done` and record usage at their own call sites (same boundary as the token counters).
- **Errors:** the engine already retries in-call (3× w/ backoff) and only `throw`s on terminal failure. The `llm.error` emit sits at that throw, **guarded by `!config.signal?.aborted`** — a user cancellation isn't a provider failure and must not inflate the error rate. The error still propagates and ends the run as `run.error`; `llm.error` is observe-only.
- Adding `"llm.error"` to `EngineEventType` is non-breaking: `SSE_ROUTES` is a `Partial<Record<...>>`, `workspace-log-sink` uses a `Set`, and the metrics/posthog sinks have non-exhaustive dispatch.
- No new label cardinality risk: `source`/`model` are the existing bounded set; no error-`kind` dimension for now (can add a bounded one later if triage needs it).

## Tests

`bun run verify` passes. New unit tests: latency observed as seconds with `{source, model}`; `llm.done` without `llmMs` doesn't observe; `llm.error` increments by model; `llm.done` doesn't touch the error counter.

## Follow-up

- deployments: add `TenantLLMLatencyHigh` + `TenantLLMErrorRateHigh` to the `tenant-llm` group (currently a deferred comment in `alert-rules.yaml`).