### PR TITLE
ci: rename runtime/web images to nimblebrain-{runtime,web}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,11 +143,11 @@ jobs:
           file: Dockerfile
           cache-scope: platform
           build-args: BUILD_SHA=${{ steps.tag.outputs.sha }}
-          tags: ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-platform:${{ steps.tag.outputs.sha }}
+          tags: ${{ steps.ecr.outputs.registry }}/nimblebrain/nimblebrain-runtime:${{ steps.tag.outputs.sha }}
       - name: Build and push web image
         uses: ./.github/actions/build-push-image
         with:
           context: web
           file: web/Dockerfile
           cache-scope: web
-          tags: ${{ steps.ecr.outputs.registry }}/nimblebrain/agent-web:${{ steps.tag.outputs.sha }}
+          tags: ${{ steps.ecr.outputs.registry }}/nimblebrain/nimblebrain-web:${{ steps.tag.outputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,15 +77,20 @@ jobs:
           # (package.json-style versions have no `v` prefix).
           PKG_VERSION=${VERSION#v}
 
+          # GHCR runtime is `nimblebrain-runtime` (canonical, matches ECR + web
+          # naming); `nimblebrain` is kept as a transitional alias so existing
+          # OSS pulls don't break. Drop the alias once consumers have moved.
           platform_tags=(
-            "$REG/nimblebrain/agent-platform:$VERSION"
-            "$REG/nimblebrain/agent-platform:$SHA"
+            "$REG/nimblebrain/nimblebrain-runtime:$VERSION"
+            "$REG/nimblebrain/nimblebrain-runtime:$SHA"
+            "ghcr.io/nimblebraininc/nimblebrain-runtime:$VERSION"
+            "ghcr.io/nimblebraininc/nimblebrain-runtime:$SHA"
             "ghcr.io/nimblebraininc/nimblebrain:$VERSION"
             "ghcr.io/nimblebraininc/nimblebrain:$SHA"
           )
           web_tags=(
-            "$REG/nimblebrain/agent-web:$VERSION"
-            "$REG/nimblebrain/agent-web:$SHA"
+            "$REG/nimblebrain/nimblebrain-web:$VERSION"
+            "$REG/nimblebrain/nimblebrain-web:$SHA"
             "ghcr.io/nimblebraininc/nimblebrain-web:$VERSION"
             "ghcr.io/nimblebraininc/nimblebrain-web:$SHA"
           )
@@ -94,6 +99,7 @@ jobs:
           case "$VERSION" in
             *-*) ;;  # pre-release: leave :latest alone
             *)
+              platform_tags+=("ghcr.io/nimblebraininc/nimblebrain-runtime:latest")
               platform_tags+=("ghcr.io/nimblebraininc/nimblebrain:latest")
               web_tags+=("ghcr.io/nimblebraininc/nimblebrain-web:latest")
               ;;

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ docker compose up
 
 Images are published to GHCR on every release:
 
-- `ghcr.io/nimblebraininc/nimblebrain` — runtime (Bun + Python 3.13 + Node 22 + mpak)
+- `ghcr.io/nimblebraininc/nimblebrain-runtime` — runtime (Bun + Python 3.13 + Node 22 + mpak). Also published as `ghcr.io/nimblebraininc/nimblebrain` (transitional alias).
 - `ghcr.io/nimblebraininc/nimblebrain-web` — Caddy serving the SPA, proxying `/v1/*` to the platform
 
 Each release is tagged with the version (e.g. `v1.2.3`) and the short git SHA. Stable releases also move `:latest` forward; pre-releases (e.g. `v0.4.0-beta.1`) do not. Pin to a version tag in production. Pass `--build` to `docker compose` to build from source instead.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,8 +83,12 @@ gh release view "$TAG" --json tagName,isPrerelease,url
 
 ### 4b. GHCR platform image
 
+The canonical runtime image is `nimblebrain-runtime`; `nimblebrain` is a
+transitional alias carrying the same digest (verify it too until the alias is
+retired).
+
 ```bash
-gh api "/orgs/NimbleBrainInc/packages/container/nimblebrain/versions" \
+gh api "/orgs/NimbleBrainInc/packages/container/nimblebrain-runtime/versions" \
   --jq ".[] | select(.metadata.container.tags | contains([\"$TAG\"])) | {tags: .metadata.container.tags, created: .created_at}"
 ```
 
@@ -109,7 +113,8 @@ From a shell where you are NOT logged in to GHCR:
 
 ```bash
 docker logout ghcr.io 2>/dev/null
-docker pull "ghcr.io/nimblebraininc/nimblebrain:$TAG"
+docker pull "ghcr.io/nimblebraininc/nimblebrain-runtime:$TAG"
+docker pull "ghcr.io/nimblebraininc/nimblebrain:$TAG"   # transitional alias
 docker pull "ghcr.io/nimblebraininc/nimblebrain-web:$TAG"
 ```
 
@@ -123,9 +128,10 @@ When a *new* image name is first published to GHCR (not a new version of an exis
 
 This is needed exactly once per image name, then never again.
 
-Current image names (already public as of v0.4.0-beta.2):
-- https://github.com/orgs/NimbleBrainInc/packages/container/nimblebrain/settings
-- https://github.com/orgs/NimbleBrainInc/packages/container/nimblebrain-web/settings
+Current image names:
+- https://github.com/orgs/NimbleBrainInc/packages/container/nimblebrain-runtime/settings — **NEW** (canonical runtime name); flip to public on its first release
+- https://github.com/orgs/NimbleBrainInc/packages/container/nimblebrain/settings — already public (transitional alias)
+- https://github.com/orgs/NimbleBrainInc/packages/container/nimblebrain-web/settings — already public
 
 To flip: visit the settings URL → "Danger Zone" section → "Change visibility" → Public → confirm.
 
@@ -145,21 +151,21 @@ git push origin ":refs/tags/$TAG"
 # 2. Delete the GitHub Release (also deletes the remote tag if still present)
 gh release delete "$TAG" --yes --cleanup-tag
 
-# 3. Delete the GHCR package versions for both images.
+# 3. Delete the GHCR package versions for every image.
 #    First, list IDs of versions that carry this tag:
-gh api "/orgs/NimbleBrainInc/packages/container/nimblebrain/versions" \
+gh api "/orgs/NimbleBrainInc/packages/container/nimblebrain-runtime/versions" \
   --jq ".[] | select(.metadata.container.tags | contains([\"$TAG\"])) | .id"
 # Then for each ID:
-gh api -X DELETE "/orgs/NimbleBrainInc/packages/container/nimblebrain/versions/<id>"
-# Repeat the two commands above with nimblebrain-web in place of nimblebrain.
+gh api -X DELETE "/orgs/NimbleBrainInc/packages/container/nimblebrain-runtime/versions/<id>"
+# Repeat the two commands above for `nimblebrain` (the alias) and `nimblebrain-web`.
 
 # 4. Delete ECR images for the botched tag (requires AWS CLI + credentials):
 aws ecr batch-delete-image \
-  --repository-name nimblebrain/agent-platform \
+  --repository-name nimblebrain/nimblebrain-runtime \
   --image-ids "imageTag=$TAG" \
   --region us-east-1
 aws ecr batch-delete-image \
-  --repository-name nimblebrain/agent-web \
+  --repository-name nimblebrain/nimblebrain-web \
   --image-ids "imageTag=$TAG" \
   --region us-east-1
 ```
@@ -178,12 +184,13 @@ Artifact map:
 
 | Registry | Repo | Tags on every release | Extra tags for stable only |
 |---|---|---|---|
-| GHCR (public) | `ghcr.io/nimblebraininc/nimblebrain` | `$TAG`, short-sha | `latest` |
+| GHCR (public) | `ghcr.io/nimblebraininc/nimblebrain-runtime` | `$TAG`, short-sha | `latest` |
+| GHCR (public) | `ghcr.io/nimblebraininc/nimblebrain` (transitional alias) | `$TAG`, short-sha | `latest` |
 | GHCR (public) | `ghcr.io/nimblebraininc/nimblebrain-web` | `$TAG`, short-sha | `latest` |
-| ECR (private) | `nimblebrain/agent-platform` | `$TAG`, short-sha | — |
-| ECR (private) | `nimblebrain/agent-web` | `$TAG`, short-sha | — |
+| ECR (private) | `nimblebrain/nimblebrain-runtime` | `$TAG`, short-sha | — |
+| ECR (private) | `nimblebrain/nimblebrain-web` | `$TAG`, short-sha | — |
 
-ECR repositories have immutable tags enabled — `:latest` is deliberately not pushed there; deploys pin to version or sha. The ECR repo names (`agent-platform`, `agent-web`) are a legacy naming artifact — a rename to match GHCR is planned but not scheduled.
+ECR repositories have immutable tags enabled — `:latest` is deliberately not pushed there; deploys pin to version or sha. ECR and GHCR repo names now match (`nimblebrain-runtime`, `nimblebrain-web`). `ghcr.io/nimblebraininc/nimblebrain` is a transitional alias for the runtime image kept so existing OSS pulls don't break; drop it once consumers have moved.
 
 ## 8. Out of scope for this runbook
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   platform:
-    image: ghcr.io/nimblebraininc/nimblebrain:latest
+    image: ghcr.io/nimblebraininc/nimblebrain-runtime:latest
     build: .
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## What

Renames the runtime and web container images to their final branded names, matching across both registries.

| | ECR (private) | GHCR (public) |
|---|---|---|
| runtime | `nimblebrain/nimblebrain-runtime` | `nimblebraininc/nimblebrain-runtime` |
| web | `nimblebrain/nimblebrain-web` | `nimblebraininc/nimblebrain-web` |

Previously ECR pushed `nimblebrain/agent-{platform,web}` (a legacy naming artifact) and GHCR runtime was the unbranded `nimblebrain`.

## Transitional alias

`release.yml` keeps pushing `ghcr.io/nimblebraininc/nimblebrain` (`$TAG`, sha, `latest`) **alongside** the new `nimblebrain-runtime`, so existing OSS pulls don't break. Drop the alias once consumers have moved. `nimblebrain-web` was already correctly named on GHCR — unchanged there.

## Changes
- `ci.yml` — ECR push targets → branded names
- `release.yml` — ECR + GHCR targets → branded names; `nimblebrain` alias retained
- `RELEASING.md` — verification calls, rollback, visibility-flip note (`nimblebrain-runtime` is a new GHCR package → flip to public on first release), artifact map
- `README.md`, `docker-compose.yml` — canonical names (alias noted in README)
- `CHANGELOG.md` — left as historical record

## Coordinated with (three-PR cutover — land together)
This PR only renames the **build/push** side. The **deploy** side lives in companion PRs; merging #500 alone is safe but a fresh `make deploy` is refused until an image is published under the new names.

- **infra#123** (ECR repos + IAM) — ✅ **merged & applied**. The branded repos exist.
- **platform#92** — chart container `platform`→`runtime` (the `runtime.image.*` value paths deployments#68 sets).
- **deployments#68** — per-tenant deploy → branded ECR names + `runtime.*` paths; `check-images` gates on image existence (fails safe, no stale deploy).

**Cutover order:** merge platform#92 + #500 → CI publishes under new names (or cut a release) → merge deployments#68 → `make deploy` tenants.

## First release after merge
`nimblebrain-runtime` is a brand-new GHCR package → GitHub creates it **private**. Flip it to public once (RELEASING.md §5) or anonymous OSS pulls 404.