### PR TITLE
ci: agent release promotes by retag instead of rebuilding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,10 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref }}
+  # Normalize across triggers: ref_name is `v0.5.1` on a tag push, matching the
+  # workflow_dispatch `tag` input — so a tag-push and a manual dispatch of the same
+  # version share one group and can't race on the immutable ECR :vX.Y.Z.
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           VERSION="${{ github.event.inputs.tag || github.ref_name }}"
           # Require vX.Y.Z (optional -prerelease / +build). A garbage version would
           # burn an immutable tag, so reject it before anything is written.
-          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+.][0-9A-Za-z.-]+)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Tag '$VERSION' is not vX.Y.Z (with optional -prerelease)"; exit 1
           fi
           SHA="$(git rev-parse --short HEAD)"
@@ -157,9 +157,17 @@ jobs:
           SRC: ${{ steps.r.outputs.sha }}
         run: |
           set -euo pipefail
-          for REPO in nimblebrain/nimblebrain-runtime nimblebrain/nimblebrain-web; do
-            DST="$VERSION"
+          REPOS=(nimblebrain/nimblebrain-runtime nimblebrain/nimblebrain-web)
+          declare -A MAN ACTION
 
+          # Two passes so the retag is all-or-nothing across BOTH images: validate
+          # every repo's guards FIRST, then mutate. Otherwise a missing web :<sha>
+          # (runtime built green but the web build failed on that ci.yml run) would
+          # leave runtime:vX.Y.Z already retagged while web errors out — a wedged,
+          # immutable, half-promoted version that even rebuild=true can't recover.
+          #
+          # Pass 1 — validate guards for every repo, mutate nothing.
+          for REPO in "${REPOS[@]}"; do
             # Guard 1: the byte-for-byte promise needs an immutable repo.
             MUT="$(aws ecr describe-repositories --repository-names "$REPO" --query 'repositories[0].imageTagMutability' --output text)"
             [ "$MUT" = "IMMUTABLE" ] || { echo "::error::ECR repo $REPO is $MUT, not IMMUTABLE — refusing to promote-by-retag"; exit 1; }
@@ -167,23 +175,33 @@ jobs:
             # Guard 2: the staging-built source image must exist (ci.yml builds it on
             # main; staging-edge runs it). Absent → this tag is off a commit that
             # never rode staging.
-            MAN="$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag="$SRC" --query 'images[0].imageManifest' --output text 2>/dev/null || true)"
-            if [ -z "$MAN" ] || [ "$MAN" = "None" ]; then
+            m="$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag="$SRC" --query 'images[0].imageManifest' --output text 2>/dev/null || true)"
+            if [ -z "$m" ] || [ "$m" = "None" ]; then
               echo "::error::No staging-built image $REPO:$SRC for this commit — it never rode staging-edge. To release anyway, re-run via 'Run workflow' with rebuild=true (and know prod won't be byte-for-byte)."
               exit 1
             fi
+            MAN[$REPO]="$m"
 
-            # Idempotent: if DST exists, succeed iff it's the same digest we'd promote
-            # (a re-run); fail if it's a DIFFERENT image (re-releasing a version is not
-            # allowed).
-            DSTDIG="$(aws ecr describe-images --repository-name "$REPO" --image-ids imageTag="$DST" --query 'imageDetails[0].imageDigest' --output text 2>/dev/null || true)"
+            # Idempotent: if VERSION exists, this run is a re-run iff it's the same
+            # digest we'd promote (→ skip); a DIFFERENT digest means someone is
+            # re-releasing a version, which is not allowed (→ fail).
+            DSTDIG="$(aws ecr describe-images --repository-name "$REPO" --image-ids imageTag="$VERSION" --query 'imageDetails[0].imageDigest' --output text 2>/dev/null || true)"
             if [ -n "$DSTDIG" ] && [ "$DSTDIG" != "None" ]; then
               SRCDIG="$(aws ecr describe-images --repository-name "$REPO" --image-ids imageTag="$SRC" --query 'imageDetails[0].imageDigest' --output text)"
