### PR TITLE
fix(ci): harden roll-staging-edge against the implicit-success() skip trap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,10 +165,18 @@ jobs:
   #   vars.STAGING_DEPLOY_REPO       — deploy-config repo name (same org)
   #   vars.EDGE_BUMP_APP_ID          — GitHub App id (Contents: write on that repo)
   #   secrets.EDGE_BUMP_APP_KEY      — that App's private key
+  #
+  # `if`: key off the build actually succeeding — which already implies push-to-main,
+  # since build-and-push's own `if` gates on that. The `!cancelled()` is load-bearing,
+  # not decoration: with no status function, GitHub adds an implicit success() over
+  # `needs`. build-and-push's needs are non-path-filtered verify jobs today, so they
+  # never skip and a bare `if` happens to work — but the day anyone path-filters them
+  # (so a job can SKIP on an unrelated change), that implicit gate would silently skip
+  # THIS job and freeze the edge roll with no error. Correct-either-way guard.
   roll-staging-edge:
     name: Roll staging edge channel
     needs: build-and-push
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ !cancelled() && needs.build-and-push.result == 'success' }}
     runs-on: ubuntu-latest
     # Authenticates with a minted App token, never GITHUB_TOKEN — needs no grants.
     permissions: {}


### PR DESCRIPTION
Proactive hardening flagged in review of a sibling fix (platform `roll-staging-fleet`), where this exact pattern silently froze the staging roll for days.

## The latent trap

`roll-staging-edge` uses a **bare `if`** (no status function):

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

A job whose `if` has no status function gets an **implicit `success()` gate** over its `needs`. That's safe **today** — `build-and-push`'s needs (`lint-and-check`/`test-unit`/`test-integration`/`smoke`) are not path-filtered, so they never skip, and the implicit gate is exactly the "all verify green" check we want.

But the day anyone **path-filters** those verify jobs (so a job can `SKIP` on an unrelated change), the implicit gate would silently **skip `roll-staging-edge`** — the staging edge channel stops rolling, with no error, until someone notices the edge tag isn't moving. That's the slow, invisible failure mode.

## The fix

Gate on the build result explicitly, with a status function to drop the implicit gate:

```yaml
if: ${{ !cancelled() && needs.build-and-push.result == 'success' }}
```

- `needs.build-and-push.result == 'success'` — the real condition. Already implies push-to-main (build-and-push's own `if` gates on that).
- `!cancelled()` — required to drop the implicit `success()` gate.

Correct **either way**, so it's cheap insurance, not a behavior change today.

## Deliberately not touched

`build-and-push`'s own bare `if` stays — its implicit `success()` over the verify jobs **is** the "all tests green before we publish" gate we want. Only the downstream roll job needed the explicit key.