### PR TITLE
feat(connectors): API-key Composio connectors (PostHog, etc.)

### DIFF
--- a/src/composio/sdk.ts
+++ b/src/composio/sdk.ts
@@ -34,7 +34,7 @@
  *     short-circuits when `COMPOSIO_API_KEY` is unset.
  */
 
-import { Composio } from "@composio/core";
+import { AuthScheme, Composio } from "@composio/core";
 import { log } from "../cli/log.ts";
 import { getBouncerMode } from "../oauth/bouncer-config.ts";
 import { publicOrigin } from "../oauth/public-origin.ts";
@@ -51,6 +51,16 @@ export const COMPOSIO_CALLBACK_PATH = "/api/v3.1/toolkits/auth/callback";
 
 /** Max time a single Composio SDK call may run before we abort. */
 const COMPOSIO_TIMEOUT_MS = 10_000;
+
+/**
+ * Verification budget for an API-key connect. `waitForConnection` polls the
+ * freshly-created connected account until it reaches ACTIVE (or throws on a
+ * terminal FAILED/EXPIRED). Non-redirect schemes normally resolve on the
+ * first poll, so a few seconds is ample. Kept below `COMPOSIO_TIMEOUT_MS` (the
+ * outer per-call backstop) so the SDK's own typed timeout/failure error
+ * surfaces first instead of our generic abort.
+ */
+const COMPOSIO_APIKEY_VERIFY_MS = 8_000;
 
 // ── Config validation ────────────────────────────────────────────────
 