-              [ "$DSTDIG" = "$SRCDIG" ] && echo "already promoted ($REPO:$DST == $SRC) — nothing to retag" \
-                || { echo "::error::$REPO:$DST already exists with a DIFFERENT digest — refusing to re-release a version"; exit 1; }
+              if [ "$DSTDIG" = "$SRCDIG" ]; then ACTION[$REPO]=skip; \
+                else echo "::error::$REPO:$VERSION already exists with a DIFFERENT digest — refusing to re-release a version"; exit 1; fi
             else
-              aws ecr put-image --repository-name "$REPO" --image-tag "$DST" --image-manifest "$MAN" >/dev/null
-              echo "promoted $REPO:$SRC -> $REPO:$DST (no rebuild)"
+              ACTION[$REPO]=promote
+            fi
+          done
+
+          # Pass 2 — every repo passed; now retag.
+          for REPO in "${REPOS[@]}"; do
+            if [ "${ACTION[$REPO]}" = "skip" ]; then
+              echo "already promoted ($REPO:$VERSION == $SRC) — nothing to retag"
+            else
+              aws ecr put-image --repository-name "$REPO" --image-tag "$VERSION" --image-manifest "${MAN[$REPO]}" >/dev/null
+              echo "promoted $REPO:$SRC -> $REPO:$VERSION (no rebuild)"
             fi
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,56 +1,63 @@
 name: Release
 
+# Release the agent runtime + web on a `v*` tag.
+#
+# PROMOTE-BY-RETAG, not rebuild. The tagged commit already merged to main, so
+# ci.yml already built + pushed the staging-verified runtime/web `:<sha>` images to
+# ECR and the staging edge channel ran them. A release therefore RE-TAGS those exact
+# manifests as `:vX.Y.Z` — so prod runs byte-for-byte what staging proved, and
+# releases stop rebuilding (and re-running verify: ci.yml already gated this commit;
+# the source-image-exists guard below is the proof it did).
+#
+#   ECR  (prod deploy)        : retag :<sha> -> :vX.Y.Z (runtime + web) via put-image.
+#   GHCR (public OSS pulls)   : copy the same ECR :<sha> manifests to the GHCR tags
+#                               via `buildx imagetools create` — edge never pushes
+#                               GHCR, so the release distributes there, still no
+#                               rebuild. GA also moves `:latest`.
+#
+# The running version is NOT baked into the image — the deployment injects NB_VERSION
+# via env at deploy time, which is what makes the retag byte-for-byte. Then
+# promote-to-prod dispatches the deploy-config receiver to roll the prod stable channel.
+#
+# Guards: the target ECR repo must be IMMUTABLE, and the `:<sha>` source must exist
+# (if not, the commit never rode staging-edge — fail loud; re-run via
+# workflow_dispatch with rebuild=true for an EMERGENCY rebuild).
+
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, e.g. v0.5.1"
+        required: true
+      rebuild:
+        description: "EMERGENCY: rebuild from source instead of promoting the staging-verified image (only for a tag off a commit that never rode staging)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false
 
 permissions:
-  contents: write
-  id-token: write
-  packages: write
-
-# Single source of truth for the bun toolchain version (matches ci.yml).
-# Pinned (not `latest`) for deterministic builds; bump here to upgrade.
-env:
-  BUN_VERSION: "1.3.14"
+  contents: read
 
 jobs:
-  # Each step below runs a `bun run verify:*` subscript; package.json is the
-  # source of truth for what "verify" means. Do not inline individual check
-  # steps here — add them to the matching subscript so local `bun run verify`
-  # stays in parity. (Matches the ci.yml convention.)
-  verify:
-    name: Verify
+  release:
+    name: Promote release images
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # AWS OIDC (ECR)
+      contents: read
+      packages: write   # GHCR push
     steps:
