### PR TITLE
prompt/cache: split system into frozen + per-workspace segments (P1 PR-2)

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -227,6 +227,12 @@ export class AgentEngine {
     systemPrompt: string,
     messages: LanguageModelV3Message[],
     tools: ToolSchema[],
+    // Optional frozen/workspace split of `systemPrompt` for the prompt cache.
+    // When provided (and the provider is Anthropic), the cache policy emits the
+    // two segments as separate cached system messages on the first iteration so
+    // the frozen identity stays warm across workspace switches. `systemPrompt`
+    // remains the source of truth for sizing and the fused (iteration 2+) path.
+    systemSegments?: { frozen: string; workspaceStable: string },
   ): Promise<EngineResult> {
     // Never mutate the caller's array
     const history = [...messages];
@@ -569,6 +575,10 @@ export class AgentEngine {
           const { prompt: cachedPrompt, tools: cachedTools } = applyCachePolicy({
             provider: callProvider,
             systemPrompt: callPrompt,
+            // The frozen/workspace split is byte-consistent with `systemPrompt`
+            // only when no transformPrompt hook rewrote it; otherwise fall back
+            // to the single (transformed) system message.
+            systemSegments: config.hooks?.transformPrompt ? undefined : systemSegments,
             messages: msgs,
             tools: modelTools,
           });

--- a/src/model/cache-policy.ts
+++ b/src/model/cache-policy.ts
@@ -44,7 +44,12 @@ import type {
  *               across most turns, but not frozen: tripped/promoted tools can
  *               change the set mid-run, which busts this breakpoint (a cache
  *               miss on tools + everything after — degraded, never incorrect).
- *   2. system  — the system prompt
+ *   2. system  — the system prompt. On the first iteration of a run (no anchor
+ *               yet) this splits into TWO breakpoints — frozen identity +
+ *               workspace-stable — so a workspace switch / connector install
+ *               rewrites only the latter, not frozen identity. From iteration 2
+ *               it fuses back to one so the step-anchor (3) keeps its slot. See
+ *               `anthropicStrategy`.
  *   3. anchor  — last message of the previous step (= prior request's tail)
  *   4. tail    — the current last message (cached for the NEXT turn to read)
  */
@@ -78,6 +83,16 @@ export interface CachePolicyInput {
   provider: string;
   /** System prompt text (sent as the prompt's leading system message). */
   systemPrompt: string;
+  /**
+   * Optional split of `systemPrompt` into the frozen (identity/core) and
+   * workspace-stable (scoped skills/overlays/apps) cache segments. When present,
+   * the Anthropic strategy emits them as two consecutive cached system messages
+   * on the first iteration of a run (so the frozen segment stays warm across
+   * workspace switches), and fuses them back to `systemPrompt` once the rolling
+   * step-anchor exists. Absent for non-Anthropic providers, transformed prompts,
+   * and plain callers — those use the single `systemPrompt` system message.
+   */
+  systemSegments?: { frozen: string; workspaceStable: string };
   /** Conversation messages (post windowing/replay transforms). */
   messages: LanguageModelV3Message[];
   /** The model's tool definitions for this call. */
@@ -150,21 +165,38 @@ const passthroughStrategy: CacheStrategy = ({ systemPrompt, messages, tools }) =
 });
 
 /**
- * Anthropic strategy: place up to four explicit `cache_control` breakpoints,
- * TTL-tiered by stability — tools (1, 1h) + system (2, 1h) on the stable
- * prefix; rolling step-anchor (3, 5m) + tail (4, 5m) on the churning history.
- * See the module header for the TTL rationale and why the step-anchor is the
- * load-bearing breakpoint.
+ * Anthropic strategy: up to four explicit `cache_control` breakpoints, TTL-tiered
+ * by stability. The system block has two modes (see the module header):
+ *
+ *  - **Split** (first iteration of a run — no step-anchor yet) when
+ *    `systemSegments` is provided: frozen (identity/core, 1h) + workspace-stable
+ *    (scoped skills/overlays/apps, 1h) go as TWO consecutive leading system
+ *    messages, so a workspace switch / connector install rewrites only the
+ *    workspace segment, not frozen identity. Budget: tools + frozen + workspace +
+ *    tail = 4.
+ *  - **Fused** (iterations 2..N where the anchor exists, or no `systemSegments`):
+ *    one system message (1h) so the rolling step-anchor (5m) keeps its slot.
+ *    Budget: tools + system + anchor + tail = 4.
+ *
+ * Never exceeds Anthropic's hard max of 4 breakpoints (a 5th is silently dropped).
  */
-const anthropicStrategy: CacheStrategy = ({ systemPrompt, messages, tools }) => {
-  // (2) system breakpoint — stable, 1-hour.
-  const cachedSystem = withCacheControl(systemMessageOf(systemPrompt), CACHE_CONTROL_1H);
+const anthropicStrategy: CacheStrategy = ({ systemPrompt, systemSegments, messages, tools }) => {
+  const tailIdx = messages.length - 1;
+  const anchorIdx = stepAnchorIndex(messages);
+
+  // System message(s) — 1-hour. Split into frozen + workspace only on the first
+  // iteration (no anchor), where the breakpoint budget allows it; fuse otherwise
+  // so the load-bearing step-anchor keeps its slot. Empty segments are dropped.
+  const cachedSystem: LanguageModelV3Message[] =
+    systemSegments && anchorIdx < 0
+      ? [systemSegments.frozen, systemSegments.workspaceStable]
+          .filter((s) => s.length > 0)
+          .map((s) => withCacheControl(systemMessageOf(s), CACHE_CONTROL_1H))
+      : [withCacheControl(systemMessageOf(systemPrompt), CACHE_CONTROL_1H)];
 
   // (3) rolling step-anchor + (4) tail — churning, 5-minute. The two indices
   // can coincide when the history is a single message; dedupe so we never
-  // double-annotate.
-  const tailIdx = messages.length - 1;
-  const anchorIdx = stepAnchorIndex(messages);
+  // double-annotate. In split mode there is no anchor, so only the tail.
   const breakpointIdxs = new Set<number>();
   if (tailIdx >= 0) breakpointIdxs.add(tailIdx);
   if (anchorIdx >= 0 && anchorIdx !== tailIdx) breakpointIdxs.add(anchorIdx);
@@ -186,7 +218,7 @@ const anthropicStrategy: CacheStrategy = ({ systemPrompt, messages, tools }) => 
             : t,
         );
 
-  return { prompt: [cachedSystem, ...cachedMessages], tools: cachedTools };
+  return { prompt: [...cachedSystem, ...cachedMessages], tools: cachedTools };
 };
 
 /**

--- a/src/prompt/compose.ts
+++ b/src/prompt/compose.ts
@@ -21,12 +21,14 @@ const SEPARATOR = "\n\n---\n\n";
 export interface TracedLayer {
   kind: TracedLayerKind;
   /**
-   * Volatility tier. `volatile` layers (current date, app/focused-app state,
-   * matched skill) change per turn and are evicted from the cached system
-   * prefix onto the latest user message; `stable` layers form the cached
-   * system prefix. See `composeSystemSegments`.
+   * Cache tier. `volatile` layers (current date, app/focused-app state, matched
+   * skill) change per turn and ride the latest user message. `frozen` layers
+   * (identity, core skills) are stable per process/model; `workspace` layers
+   * (scoped skills, overlays, apps) change on workspace switch / connector
+   * install. Frozen + workspace form the cached system prefix, split into two
+   * segments by `composeSystemSegments`.
    */
-  segment: "stable" | "volatile";
+  segment: "frozen" | "workspace" | "volatile";
   /**
    * Stable identifier. Filesystem path for file-backed layers; `nb:<slug>`
    * for runtime-derived layers; `instructions://<scope>` for overlays.
@@ -96,10 +98,19 @@ export interface ComposedPrompt {
  * message so a per-turn change no longer rewrites the cached system prefix.
  * `volatileHead` is "" when there is no volatile content.
  *
- * `layers` and `totalTokens` mirror `ComposedPrompt` (the full set, both tiers).
+ * `stableSystem` (= `frozen` + `workspaceStable`) is kept for sizing/back-compat;
+ * cache-policy splits the two segments into separate cached system messages on
+ * the first iteration of a run, then fuses them thereafter.
+ *
+ * `layers` and `totalTokens` mirror `ComposedPrompt` (the full set, all tiers).
  */
 export interface ComposedSegments {
+  /** Frozen + workspace, joined — the full cached system prefix (sizing/back-compat). */
   stableSystem: string;
+  /** Frozen segment (identity, core skills) — stable per process/model. */
+  frozen: string;
+  /** Workspace segment (scoped skills, overlays, apps) — stable per workspace. */
+  workspaceStable: string;
   volatileHead: string;
   layers: TracedLayer[];
   totalTokens: number;
@@ -111,6 +122,15 @@ const VOLATILE_KINDS: ReadonlySet<TracedLayerKind> = new Set([
   "app_state",
   "focused_app",
   "matched_skill",
+]);
+
+/** Layer kinds stable per process/model — the frozen cache segment (A). The
+ * remaining stable kinds (scoped skills, overlays, apps) are the workspace
+ * segment (B), which changes on workspace switch / connector install. */
+const FROZEN_KINDS: ReadonlySet<TracedLayerKind> = new Set([
+  "task_identity",
+  "default_identity",
+  "core_skill",
 ]);
 
 /**
@@ -549,11 +569,15 @@ export function composeSystemPromptTraced(
     });
   }
 
-  // Stamp the volatility tier from the layer kind (single source of truth for
-  // the stable/volatile classification — see `composeSystemSegments`).
+  // Stamp the cache tier from the layer kind (single source of truth for the
+  // frozen/workspace/volatile classification — see `composeSystemSegments`).
   const tagged: TracedLayer[] = layers.map((l) => ({
     ...l,
-    segment: VOLATILE_KINDS.has(l.kind) ? "volatile" : "stable",
+    segment: VOLATILE_KINDS.has(l.kind)
+      ? "volatile"
+      : FROZEN_KINDS.has(l.kind)
+        ? "frozen"
+        : "workspace",
   }));
   const text = tagged.map((l) => l.text).join(SEPARATOR);
   const totalTokens = tagged.reduce((sum, l) => sum + l.tokens, 0);
@@ -595,10 +619,19 @@ export function composeSystemSegments(
     layer3Skills,
     mode,
   );
-  const stableSystem = composed.layers
-    .filter((l) => l.segment === "stable")
+  const frozen = composed.layers
+    .filter((l) => l.segment === "frozen")
     .map((l) => l.text)
     .join(SEPARATOR);
+  const workspaceStable = composed.layers
+    .filter((l) => l.segment === "workspace")
+    .map((l) => l.text)
+    .join(SEPARATOR);
+  // The full cached prefix, kept for sizing/back-compat. Byte-identical to
+  // joining all non-volatile layers in order, since frozen layers always
+  // precede workspace layers. cache-policy splits frozen|workspace into two
+  // cached system messages on the first iteration; fuses to this string after.
+  const stableSystem = [frozen, workspaceStable].filter((s) => s.length > 0).join(SEPARATOR);
   const volatileBody = composed.layers
     .filter((l) => l.segment === "volatile")
     .map((l) => l.text)
@@ -612,6 +645,8 @@ export function composeSystemSegments(
       : "";
   return {
     stableSystem,
+    frozen,
+    workspaceStable,
     volatileHead,
     layers: composed.layers,
     totalTokens: composed.totalTokens,

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1543,7 +1543,7 @@ export class Runtime {
       reason: s.reason,
     }));
 
-    const { stableSystem, volatileHead } = composeSystemSegments(
+    const { stableSystem, frozen, workspaceStable, volatileHead } = composeSystemSegments(
       requestContextSkills,
       skill,
       apps,
@@ -1804,7 +1804,17 @@ export class Runtime {
     // identity is in scope; the llm.call and tool.dispatch spans nest under it.
     const result = await runWithRequestContext(reqCtx, () =>
       withSpan("agent.turn", { "llm.model": model, ...requestIdentityAttrs() }, () =>
-        engine.run(engineConfig, engineSystem, messages, tools),
+        // Pass the frozen/workspace split for the prompt cache, but only when the
+        // volatile head was prepended to a user message (engineSystem === stableSystem).
+        // If it was folded back into engineSystem (no user message), the split would
+        // drop it, so fall back to the single system string.
+        engine.run(
+          engineConfig,
+          engineSystem,
+          messages,
+          tools,
+          engineSystem === stableSystem ? { frozen, workspaceStable } : undefined,
+        ),
       ),
     );
 
@@ -2078,7 +2088,7 @@ export class Runtime {
     }));
 
     // Compose with mode: "task" — prepends TASK_IDENTITY before core skills.
-    const { stableSystem, volatileHead } = composeSystemSegments(
+    const { stableSystem, frozen, workspaceStable, volatileHead } = composeSystemSegments(
       requestContextSkills,
       null, // no matched skill (task mode doesn't match on prompt)
       apps,
@@ -2290,7 +2300,17 @@ export class Runtime {
     let result: EngineResult;
     try {
       result = await runWithRequestContext(reqCtx, () =>
-        engine.run(engineConfig, engineSystem, messages, tools),
+        // Pass the frozen/workspace split for the prompt cache, but only when the
+        // volatile head was prepended to a user message (engineSystem === stableSystem).
+        // If it was folded back into engineSystem (no user message), the split would
+        // drop it, so fall back to the single system string.
+        engine.run(
+          engineConfig,
+          engineSystem,
+          messages,
+          tools,
+          engineSystem === stableSystem ? { frozen, workspaceStable } : undefined,
+        ),
       );
     } catch (err) {
       // Non-abort errors are genuine failures — rethrow so the caller

--- a/src/tools/platform/compose.ts
+++ b/src/tools/platform/compose.ts
@@ -373,7 +373,7 @@ async function composeHistorical(
 
     layers.push({
       kind: "layer3_skills",
-      segment: "stable",
+      segment: "workspace",
       id: "nb:layer3-skills",
       source: `layer 3 skills as of run ${runId}`,
       text: bodyRows.join("\n"),

--- a/test/helpers/mock-model.ts
+++ b/test/helpers/mock-model.ts
@@ -50,6 +50,22 @@ export function runtimeContextHead(prompt: LanguageModelV3CallOptions["prompt"])
 }
 
 /**
+ * Capture the full system text the model received: all system messages joined
+ * (the cache policy may split the cached system into a frozen + workspace pair on
+ * the first iteration of a run, under the Anthropic provider), plus the
+ * `<runtime-context>` head the runtime prepends to the latest user message
+ * (volatile tier). Tests asserting on "what the model sees" should use this
+ * rather than reading a single system message.
+ */
+export function capturedSystemText(prompt: LanguageModelV3CallOptions["prompt"]): string {
+  const system = prompt
+    .filter((m) => m.role === "system")
+    .map((m) => (typeof m.content === "string" ? m.content : ""))
+    .join("\n\n");
+  return system + runtimeContextHead(prompt);
+}
+
+/**
  * Creates a LanguageModelV3 from a function that returns MockModelResponse.
  * This makes it easy to port old ModelPort-style mocks.
  *

--- a/test/integration/skill-lifecycle.test.ts
+++ b/test/integration/skill-lifecycle.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { Runtime } from "../../src/runtime/runtime.ts";
 import { runWithRequestContext } from "../../src/runtime/request-context.ts";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import { createMockModel, runtimeContextHead } from "../helpers/mock-model.ts";
+import { capturedSystemText, createMockModel } from "../helpers/mock-model.ts";
 import { extractText } from "../../src/engine/content-helpers.ts";
 import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
 
@@ -19,12 +19,10 @@ afterAll(() => {
 function createCapturingModel(): { model: LanguageModelV3; getSystem: () => string } {
 	let capturedSystem = "";
 	const model = createMockModel((options) => {
-		const systemMsg = options.prompt.find((m) => m.role === "system");
-		if (systemMsg && typeof systemMsg.content === "string") {
-			// Skip auto-title calls (they have a short, distinctive system prompt)
-			if (!systemMsg.content.includes("Generate a 3-6 word title")) {
-				capturedSystem = systemMsg.content + runtimeContextHead(options.prompt);
-			}
+		const sys = capturedSystemText(options.prompt);
+		// Skip auto-title calls (they have a short, distinctive system prompt)
+		if (!sys.includes("Generate a 3-6 word title")) {
+			capturedSystem = sys;
 		}
 		return {
 			content: [{ type: "text", text: "ok" }],

--- a/test/integration/skills-always-loading.test.ts
+++ b/test/integration/skills-always-loading.test.ts
@@ -33,7 +33,7 @@ import { extractText } from "../../src/engine/content-helpers.ts";
 import { DEV_IDENTITY } from "../../src/identity/providers/dev.ts";
 import { runWithRequestContext } from "../../src/runtime/request-context.ts";
 import { Runtime } from "../../src/runtime/runtime.ts";
-import { createMockModel } from "../helpers/mock-model.ts";
+import { capturedSystemText, createMockModel } from "../helpers/mock-model.ts";
 import { TEST_WORKSPACE_ID, provisionTestWorkspace } from "../helpers/test-workspace.ts";
 
 const DERIVED_SKILL_NAME = "user-orbital-protocol";
@@ -48,11 +48,9 @@ let getSystem: () => string;
 function createCapturingModel(): { model: LanguageModelV3; getSystem: () => string } {
   let captured = "";
   const model = createMockModel((options) => {
-    const systemMsg = options.prompt.find((m) => m.role === "system");
-    if (systemMsg && typeof systemMsg.content === "string") {
-      if (!systemMsg.content.includes("Generate a 3-6 word title")) {
-        captured = systemMsg.content;
-      }
+    const sys = capturedSystemText(options.prompt);
+    if (!sys.includes("Generate a 3-6 word title")) {
+      captured = sys;
     }
     return { content: [{ type: "text", text: "ok" }], inputTokens: 10, outputTokens: 5 };
   });

--- a/test/unit/cache-policy.test.ts
+++ b/test/unit/cache-policy.test.ts
@@ -295,3 +295,90 @@ describe("applyCachePolicy — edge cases", () => {
     expect(hasCache(prompt[0])).toBe(true);
   });
 });
+
+describe("applyCachePolicy — frozen/workspace system split (PR-2)", () => {
+  const SEGMENTS = { frozen: "FROZEN identity", workspaceStable: "WORKSPACE skills" };
+  const FUSED = "FROZEN identity\n\n---\n\nWORKSPACE skills";
+  const sysContent = (m: LanguageModelV3Message | undefined): string =>
+    (m as { content: string } | undefined)?.content ?? "";
+
+  test("first iteration (no anchor): two consecutive leading 1h system messages", () => {
+    const { prompt } = applyCachePolicy({
+      provider: "anthropic",
+      systemPrompt: FUSED,
+      systemSegments: SEGMENTS,
+      messages: [userMsg("go")],
+      tools: TOOLS,
+    });
+    // first AND consecutive — required to avoid the mid-conversation-system beta.
+    expect(prompt[0]!.role).toBe("system");
+    expect(prompt[1]!.role).toBe("system");
+    expect(sysContent(prompt[0])).toBe(SEGMENTS.frozen);
+    expect(sysContent(prompt[1])).toBe(SEGMENTS.workspaceStable);
+    expect(ttlOf(prompt[0])).toBe("1h");
+    expect(ttlOf(prompt[1])).toBe("1h");
+  });
+
+  test("split mode uses exactly 4 breakpoints (tools + frozen + workspace + tail)", () => {
+    const { prompt, tools } = applyCachePolicy({
+      provider: "anthropic",
+      systemPrompt: FUSED,
+      systemSegments: SEGMENTS,
+      messages: [userMsg("go")],
+      tools: TOOLS,
+    });
+    const total = breakpointIdxs(prompt).length + tools.filter((t) => hasCache(t)).length;
+    expect(total).toBe(4);
+  });
+
+  test("once the step-anchor exists (iteration 2+), fuses to ONE system message", () => {
+    const history = [userMsg("go")];
+    appendStep(history, 0, 3); // an assistant step → step-anchor exists
+    const { prompt, tools } = applyCachePolicy({
+      provider: "anthropic",
+      systemPrompt: FUSED,
+      systemSegments: SEGMENTS,
+      messages: history,
+      tools: TOOLS,
+    });
+    const systemMsgs = prompt.filter((m) => m.role === "system");
+    expect(systemMsgs).toHaveLength(1);
+    expect(sysContent(systemMsgs[0])).toBe(FUSED);
+    const total = breakpointIdxs(prompt).length + tools.filter((t) => hasCache(t)).length;
+    expect(total).toBeLessThanOrEqual(4); // tools + system + anchor + tail
+  });
+
+  test("empty workspace segment collapses to one system message", () => {
+    const { prompt } = applyCachePolicy({
+      provider: "anthropic",
+      systemPrompt: "FROZEN identity",
+      systemSegments: { frozen: "FROZEN identity", workspaceStable: "" },
+      messages: [userMsg("go")],
+      tools: TOOLS,
+    });
+    expect(prompt.filter((m) => m.role === "system")).toHaveLength(1);
+    expect(sysContent(prompt[0])).toBe("FROZEN identity");
+  });
+
+  test("no systemSegments → unchanged single fused system message", () => {
+    const { prompt } = applyCachePolicy({
+      provider: "anthropic",
+      systemPrompt: "sys",
+      messages: [userMsg("go")],
+      tools: TOOLS,
+    });
+    expect(prompt.filter((m) => m.role === "system")).toHaveLength(1);
+  });
+
+  test("passthrough (non-Anthropic) ignores systemSegments", () => {
+    const { prompt } = applyCachePolicy({
+      provider: "openai",
+      systemPrompt: FUSED,
+      systemSegments: SEGMENTS,
+      messages: [userMsg("go")],
+      tools: TOOLS,
+    });
+    expect(prompt.filter((m) => m.role === "system")).toHaveLength(1);
+    expect(breakpointIdxs(prompt)).toEqual([]);
+  });
+});

--- a/test/unit/compose-segments.test.ts
+++ b/test/unit/compose-segments.test.ts
@@ -61,22 +61,42 @@ function full() {
 }
 
 describe("composeSystemSegments", () => {
-  it("routes each layer to the correct volatility tier", () => {
+  it("routes each layer to the correct cache tier (frozen/workspace/volatile)", () => {
     const { layers } = full();
     const seg = (kind: string) => layers.find((l) => l.kind === kind)?.segment;
-    // Stable prefix — cached.
-    expect(seg("core_skill")).toBe("stable");
-    expect(seg("user_context_skill")).toBe("stable");
-    expect(seg("user_prefs")).toBe("stable");
-    expect(seg("workspace_context")).toBe("stable");
-    expect(seg("workspace_overlay")).toBe("stable");
-    expect(seg("layer3_skills")).toBe("stable");
-    expect(seg("apps")).toBe("stable");
+    // Frozen — stable per process/model.
+    expect(seg("core_skill")).toBe("frozen");
+    // Workspace — stable per workspace (scoped skills, identity prefs, overlays, apps).
+    expect(seg("user_context_skill")).toBe("workspace");
+    expect(seg("user_prefs")).toBe("workspace");
+    expect(seg("workspace_context")).toBe("workspace");
+    expect(seg("workspace_overlay")).toBe("workspace");
+    expect(seg("layer3_skills")).toBe("workspace");
+    expect(seg("apps")).toBe("workspace");
     // Volatile head — evicted onto the latest user message.
     expect(seg("current_date")).toBe("volatile");
     expect(seg("app_state")).toBe("volatile");
     expect(seg("focused_app")).toBe("volatile");
     expect(seg("matched_skill")).toBe("volatile");
+  });
+
+  it("splits the cached prefix into frozen (identity/core) + workspaceStable (skills/overlays/apps)", () => {
+    const { frozen, workspaceStable, stableSystem } = full();
+    // Frozen = identity + core skills only.
+    expect(frozen).toContain("I am Nira.");
+    expect(frozen).not.toContain("## Installed Apps");
+    expect(frozen).not.toContain("## User");
+    expect(frozen).not.toContain("L3 body.");
+    // Workspace = scoped skills / identity prefs / overlays / apps.
+    expect(workspaceStable).toContain("## Installed Apps");
+    expect(workspaceStable).toContain("## User");
+    expect(workspaceStable).toContain("L3 body.");
+    expect(workspaceStable).not.toContain("I am Nira.");
+    // stableSystem is the byte-identical fusion (frozen + SEPARATOR + workspaceStable).
+    expect(stableSystem).toBe(`${frozen}\n\n---\n\n${workspaceStable}`);
+    // No volatile content leaked into either cached segment.
+    expect(frozen).not.toContain("<runtime-context>");
+    expect(workspaceStable).not.toContain("## Current Date");
   });
 
   it("stableSystem holds only stable layers (no volatile content, identity before apps)", () => {
@@ -116,7 +136,7 @@ describe("composeSystemSegments", () => {
   it("is non-lossy: every layer's text lands in its own segment", () => {
     const segs = full();
     for (const layer of segs.layers) {
-      const where = layer.segment === "stable" ? segs.stableSystem : segs.volatileHead;
+      const where = layer.segment === "volatile" ? segs.volatileHead : segs.stableSystem;
       expect(where).toContain(layer.text);
     }
     expect(segs.stableSystem.length).toBeGreaterThan(0);

--- a/test/unit/prompt.test.ts
+++ b/test/unit/prompt.test.ts
@@ -932,7 +932,7 @@ describe("composeSystemPromptTraced", () => {
     expect(traced.layers.length).toBeGreaterThan(0);
     for (const layer of traced.layers) {
       expect(knownKinds.has(layer.kind)).toBe(true);
-      expect(["stable", "volatile"]).toContain(layer.segment);
+      expect(["frozen", "workspace", "volatile"]).toContain(layer.segment);
       expect(layer.id.length).toBeGreaterThan(0);
       expect(layer.source.length).toBeGreaterThan(0);
       expect(layer.text.length).toBeGreaterThan(0);


### PR DESCRIPTION
## What

Splits the cached stable system prompt into two segments:
- **Frozen** — identity + core skills (stable per process/model).
- **Per-workspace** — scoped skills, overlays, apps (stable per workspace).

Under the Anthropic provider, on the **first iteration** of a run the cache policy emits them as **two consecutive cached system messages**, so switching workspace or installing a connector rewrites only the workspace segment — frozen identity stays warm. From **iteration 2** (once the rolling step-anchor exists) it **fuses** them back into one system message so the step-anchor keeps its breakpoint.

## Breakpoint budget (Anthropic max = 4)

- Split (iteration 1, no anchor): tools + frozen + workspace + tail = 4.
- Fused (iteration 2+): tools + system + anchor + tail = 4.

A 5th `cache_control` is silently dropped by the SDK, so a unit test asserts ≤4 in both modes, and that the two system messages are first + consecutive (avoids the `mid-conversation-system` beta).

## Unchanged

PR-1's volatile-head move (date / app-state / focused-app / matched-skill → `<runtime-context>` head on the latest user message) is untouched. `composeSystemSegments` now also returns `{frozen, workspaceStable}`; `stableSystem` stays the byte-identical fusion for sizing/back-compat. Non-Anthropic providers, transformed prompts, and plain callers keep the single-system-message path.

## Test surface

Under the Anthropic provider the prompt now has two system messages on iteration 1. Capturing-model test helpers that read a single system message would miss workspace-tier content, so they join all system messages via a shared `capturedSystemText` helper.

## Verification

All four gates green: `verify:static`, `test:unit` (3745), `test:integration` (601), `smoke` (23).

## Follow-up

PR-3: deterministic `layer3_skills` ordering + per-segment cache attribution.
