### PR TITLE
docs(ci): fix copy-pasted -f comment on the prod dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
-          # -f (raw string), NOT -F: -F coerces all-digit payloads to JSON numbers.
+          # -f keeps client_payload values as raw strings (target + version are strings).
           gh api "repos/${{ github.repository_owner }}/${{ vars.DEPLOY_CONFIG_REPO }}/dispatches" \
             -f event_type=prod-image-promoted \
             -f "client_payload[target]=agent" \


### PR DESCRIPTION
QA follow-up (suggestion #4 on #516, which merged before this landed). The `-f`'s "coerces all-digit payloads" note was copy-pasted from the SHA-payload dispatch; a `vX.Y.Z` version is never all-digit. `-f` is still correct (raw string); the comment now says that plainly. Trivial.