+      # Check out the tagged commit (the `ref` covers both triggers). Shallow, same
+      # as ci.yml's build — so `git rev-parse --short HEAD` yields the same 7-char
+      # SHA ci.yml tagged the edge image with.
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
-      - name: Install dependencies
-        run: bun install
-      - name: Install web dependencies
-        run: cd web && bun install
-      - name: Install bundle dependencies
-        # verify:test-unit runs test:bundles, which `bun test`s inside each
-        # src/bundles/*/ui package — those need their own deps (dompurify, etc.).
-        # Mirrors ci.yml; without it test:bundles fails "Cannot find package".
-        run: bun run install:bundles
-      - name: Verify (static)
-        run: bun run verify:static
-      - name: Verify (unit + web tests)
-        run: bun run verify:test-unit
-      - name: Integration tests
-        run: bun run test:integration
-
-  build-and-push:
-    name: Build & Push
-    needs: verify
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      # buildx (docker-container driver) is required for the GitHub Actions
-      # layer cache used by ./.github/actions/build-push-image.
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: docker/setup-buildx-action@v3
       - uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -64,114 +71,188 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Compute the full tag list per image up front. `:latest` (GHCR only —
-      # ECR has immutable tags and can't reuse it) is appended for stable
-      # releases. SemVer pre-release tags always contain a hyphen
-      # (v0.4.0-beta.1, v1.0.0-rc.1); GA tags don't — so the hyphen test keeps
-      # `:latest` pointing at the most recent GA release. Building `:latest`
-      # into the push (rather than a post-build `docker tag`) is also required
-      # by the buildx docker-container driver, which never loads the image into
-      # the local daemon for a subsequent retag.
-      - name: Set image tags
-        id: tags
+      - name: Resolve version + source SHA
+        id: r
         run: |
-          VERSION=${GITHUB_REF_NAME}
-          SHA=$(git rev-parse --short HEAD)
-          REG=${{ steps.ecr.outputs.registry }}
-          # Strip the leading `v` for injection into the running binary
-          # (package.json-style versions have no `v` prefix).
-          PKG_VERSION=${VERSION#v}
+          set -euo pipefail
+          VERSION="${{ github.event.inputs.tag || github.ref_name }}"
+          # Require vX.Y.Z (optional -prerelease / +build). A garbage version would
+          # burn an immutable tag, so reject it before anything is written.
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag '$VERSION' is not vX.Y.Z (with optional -prerelease)"; exit 1
+          fi
+          SHA="$(git rev-parse --short HEAD)"
+          # Pre-release semver tags contain a hyphen (v0.5.0-rc.1); GA tags don't.
+          # Only GA moves GHCR :latest.
+          case "$VERSION" in *-*) PRERELEASE=true ;; *) PRERELEASE=false ;; esac
+          {
+            echo "version=$VERSION"
+            echo "sha=$SHA"
+            echo "prerelease=$PRERELEASE"
+          } >> "$GITHUB_OUTPUT"
 
