### PR TITLE
ci(release): install bundle UI deps before verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
         run: bun install
       - name: Install web dependencies
         run: cd web && bun install
+      - name: Install bundle dependencies
+        # verify:test-unit runs test:bundles, which `bun test`s inside each
+        # src/bundles/*/ui package — those need their own deps (dompurify, etc.).
+        # Mirrors ci.yml; without it test:bundles fails "Cannot find package".
+        run: bun run install:bundles
       - name: Verify (static)
         run: bun run verify:static
       - name: Verify (unit + web tests)


### PR DESCRIPTION
release.yml didn't install bundle UI deps, so test:bundles (in verify:test-unit) failed on dompurify and blocked the v0.5.0 release. Mirror ci.yml's install:bundles step.