### PR TITLE
feat(ci): promote the stable channel on a GA release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
   #
   # Fully optional: if the App isn't configured (vars/secrets unset) the job
   # no-ops, so forks and pre-setup CI stay green. Config:
-  #   vars.STAGING_DEPLOY_REPO       — deploy-config repo name (same org)
+  #   vars.DEPLOY_CONFIG_REPO       — deploy-config repo name (same org)
   #   vars.EDGE_BUMP_APP_ID          — GitHub App id (Contents: write on that repo)
   #   secrets.EDGE_BUMP_APP_KEY      — that App's private key
   roll-staging-edge:
@@ -177,13 +177,13 @@ jobs:
         id: cfg
         env:
           APP_ID: ${{ vars.EDGE_BUMP_APP_ID }}
-          REPO: ${{ vars.STAGING_DEPLOY_REPO }}
+          REPO: ${{ vars.DEPLOY_CONFIG_REPO }}
           KEY: ${{ secrets.EDGE_BUMP_APP_KEY }}
         run: |
           if [ -n "$APP_ID" ] && [ -n "$REPO" ] && [ -n "$KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
-            echo "edge-bump not fully configured (need EDGE_BUMP_APP_ID + STAGING_DEPLOY_REPO vars + EDGE_BUMP_APP_KEY secret) — skipping"
+            echo "edge-bump not fully configured (need EDGE_BUMP_APP_ID + DEPLOY_CONFIG_REPO vars + EDGE_BUMP_APP_KEY secret) — skipping"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Mint deploy-repo token
@@ -194,7 +194,7 @@ jobs:
           app-id: ${{ vars.EDGE_BUMP_APP_ID }}
           private-key: ${{ secrets.EDGE_BUMP_APP_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ vars.STAGING_DEPLOY_REPO }}
+          repositories: ${{ vars.DEPLOY_CONFIG_REPO }}
       - name: Fire edge bump
         if: steps.cfg.outputs.enabled == 'true'
         env:
@@ -203,6 +203,6 @@ jobs:
           # -f (raw string), NOT -F: -F type-coerces all-digit values to JSON
           # numbers, which mangles all-digit SHAs (esp. leading-zero). A SHA is an
           # opaque string.
-          gh api "repos/${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPO }}/dispatches" \
+          gh api "repos/${{ github.repository_owner }}/${{ vars.DEPLOY_CONFIG_REPO }}/dispatches" \
             -f event_type=runtime-image-pushed \
             -f "client_payload[sha]=${{ needs.build-and-push.outputs.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,3 +158,53 @@ jobs:
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  # Promote the agent's STABLE channel to prod: dispatch the deploy-config repo's
+  # prod-promote receiver (target: agent), which records the prod stable image; the
+  # auto-sync per-tenant ApplicationSet then rolls every `stable` tenant.
+  # Mirrors ci.yml's roll-staging-edge — same App-token gating, the prod-promote App
+  # instead. GA only: pre-releases publish the image but never touch the stable channel.
+  # Fully optional: if the App vars/secrets are unset (forks, pre-setup CI) the job
+  # no-ops, so forks stay green. (NB_VERSION is baked at build, so the release rebuilds
+  # rather than promote-by-retag; the image this dispatch points prod at is the one
+  # build-and-push just pushed.)
+  promote-to-prod:
+    name: Promote to prod (stable channel)
+    needs: build-and-push
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Check prod-promote config
+        id: cfg
+        env:
+          APP_ID: ${{ vars.PROD_PROMOTE_APP_ID }}
+          REPO: ${{ vars.STAGING_DEPLOY_REPO }}
+          KEY: ${{ secrets.PROD_PROMOTE_APP_KEY }}
+        run: |
+          if [ -n "$APP_ID" ] && [ -n "$REPO" ] && [ -n "$KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prod-promote not configured (need PROD_PROMOTE_APP_ID + STAGING_DEPLOY_REPO vars + PROD_PROMOTE_APP_KEY secret) — skipping"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Mint prod-promote token
+        if: steps.cfg.outputs.enabled == 'true'
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PROD_PROMOTE_APP_ID }}
+          private-key: ${{ secrets.PROD_PROMOTE_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ vars.STAGING_DEPLOY_REPO }}
+      - name: Dispatch prod-image-promoted (target agent)
+        if: steps.cfg.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          # -f (raw string), NOT -F: -F coerces all-digit payloads to JSON numbers.
+          gh api "repos/${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPO }}/dispatches" \
+            -f event_type=prod-image-promoted \
+            -f "client_payload[target]=agent" \
+            -f "client_payload[version]=${{ github.ref_name }}"
+          echo "dispatched prod-image-promoted: target=agent version=${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,13 +179,13 @@ jobs:
         id: cfg
         env:
           APP_ID: ${{ vars.PROD_PROMOTE_APP_ID }}