-          # ECR gets the :VERSION tag ONLY. The :SHA tag in ECR is owned by the
-          # edge pipeline (it pushes nimblebrain-{runtime,web}:<sha> on every main
-          # build for the staging edge channel), and ECR tags are immutable — so a
-          # release re-pushing :SHA collides ("tag already exists ... immutable").
-          # GHCR keeps both :VERSION and :SHA (GHCR is mutable + edge doesn't push
-          # there); the runbook's dual-addressability check (§4b) reads GHCR.
-          #
-          # GHCR runtime is `nimblebrain-runtime` (canonical, matches ECR + web
-          # naming); `nimblebrain` is kept as a transitional alias so existing
-          # OSS pulls don't break. Drop the alias once consumers have moved.
-          platform_tags=(
+      # ── EMERGENCY rebuild path (workflow_dispatch + rebuild=true) ──────────────
+      # Build from source instead of promoting the staging-verified image. Loud on
+      # purpose — prod won't be byte-for-byte. Pushes the same ECR + GHCR tag set the
+      # normal path produces. NB_VERSION is still NOT baked (it's deploy-injected), so
+      # a rebuilt image behaves identically to a retagged one at runtime.
+      - name: Compute rebuild tags (EMERGENCY)
+        if: ${{ github.event.inputs.rebuild == 'true' }}
+        id: rb
+        env:
+          REG: ${{ steps.ecr.outputs.registry }}
+          VERSION: ${{ steps.r.outputs.version }}
+          SHA: ${{ steps.r.outputs.sha }}
+          PRERELEASE: ${{ steps.r.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          runtime=(
             "$REG/nimblebrain/nimblebrain-runtime:$VERSION"
             "ghcr.io/nimblebraininc/nimblebrain-runtime:$VERSION"
             "ghcr.io/nimblebraininc/nimblebrain-runtime:$SHA"
             "ghcr.io/nimblebraininc/nimblebrain:$VERSION"
             "ghcr.io/nimblebraininc/nimblebrain:$SHA"
           )
-          web_tags=(
+          web=(
             "$REG/nimblebrain/nimblebrain-web:$VERSION"
             "ghcr.io/nimblebraininc/nimblebrain-web:$VERSION"
             "ghcr.io/nimblebraininc/nimblebrain-web:$SHA"
           )
-
-          # Stable releases (no hyphen in the semver tag) also move GHCR :latest.
-          case "$VERSION" in
-            *-*) ;;  # pre-release: leave :latest alone
-            *)
-              platform_tags+=("ghcr.io/nimblebraininc/nimblebrain-runtime:latest")
-              platform_tags+=("ghcr.io/nimblebraininc/nimblebrain:latest")
-              web_tags+=("ghcr.io/nimblebraininc/nimblebrain-web:latest")
-              ;;
-          esac
-
+          if [ "$PRERELEASE" = "false" ]; then
+            runtime+=("ghcr.io/nimblebraininc/nimblebrain-runtime:latest" "ghcr.io/nimblebraininc/nimblebrain:latest")
+            web+=("ghcr.io/nimblebraininc/nimblebrain-web:latest")
+          fi
           {
-            echo "sha=$SHA"
-            echo "pkg_version=$PKG_VERSION"
-            echo "platform_tags<<TAGS_EOF"
-            printf '%s\n' "${platform_tags[@]}"
-            echo "TAGS_EOF"
-            echo "web_tags<<TAGS_EOF"
-            printf '%s\n' "${web_tags[@]}"
-            echo "TAGS_EOF"
+            echo "runtime_tags<<EOF"; printf '%s\n' "${runtime[@]}"; echo "EOF"
+            echo "web_tags<<EOF";     printf '%s\n' "${web[@]}";     echo "EOF"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push platform image
+      - name: Rebuild + push runtime (EMERGENCY)
+        if: ${{ github.event.inputs.rebuild == 'true' }}
         uses: ./.github/actions/build-push-image
         with:
           context: .
           file: Dockerfile
           cache-scope: platform
-          build-args: |
-            BUILD_SHA=${{ steps.tags.outputs.sha }}
-            VERSION=${{ steps.tags.outputs.pkg_version }}
-          tags: ${{ steps.tags.outputs.platform_tags }}
-
-      - name: Build and push web image
+          build-args: BUILD_SHA=${{ steps.r.outputs.sha }}
+          tags: ${{ steps.rb.outputs.runtime_tags }}
+      - name: Rebuild + push web (EMERGENCY)
+        if: ${{ github.event.inputs.rebuild == 'true' }}
         uses: ./.github/actions/build-push-image
         with:
           context: web
           file: web/Dockerfile
           cache-scope: web
-          tags: ${{ steps.tags.outputs.web_tags }}
+          tags: ${{ steps.rb.outputs.web_tags }}
+      - name: Flag emergency rebuild
+        if: ${{ github.event.inputs.rebuild == 'true' }}
+        run: echo "::warning::REBUILT runtime+web for ${{ steps.r.outputs.version }} from source — NOT the staging-verified image. Prod will not be byte-for-byte what staging proved."
+
+      # ── Normal path: promote-by-retag ─────────────────────────────────────────
+      # ECR: retag the staging-verified :<sha> manifest -> :vX.Y.Z for runtime + web,
+      # with three guards (immutable repo / source exists / idempotent).
+      - name: Promote-by-retag in ECR (runtime + web)
+        if: ${{ github.event.inputs.rebuild != 'true' }}
+        env:
+          VERSION: ${{ steps.r.outputs.version }}
+          SRC: ${{ steps.r.outputs.sha }}
+        run: |
+          set -euo pipefail
+          for REPO in nimblebrain/nimblebrain-runtime nimblebrain/nimblebrain-web; do
+            DST="$VERSION"
+
+            # Guard 1: the byte-for-byte promise needs an immutable repo.
+            MUT="$(aws ecr describe-repositories --repository-names "$REPO" --query 'repositories[0].imageTagMutability' --output text)"
+            [ "$MUT" = "IMMUTABLE" ] || { echo "::error::ECR repo $REPO is $MUT, not IMMUTABLE — refusing to promote-by-retag"; exit 1; }
+
+            # Guard 2: the staging-built source image must exist (ci.yml builds it on
+            # main; staging-edge runs it). Absent → this tag is off a commit that
+            # never rode staging.
+            MAN="$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag="$SRC" --query 'images[0].imageManifest' --output text 2>/dev/null || true)"
+            if [ -z "$MAN" ] || [ "$MAN" = "None" ]; then
+              echo "::error::No staging-built image $REPO:$SRC for this commit — it never rode staging-edge. To release anyway, re-run via 'Run workflow' with rebuild=true (and know prod won't be byte-for-byte)."
+              exit 1
+            fi
+
+            # Idempotent: if DST exists, succeed iff it's the same digest we'd promote
+            # (a re-run); fail if it's a DIFFERENT image (re-releasing a version is not
+            # allowed).
+            DSTDIG="$(aws ecr describe-images --repository-name "$REPO" --image-ids imageTag="$DST" --query 'imageDetails[0].imageDigest' --output text 2>/dev/null || true)"
+            if [ -n "$DSTDIG" ] && [ "$DSTDIG" != "None" ]; then
+              SRCDIG="$(aws ecr describe-images --repository-name "$REPO" --image-ids imageTag="$SRC" --query 'imageDetails[0].imageDigest' --output text)"
+              [ "$DSTDIG" = "$SRCDIG" ] && echo "already promoted ($REPO:$DST == $SRC) — nothing to retag" \
+                || { echo "::error::$REPO:$DST already exists with a DIFFERENT digest — refusing to re-release a version"; exit 1; }
+            else
+              aws ecr put-image --repository-name "$REPO" --image-tag "$DST" --image-manifest "$MAN" >/dev/null
+              echo "promoted $REPO:$SRC -> $REPO:$DST (no rebuild)"
+            fi
+          done
+
+      # GHCR: edge never pushes there, so distribute the OSS image by copying the same
+      # ECR :<sha> manifest to the GHCR tags (cross-registry, no rebuild). GA moves
+      # :latest. `nimblebrain` (unscoped) is the transitional alias for the runtime.
+      - name: Distribute to GHCR (imagetools copy, no rebuild)
+        if: ${{ github.event.inputs.rebuild != 'true' }}
+        env:
+          REG: ${{ steps.ecr.outputs.registry }}
+          VERSION: ${{ steps.r.outputs.version }}
+          SHA: ${{ steps.r.outputs.sha }}
+          PRERELEASE: ${{ steps.r.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          runtime_src="$REG/nimblebrain/nimblebrain-runtime:$SHA"
+          web_src="$REG/nimblebrain/nimblebrain-web:$SHA"
+
+          runtime_tags=(
+            "ghcr.io/nimblebraininc/nimblebrain-runtime:$VERSION"
+            "ghcr.io/nimblebraininc/nimblebrain-runtime:$SHA"
+            "ghcr.io/nimblebraininc/nimblebrain:$VERSION"
+            "ghcr.io/nimblebraininc/nimblebrain:$SHA"
+          )
+          web_tags=(
+            "ghcr.io/nimblebraininc/nimblebrain-web:$VERSION"
+            "ghcr.io/nimblebraininc/nimblebrain-web:$SHA"
+          )
+          if [ "$PRERELEASE" = "false" ]; then
+            runtime_tags+=("ghcr.io/nimblebraininc/nimblebrain-runtime:latest" "ghcr.io/nimblebraininc/nimblebrain:latest")
+            web_tags+=("ghcr.io/nimblebraininc/nimblebrain-web:latest")
+          fi
+
+          rt_args=(); for t in "${runtime_tags[@]}"; do rt_args+=(-t "$t"); done
+          web_args=(); for t in "${web_tags[@]}"; do web_args+=(-t "$t"); done
+          docker buildx imagetools create "${rt_args[@]}" "$runtime_src"
+          docker buildx imagetools create "${web_args[@]}" "$web_src"
+          echo "distributed runtime+web $SHA to GHCR as $VERSION"
 
   github-release:
     name: GitHub Release
-    needs: build-and-push
+    needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(github.event.inputs.tag || github.ref_name, '-') }}
 
   # Promote the agent's STABLE channel to prod: dispatch the deploy-config repo's
-  # prod-promote receiver (target: agent), which records the prod stable image; the
-  # auto-sync per-tenant ApplicationSet then rolls every `stable` tenant.
-  # Mirrors ci.yml's roll-staging-edge — same App-token gating, the prod-promote App
-  # instead. GA only: pre-releases publish the image but never touch the stable channel.
+  # prod-promote receiver (target: agent), which records the prod stable image tag;
+  # the auto-sync per-tenant ApplicationSet then rolls every `stable` tenant. Mirrors
+  # ci.yml's roll-staging-edge — same App-token gating, the prod-promote App instead.
+  # GA only: pre-releases publish the image but never touch the stable channel.
   # Fully optional: if the App vars/secrets are unset (forks, pre-setup CI) the job
-  # no-ops, so forks stay green. (NB_VERSION is baked at build, so the release rebuilds
-  # rather than promote-by-retag; the image this dispatch points prod at is the one
-  # build-and-push just pushed.)
+  # no-ops, so forks stay green. The image this points prod at is the byte-for-byte
+  # staging-verified one the `release` job just retagged.
   promote-to-prod:
     name: Promote to prod (stable channel)
-    needs: build-and-push
-    if: ${{ !contains(github.ref_name, '-') }}
+    needs: release
+    if: ${{ !contains(github.event.inputs.tag || github.ref_name, '-') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -201,10 +282,11 @@ jobs:
         if: steps.cfg.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
+          VERSION: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           # -f keeps client_payload values as raw strings (target + version are strings).
           gh api "repos/${{ github.repository_owner }}/${{ vars.DEPLOY_CONFIG_REPO }}/dispatches" \
             -f event_type=prod-image-promoted \
             -f "client_payload[target]=agent" \
-            -f "client_payload[version]=${{ github.ref_name }}"
-          echo "dispatched prod-image-promoted: target=agent version=${{ github.ref_name }}"
+            -f "client_payload[version]=$VERSION"
+          echo "dispatched prod-image-promoted: target=agent version=$VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,14 @@ USER 1000
 
 VOLUME /data
 
+# NB_BUILD_SHA is BAKED — a genuine build fact (which commit produced these
+# bytes), and correct even after the image is promoted-by-retag to a release tag.
+# NB_VERSION is deliberately NOT baked: it's injected at deploy time via the
+# NB_VERSION env, so the same image can be retagged :<sha> -> :vX.Y.Z and shipped
+# byte-for-byte with no rebuild (see release.yml). When NB_VERSION is unset (local
+# `docker run` / compose) the runtime falls back to package.json.
 ARG BUILD_SHA=""
 ENV NB_BUILD_SHA=$BUILD_SHA
-ARG VERSION=""
-ENV NB_VERSION=$VERSION
 ENV NB_WORK_DIR=/data
 ENV NB_HOST=0.0.0.0
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,7 @@ v0.4.0-beta.1 → v0.4.0-beta.2 → v0.4.0-rc.1 → v0.4.0
 
 If a release is botched, bump to the next number rather than re-tagging — §6.
 
-**`package.json` is a sentinel — do not bump.** It is pinned to `"version": "0.0.0-dev"` and stays there forever. Released artifacts get the real version injected at build time from the git tag (Dockerfile `VERSION` build arg → `NB_VERSION` env). Local dev builds without `NB_VERSION` fall through to `pkg.version` and self-report `0.0.0-dev`, which is intentionally clearly-not-a-release. Bumping this field per release would re-introduce the drift bug PR #73 fixed.
+**`package.json` is a sentinel — do not bump.** It is pinned to `"version": "0.0.0-dev"` and stays there forever. The image is version-agnostic — the version is injected at **deploy time** via the `NB_VERSION` env (the platform chart sets it from the image tag), which is what lets a release promote the staging-verified image by retag instead of rebuilding. Builds without `NB_VERSION` (local dev, non-deployed) fall through to `pkg.version` and self-report `0.0.0-dev`, which is intentionally clearly-not-a-release. Bumping this field per release would re-introduce the drift bug PR #73 fixed.
 
 ## 2. Prerequisites
 
@@ -174,11 +174,11 @@ Then fix the underlying issue on `main` and cut the **next** pre-release number 
 
 ## 7. Workflow reference
 
-`.github/workflows/release.yml` fires on any `v*` tag push and runs three jobs:
+`.github/workflows/release.yml` fires on any `v*` tag push (and `workflow_dispatch` with a `tag` input + an EMERGENCY `rebuild` toggle) and runs three jobs:
 
-1. **Verify** — runs the same `verify:*` subscripts as CI, plus `test:integration`
-2. **Build & Push** — builds platform + web images, pushes to ECR and GHCR; for stable-only, also promotes `:latest` on GHCR
-3. **GitHub Release** — creates a release with auto-generated notes; `prerelease` flag mirrors the hyphen rule
+1. **Promote release images** — **promote-by-retag, not rebuild.** `ci.yml` already built and pushed the staging-verified runtime + web `:<sha>` images to ECR on merge; this re-tags those exact manifests to `:vX.Y.Z` via `aws ecr put-image` (guarded: target repo must be IMMUTABLE, the `:<sha>` source must exist, and a re-run is idempotent — same digest skips, a different digest fails). It then copies the same `:<sha>` manifests to the GHCR tags with `docker buildx imagetools create` (edge never pushes GHCR), and for stable releases moves `:latest`. There is no Verify or rebuild step — `ci.yml` already gated the commit, and the source-image-exists guard proves it. The `workflow_dispatch` `rebuild=true` escape hatch rebuilds from source instead (loud warning: prod won't be byte-for-byte) — only for a tag off a commit that never rode staging.
+2. **GitHub Release** — creates a release with auto-generated notes; `prerelease` flag mirrors the hyphen rule
+3. **Promote to prod (stable channel)** — GA only; dispatches the deploy-config receiver to record the new prod stable image tag, which the auto-sync per-tenant ApplicationSet then rolls. No-ops when the prod-promote App isn't configured (forks/pre-setup CI).
 
 Artifact map:
 

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -50,10 +50,12 @@ import { apiError } from "./types.ts";
 
 const pkgPath = resolve(import.meta.dirname ?? __dirname, "../../package.json");
 const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
-// Release builds inject the git tag via NB_VERSION (see Dockerfile). Local
-// dev / non-release builds fall back to package.json, which is pinned to
-// the sentinel "0.0.0-dev" and intentionally never bumped — the git tag
-// is the sole source of truth for released versions (see RELEASING.md §1).
+// Deployments inject NB_VERSION at deploy time via env — the image itself is
+// version-agnostic, so releases promote-by-retag instead of rebuilding (see
+// release.yml). Local dev / non-deployed builds leave it unset and fall back to
+// package.json, which is pinned to the sentinel "0.0.0-dev" and intentionally
+// never bumped — the git tag is the sole source of truth for released versions
+// (see RELEASING.md §1).
 const VERSION = process.env.NB_VERSION || pkg.version;
 
 /**

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -36,7 +36,7 @@
 	handle /config.js {
 		header Content-Type "application/javascript; charset=utf-8"
 		header Cache-Control "no-store"
-		respond `window.__NB_CONFIG__ = {"tenantId":"{$NB_TENANT_ID:}","environment":"{$NB_SENTRY_ENV:}","release":"{$NB_RELEASE:}","sentry":{"dsn":"{$NB_SENTRY_DSN:}","enabled":"{$NB_SENTRY_ENABLED:false}","tracesSampleRate":"{$NB_SENTRY_TRACES_SAMPLE_RATE:0}"},"posthog":{"key":"{$NB_POSTHOG_KEY:}","enabled":"{$NB_POSTHOG_ENABLED:false}"}};` 200
+		respond `window.__NB_CONFIG__ = {"tenantId":"{$NB_TENANT_ID:}","environment":"{$NB_SENTRY_ENV:}","release":"{$NB_VERSION:}","sentry":{"dsn":"{$NB_SENTRY_DSN:}","enabled":"{$NB_SENTRY_ENABLED:false}","tracesSampleRate":"{$NB_SENTRY_TRACES_SAMPLE_RATE:0}"},"posthog":{"key":"{$NB_POSTHOG_KEY:}","enabled":"{$NB_POSTHOG_ENABLED:false}"}};` 200
 	}
 	handle {
 		root * /srv


### PR DESCRIPTION
## What

Stop baking the version into the runtime image, and switch the release from **rebuild-at-tag** to **promote-by-retag** — so prod runs byte-for-byte the same image staging verified, and releases stop rebuilding.

- **Dockerfile** — drop the `VERSION` `ARG`/`ENV`. `NB_VERSION` is now injected at **deploy time via env** (the image is version-agnostic). `NB_BUILD_SHA` stays baked — it's a genuine build fact, correct through a retag.
- **`handlers.ts`** — refresh the `/about` `VERSION` comment; the runtime already read `process.env.NB_VERSION || pkg.version`.
- **`web/Caddyfile`** — read `{$NB_VERSION:}` for the web client's Sentry release (was `{$NB_RELEASE:}`). Version and release are one fact, so web uses the same env as the runtime. The `release` JSON field name stays (it maps to Sentry's `release`). Pairs with the deploy side setting `NB_VERSION` on the web container (platform#127).
- **`release.yml`** — replace the verify + build-and-push jobs with a retag job:
  - **ECR** (deploy images): retag the `ci.yml`-built, staging-verified `:<sha>` runtime + web images to `:vX.Y.Z` via `aws ecr put-image`. Guards: immutable repo / source-exists / idempotent. Validated **all-or-nothing across both repos** (pre-flight both, then mutate) so a missing web source can't half-promote runtime.
  - **GHCR** (public OSS pulls): copy the same ECR `:<sha>` manifests to the GHCR tags via `docker buildx imagetools create` (no rebuild). GA also moves `:latest`. `nimblebrain` alias preserved.
  - `workflow_dispatch` gains an **EMERGENCY `rebuild=true`** escape hatch.
  - **No verify job**: `ci.yml` already gated the commit; the source-image-exists guard is the proof.
- **`RELEASING.md`** — refresh §1 (deploy-time `NB_VERSION`, not a build arg) and §7 (the new job list), since this PR makes them stale and `handlers.ts` points at §1.

## Merge gate ⚠️

Depends on the deploy side injecting `NB_VERSION` at deploy time — it **must be live in prod first** (platform#127, **merged + rolled**; verified zero-diff on the runtime-chart tenant). Otherwise a retagged image reports `0.0.0-dev` at `/about` **and** the web client's Sentry release tag goes empty (the Caddyfile now reads `NB_VERSION`). Both surfaces depend on the same env, so the gate covers both.

## Verification

- `release.yml` YAML validated; semver regex accepts `vX.Y.Z` (+ `-prerelease`/`+build`), rejects 4-part (`v0.5.1.7`) and junk; GA-vs-prerelease `:latest` gating and `imagetools` assembly dry-run as expected; two-pass retag confirmed to abort before mutating runtime when the web source is absent.
- Only `src/` change is a comment, so `bun run verify` (biome/tsc) is unaffected — CI green.