@@ -262,6 +272,72 @@ export async function initiateComposioConnection(opts: {
     throw new Error("Composio initiate: missing connected_account_id on connection request");
   }
   return { redirectUrl, connectedAccountId };
+}
+
+/**
+ * Connect a Composio toolkit that authenticates by API key (or another
+ * non-redirect scheme) for `userId`. Unlike {@link initiateComposioConnection}
+ * there is no browser redirect: the user's key — plus any toolkit-specific
+ * fields like PostHog's `subdomain` — is handed to Composio, which custodies
+ * it. The platform persists only the opaque `connectedAccountId`, exactly the
+ * trust posture of the OAuth path's `connection.json` (we never hold the key).
+ *
+ * `initiate` is the correct AND non-deprecated call here: the 2026-07-03 sunset
+ * that pushes Composio-managed OAuth to `link()` explicitly excludes non-OAuth
+ * schemes (API key / bearer / basic). For an API-key auth config Composio
+ * returns a connected account with no `redirectUrl`; `waitForConnection` then
+ * polls it to ACTIVE (or throws on a terminal FAILED/EXPIRED) — that poll is
+ * our verification that the credential is usable. (Composio marks some API-key
+ * accounts ACTIVE without a live upstream check, so a bad key may still only
+ * surface on first tool call; `ConnectionRevalidator` catches that later.)
+ *
+ * On verification failure the half-created connected account is deleted
+ * best-effort so a retry starts clean and the dangling record doesn't trip
+ * Composio's `allowMultiple` guard. `fields` values live only for the duration
+ * of this call — they're never returned, logged, or persisted.
+ */
+export async function connectComposioApiKey(opts: {
+  apiKey: string;
+  userId: string;
+  authConfigId: string;
+  fields: Record<string, string>;
+}): Promise<{ connectedAccountId: string; status: string }> {
+  const composio = composioClient(opts.apiKey);
+  // SDK types the `config` as a broad ConnectionData union; `AuthScheme.APIKey`
+  // builds the API_KEY-shaped member ({ authScheme, val: { status, ...fields } }).
+  const connRequest = (await withTimeout("connectedAccounts.initiate(apikey)", () =>
+    composio.connectedAccounts.initiate(opts.userId, opts.authConfigId, {
+      config: AuthScheme.APIKey(opts.fields),
+      allowMultiple: true,
+    }),
+  )) as unknown as {
+    id?: unknown;
+    waitForConnection: (timeoutMs?: number) => Promise<{ id?: unknown; status?: unknown }>;
+  };
+
+  const initiatedId = typeof connRequest.id === "string" ? connRequest.id : "";
+
+  try {
+    const account = await withTimeout("connectedAccounts.waitForConnection(apikey)", () =>
+      connRequest.waitForConnection(COMPOSIO_APIKEY_VERIFY_MS),
+    );
+    const id = typeof account.id === "string" && account.id.length > 0 ? account.id : initiatedId;
+    if (!id) {
+      throw new Error("Composio API-key connect: missing connected_account_id");
+    }
+    const status = typeof account.status === "string" ? account.status : "ACTIVE";
+    return { connectedAccountId: id, status };
+  } catch (err) {
+    // Verification failed (bad/insufficient key), timed out, or the account is
+    // stuck non-ACTIVE — drop the dangling record so the next attempt is clean.
+    if (initiatedId) {
+      await deleteComposioConnectedAccount({
+        apiKey: opts.apiKey,
+        connectedAccountId: initiatedId,
+      });
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/composio/sdk.ts
+++ b/src/composio/sdk.ts
@@ -335,7 +335,18 @@ export async function connectComposioApiKey(opts: {
     if (!id) {
       throw new Error("Composio API-key connect: missing connected_account_id");
     }
-    const status = typeof account.status === "string" ? account.status : "ACTIVE";
+    // `waitForConnection` resolves only at ACTIVE (it throws on
+    // FAILED/EXPIRED/timeout), but assert it explicitly so this helper's
+    // postcondition — and the caller's subsequent "running" flip — can't drift
+    // from the boot-state gate (which keys on status === "ACTIVE") if the SDK's
+    // resolve contract ever changes. A non-ACTIVE resolve falls into the catch
+    // below and deletes the half-created account.
+    const status = typeof account.status === "string" ? account.status : "";
+    if (status !== "ACTIVE") {
+      throw new Error(
+        `Composio API-key connect: account ${id} did not reach ACTIVE (status=${status || "unknown"})`,
+      );
+    }
     return { connectedAccountId: id, status };
   } catch (err) {
     // Verification failed (bad/insufficient key), timed out, or the account is

--- a/src/composio/sdk.ts
+++ b/src/composio/sdk.ts
@@ -312,10 +312,20 @@ export async function connectComposioApiKey(opts: {
     }),
   )) as unknown as {
     id?: unknown;
+    connectedAccountId?: unknown;
     waitForConnection: (timeoutMs?: number) => Promise<{ id?: unknown; status?: unknown }>;
   };
 
-  const initiatedId = typeof connRequest.id === "string" ? connRequest.id : "";
+  // `initiate` populates `.id`, but mirror the OAuth sibling's
+  // `id ?? connectedAccountId` fallback so the failure-cleanup delete below
+  // can't be silently skipped (leaking a dangling account) if a future SDK
+  // shape returns the id under `connectedAccountId` instead.
+  const initiatedId =
+    typeof connRequest.id === "string" && connRequest.id.length > 0
+      ? connRequest.id
+      : typeof connRequest.connectedAccountId === "string"
+        ? connRequest.connectedAccountId
+        : "";
 
   try {
     const account = await withTimeout("connectedAccounts.waitForConnection(apikey)", () =>

--- a/src/connectors/server-detail.ts
+++ b/src/connectors/server-detail.ts
@@ -96,6 +96,62 @@ export interface Package {
 }
 
 /**
+ * A single field collected from the connecting user for a non-redirect
+ * Composio auth scheme (API key, bearer token, basic auth) — the form the
+ * platform renders in place of the OAuth consent bounce.
+ *
+ * `key` is the **Composio connection-initiation field name** — the key that
+ * lands in the connected account's `val` when the platform calls
+ * `connectedAccounts.initiate`. It must match what Composio expects for the
+ * toolkit + scheme (verify via the SDK's `getConnectedAccountInitiationFields`
+ * or the toolkit's auth page on composio.dev). Example for PostHog: `api_key`
+ * + `subdomain`.
+ *
+ * This is NOT a NimbleBrain-side credential. The value is handed to Composio
+ * at connect time and never persisted by the platform — the same trust
+ * posture as the OAuth path, which keeps only the opaque `connectedAccountId`.
+ */
+export interface ComposioConnectField {
+  key: string;
+  title: string;
+  description?: string;
+  /** Hide the value in the UI and redact it from logs (passwords, API keys). */
+  sensitive?: boolean;
+  required?: boolean;
+  placeholder?: string;
+}
+
+/**
+ * Composio connector config. Single source of truth for the shape carried in
+ * the connector `_meta` and threaded verbatim through the install action and
+ * directory entry (previously duplicated inline across three files).
+ *
+ * - `toolkit`: Composio's slug for the upstream (`gmail`, `posthog`, …).
+ *   Passed as the `authConfigs` key to `composio.create(...)` at install and
+ *   used as the directory name for the per-workspace `connection.json`.
+ * - `authConfigEnv`: name of the env var holding Composio's `auth_config_id`
+ *   (e.g. `ac_…`). The catalog is OSS and shared across deployments; the
+ *   actual id varies per Composio account, hence the indirection.
+ * - `tools`: optional allowlist of Composio tool slugs to expose. Required in
+ *   practice for any toolkit with more than ~20 tools (the agent's tool-search
+ *   dumps every match's full description into context otherwise).
+ * - `authScheme`: how the user connects. Defaults to `OAUTH2` (the redirect
+ *   flow) when omitted — the historical behavior, so existing entries are
+ *   unchanged. `API_KEY` (and other non-redirect schemes) skip the OAuth
+ *   dance: the platform collects `fields` from the user, hands them to
+ *   Composio at connect time, and persists only the `connectedAccountId`.
+ * - `fields`: required for non-redirect `authScheme`s — what to collect from
+ *   the connecting user. Omitted/empty for `OAUTH2`.
+ */
+export interface ComposioConnectorConfig {
+  toolkit: string;
+  authConfigEnv: string;
+  tools?: string[];
+  authScheme?: "OAUTH2" | "API_KEY";
+  fields?: ComposioConnectField[];
+}
+
+/**
  * NimbleBrain-specific extension carried inside `ServerDetail._meta`
  * under the key `ai.nimblebrain/connector`. Holds the platform-specific
  * fields that don't fit upstream slots: OAuth flow type, operator-setup
@@ -128,35 +184,14 @@ export interface NimbleBrainConnectorMeta {
     clientSecretKey: string;
   };
   /**
-   * Required for `auth: "composio"`. Names the toolkit at Composio
-   * and the env var holding the operator-controlled auth-config id.
+   * Required for `auth: "composio"`. See {@link ComposioConnectorConfig}
+   * for the full shape (toolkit, authConfigEnv, tools, authScheme, fields).
    *
-   * - `toolkit`: Composio's slug for the upstream (`gmail`, `slack`,
-   *   `hubspot`, …). Passed as the `authConfigs` key when calling
-   *   `composio.create(userId, { authConfigs: { [toolkit]: ac_… } })`
-   *   at install time, and used as the directory name for the
-   *   per-workspace `connection.json`.
-   * - `authConfigEnv`: name of the env var holding Composio's
-   *   `auth_config_id` (e.g. `ac_…`). The catalog file is OSS and
-   *   shared across deployments; the actual id varies per Composio
-   *   account, hence the indirection.
-   *
-   * The MCP URL and headers are obtained from Composio's session API
-   * at install time — operators do not pre-create an MCP server
-   * config or specify a server id.
-   *
-   * `tools` is an optional allowlist of Composio tool slugs to expose
-   * on the MCP endpoint. Required in practice for any toolkit with
-   * more than ~20 tools: without it the agent's tool-discovery search
-   * dumps every matching tool's full description into the context
-   * (Outlook = 282 tools, ~225K tokens). Curate per connector to a
-   * working set. Omit / leave empty for small toolkits.
+   * The MCP URL and headers are obtained from Composio's session API at
+   * install time — operators do not pre-create an MCP server config or
+   * specify a server id.
    */
-  composio?: {
-    toolkit: string;
-    authConfigEnv: string;
-    tools?: string[];
-  };
+  composio?: ComposioConnectorConfig;
   /**
    * Required for `auth: "provider"`. Names the credential provider and its
    * opaque config — e.g. `{ provider: "minted", config: { audience, scope } }`.

--- a/src/registries/projection.ts
+++ b/src/registries/projection.ts
@@ -19,6 +19,7 @@
 import { hostMetaToUiMeta, sanitizePlacements } from "../bundles/defaults.ts";
 import type { BundleUiMeta } from "../bundles/types.ts";
 import {
+  type ComposioConnectorConfig,
   getNimbleBrainConnectorMeta,
   getNimbleBrainHostMeta,
   type NimbleBrainConnectorMeta,
@@ -59,7 +60,7 @@ function connectorMetaAuthFields(meta: NimbleBrainConnectorMeta | undefined): {
   requiredScopes?: string[];
   additionalAuthorizationParams?: Record<string, string>;
   operatorSetup?: { portalUrl: string; hint: string; clientSecretKey: string };
-  composio?: { toolkit: string; authConfigEnv: string; tools?: string[] };
+  composio?: ComposioConnectorConfig;
   providerAuth?: { provider: string; config: Record<string, unknown> };
 } {
   return {
@@ -164,7 +165,7 @@ export interface ConnectorCatalogEntry {
    * time and to look up the toolkit slug when persisting
    * `connection.json`. Absent on dcr/static entries.
    */
-  composio?: { toolkit: string; authConfigEnv: string; tools?: string[] };
+  composio?: ComposioConnectorConfig;
   /**
    * Required for `auth: "provider"` entries: the credential provider name + its
    * opaque config (e.g. `{ provider: "minted", config: { audience, scope } }`).

--- a/src/registries/types.ts
+++ b/src/registries/types.ts
@@ -33,7 +33,7 @@
  *     (advanced; bypasses curation).
  */
 
-import type { ServerDetail } from "../connectors/server-detail.ts";
+import type { ComposioConnectorConfig, ServerDetail } from "../connectors/server-detail.ts";
 
 /** Stable registry kind, used for source-type-driven dispatch. */
 export type RegistryType = "static" | "mpak" | "mcp" | "custom-url";
@@ -133,9 +133,9 @@ export interface RemoteOAuthInstall {
   /**
    * Required for `auth: "composio"`. Names the Composio toolkit and
    * the env var holding the auth-config id. See
-   * `NimbleBrainConnectorMeta.composio` for the canonical shape.
+   * {@link ComposioConnectorConfig} for the canonical shape.
    */
-  composio?: { toolkit: string; authConfigEnv: string; tools?: string[] };
+  composio?: ComposioConnectorConfig;
   /**
    * Required for `auth: "provider"`. Names the credential provider and its
    * opaque config (e.g. `{ provider: "minted", config: { audience, scope } }`).

--- a/src/tools/connector-tools.ts
+++ b/src/tools/connector-tools.ts
@@ -1,7 +1,11 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { mcpAuthCallbackUrl } from "../api/routes/mcp-auth.ts";
-import { type ComposioConnection, saveComposioConnection } from "../bundles/composio-connection.ts";
+import {
+  type ComposioConnection,
+  readComposioConnection,
+  saveComposioConnection,
+} from "../bundles/composio-connection.ts";
 import { WORKSPACE_PRINCIPAL_ID } from "../bundles/connection.ts";
 import { sanitizePlacements } from "../bundles/defaults.ts";
 import { getMpak } from "../bundles/mpak.ts";
@@ -10,7 +14,12 @@ import { startBundleSource } from "../bundles/startup.ts";
 import type { BundleManifest, BundleRef, RemoteTransportConfig } from "../bundles/types.ts";
 import { installBundleInWorkspace } from "../bundles/workspace-ops.ts";
 import { log } from "../cli/log.ts";
-import { composioUserId, connectComposioApiKey, createComposioSession } from "../composio/sdk.ts";
+import {
+  composioUserId,
+  connectComposioApiKey,
+  createComposioSession,
+  deleteComposioConnectedAccount,
+} from "../composio/sdk.ts";
 import type { UserConfigFieldDef } from "../config/workspace-credentials.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
@@ -990,6 +999,13 @@ async function handleConnectApiKey(
     );
   }
 
+  // Capture any prior connected account before minting a new one. We can't
+  // adopt-existing like the OAuth path — an API-key re-submit may carry a
+  // rotated key, so the old account must be REPLACED, not reused. The revoke
+  // happens only after the new connect succeeds and persists (below), so a
+  // failed rotation leaves the working account intact.
+  const prior = await readComposioConnection(workDir, wsId, catalogId);
+
   // Hand the key(s) to Composio and verify the connection reaches ACTIVE. On
   // failure the SDK helper deletes the half-created account; surface a generic
   // message and never echo the submitted values.
@@ -1014,6 +1030,24 @@ async function handleConnectApiKey(
   };
   await saveComposioConnection(workDir, wsId, catalogId, connection);
   lifecycle.recordConnectionStateChange(serverName, wsId, WORKSPACE_PRINCIPAL_ID, "running");
+
+  // Rotation cleanup: revoke the account we just replaced so a rotated-away key
+  // stops being authorized at Composio and orphans don't accumulate. Runs after
+  // the new account is persisted, so the old one is only dropped once its
+  // replacement is live. Best-effort — deleteComposioConnectedAccount never
+  // throws; on failure the prior key may linger at Composio until removed there.
+  if (prior?.connectedAccountId && prior.connectedAccountId !== connected.connectedAccountId) {
+    const revoked = await deleteComposioConnectedAccount({
+      apiKey,
+      connectedAccountId: prior.connectedAccountId,
+    });
+    if (!revoked) {
+      log.warn(
+        `[connect_api_key] could not revoke the replaced Composio account for ${catalogId} ` +
+          `in ${wsId}; the prior key may remain authorized until removed at Composio`,
+      );
+    }
+  }
 
   return {
     content: textContent(`Connected ${entry.name}.`),

--- a/src/tools/connector-tools.ts
+++ b/src/tools/connector-tools.ts
@@ -1013,9 +1013,18 @@ async function handleConnectApiKey(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.warn(`[connect_api_key] source registration failed for ${catalogId} in ${wsId}: ${msg}`);
+    // Two distinct causes share this branch: the connector isn't installed (no
+    // ref) vs. it IS installed but the MCP source transiently failed to start.
+    // Distinguish on whether a ref exists so the message points at the right
+    // fix (mirrors the OAuth adopt path's two messages).
+    const isInstalled =
+      Array.isArray(ws.bundles) && ws.bundles.some((b) => b.serverName === serverName);
     return errResult(
-      `Connector "${catalogId}" must be installed before connecting. ` +
-        "Install it, then submit the API key.",
+      isInstalled
+        ? `Connector "${catalogId}" is installed but its MCP source could not start. ` +
+            "Try Disconnect, then Connect again."
+        : `Connector "${catalogId}" must be installed before connecting. ` +
+            "Install it, then submit the API key.",
     );
   }
 

--- a/src/tools/connector-tools.ts
+++ b/src/tools/connector-tools.ts
@@ -983,6 +983,26 @@ async function handleConnectApiKey(
   const lifecycle = ctx.runtime.getLifecycle();
   const workDir = ctx.runtime.getWorkDir();
 
+  // Capture any prior connected account up front: it both gates the rotation
+  // case below and is the id we revoke after a successful replace. We can't
+  // adopt-existing like the OAuth path — an API-key re-submit may carry a
+  // rotated key, so the old account is REPLACED, not reused.
+  const prior = await readComposioConnection(workDir, wsId, catalogId);
+
+  // Authz: a FIRST connect (no prior) is member-level, matching the OAuth
+  // connect route. But a RE-CONNECT/rotation replaces and revokes the shared
+  // credential every member's agent runs under — destructive like `disconnect`,
+  // which is admin-gated. So gate only the rotation case on workspace admin.
+  if (prior?.connectedAccountId && !isWorkspaceAdmin(ws, identity)) {
+    return {
+      content: textContent(
+        "Workspace admin role required to replace an already-connected connector's credential.",
+      ),
+      structuredContent: { error: "permission_denied" },
+      isError: true,
+    };
+  }
+
   // Bring the MCP source online BEFORE persisting connection.json — the same
   // ordering invariant as the OAuth adopt path (a failure here leaves no
   // connection.json behind, so boot-state derivation stays honest). A connector
@@ -998,13 +1018,6 @@ async function handleConnectApiKey(
         "Install it, then submit the API key.",
     );
   }
-
-  // Capture any prior connected account before minting a new one. We can't
-  // adopt-existing like the OAuth path — an API-key re-submit may carry a
-  // rotated key, so the old account must be REPLACED, not reused. The revoke
-  // happens only after the new connect succeeds and persists (below), so a
-  // failed rotation leaves the working account intact.
-  const prior = await readComposioConnection(workDir, wsId, catalogId);
 
   // Hand the key(s) to Composio and verify the connection reaches ACTIVE. On
   // failure the SDK helper deletes the half-created account; surface a generic

--- a/src/tools/connector-tools.ts
+++ b/src/tools/connector-tools.ts
@@ -1,6 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { mcpAuthCallbackUrl } from "../api/routes/mcp-auth.ts";
+import { type ComposioConnection, saveComposioConnection } from "../bundles/composio-connection.ts";
+import { WORKSPACE_PRINCIPAL_ID } from "../bundles/connection.ts";
 import { sanitizePlacements } from "../bundles/defaults.ts";
 import { getMpak } from "../bundles/mpak.ts";
 import { deriveServerName, slugifyServerName } from "../bundles/paths.ts";
@@ -8,7 +10,7 @@ import { startBundleSource } from "../bundles/startup.ts";
 import type { BundleManifest, BundleRef, RemoteTransportConfig } from "../bundles/types.ts";
 import { installBundleInWorkspace } from "../bundles/workspace-ops.ts";
 import { log } from "../cli/log.ts";
-import { composioUserId, createComposioSession } from "../composio/sdk.ts";
+import { composioUserId, connectComposioApiKey, createComposioSession } from "../composio/sdk.ts";
 import type { UserConfigFieldDef } from "../config/workspace-credentials.ts";
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolResult } from "../engine/types.ts";
@@ -205,6 +207,7 @@ export function createManageConnectorsTool(ctx: ManageConnectorsContext): InProc
             "list_tools",
             "list_tools_with_permissions",
             "install",
+            "connect_api_key",
             "disconnect",
             "uninstall",
             "get_permissions",
@@ -219,7 +222,8 @@ export function createManageConnectorsTool(ctx: ManageConnectorsContext): InProc
         },
         catalogId: {
           type: "string",
-          description: "Catalog entry id (required for setup_operator, remove_operator_setup).",
+          description:
+            "Catalog entry id (required for setup_operator, remove_operator_setup, connect_api_key).",
         },
         entry: {
           type: "object",
@@ -259,7 +263,7 @@ export function createManageConnectorsTool(ctx: ManageConnectorsContext): InProc
         fields: {
           type: "object",
           description:
-            "For set_user_config: map of bundle user_config field name → string value. Empty string clears that field. Omitted fields are unchanged. Unknown field names are rejected (default-deny).",
+            "For set_user_config: map of bundle user_config field name → string value. Empty string clears that field. Omitted fields are unchanged. Unknown field names are rejected (default-deny). For connect_api_key: map of the connector's declared Composio field key → value (e.g. api_key, subdomain); handed to Composio and never persisted by the platform.",
           additionalProperties: { type: "string" },
         },
       },
@@ -311,6 +315,14 @@ export function createManageConnectorsTool(ctx: ManageConnectorsContext): InProc
             // what closes the "Bundle not installed" scope mismatch (an
             // install seeded under one workspace, then read under another).
             input.wsId === undefined ? (wsId ?? undefined) : String(input.wsId),
+          );
+        case "connect_api_key":
+          return handleConnectApiKey(
+            ctx,
+            wsId,
+            identity,
+            String(input.catalogId ?? ""),
+            (input.fields as Record<string, unknown>) ?? {},
           );
         case "disconnect":
           return handleDisconnect(
@@ -865,6 +877,149 @@ async function handleInstall(
     case "direct-url":
       return errResult("direct-url install is not yet supported.");
   }
+}
+
+/**
+ * `connect_api_key` — authenticate an already-installed Composio connector
+ * whose toolkit uses a non-redirect (API-key) auth scheme. The API-key sibling
+ * of the OAuth `/v1/composio-auth/initiate` route: there is no browser
+ * redirect, so it's a tool action, not a route (no state cookie, no callback —
+ * the two reasons that path stays a route). The web shell renders a form from
+ * the connector's declared `composio.fields` and submits the values here.
+ *
+ * Trust posture (mirrors the OAuth path):
+ *  - The connector, its field declarations, and its auth-config env all come
+ *    from the SERVER-trusted catalog (`catalogById`), never the caller. The
+ *    only caller input is the connectorId and the field *values*.
+ *  - Field values are handed to Composio and NEVER persisted by the platform —
+ *    `connection.json` keeps only the opaque `connectedAccountId`, exactly like
+ *    the OAuth path. We don't custody the user's key.
+ *  - Membership-gated: the workspace-scoped tool routing already authorized the
+ *    caller as a member of `wsId` (the same level as the OAuth connect route's
+ *    `requireWorkspace`). Install — which widens the workspace surface — is
+ *    admin-gated; completing auth on an installed connector is member-level.
+ */
+async function handleConnectApiKey(
+  ctx: ManageConnectorsContext,
+  wsId: string | null,
+  identity: UserIdentity | null,
+  catalogId: string,
+  rawFields: Record<string, unknown>,
+): Promise<ToolResult> {
+  if (!identity) return errResult("Authentication required.");
+  if (!wsId) return errResult("wsId is required for connect_api_key.");
+  if (!catalogId) return errResult("catalogId is required for connect_api_key.");
+
+  const ws = await ctx.runtime.getWorkspaceStore().get(wsId);
+  if (!ws) return errResult(`Workspace "${wsId}" not found.`);
+
+  const entry = await ctx.runtime.getConnectorDirectory().catalogById(catalogId);
+  if (!entry) return errResult(`Connector "${catalogId}" not in catalog.`);
+  if (entry.auth !== "composio" || !entry.composio) {
+    return errResult(`Connector "${catalogId}" is not Composio-backed (auth=${entry.auth}).`);
+  }
+  if (entry.composio.authScheme !== "API_KEY") {
+    return errResult(
+      `Connector "${catalogId}" does not use API-key auth (authScheme=${
+        entry.composio.authScheme ?? "OAUTH2"
+      }). Use the OAuth connect flow instead.`,
+    );
+  }
+
+  // Validate submitted values against the declared fields: every required field
+  // present and non-empty; unknown keys rejected (default-deny, same posture as
+  // set_user_config). Only declared keys are forwarded to Composio.
+  const declared = entry.composio.fields ?? [];
+  if (declared.length === 0) {
+    return errResult(`Connector "${catalogId}" declares no API-key fields to collect.`);
+  }
+  const declaredKeys = new Set(declared.map((f) => f.key));
+  for (const key of Object.keys(rawFields)) {
+    if (!declaredKeys.has(key)) {
+      return errResult(`Unknown field "${key}" for connector "${catalogId}".`);
+    }
+  }
+  const values: Record<string, string> = {};
+  for (const field of declared) {
+    const raw = rawFields[field.key];
+    const value = typeof raw === "string" ? raw.trim() : "";
+    if (!value) {
+      if (field.required !== false) {
+        return errResult(`Field "${field.key}" (${field.title}) is required.`);
+      }
+      continue;
+    }
+    values[field.key] = value;
+  }
+
+  // Operator config — same indirection as the OAuth path. Missing keys are a
+  // deploy-time error; surface a clear (non-secret) message.
+  const apiKey = process.env.COMPOSIO_API_KEY?.trim();
+  if (!apiKey) {
+    return errResult(
+      `"${entry.name}" requires COMPOSIO_API_KEY in the platform env. ` +
+        "Set the platform-wide Composio API key and restart the API.",
+    );
+  }
+  const authConfigId = process.env[entry.composio.authConfigEnv]?.trim();
+  if (!authConfigId) {
+    return errResult(
+      `"${entry.name}" requires ${entry.composio.authConfigEnv} in the platform env. ` +
+        "Create the API_KEY auth config in the Composio dashboard and set the env var.",
+    );
+  }
+
+  const serverName = slugifyServerName(catalogId);
+  const userId = composioUserId(wsId);
+  const lifecycle = ctx.runtime.getLifecycle();
+  const workDir = ctx.runtime.getWorkDir();
+
+  // Bring the MCP source online BEFORE persisting connection.json — the same
+  // ordering invariant as the OAuth adopt path (a failure here leaves no
+  // connection.json behind, so boot-state derivation stays honest). A connector
+  // that hasn't been installed has no ref yet, so this doubles as the
+  // "install first" guard.
+  try {
+    await lifecycle.ensureSourceRegistered(serverName, wsId, workDir);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`[connect_api_key] source registration failed for ${catalogId} in ${wsId}: ${msg}`);
+    return errResult(
+      `Connector "${catalogId}" must be installed before connecting. ` +
+        "Install it, then submit the API key.",
+    );
+  }
+
+  // Hand the key(s) to Composio and verify the connection reaches ACTIVE. On
+  // failure the SDK helper deletes the half-created account; surface a generic
+  // message and never echo the submitted values.
+  let connected: { connectedAccountId: string; status: string };
+  try {
+    connected = await connectComposioApiKey({ apiKey, userId, authConfigId, fields: values });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`[connect_api_key] Composio connect failed for ${catalogId} in ${wsId}: ${msg}`);
+    return errResult(
+      "Could not connect with the provided credentials. Check the key (and any " +
+        "region / subdomain) and try again.",
+    );
+  }
+
+  const connection: ComposioConnection = {
+    connectedAccountId: connected.connectedAccountId,
+    toolkit: entry.composio.toolkit,
+    userId,
+    connectedAt: new Date().toISOString(),
+    status: connected.status,
+  };
+  await saveComposioConnection(workDir, wsId, catalogId, connection);
+  lifecycle.recordConnectionStateChange(serverName, wsId, WORKSPACE_PRINCIPAL_ID, "running");
+
+  return {
+    content: textContent(`Connected ${entry.name}.`),
+    structuredContent: { connected: true, serverName, status: connected.status },
+    isError: false,
+  };
 }
 
 /**

--- a/test/unit/connector-tools-composio-apikey.test.ts
+++ b/test/unit/connector-tools-composio-apikey.test.ts
@@ -70,7 +70,10 @@ mock.module("@composio/core", () => ({
 }));
 
 import { NoopEventSink } from "../../src/adapters/noop-events.ts";
-import { readComposioConnection } from "../../src/bundles/composio-connection.ts";
+import {
+  readComposioConnection,
+  saveComposioConnection,
+} from "../../src/bundles/composio-connection.ts";
 import { BundleLifecycleManager } from "../../src/bundles/lifecycle.ts";
 import { slugifyServerName } from "../../src/bundles/paths.ts";
 import { _resetComposioConfigForTest, connectComposioApiKey } from "../../src/composio/sdk.ts";
@@ -544,5 +547,42 @@ describe("manage_connectors.connect_api_key — lifecycle tail", () => {
     expect(ctx.__calls.recordConnectionStateChange.callCount).toBe(0);
     // The SDK helper cleaned up the dangling connected account.
     expect(apiKeyCalls.deletedIds).toContain("ca_bad");
+  });
+
+  test("re-connect (key rotation) revokes the previously-connected account", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    process.env.COMPOSIO_POSTHOG_AUTH_CONFIG_ID = "ac_posthog";
+    _resetComposioConfigForTest();
+
+    // Pre-seed a prior, already-connected account.
+    await saveComposioConnection(workDir, WS, POSTHOG_ID, {
+      connectedAccountId: "ca_old",
+      toolkit: "posthog",
+      userId: "u",
+      connectedAt: "2026-01-01T00:00:00Z",
+      status: "ACTIVE",
+    });
+
+    // The rotated submit mints a fresh account.
+    apiKeyCalls.initiateImpl = () => ({
+      id: "ca_new",
+      waitForConnection: async () => ({ id: "ca_new", status: "ACTIVE" }),
+    });
+
+    const ctx = stubCtx({ workDir, wsId: WS, entry: POSTHOG_ENTRY });
+    const r = await createManageConnectorsTool(ctx).handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "phx_rotated", subdomain: "us" },
+    });
+
+    expect(r.isError).toBe(false);
+    // connection.json now points at the new account...
+    const conn = await readComposioConnection(workDir, WS, POSTHOG_ID);
+    expect(conn?.connectedAccountId).toBe("ca_new");
+    // ...and the replaced account was revoked at Composio (no orphan, old key
+    // de-authorized). The new account is NOT deleted.
+    expect(apiKeyCalls.deletedIds).toContain("ca_old");
+    expect(apiKeyCalls.deletedIds).not.toContain("ca_new");
   });
 });

--- a/test/unit/connector-tools-composio-apikey.test.ts
+++ b/test/unit/connector-tools-composio-apikey.test.ts
@@ -141,6 +141,14 @@ const ADMIN: UserIdentity = {
   preferences: {},
 };
 
+const MEMBER: UserIdentity = {
+  id: "usr_member",
+  email: "member@test",
+  displayName: "Member",
+  orgRole: "member",
+  preferences: {},
+};
+
 interface Harness {
   workDir: string;
   wsId: string;
@@ -286,6 +294,27 @@ describe("connectComposioApiKey", () => {
     // The half-created account is cleaned up so a retry starts clean.
     expect(apiKeyCalls.deletedIds).toContain("ca_bad");
   });
+
+  test("rejects (and cleans up) a non-ACTIVE resolve", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    _resetComposioConfigForTest();
+    // A defensive guard against an SDK contract change: waitForConnection
+    // resolving with a non-ACTIVE status must not be treated as success.
+    apiKeyCalls.initiateImpl = () => ({
+      id: "ca_pending",
+      waitForConnection: async () => ({ id: "ca_pending", status: "INITIATED" }),
+    });
+
+    await expect(
+      connectComposioApiKey({
+        apiKey: "k_test",
+        userId: "u1",
+        authConfigId: "ac_x",
+        fields: { api_key: "k" },
+      }),
+    ).rejects.toThrow(/did not reach ACTIVE/);
+    expect(apiKeyCalls.deletedIds).toContain("ca_pending");
+  });
 });
 
 // ── manage_connectors.connect_api_key (validation + trust) ──────────
@@ -393,7 +422,11 @@ function stubCtx(opts: {
   wsId: string;
   entry: unknown | null;
   ensureSourceRegisteredError?: Error;
+  identity?: UserIdentity;
+  role?: "admin" | "member";
 }): ManageConnectorsContext & { __calls: StubCalls } {
+  const identity = opts.identity ?? ADMIN;
+  const role = opts.role ?? "admin";
   const calls: StubCalls = { recordConnectionStateChange: { lastCall: null, callCount: 0 } };
   const lifecycle = {
     async ensureSourceRegistered(): Promise<void> {
@@ -415,7 +448,7 @@ function stubCtx(opts: {
       get: async () => ({
         id: opts.wsId,
         name: "Test",
-        members: [{ userId: ADMIN.id, role: "admin" }],
+        members: [{ userId: identity.id, role }],
       }),
     }),
     getConnectorDirectory: () => ({
@@ -426,7 +459,7 @@ function stubCtx(opts: {
   } as unknown as Runtime;
   return {
     runtime,
-    getIdentity: () => ADMIN,
+    getIdentity: () => identity,
     getWorkspaceId: () => opts.wsId,
     __calls: calls,
   } as unknown as ManageConnectorsContext & { __calls: StubCalls };
@@ -584,5 +617,37 @@ describe("manage_connectors.connect_api_key — lifecycle tail", () => {
     // de-authorized). The new account is NOT deleted.
     expect(apiKeyCalls.deletedIds).toContain("ca_old");
     expect(apiKeyCalls.deletedIds).not.toContain("ca_new");
+  });
+
+  test("rotation is admin-gated: a non-admin member can't replace the credential", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    process.env.COMPOSIO_POSTHOG_AUTH_CONFIG_ID = "ac_posthog";
+    _resetComposioConfigForTest();
+
+    // A connector is already connected...
+    await saveComposioConnection(workDir, WS, POSTHOG_ID, {
+      connectedAccountId: "ca_old",
+      toolkit: "posthog",
+      userId: "u",
+      connectedAt: "2026-01-01T00:00:00Z",
+      status: "ACTIVE",
+    });
+
+    // ...and a non-admin member tries to rotate it.
+    const ctx = stubCtx({ workDir, wsId: WS, entry: POSTHOG_ENTRY, identity: MEMBER, role: "member" });
+    const r = await createManageConnectorsTool(ctx).handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "phx_member", subdomain: "us" },
+    });
+
+    expect(r.isError).toBe(true);
+    expect((r.structuredContent as { error?: string })?.error).toBe("permission_denied");
+    // Nothing happened: no new connect, the old account survives, state unchanged.
+    expect(apiKeyCalls.initiateArgs.length).toBe(0);
+    expect(apiKeyCalls.deletedIds).not.toContain("ca_old");
+    const conn = await readComposioConnection(workDir, WS, POSTHOG_ID);
+    expect(conn?.connectedAccountId).toBe("ca_old");
+    expect(ctx.__calls.recordConnectionStateChange.callCount).toBe(0);
   });
 });

--- a/test/unit/connector-tools-composio-apikey.test.ts
+++ b/test/unit/connector-tools-composio-apikey.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Tests for the API-key Composio path:
+ *   - `connectComposioApiKey` in `src/composio/sdk.ts` (the SDK helper that
+ *     hands the user's key to Composio and verifies via `waitForConnection`)
+ *   - `manage_connectors.connect_api_key` validation + trust boundary in
+ *     `src/tools/connector-tools.ts`
+ *
+ * Kept separate from the OAuth install tests because this path needs the
+ * `@composio/core` mock to export `AuthScheme` and to return a connection
+ * request with `waitForConnection`.
+ *
+ * What's covered:
+ *   - connectComposioApiKey forwards `fields` via `AuthScheme.APIKey`, passes
+ *     allowMultiple, and returns the verified connectedAccountId + status
+ *   - verification failure deletes the dangling connected account and rethrows
+ *   - connect_api_key rejects unknown field keys (default-deny)
+ *   - connect_api_key rejects a missing required field
+ *   - connect_api_key rejects a non-API_KEY composio connector
+ *   - connect_api_key surfaces an operator-config error when COMPOSIO_API_KEY
+ *     is unset (i.e. field validation passed and we reached the env check)
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── @composio/core mock (hoisted) ───────────────────────────────────
+interface ApiKeyCalls {
+  initiateArgs: unknown[];
+  apiKeyParamsSeen: Record<string, string> | undefined;
+  deletedIds: string[];
+  initiateImpl: (...args: unknown[]) => {
+    id: string;
+    waitForConnection: (t?: number) => Promise<{ id: string; status: string }>;
+  };
+}
+const apiKeyCalls: ApiKeyCalls = {
+  initiateArgs: [],
+  apiKeyParamsSeen: undefined,
+  deletedIds: [],
+  initiateImpl: () => ({
+    id: "ca_default",
+    waitForConnection: async () => ({ id: "ca_default", status: "ACTIVE" }),
+  }),
+};
+mock.module("@composio/core", () => ({
+  AuthScheme: {
+    APIKey: (params: Record<string, string>) => {
+      apiKeyCalls.apiKeyParamsSeen = params;
+      return { authScheme: "API_KEY", val: { status: "ACTIVE", ...params } };
+    },
+  },
+  Composio: class {
+    connectedAccounts = {
+      list: async () => ({ items: [] }),
+      initiate: (...args: unknown[]) => {
+        apiKeyCalls.initiateArgs = args;
+        return apiKeyCalls.initiateImpl(...args);
+      },
+      delete: async (id: string) => {
+        apiKeyCalls.deletedIds.push(id);
+      },
+    };
+    create() {
+      return { mcp: { type: "http", url: "https://composio.test/mcp/x", headers: {} } };
+    }
+    constructor(_opts: unknown) {}
+  },
+}));
+
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { BundleLifecycleManager } from "../../src/bundles/lifecycle.ts";
+import { _resetComposioConfigForTest, connectComposioApiKey } from "../../src/composio/sdk.ts";
+import type { UserIdentity } from "../../src/identity/provider.ts";
+import { ConnectorDirectory } from "../../src/registries/directory.ts";
+import { RegistryStore } from "../../src/registries/registry-store.ts";
+import type { Runtime } from "../../src/runtime/runtime.ts";
+import {
+  createManageConnectorsTool,
+  type ManageConnectorsContext,
+} from "../../src/tools/connector-tools.ts";
+import { ToolRegistry } from "../../src/tools/registry.ts";
+import { WorkspaceStore } from "../../src/workspace/workspace-store.ts";
+
+const POSTHOG_ID = "com.posthog/analytics";
+const GMAIL_ID = "com.google/gmail";
+
+// Catalog with one API_KEY connector (posthog) and one OAUTH2-default
+// connector (gmail, no authScheme) so the non-API_KEY rejection is covered.
+const CATALOG_YAML = `servers:
+  - name: ${POSTHOG_ID}
+    title: PostHog
+    description: Product analytics (via Composio)
+    version: "0.1.0"
+    remotes:
+      - type: streamable-http
+        url: https://backend.composio.dev/v3/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: posthog
+          authConfigEnv: COMPOSIO_POSTHOG_AUTH_CONFIG_ID
+          authScheme: API_KEY
+          fields:
+            - key: api_key
+              title: API Key
+              sensitive: true
+              required: true
+            - key: subdomain
+              title: Region
+              required: true
+        tags: [analytics]
+  - name: ${GMAIL_ID}
+    title: Gmail
+    description: Mail (via Composio)
+    version: "0.1.0"
+    remotes:
+      - type: streamable-http
+        url: https://backend.composio.dev/v3/mcp
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: gmail
+          authConfigEnv: COMPOSIO_GMAIL_AUTH_CONFIG_ID
+        tags: [email]
+`;
+
+const ADMIN: UserIdentity = {
+  id: "usr_admin",
+  email: "admin@test",
+  displayName: "Admin",
+  orgRole: "member",
+  preferences: {},
+};
+
+interface Harness {
+  workDir: string;
+  wsId: string;
+  runtime: Runtime;
+}
+
+function buildHarness(): Harness {
+  const workDir = mkdtempSync(join(tmpdir(), "nb-composio-apikey-"));
+  const wsId = "ws_test";
+  const workspaceStore = new WorkspaceStore(workDir);
+  const catalogPath = join(workDir, "catalog.yaml");
+  writeFileSync(catalogPath, CATALOG_YAML);
+  writeFileSync(
+    join(workDir, "registries.json"),
+    JSON.stringify({
+      registries: [
+        {
+          id: "bundled-static",
+          name: "Curated",
+          type: "static",
+          enabled: true,
+          locked: true,
+          url: catalogPath,
+        },
+        { id: "mpak", name: "mpak", type: "mpak", enabled: false },
+      ],
+    }),
+  );
+  const registryStore = new RegistryStore(workDir);
+  const lifecycle = new BundleLifecycleManager(new NoopEventSink(), undefined);
+  const workspaceRegistry = new ToolRegistry();
+
+  const runtime = {
+    getWorkDir: () => workDir,
+    getWorkspaceStore: () => workspaceStore,
+    getRegistryStore: () => registryStore,
+    getConnectorDirectory: () => new ConnectorDirectory(registryStore),
+    getLifecycle: () => lifecycle,
+    getRegistryForWorkspace: () => workspaceRegistry,
+    getAllowInsecureRemotes: () => false,
+    getEventSink: () => new NoopEventSink(),
+    getBundleInstancesForWorkspace: () => lifecycle.getInstances(),
+  } as unknown as Runtime;
+
+  return { workDir, wsId, runtime };
+}
+
+async function provision(h: Harness): Promise<void> {
+  const store = h.runtime.getWorkspaceStore();
+  await store.create("Test", h.wsId.slice(3));
+  await store.addMember(h.wsId, ADMIN.id, "admin");
+}
+
+function buildTool(h: Harness) {
+  const ctx: ManageConnectorsContext = {
+    runtime: h.runtime,
+    getIdentity: () => ADMIN,
+    getWorkspaceId: () => h.wsId,
+  };
+  return createManageConnectorsTool(ctx);
+}
+
+const TRACKED_ENV = [
+  "COMPOSIO_API_KEY",
+  "COMPOSIO_POSTHOG_AUTH_CONFIG_ID",
+  "COMPOSIO_GMAIL_AUTH_CONFIG_ID",
+  "NB_TENANT_ID",
+];
+const SAVED_ENV: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of TRACKED_ENV) SAVED_ENV[k] = process.env[k];
+  for (const k of TRACKED_ENV) delete process.env[k];
+  _resetComposioConfigForTest();
+  apiKeyCalls.initiateArgs = [];
+  apiKeyCalls.apiKeyParamsSeen = undefined;
+  apiKeyCalls.deletedIds = [];
+  apiKeyCalls.initiateImpl = () => ({
+    id: "ca_default",
+    waitForConnection: async () => ({ id: "ca_default", status: "ACTIVE" }),
+  });
+});
+
+afterEach(() => {
+  for (const k of TRACKED_ENV) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+  _resetComposioConfigForTest();
+});
+
+// ── connectComposioApiKey (SDK) ─────────────────────────────────────
+
+describe("connectComposioApiKey", () => {
+  test("forwards fields via AuthScheme.APIKey and returns the verified account", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    _resetComposioConfigForTest();
+    apiKeyCalls.initiateImpl = () => ({
+      id: "ca_new",
+      waitForConnection: async () => ({ id: "ca_new", status: "ACTIVE" }),
+    });
+
+    const res = await connectComposioApiKey({
+      apiKey: "k_test",
+      userId: "u1",
+      authConfigId: "ac_posthog",
+      fields: { api_key: "phx_secret", subdomain: "us" },
+    });
+
+    expect(res).toEqual({ connectedAccountId: "ca_new", status: "ACTIVE" });
+    // The submitted values were handed to AuthScheme.APIKey verbatim.
+    expect(apiKeyCalls.apiKeyParamsSeen).toEqual({ api_key: "phx_secret", subdomain: "us" });
+    // initiate(userId, authConfigId, { config, allowMultiple }).
+    expect(apiKeyCalls.initiateArgs[0]).toBe("u1");
+    expect(apiKeyCalls.initiateArgs[1]).toBe("ac_posthog");
+    const opts = apiKeyCalls.initiateArgs[2] as { allowMultiple?: boolean; config?: unknown };
+    expect(opts.allowMultiple).toBe(true);
+    expect(opts.config).toEqual({
+      authScheme: "API_KEY",
+      val: { status: "ACTIVE", api_key: "phx_secret", subdomain: "us" },
+    });
+  });
+
+  test("deletes the dangling account and rethrows when verification fails", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    _resetComposioConfigForTest();
+    apiKeyCalls.initiateImpl = () => ({
+      id: "ca_bad",
+      waitForConnection: async () => {
+        throw new Error("Connection request failed with status: FAILED");
+      },
+    });
+
+    await expect(
+      connectComposioApiKey({
+        apiKey: "k_test",
+        userId: "u1",
+        authConfigId: "ac_x",
+        fields: { api_key: "bad-key" },
+      }),
+    ).rejects.toThrow(/FAILED/);
+
+    // The half-created account is cleaned up so a retry starts clean.
+    expect(apiKeyCalls.deletedIds).toContain("ca_bad");
+  });
+});
+
+// ── manage_connectors.connect_api_key (validation + trust) ──────────
+
+describe("manage_connectors.connect_api_key", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    h = buildHarness();
+    await provision(h);
+  });
+
+  afterEach(() => {
+    rmSync(h.workDir, { recursive: true, force: true });
+  });
+
+  test("rejects an unknown field key (default-deny)", async () => {
+    const tool = buildTool(h);
+    const r = await tool.handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "x", subdomain: "us", bogus: "y" },
+    });
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain("Unknown field");
+    expect(JSON.stringify(r)).toContain("bogus");
+    // Never reached Composio.
+    expect(apiKeyCalls.initiateArgs.length).toBe(0);
+  });
+
+  test("rejects a missing required field", async () => {
+    const tool = buildTool(h);
+    const r = await tool.handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { subdomain: "us" }, // api_key missing
+    });
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain("api_key");
+    expect(apiKeyCalls.initiateArgs.length).toBe(0);
+  });
+
+  test("rejects a non-API_KEY composio connector", async () => {
+    const tool = buildTool(h);
+    const r = await tool.handler({
+      action: "connect_api_key",
+      catalogId: GMAIL_ID, // authScheme defaults to OAUTH2
+      fields: { api_key: "x" },
+    });
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain("does not use API-key auth");
+    expect(apiKeyCalls.initiateArgs.length).toBe(0);
+  });
+
+  test("surfaces an operator-config error when COMPOSIO_API_KEY is unset", async () => {
+    // Valid fields → field validation passes → reaches the env check.
+    const tool = buildTool(h);
+    const r = await tool.handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "phx_secret", subdomain: "us" },
+    });
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain("COMPOSIO_API_KEY");
+    expect(apiKeyCalls.initiateArgs.length).toBe(0);
+  });
+});

--- a/test/unit/connector-tools-composio-apikey.test.ts
+++ b/test/unit/connector-tools-composio-apikey.test.ts
@@ -70,7 +70,9 @@ mock.module("@composio/core", () => ({
 }));
 
 import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { readComposioConnection } from "../../src/bundles/composio-connection.ts";
 import { BundleLifecycleManager } from "../../src/bundles/lifecycle.ts";
+import { slugifyServerName } from "../../src/bundles/paths.ts";
 import { _resetComposioConfigForTest, connectComposioApiKey } from "../../src/composio/sdk.ts";
 import type { UserIdentity } from "../../src/identity/provider.ts";
 import { ConnectorDirectory } from "../../src/registries/directory.ts";
@@ -346,5 +348,201 @@ describe("manage_connectors.connect_api_key", () => {
     expect(r.isError).toBe(true);
     expect(JSON.stringify(r)).toContain("COMPOSIO_API_KEY");
     expect(apiKeyCalls.initiateArgs.length).toBe(0);
+  });
+});
+
+// ── connect_api_key lifecycle tail (stubbed lifecycle) ──────────────
+//
+// The validation describe above runs against a real lifecycle with no
+// workspace registry, so a happy-path call dead-ends at the install-first
+// guard. To cover the tail (the success path + the post-validation branches),
+// stub `getLifecycle()` the same way composio-auth.test.ts stubs its ctx: a
+// no-op (or erroring) `ensureSourceRegistered` and a recording
+// `recordConnectionStateChange`. The `@composio/core` mock drives the connect
+// result.
+
+interface StubCalls {
+  recordConnectionStateChange: {
+    lastCall: { serverName: string; wsId: string; principalId: string; state: string } | null;
+    callCount: number;
+  };
+}
+
+const POSTHOG_ENTRY = {
+  id: POSTHOG_ID,
+  name: "PostHog",
+  description: "Product analytics (via Composio)",
+  url: "https://backend.composio.dev/v3/mcp",
+  auth: "composio" as const,
+  composio: {
+    toolkit: "posthog",
+    authConfigEnv: "COMPOSIO_POSTHOG_AUTH_CONFIG_ID",
+    authScheme: "API_KEY" as const,
+    fields: [
+      { key: "api_key", title: "API Key", sensitive: true, required: true },
+      { key: "subdomain", title: "Region", required: true },
+    ],
+  },
+};
+
+function stubCtx(opts: {
+  workDir: string;
+  wsId: string;
+  entry: unknown | null;
+  ensureSourceRegisteredError?: Error;
+}): ManageConnectorsContext & { __calls: StubCalls } {
+  const calls: StubCalls = { recordConnectionStateChange: { lastCall: null, callCount: 0 } };
+  const lifecycle = {
+    async ensureSourceRegistered(): Promise<void> {
+      if (opts.ensureSourceRegisteredError) throw opts.ensureSourceRegisteredError;
+    },
+    recordConnectionStateChange(
+      serverName: string,
+      wsId: string,
+      principalId: string,
+      state: string,
+    ): void {
+      calls.recordConnectionStateChange.lastCall = { serverName, wsId, principalId, state };
+      calls.recordConnectionStateChange.callCount++;
+    },
+  };
+  const runtime = {
+    getWorkDir: () => opts.workDir,
+    getWorkspaceStore: () => ({
+      get: async () => ({
+        id: opts.wsId,
+        name: "Test",
+        members: [{ userId: ADMIN.id, role: "admin" }],
+      }),
+    }),
+    getConnectorDirectory: () => ({
+      catalogById: async (id: string) =>
+        opts.entry && (opts.entry as { id: string }).id === id ? opts.entry : null,
+    }),
+    getLifecycle: () => lifecycle,
+  } as unknown as Runtime;
+  return {
+    runtime,
+    getIdentity: () => ADMIN,
+    getWorkspaceId: () => opts.wsId,
+    __calls: calls,
+  } as unknown as ManageConnectorsContext & { __calls: StubCalls };
+}
+
+describe("manage_connectors.connect_api_key — lifecycle tail", () => {
+  const WS = "ws_test";
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "nb-ph-connect-"));
+  });
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("happy path writes connection.json and records running state", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    process.env.COMPOSIO_POSTHOG_AUTH_CONFIG_ID = "ac_posthog";
+    _resetComposioConfigForTest();
+    apiKeyCalls.initiateImpl = () => ({
+      id: "ca_ph",
+      waitForConnection: async () => ({ id: "ca_ph", status: "ACTIVE" }),
+    });
+
+    const ctx = stubCtx({ workDir, wsId: WS, entry: POSTHOG_ENTRY });
+    const r = await createManageConnectorsTool(ctx).handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "phx_secret", subdomain: "us" },
+    });
+
+    expect(r.isError).toBe(false);
+    expect((r.structuredContent as { connected?: boolean })?.connected).toBe(true);
+
+    // connection.json persisted with the verified account + toolkit + status.
+    const conn = await readComposioConnection(workDir, WS, POSTHOG_ID);
+    expect(conn?.connectedAccountId).toBe("ca_ph");
+    expect(conn?.toolkit).toBe("posthog");
+    expect(conn?.status).toBe("ACTIVE");
+    // The submitted key is never written to disk.
+    expect(JSON.stringify(conn)).not.toContain("phx_secret");
+
+    // Bundle flipped to running via the shared tail.
+    expect(ctx.__calls.recordConnectionStateChange.callCount).toBe(1);
+    expect(ctx.__calls.recordConnectionStateChange.lastCall).toEqual({
+      serverName: slugifyServerName(POSTHOG_ID),
+      wsId: WS,
+      principalId: "_workspace",
+      state: "running",
+    });
+  });
+
+  test("ensureSourceRegistered failure → install-first message, no persistence", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    process.env.COMPOSIO_POSTHOG_AUTH_CONFIG_ID = "ac_posthog";
+    _resetComposioConfigForTest();
+
+    const ctx = stubCtx({
+      workDir,
+      wsId: WS,
+      entry: POSTHOG_ENTRY,
+      ensureSourceRegisteredError: new Error("no ref in workspace.json"),
+    });
+    const r = await createManageConnectorsTool(ctx).handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "phx_secret", subdomain: "us" },
+    });
+
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain("installed");
+    // ensureSourceRegistered runs before the Composio connect, so nothing was
+    // created and nothing persisted.
+    expect(apiKeyCalls.initiateArgs.length).toBe(0);
+    expect(await readComposioConnection(workDir, WS, POSTHOG_ID)).toBeFalsy();
+    expect(ctx.__calls.recordConnectionStateChange.callCount).toBe(0);
+  });
+
+  test("auth-config env unset → operator-config error (after field validation)", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    delete process.env.COMPOSIO_POSTHOG_AUTH_CONFIG_ID;
+    _resetComposioConfigForTest();
+
+    const ctx = stubCtx({ workDir, wsId: WS, entry: POSTHOG_ENTRY });
+    const r = await createManageConnectorsTool(ctx).handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "phx_secret", subdomain: "us" },
+    });
+
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain("COMPOSIO_POSTHOG_AUTH_CONFIG_ID");
+    expect(apiKeyCalls.initiateArgs.length).toBe(0);
+  });
+
+  test("Composio connect failure → generic message, no persistence, account cleaned up", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    process.env.COMPOSIO_POSTHOG_AUTH_CONFIG_ID = "ac_posthog";
+    _resetComposioConfigForTest();
+    apiKeyCalls.initiateImpl = () => ({
+      id: "ca_bad",
+      waitForConnection: async () => {
+        throw new Error("Connection request failed with status: FAILED");
+      },
+    });
+
+    const ctx = stubCtx({ workDir, wsId: WS, entry: POSTHOG_ENTRY });
+    const r = await createManageConnectorsTool(ctx).handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "bad-key", subdomain: "us" },
+    });
+
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain("Could not connect");
+    expect(await readComposioConnection(workDir, WS, POSTHOG_ID)).toBeFalsy();
+    expect(ctx.__calls.recordConnectionStateChange.callCount).toBe(0);
+    // The SDK helper cleaned up the dangling connected account.
+    expect(apiKeyCalls.deletedIds).toContain("ca_bad");
   });
 });

--- a/test/unit/connector-tools-composio-apikey.test.ts
+++ b/test/unit/connector-tools-composio-apikey.test.ts
@@ -424,6 +424,7 @@ function stubCtx(opts: {
   ensureSourceRegisteredError?: Error;
   identity?: UserIdentity;
   role?: "admin" | "member";
+  bundles?: Array<{ serverName: string }>;
 }): ManageConnectorsContext & { __calls: StubCalls } {
   const identity = opts.identity ?? ADMIN;
   const role = opts.role ?? "admin";
@@ -449,6 +450,7 @@ function stubCtx(opts: {
         id: opts.wsId,
         name: "Test",
         members: [{ userId: identity.id, role }],
+        bundles: opts.bundles ?? [],
       }),
     }),
     getConnectorDirectory: () => ({
@@ -532,11 +534,37 @@ describe("manage_connectors.connect_api_key — lifecycle tail", () => {
 
     expect(r.isError).toBe(true);
     expect(JSON.stringify(r)).toContain("installed");
+    expect(JSON.stringify(r)).toContain("must be installed");
     // ensureSourceRegistered runs before the Composio connect, so nothing was
     // created and nothing persisted.
     expect(apiKeyCalls.initiateArgs.length).toBe(0);
     expect(await readComposioConnection(workDir, WS, POSTHOG_ID)).toBeFalsy();
     expect(ctx.__calls.recordConnectionStateChange.callCount).toBe(0);
+  });
+
+  test("source-start failure on an INSTALLED connector → 'could not start', not 'install first'", async () => {
+    process.env.COMPOSIO_API_KEY = "k_test";
+    process.env.COMPOSIO_POSTHOG_AUTH_CONFIG_ID = "ac_posthog";
+    _resetComposioConfigForTest();
+
+    // The connector IS installed (a ref exists) but the source transiently fails.
+    const ctx = stubCtx({
+      workDir,
+      wsId: WS,
+      entry: POSTHOG_ENTRY,
+      bundles: [{ serverName: slugifyServerName(POSTHOG_ID) }],
+      ensureSourceRegisteredError: new Error("transport handshake failed"),
+    });
+    const r = await createManageConnectorsTool(ctx).handler({
+      action: "connect_api_key",
+      catalogId: POSTHOG_ID,
+      fields: { api_key: "phx_secret", subdomain: "us" },
+    });
+
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain("could not start");
+    expect(JSON.stringify(r)).not.toContain("must be installed");
+    expect(apiKeyCalls.initiateArgs.length).toBe(0);
   });
 
   test("auth-config env unset → operator-config error (after field validation)", async () => {


### PR DESCRIPTION
## What

Adds a non-redirect **API-key** auth path for Composio-backed connectors. Until now every Composio connector assumed the OAuth aggregator flow (redirect → vendor consent → callback). Toolkits like **PostHog** (and Exa, Firecrawl, SerpAPI, Perplexity, …) authenticate by API key — there is no redirect; Composio expects the key submitted at connect time. This unlocks that whole class, not just PostHog.

## How

- **`ComposioConnectorConfig`** (`server-detail.ts`) — one shared type for the composio block (was duplicated inline across `server-detail`, `registries/types`, and `projection`). Adds two fields:
  - `authScheme?: "OAUTH2" | "API_KEY"` — defaults to `OAUTH2`, so every existing connector entry is unchanged.
  - `fields?: ComposioConnectField[]` — what to collect from the user for non-redirect schemes.
- **`connectComposioApiKey()`** (`composio/sdk.ts`) — `AuthScheme.APIKey(fields)` → `connectedAccounts.initiate()` → `waitForConnection()` to verify the account reaches ACTIVE; deletes the half-created account on failure so a retry starts clean. `initiate` is the correct, **non-deprecated** call for non-OAuth schemes (the 2026-07-03 `link()` sunset explicitly excludes API key / bearer / basic).
- **`manage_connectors.connect_api_key`** (`connector-tools.ts`) — the API-key sibling of the OAuth `/v1/composio-auth/initiate` route. It's a **tool action, not a route**: there's no state cookie and no redirect/callback, so neither reason that path is a route applies. Server-trusted catalog lookup (`catalogById`), default-deny field validation (required present, unknown keys rejected), membership-gated, then reuses the OAuth connect tail (`ensureSourceRegistered` → `saveComposioConnection` → `recordConnectionStateChange("running")`).

## Trust posture

Identical to the OAuth path: the user's key is handed to Composio and **never persisted by the platform** — `connection.json` keeps only the opaque `connectedAccountId`. This deliberately does **not** reuse the stdio-bundle credential-store / env-inject convention; that would put the platform in needless custody of a key it never replays. The handler logs only `catalogId` / `wsId` / error text — never field values, and `api_key` is in the logger's auto-redact set.

## Testing

- `bun run verify` green (static: format/lint/tsc/cycles; 564 unit + web; smoke).
- New `test/unit/connector-tools-composio-apikey.test.ts` (6 tests): SDK forward-fields + verify-failure cleanup; action unknown-field / missing-required / non-API_KEY / unconfigured rejections.

## Out of scope / follow-ups

- **Web form** — the shell still needs to render the declared `fields` and POST `connect_api_key`. The backend is complete and exercisable via the tool action; the form is a separate PR.
- **PostHog catalog entry + auth-config** are deployment config (`deployments/nimblebrain/connectors/composio.yaml`, tracked separately), gated on **staging verification** of the exact field keys (`getConnectedAccountInitiationFields("posthog","API_KEY")` — may be `generic_api_key`) and the curated tool slugs.
- **OAuth-path `link()` migration** — the existing `initiateComposioConnection` is hit by the same 2026-07-03 deprecation; unrelated to this PR, worth a separate ticket.
