### PR TITLE
metrics(llm): split nb_llm_tokens_total cache_write by TTL tier

### DIFF
--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -80,7 +80,7 @@ export const httpRequestDurationSeconds = new Histogram({
  * `cache_write`, `ttl` tiers the write by breakpoint stability: `1h` = the stable
  * prefix (system + tools), `5m` = the rolling history (see `model/cache-policy.ts`).
  * A high `cache_write{ttl="1h"}` rate is the smoking gun for a system-prompt prefix
- * rewritten every turn (see hq research/SPEC-skill-system.md §3.2). `ttl="none"` on
+ * rewritten every turn. `ttl="none"` on
  * non-write kinds. `sum`ing `kind="cache_write"` without grouping by `ttl` still
  * yields the total, so existing queries are unaffected.
  */

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -61,7 +61,8 @@ export const httpRequestDurationSeconds = new Histogram({
 // Domain metrics — LLM tokens, calls, tool execution, and tool promotion.
 //
 // All labels are bounded: `direction` (input/output), `kind` (fresh/cache_read/
-// cache_write/text), `source` (main + the forked fast-slot calls), `model`
+// cache_write/text), `ttl` (none/1h/5m — the cache-write TTL tier; `none` for
+// non-write kinds), `source` (main + the forked fast-slot calls), `model`
 // (the catalog set — bounded by deployment config today; if custom model ids
 // ever become user-settable, this label would need capping), `ok`
 // (true/false). No tool names or ids — those would be client-unbounded and
@@ -75,12 +76,18 @@ export const httpRequestDurationSeconds = new Histogram({
 /**
  * LLM tokens processed. `kind` splits input into fresh / cache_read / cache_write
  * (the cache-cost story: a large `cache_read` next to small `fresh` is the
- * cheap-re-read pattern; a spike in `cache_write` is a prefix re-write).
+ * cheap-re-read pattern; a spike in `cache_write` is a prefix re-write). For
+ * `cache_write`, `ttl` tiers the write by breakpoint stability: `1h` = the stable
+ * prefix (system + tools), `5m` = the rolling history (see `model/cache-policy.ts`).
+ * A high `cache_write{ttl="1h"}` rate is the smoking gun for a system-prompt prefix
+ * rewritten every turn (see hq research/SPEC-skill-system.md §3.2). `ttl="none"` on
+ * non-write kinds. `sum`ing `kind="cache_write"` without grouping by `ttl` still
+ * yields the total, so existing queries are unaffected.
  */
 export const llmTokensTotal = new Counter({
   name: "nb_llm_tokens_total",
-  help: "LLM tokens processed, by direction, cache kind, call source, and model.",
-  labelNames: ["direction", "kind", "source", "model"] as const,
+  help: "LLM tokens processed, by direction, cache kind, cache-write TTL tier, call source, and model.",
+  labelNames: ["direction", "kind", "ttl", "source", "model"] as const,
   registers: [metricsRegistry],
 });
 
@@ -287,6 +294,12 @@ interface UsageForMetrics {
   outputTokens: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+  /**
+   * 1-hour-TTL portion of `cacheWriteTokens` (the stable system+tools prefix).
+   * Absent = no split reported; treated as all-1h (mirrors `usage/cost.ts`) so
+   * 1h-tier thrash is never undercounted. The 5-minute remainder is derived.
+   */
+  cacheWrite1hTokens?: number;
 }
 
 /**
@@ -310,13 +323,33 @@ export function recordLlmUsage(
   const cacheRead = usage.cacheReadTokens ?? 0;
   const cacheWrite = usage.cacheWriteTokens ?? 0;
   const fresh = Math.max(usage.inputTokens - cacheRead - cacheWrite, 0);
+  // TTL split mirrors `usage/cost.ts`: an absent 1h figure means "no split
+  // reported", treated as all-1h (the conservative tier) so 1h thrash is never
+  // undercounted. The 5-minute remainder is derived.
+  const cacheWrite1h = Math.min(usage.cacheWrite1hTokens ?? cacheWrite, cacheWrite);
+  const cacheWrite5m = Math.max(cacheWrite - cacheWrite1h, 0);
 
   llmCallsTotal.inc({ source, model });
-  if (fresh > 0) llmTokensTotal.inc({ direction: "input", kind: "fresh", source, model }, fresh);
+  if (fresh > 0)
+    llmTokensTotal.inc({ direction: "input", kind: "fresh", ttl: "none", source, model }, fresh);
   if (cacheRead > 0)
-    llmTokensTotal.inc({ direction: "input", kind: "cache_read", source, model }, cacheRead);
-  if (cacheWrite > 0)
-    llmTokensTotal.inc({ direction: "input", kind: "cache_write", source, model }, cacheWrite);
+    llmTokensTotal.inc(
+      { direction: "input", kind: "cache_read", ttl: "none", source, model },
+      cacheRead,
+    );
+  if (cacheWrite1h > 0)
+    llmTokensTotal.inc(
+      { direction: "input", kind: "cache_write", ttl: "1h", source, model },
+      cacheWrite1h,
+    );
+  if (cacheWrite5m > 0)
+    llmTokensTotal.inc(
+      { direction: "input", kind: "cache_write", ttl: "5m", source, model },
+      cacheWrite5m,
+    );
   if (usage.outputTokens > 0)
-    llmTokensTotal.inc({ direction: "output", kind: "text", source, model }, usage.outputTokens);
+    llmTokensTotal.inc(
+      { direction: "output", kind: "text", ttl: "none", source, model },
+      usage.outputTokens,
+    );
 }

--- a/test/unit/metrics.test.ts
+++ b/test/unit/metrics.test.ts
@@ -39,10 +39,11 @@ async function readTotal(counter: Counter<any>): Promise<number> {
 describe("recordLlmUsage", () => {
   it("splits input into fresh/cache_read/cache_write and counts output + calls", async () => {
     const base = { source: "compaction", model: "tm-record" };
-    const fresh = { direction: "input", kind: "fresh", ...base };
-    const cr = { direction: "input", kind: "cache_read", ...base };
-    const cw = { direction: "input", kind: "cache_write", ...base };
-    const out = { direction: "output", kind: "text", ...base };
+    const fresh = { direction: "input", kind: "fresh", ttl: "none", ...base };
+    const cr = { direction: "input", kind: "cache_read", ttl: "none", ...base };
+    // 300 writes with no 1h split reported → all-1h (the conservative tier).
+    const cw = { direction: "input", kind: "cache_write", ttl: "1h", ...base };
+    const out = { direction: "output", kind: "text", ttl: "none", ...base };
 
     const before = {
       fresh: await read(llmTokensTotal, fresh),
@@ -65,6 +66,25 @@ describe("recordLlmUsage", () => {
     expect((await read(llmTokensTotal, cw)) - before.cw).toBe(300);
     expect((await read(llmTokensTotal, out)) - before.out).toBe(50);
     expect((await read(llmCallsTotal, base)) - before.calls).toBe(1);
+  });
+
+  it("tiers cache_write into 1h/5m when the engine reports the 1h portion", async () => {
+    const base = { source: "main", model: "tm-ttl" };
+    const cw1h = { direction: "input", kind: "cache_write", ttl: "1h", ...base };
+    const cw5m = { direction: "input", kind: "cache_write", ttl: "5m", ...base };
+    const before = { h: await read(llmTokensTotal, cw1h), m: await read(llmTokensTotal, cw5m) };
+
+    // 500 cache writes, 200 on the 1h (stable-prefix) tier → 300 are the 5m remainder.
+    recordLlmUsage("main", "tm-ttl", {
+      inputTokens: 500,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 500,
+      cacheWrite1hTokens: 200,
+    });
+
+    expect((await read(llmTokensTotal, cw1h)) - before.h).toBe(200);
+    expect((await read(llmTokensTotal, cw5m)) - before.m).toBe(300);
   });
 });
 


### PR DESCRIPTION
## What

Adds a `ttl` label to `nb_llm_tokens_total` and splits `cache_write` into `ttl="1h"` (the stable system+tools prefix) and `ttl="5m"` (the rolling history), sourced from the `cacheWrite1hTokens` the engine already derives from `cache_creation.ephemeral_1h_input_tokens` (`engine.ts`). Non-write kinds (`fresh`/`cache_read`/`text`) carry `ttl="none"`.

## Why

Instrumentation ahead of a prompt-cache fix. The main loop currently runs ~1:1 cache write:read, which means the 1h-cached **system prefix** is being rewritten roughly every turn (`model/cache-policy.ts` puts the whole system block under one 1h breakpoint, and volatile content shares it). The flattened `cache_write` couldn't say *which* tier was thrashing; splitting by TTL makes **`cache_write{ttl="1h"}`** the direct smoking-gun signal — 1h writes should be near-zero in steady state. It also enables a sharper per-tenant cache-thrash alert in our monitoring config, and gives a measured before/after for the upcoming composition fix.

## Backward compatibility

`sum(...kind="cache_write")` without grouping by `ttl` still yields the total, so existing queries/dashboards (and any recording rule on this metric) are unaffected. An absent 1h figure is treated as **all-1h** (mirrors `usage/cost.ts`), so forked fast-slot calls (~0 writes) and any non-reporting provider never undercount the 1h tier.

## Test

- New unit test: `cache_write` splits into 1h/5m when the engine reports the 1h portion; the existing test is pinned to the all-1h fallback.
- `bun run verify:static` ✓ · `bun run test:unit` ✓ (3732 pass). Integration/smoke run in CI.

## Follow-up (not here)

Volatility-tiered prompt composition (the actual fix). Full per-segment attribution (system-prefix vs history) beyond this TTL proxy lands with it.