-          REPO: ${{ vars.STAGING_DEPLOY_REPO }}
+          REPO: ${{ vars.DEPLOY_CONFIG_REPO }}
           KEY: ${{ secrets.PROD_PROMOTE_APP_KEY }}
         run: |
           if [ -n "$APP_ID" ] && [ -n "$REPO" ] && [ -n "$KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
-            echo "prod-promote not configured (need PROD_PROMOTE_APP_ID + STAGING_DEPLOY_REPO vars + PROD_PROMOTE_APP_KEY secret) — skipping"
+            echo "prod-promote not configured (need PROD_PROMOTE_APP_ID + DEPLOY_CONFIG_REPO vars + PROD_PROMOTE_APP_KEY secret) — skipping"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Mint prod-promote token
@@ -196,14 +196,14 @@ jobs:
           app-id: ${{ vars.PROD_PROMOTE_APP_ID }}
           private-key: ${{ secrets.PROD_PROMOTE_APP_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ vars.STAGING_DEPLOY_REPO }}
+          repositories: ${{ vars.DEPLOY_CONFIG_REPO }}
       - name: Dispatch prod-image-promoted (target agent)
         if: steps.cfg.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           # -f (raw string), NOT -F: -F coerces all-digit payloads to JSON numbers.
-          gh api "repos/${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPO }}/dispatches" \
+          gh api "repos/${{ github.repository_owner }}/${{ vars.DEPLOY_CONFIG_REPO }}/dispatches" \
             -f event_type=prod-image-promoted \
             -f "client_payload[target]=agent" \
             -f "client_payload[version]=${{ github.ref_name }}"


### PR DESCRIPTION
## What

A GA release tag now **promotes the stable channel to prod**, completing the release→deploy path for the agent.

After `build-and-push` publishes `runtime`/`web:vX.Y.Z`, a new `promote-to-prod` job dispatches `prod-image-promoted` (`target: agent`, `version:` the tag) to the deploy-config repo's prod-promote receiver, which records the stable image; the per-tenant deployment auto-syncs it.

## Mirrors the existing staging dispatch

Same shape as `ci.yml`'s `roll-staging-edge`: a GitHub App gated on `PROD_PROMOTE_APP_ID` / `PROD_PROMOTE_APP_KEY` + `STAGING_DEPLOY_REPO`, **no-op when unconfigured** so forks and pre-setup CI stay green. Repo/App come from vars/secrets, never literals.

## Scope

- **GA only** — `if: !contains(github.ref_name, '-')`. Pre-releases publish the image but don't touch the stable channel.
- **Still rebuilds** — `NB_VERSION` is baked at build time (for `/about`), and the edge `:sha` image carries no version, so the release can't promote-by-retag; this dispatch points prod at the freshly built `:vX.Y.Z`. (A byte-for-byte retag would require moving the version to deploy-time injection — a separate change.)

## Validation

YAML parses; no literal private names (all via vars/secrets); GA-gate + `target: agent` payload verified.