### PR TITLE
skills: role-based composition — type decides the channel (no de-dup) [P3]

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -98,7 +98,7 @@ import {
   partitionSkills,
 } from "../skills/loader.ts";
 import { SkillMatcher } from "../skills/matcher.ts";
-import { type SelectedSkill, selectLayer3Skills } from "../skills/select.ts";
+import { partitionSkillsByRole, type SelectedSkill, selectLayer3Skills } from "../skills/select.ts";
 import { approxTokens } from "../skills/tokens.ts";
 import { MAX_SKILL_BODY_CHARS, truncateMarkdownToBudget } from "../skills/truncate.ts";
 import type { Skill } from "../skills/types.ts";
@@ -1312,9 +1312,15 @@ export class Runtime {
     // hoisted from its later definition site for this reason; keep it a single
     // definition (the layer-3 call reuses it).
     const userId = requestIdentity.id;
-    const layer3Pool = this.loadConversationSkills(focusedWsId ?? sessionWsId, userId);
+    // Partition the conversation pool by ROLE once: `context` skills (every tier)
+    // compose into the always-on Layer 0/1 channel; `capability` skills feed the
+    // conditional channels (keyword matcher + tool-affinity Layer 3). Disjoint by
+    // `type`, so nothing is injected twice — no downstream de-dup.
+    const conversationPool = this.loadConversationSkills(focusedWsId ?? sessionWsId, userId);
+    const { context: poolContext, capability: poolCapability } =
+      partitionSkillsByRole(conversationPool);
     const requestMatcher = new SkillMatcher();
-    requestMatcher.load(layer3Pool);
+    requestMatcher.load(poolCapability);
     let skill = requestMatcher.match(request.message);
 
     // Dependency checking: warn if a matched skill requires bundles that aren't installed
@@ -1499,7 +1505,9 @@ export class Runtime {
     const identityOverride = activeWorkspace?.identity
       ? makeIdentitySkill(activeWorkspace.identity)
       : null;
-    const contextBase = this.activeContextSkills();
+    // Always-on context channel: the `type: context` skills across every tier
+    // (core/builtin/org + workspace + user), not just the boot-time set.
+    const contextBase = poolContext;
     const requestContextSkills = identityOverride
       ? [...contextBase, identityOverride]
       : contextBase;
@@ -1529,7 +1537,7 @@ export class Runtime {
       ownerId,
       userId,
       activeToolNames: tools.map((t) => t.name),
-      layer3Pool,
+      capabilityPool: poolCapability,
       ...(request.appContext?.serverName
         ? { appContextServerName: request.appContext.serverName }
         : {}),
@@ -2041,10 +2049,6 @@ export class Runtime {
     const identityOverride = activeWorkspace?.identity
       ? makeIdentitySkill(activeWorkspace.identity)
       : null;
-    const contextBase = this.activeContextSkills();
-    const requestContextSkills = identityOverride
-      ? [...contextBase, identityOverride]
-      : contextBase;
 
     // Layer 3 selection — bundle workflow guidance still applies based on
     // the active tool set. No `appContextServerName` (tasks don't have
@@ -2057,12 +2061,20 @@ export class Runtime {
     // every `loading_strategy: always` skill in that workspace before
     // this parity fix.
     const userId = requestIdentity.id;
-    const layer3Pool = this.loadConversationSkills(focusedWsId ?? sessionWsId, userId);
+    // Partition by role (same as `_chatInner`): context → Layer 0/1; capability
+    // → conditional Layer 3. Disjoint by `type`, so no skill injects twice.
+    const conversationPool = this.loadConversationSkills(focusedWsId ?? sessionWsId, userId);
+    const { context: poolContext, capability: poolCapability } =
+      partitionSkillsByRole(conversationPool);
+    const contextBase = poolContext;
+    const requestContextSkills = identityOverride
+      ? [...contextBase, identityOverride]
+      : contextBase;
     const accessibleForSkills = await this._workspaceStore.getWorkspacesForUser(ownerId);
     const bundleSkills = (
       await Promise.all(accessibleForSkills.map((ws) => this.loadBundleSkills(ws.id, {})))
     ).flat();
-    const mergedLayer3Pool: Skill[] = [...layer3Pool, ...bundleSkills];
+    const mergedLayer3Pool: Skill[] = [...poolCapability, ...bundleSkills];
     const activeToolNames = tools.map((t) => t.name);
     const selectedLayer3 = selectLayer3Skills({
       skills: mergedLayer3Pool,
@@ -3453,23 +3465,17 @@ export class Runtime {
   }
 
   /**
-   * Boot-time context skills with any toggled Off (`status: "disabled"`)
-   * removed — the canonical always-on context channel.
+   * BOOT-TIME context skills (org/core/builtin) with any toggled Off
+   * (`status: "disabled"`) removed. Audit/management helper only.
    *
-   * `compose` injects every context-skill body verbatim (Layer 0 / Layer 1)
-   * with NO status check; the disable filter otherwise lives only on the
-   * Layer-3 path (`selectLayer3Skills`, `select.ts`). Without this, a context
-   * rule (e.g. an org "rule" authored as `type: "context"`) toggled Off in the
-   * UI keeps being injected — it rides this channel while being correctly
-   * dropped from the Layer-3 `skills.loaded` set. Mirrors `select.ts`'s keep-
-   * predicate exactly. `reloadSkills()` refreshes `this.contextSkills` on every
-   * skills-tool mutation, so the toggle is reflected here on the next turn.
-   *
-   * EVERY surface that mirrors prompt composition must read through here, not
-   * `getContextSkills()`, or status and composition diverge — the failure
-   * {@link selectRequestLayer3} exists to prevent. Today that's the two
-   * `composeSystemPrompt` call sites, `describeRequestSkills` (`nb__status`),
-   * and `composeLive` (`compose_effective_context`).
+   * NOTE: the prompt composition path no longer reads this. Compose routes by
+   * ROLE via `partitionSkillsByRole(loadConversationSkills(...))`, whose
+   * `context` set spans EVERY tier (boot + workspace + user) and applies the
+   * same active-status filter. This method is the boot-only subset — use it for
+   * surfaces that only need the static vendored/org set, not for anything that
+   * must mirror what the prompt actually contains (use the partitioned pool).
+   * `reloadSkills()` refreshes `this.contextSkills` on every skills-tool
+   * mutation, so the toggle is reflected here on the next turn.
    */
   activeContextSkills(): Skill[] {
     return this.contextSkills.filter(
@@ -3570,14 +3576,18 @@ export class Runtime {
     /** Skip a server's usage skill when its `<app-guide>` is already injected. */
     appContextServerName?: string;
     /**
-     * Precomputed conversation-skill pool (org + workspace + user). When the
-     * caller already built it for the per-request matcher, thread it through
-     * so the disk read isn't repeated. Omitted callers (e.g.
-     * `describeRequestSkills`) load it internally — behavior unchanged.
+     * Precomputed CAPABILITY skills (`type: skill`) from the conversation pool —
+     * the output of `partitionSkillsByRole(...).capability`. When the caller
+     * already partitioned for the per-request matcher / context channel, thread
+     * it through so the disk read isn't repeated. Omitted callers (e.g.
+     * `describeRequestSkills`) load + partition internally. Context skills are
+     * NOT in this set — they compose into Layer 0/1 by role, never Layer 3.
      */
-    layer3Pool?: Skill[];
+    capabilityPool?: Skill[];
   }): Promise<SelectedSkill[]> {
-    const layer3Pool = params.layer3Pool ?? this.loadConversationSkills(params.wsId, params.userId);
+    const capabilityPool =
+      params.capabilityPool ??
+      partitionSkillsByRole(this.loadConversationSkills(params.wsId, params.userId)).capability;
     const accessibleForSkills = await this._workspaceStore.getWorkspacesForUser(params.ownerId);
     const bundleSkills = (
       await Promise.all(
@@ -3591,7 +3601,7 @@ export class Runtime {
       )
     ).flat();
     return selectLayer3Skills({
-      skills: [...layer3Pool, ...bundleSkills],
+      skills: [...capabilityPool, ...bundleSkills],
       activeTools: params.activeToolNames,
     });
   }
@@ -3618,11 +3628,22 @@ export class Runtime {
     const userId = identity?.id ?? ownerId;
     const registry = await this.ensureWorkspaceRegistry(wsId);
     const activeToolNames = (await registry.availableTools()).map((t) => t.name);
-    const layer3 = await this.selectRequestLayer3({ wsId, ownerId, userId, activeToolNames });
-    // Filtered, not raw `this.contextSkills`: the status surface must match what
-    // compose actually injects, or a rule toggled Off still prints as "always
-    // active" here — the divergence this reporter's own design exists to kill.
-    return { context: this.activeContextSkills(), layer3 };
+    // Partition the same way compose does, so the status surface matches the
+    // prompt exactly: `context` (every tier, active only) is the Layer 0/1 set;
+    // `capability` feeds Layer 3. Reading the raw boot-time `this.contextSkills`
+    // would both miss workspace/user-tier context skills and show toggled-Off
+    // rules as active — the divergence this reporter exists to kill.
+    const { context, capability } = partitionSkillsByRole(
+      this.loadConversationSkills(wsId, userId),
+    );
+    const layer3 = await this.selectRequestLayer3({
+      wsId,
+      ownerId,
+      userId,
+      activeToolNames,
+      capabilityPool: capability,
+    });
+    return { context, layer3 };
   }
 
   /** Get the path to the nimblebrain.json config file (Helm-managed seed). */

--- a/src/skills/builtin/authoring-guide.md
+++ b/src/skills/builtin/authoring-guide.md
@@ -2,7 +2,7 @@
 name: authoring-guide
 description: Guide for authoring NimbleBrain platform Layer 3 skills (voice, workflow, personal, tool routing). Vendored Layer 1 content shipped with the nb__skills bundle.
 version: 1.0.0
-type: context
+type: skill
 priority: 25
 scope: bundle
 loading-strategy: tool_affined

--- a/src/skills/core/automation-authoring.md
+++ b/src/skills/core/automation-authoring.md
@@ -1,8 +1,11 @@
 ---
 name: automation-authoring
 description: Teaches the agent how to create and manage scheduled automations
-type: context
-priority: 16
+type: skill
+priority: 50
+loading-strategy: tool_affined
+applies-to-tools:
+  - automations__*
 ---
 
 # Automation Management

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -285,11 +285,15 @@ export function parseSkillContent(
     data["applies-to-tools"] ?? data.applies_to_tools ?? data.appliesToTools,
   );
 
-  // `loading-strategy` resolution:
+  // `loading-strategy` resolution. `type` (role) and `loading-strategy` (when)
+  // are orthogonal: strategy is a CAPABILITY-skill concept. A `type: context`
+  // skill is always-on by role — it carries no strategy and is routed to the
+  // context channel (Layer 0/1) by `partitionSkillsByRole`, never selected into
+  // Layer 3. Resolution:
   //   1. Use the value if it's a recognized strategy.
   //   2. Else if applies-to-tools is set → tool_affined.
-  //   3. Else if type === "context" → always.
-  //   4. Else undefined (legacy `type: skill` keeps using SkillMatcher).
+  //   3. Else undefined (legacy `type: skill` keeps using SkillMatcher; a
+  //      `type: context` skill stays undefined — role, not strategy, places it).
   const rawLoadingStrategy =
     data["loading-strategy"] ?? data.loading_strategy ?? data.loadingStrategy;
   let loadingStrategy: SkillLoadingStrategy | undefined;
@@ -302,12 +306,8 @@ export function parseSkillContent(
       );
     }
   }
-  if (!loadingStrategy) {
-    if (appliesToTools && appliesToTools.length > 0) {
-      loadingStrategy = "tool_affined";
-    } else if (type === "context") {
-      loadingStrategy = "always";
-    }
+  if (!loadingStrategy && appliesToTools && appliesToTools.length > 0) {
+    loadingStrategy = "tool_affined";
   }
 
   // `status` defaults to "active" when missing or invalid. Legacy

--- a/src/skills/select.ts
+++ b/src/skills/select.ts
@@ -146,3 +146,33 @@ export function selectLayer3Skills(input: SelectInput): SelectedSkill[] {
   selected.sort((a, b) => a.skill.manifest.priority - b.skill.manifest.priority);
   return selected;
 }
+
+/**
+ * Partition a conversation skill pool by ROLE — the single composition-routing
+ * authority. A skill's `type` decides its channel, by construction:
+ *
+ *  - `context` → always-on identity/voice content. Goes to the context channel
+ *    (Layer 0/1), rendered from every tier (core/builtin/org + workspace + user),
+ *    sorted by priority. Disabled context skills are dropped here (the always-on
+ *    channel has no per-turn status gate of its own).
+ *  - everything else (`skill`) → capability content for the conditional channels:
+ *    tool-affinity Layer 3 (`selectLayer3Skills`) and the keyword matcher.
+ *
+ * The two sets are DISJOINT by `type`, so a skill can never enter two channels —
+ * there is no overlap to de-duplicate downstream. Role placement replaces the
+ * old "context skills also default to `always` and get selected into Layer 3"
+ * conflation that required after-the-fact filtering.
+ */
+export function partitionSkillsByRole(pool: Skill[]): { context: Skill[]; capability: Skill[] } {
+  const context: Skill[] = [];
+  const capability: Skill[] = [];
+  for (const s of pool) {
+    if (s.manifest.type === "context") {
+      if (s.manifest.status === undefined || s.manifest.status === "active") context.push(s);
+    } else {
+      capability.push(s);
+    }
+  }
+  context.sort((a, b) => a.manifest.priority - b.manifest.priority);
+  return { context, capability };
+}

--- a/src/tools/platform/compose.ts
+++ b/src/tools/platform/compose.ts
@@ -51,7 +51,7 @@ import { getRequestContext } from "../../runtime/request-context.ts";
 import { makeIdentitySkill, type Runtime } from "../../runtime/runtime.ts";
 import { hashSkillBody } from "../../runtime/skills-loaded-payload.ts";
 import { parseSkillContent } from "../../skills/loader.ts";
-import { selectLayer3Skills } from "../../skills/select.ts";
+import { partitionSkillsByRole, selectLayer3Skills } from "../../skills/select.ts";
 import type { InProcessTool } from "../in-process-app.ts";
 import { defineInProcessApp } from "../in-process-app.ts";
 import type { McpSource } from "../mcp-source.ts";
@@ -210,12 +210,16 @@ async function composeLive(runtime: Runtime, convId: string): Promise<ComposeRes
   const ws = await runtime.getWorkspaceStore().get(wsId);
   const workspaceContext: WorkspaceContext = ws ? { id: ws.id, name: ws.name } : { id: wsId };
   const identityOverride = ws?.identity ? makeIdentitySkill(ws.identity) : null;
-  // `activeContextSkills`, not the raw getter: this trace must equal what
-  // `runtime.chat()` composes, which filters disabled context skills. Reading
-  // the raw cache here would report a toggled-Off rule as present in the prompt.
-  const requestContextSkills = identityOverride
-    ? [...runtime.activeContextSkills(), identityOverride]
-    : runtime.activeContextSkills();
+  // Partition the conversation pool by ROLE, exactly as `runtime.chat()` does:
+  // `context` (every tier, active only) → Layer 0/1; `capability` → Layer 3.
+  // This trace must equal what chat composes — including workspace/user-tier
+  // context skills, which the boot-only `activeContextSkills()` would miss, and
+  // it filters disabled context skills the same way.
+  const userId = identity?.id ?? null;
+  const { context: poolContext, capability: poolCapability } = partitionSkillsByRole(
+    runtime.loadConversationSkills(wsId, userId),
+  );
+  const requestContextSkills = identityOverride ? [...poolContext, identityOverride] : poolContext;
 
   // Gather inputs in parallel where possible.
   const [apps, overlays] = await Promise.all([
@@ -242,10 +246,8 @@ async function composeLive(runtime: Runtime, convId: string): Promise<ComposeRes
   const { direct: directTools, proxied } = surfaceTools(allTools, null, {});
   const activeToolNames = directTools.map((t) => t.name);
 
-  const userId = identity?.id ?? null;
-  const layer3Pool = runtime.loadConversationSkills(wsId, userId);
   const selectedLayer3 = selectLayer3Skills({
-    skills: layer3Pool,
+    skills: poolCapability,
     activeTools: activeToolNames,
   });
   const layer3Entries: Layer3SkillEntry[] = selectedLayer3.map((s) => ({

--- a/test/integration/compose-effective-context.test.ts
+++ b/test/integration/compose-effective-context.test.ts
@@ -176,6 +176,14 @@ describe("compose_effective_context — live mode", () => {
     expect(userCtxRow).toBeDefined();
     expect(userCtxRow!.text).toContain(skillBody);
 
+    // ...and it must NOT ALSO appear in Layer 3. `partitionSkillsByRole` routes a
+    // `type: context` skill to the always-on Layer 0/1 channel by role; it can't
+    // enter the conditional Layer 3 channel, so there's nothing to de-dup.
+    const l3Layer = r.layers.find((l) => l.kind === "layer3_skills");
+    const l3HasVoiceRules =
+      l3Layer?.subItems?.some((s) => s.id.endsWith("voice-rules.md")) ?? false;
+    expect(l3HasVoiceRules).toBe(false);
+
     // totalTokens = sum of per-layer tokens (lossless trace).
     const sum = r.layers.reduce((s, l) => s + l.tokens, 0);
     expect(r.totalTokens).toBe(sum);
@@ -282,9 +290,12 @@ describe("compose_effective_context — historical mode", () => {
     mkdirSync(join(workDir, "skills"), { recursive: true });
     const skillBody = "Use patch_source for all revisions.";
     const skillPath = join(workDir, "skills", "collateral-rules.md");
+    // `type: skill` (capability role) so it lands in Layer 3, where this tool
+    // audits skill hashes — `type: context` would route to the always-on Layer
+    // 0/1 channel instead. `always` keeps selection deterministic in the test.
     writeFileSync(
       skillPath,
-      `---\nname: collateral-rules\ndescription: Routing\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n\n${skillBody}\n`,
+      `---\nname: collateral-rules\ndescription: Routing\nversion: 1.0.0\ntype: skill\npriority: 30\nloading_strategy: always\n---\n\n${skillBody}\n`,
     );
     await runtime.reloadSkills();
 
@@ -331,7 +342,7 @@ describe("compose_effective_context — historical mode", () => {
     const skillPath = join(workDir, "skills", "drift-rules.md");
     writeFileSync(
       skillPath,
-      `---\nname: drift-rules\ndescription: Test\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n\n${originalBody}\n`,
+      `---\nname: drift-rules\ndescription: Test\nversion: 1.0.0\ntype: skill\npriority: 30\nloading_strategy: always\n---\n\n${originalBody}\n`,
     );
     await runtime.reloadSkills();
 
@@ -348,7 +359,7 @@ describe("compose_effective_context — historical mode", () => {
     const editedBody = "Edited rule: use set_source instead.";
     writeFileSync(
       skillPath,
-      `---\nname: drift-rules\ndescription: Test\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n\n${editedBody}\n`,
+      `---\nname: drift-rules\ndescription: Test\nversion: 1.0.0\ntype: skill\npriority: 30\nloading_strategy: always\n---\n\n${editedBody}\n`,
     );
     await runtime.reloadSkills();
 
@@ -387,7 +398,7 @@ describe("compose_effective_context — historical mode", () => {
     const originalBody = "Recoverable rule: vintage instruction.";
     const skillPath = join(workDir, "skills", "recoverable.md");
     const frontmatter =
-      "---\nname: recoverable\ndescription: Test\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n";
+      "---\nname: recoverable\ndescription: Test\nversion: 1.0.0\ntype: skill\npriority: 30\nloading_strategy: always\n---\n";
     writeFileSync(skillPath, `${frontmatter}\n${originalBody}\n`);
     await runtime.reloadSkills();
 
@@ -452,11 +463,11 @@ describe("compose_effective_context — bundle filter", () => {
     mkdirSync(crmDir, { recursive: true });
     writeFileSync(
       join(collateralDir, "rules.md"),
-      `---\nname: collateral-rules\ndescription: CR\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n\nCollateral content.\n`,
+      `---\nname: collateral-rules\ndescription: CR\nversion: 1.0.0\ntype: skill\npriority: 30\nloading_strategy: always\n---\n\nCollateral content.\n`,
     );
     writeFileSync(
       join(crmDir, "rules.md"),
-      `---\nname: crm-rules\ndescription: CR\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n\nCRM content.\n`,
+      `---\nname: crm-rules\ndescription: CR\nversion: 1.0.0\ntype: skill\npriority: 30\nloading_strategy: always\n---\n\nCRM content.\n`,
     );
     await runtime.reloadSkills();
 

--- a/test/integration/execute-task.test.ts
+++ b/test/integration/execute-task.test.ts
@@ -351,7 +351,9 @@ describe("runtime.executeTask", () => {
     mkdirSync(sharedSkillsDir, { recursive: true });
     writeFileSync(
       join(sharedSkillsDir, `${SKILL_NAME}.md`),
-      `---\nname: ${SKILL_NAME}\ndescription: voice for the shared workspace\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n\nAlways answer in plain English.\n`,
+      // `type: skill` (capability role) → Layer 3, where this asserts task/chat
+      // parity for focused-workspace skill loading. `always` keeps it deterministic.
+      `---\nname: ${SKILL_NAME}\ndescription: workflow for the shared workspace\nversion: 1.0.0\ntype: skill\npriority: 30\nloading_strategy: always\n---\n\nAlways answer in plain English.\n`,
     );
 
     const result = await runtime.executeTask({

--- a/test/integration/skills-read-tools.test.ts
+++ b/test/integration/skills-read-tools.test.ts
@@ -85,7 +85,9 @@ describe("skills read tools — end-to-end", () => {
         'name: voice-rules',
         'description: Voice rules',
         'version: "1.0.0"',
-        "type: context",
+        // `type: skill` (capability role) → loads into Layer 3 (`skills.loaded`/
+        // loading_log), where this test asserts. `always` keeps it deterministic.
+        "type: skill",
         "priority: 25",
         "loading-strategy: always",
         "---",

--- a/test/integration/workspace-tier-skills.test.ts
+++ b/test/integration/workspace-tier-skills.test.ts
@@ -1,20 +1,20 @@
 /**
- * Regression test for Layer 3 workspace-tier skill loading.
+ * Regression test for workspace-tier skill loading from the FOCUSED workspace.
  *
- * A skill at `{workDir}/workspaces/<focusedWsId>/skills/` with
- * `loading_strategy: always` must reach the `skills.loaded` event when a
- * chat is focused on that workspace, regardless of which workspace is the
- * session (personal) workspace.
- *
- * Why this test exists: Stage 2 (#272) wired Layer 3 selection to read
+ * Why this test exists: Stage 2 (#272) wired skill selection to read
  * workspace-tier skills from the session (personal) workspace instead of
- * the focused workspace. The result was that any workspace-tier skill in
- * a non-personal workspace — the typical place for team-wide voice rules,
- * org schema notes, etc. — silently disappeared from agent context. The
- * fix passes `focusedWsId ?? sessionWsId` into `loadConversationSkills`.
+ * the focused workspace, so any workspace-tier skill in a non-personal
+ * workspace silently disappeared from agent context. The fix passes
+ * `focusedWsId ?? sessionWsId` into `loadConversationSkills`.
  *
- * Failure mode the test pins: load the focused-workspace skill and assert
- * it lands in the recorded `skills.loaded` skills array.
+ * The focused-vs-personal guarantee applies to BOTH composition channels,
+ * which this file covers:
+ *   - Capability skills (`type: skill`) → Layer 3 (`skills.loaded`).
+ *   - Context skills (`type: context`) → the always-on context channel,
+ *     surfaced via `describeRequestSkills().context`.
+ * Channel ROUTING itself (role → channel) is unit-tested in
+ * `partitionSkillsByRole`; here we pin the focused-workspace + end-to-end
+ * behavior for each channel.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
@@ -46,15 +46,16 @@ beforeAll(async () => {
   });
   await provisionTestWorkspace(runtime);
 
-  // Plant a workspace-tier `loading_strategy: always` skill in the FOCUSED
-  // (shared) workspace — not the personal workspace. The session workspace
+  // Plant a workspace-tier capability skill (`type: skill` + `always`) in the
+  // FOCUSED (shared) workspace — not the personal one. The session workspace
   // (personalWorkspaceIdFor(DEV_IDENTITY.id)) is a different dir on disk;
-  // before the fix, Layer 3 read from there and never saw this file.
+  // before the fix, selection read from there and never saw this file.
+  // `type: skill` (capability role) routes it to Layer 3 (`skills.loaded`).
   const sharedSkillsDir = join(testDir, "workspaces", TEST_WORKSPACE_ID, "skills");
   mkdirSync(sharedSkillsDir, { recursive: true });
   writeFileSync(
     join(sharedSkillsDir, `${SHARED_SKILL_NAME}.md`),
-    `---\nname: ${SHARED_SKILL_NAME}\ndescription: Team voice rules\nversion: 1.0.0\ntype: context\npriority: 30\nloading_strategy: always\n---\n\n${SHARED_SKILL_BODY}\n`,
+    `---\nname: ${SHARED_SKILL_NAME}\ndescription: Team workflow rules\nversion: 1.0.0\ntype: skill\npriority: 30\nloading_strategy: always\n---\n\n${SHARED_SKILL_BODY}\n`,
   );
 });
 
@@ -119,6 +120,25 @@ describe("Layer 3 — workspace-tier `loading_strategy: always` skills", () => {
     expect(entry).toBeDefined();
     expect(entry?.skill.manifest.scope).toBe("workspace");
     expect(entry?.loadedBy).toBe("always");
+  });
+
+  it("composes a workspace-tier `type: context` skill into the context channel, not Layer 3", async () => {
+    // Companion to the Layer-3 cases above. An always-on workspace CONTEXT skill
+    // reaches the prompt via the context channel (Layer 0/1), surfaced by
+    // describeRequestSkills().context — NOT the Layer-3 set. This is the
+    // kill-always regression guard at the integration level: a workspace context
+    // skill must NOT be silently dropped now that it no longer rides Layer 3.
+    const ctxName = "shared-context-rule";
+    const dir = join(testDir, "workspaces", TEST_WORKSPACE_ID, "skills");
+    writeFileSync(
+      join(dir, `${ctxName}.md`),
+      `---\nname: ${ctxName}\ndescription: Team voice\nversion: 1.0.0\ntype: context\npriority: 30\n---\n\nMatch the user's voice.\n`,
+    );
+
+    const { context, layer3 } = await runtime.describeRequestSkills(TEST_WORKSPACE_ID);
+    expect(context.some((s) => s.manifest.name === ctxName)).toBe(true);
+    expect(context.find((s) => s.manifest.name === ctxName)?.manifest.scope).toBe("workspace");
+    expect(layer3.some((s) => s.skill.manifest.name === ctxName)).toBe(false);
   });
 
   it("does NOT load the focused workspace's skill when chatting from home (no focus)", async () => {

--- a/test/unit/skills/authoring-guide.test.ts
+++ b/test/unit/skills/authoring-guide.test.ts
@@ -25,7 +25,9 @@ describe("authoring-guide Layer 1 skill", () => {
     if (!skill) throw new Error("parseSkillFile returned null");
 
     expect(skill.manifest.name).toBe("authoring-guide");
-    expect(skill.manifest.type).toBe("context");
+    // `type: skill` (capability role): loads on tool-affinity (skills__*), NOT as
+    // always-on context. Routed to Layer 3 by `partitionSkillsByRole`.
+    expect(skill.manifest.type).toBe("skill");
     expect(skill.manifest.priority).toBe(25);
     expect(skill.manifest.scope).toBe("bundle");
     expect(skill.manifest.loadingStrategy).toBe("tool_affined");

--- a/test/unit/skills/manifest-extension.test.ts
+++ b/test/unit/skills/manifest-extension.test.ts
@@ -127,16 +127,18 @@ applies-to-tools:
     expect(skill.manifest.loadingStrategy).toBe("tool_affined");
   });
 
-  test("loading-strategy defaults to always for type:context with no applies-to-tools", () => {
+  test("loading-strategy is undefined for type:context (role places it, not strategy)", () => {
     const skill = parse(`---
-name: context-always
+name: context-role
 description: x
 version: 1.0.0
 type: context
 priority: 25
 ---
 `);
-    expect(skill.manifest.loadingStrategy).toBe("always");
+    // `type: context` is always-on by ROLE — it carries no loading-strategy and
+    // is routed to Layer 0/1 by `partitionSkillsByRole`, never into Layer 3.
+    expect(skill.manifest.loadingStrategy).toBeUndefined();
   });
 
   test("loading-strategy is undefined for type:skill with no applies-to-tools", () => {
@@ -177,8 +179,9 @@ priority: 25
 loading-strategy: bogus
 ---
 `);
-    // type: context with no applies-to-tools → default = always
-    expect(skill.manifest.loadingStrategy).toBe("always");
+    // Invalid strategy is dropped; `type: context` has no default strategy
+    // (role, not strategy, routes it to Layer 0/1) → undefined.
+    expect(skill.manifest.loadingStrategy).toBeUndefined();
   });
 
   test("invalid status falls back to active", () => {

--- a/test/unit/skills/select.test.ts
+++ b/test/unit/skills/select.test.ts
@@ -7,19 +7,26 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { selectLayer3Skills, toolMatches } from "../../../src/skills/select.ts";
+import {
+  partitionSkillsByRole,
+  selectLayer3Skills,
+  toolMatches,
+} from "../../../src/skills/select.ts";
 import type {
   Skill,
   SkillLoadingStrategy,
   SkillStatus,
+  SkillType,
 } from "../../../src/skills/types.ts";
 
 interface SkillFixtureOptions {
   name: string;
+  type?: SkillType;
   priority?: number;
   loadingStrategy?: SkillLoadingStrategy;
   appliesToTools?: string[];
   status?: SkillStatus;
+  sourcePath?: string;
 }
 
 function makeSkill(opts: SkillFixtureOptions): Skill {
@@ -28,14 +35,14 @@ function makeSkill(opts: SkillFixtureOptions): Skill {
       name: opts.name,
       description: `${opts.name} description`,
       version: "1.0.0",
-      type: "context",
+      type: opts.type ?? "context",
       priority: opts.priority ?? 50,
       loadingStrategy: opts.loadingStrategy,
       appliesToTools: opts.appliesToTools,
       status: opts.status,
     },
     body: `# ${opts.name}\n`,
-    sourcePath: `/virtual/${opts.name}.md`,
+    sourcePath: opts.sourcePath ?? `/virtual/${opts.name}.md`,
   };
 }
 
@@ -296,5 +303,69 @@ describe("selectLayer3Skills — mixed input + ordering", () => {
       "p50",
       "p99",
     ]);
+  });
+});
+
+describe("partitionSkillsByRole", () => {
+  test("routes by `type`: context → context channel, skill → capability channel", () => {
+    const pool: Skill[] = [
+      makeSkill({ name: "soul", type: "context", priority: 0 }),
+      makeSkill({ name: "tool-helper", type: "skill", loadingStrategy: "tool_affined" }),
+      makeSkill({ name: "voice", type: "context", priority: 30 }),
+    ];
+    const { context, capability } = partitionSkillsByRole(pool);
+    expect(context.map((s) => s.manifest.name)).toEqual(["soul", "voice"]);
+    expect(capability.map((s) => s.manifest.name)).toEqual(["tool-helper"]);
+  });
+
+  test("the two sets are disjoint — no skill appears in both (no de-dup needed)", () => {
+    const pool: Skill[] = [
+      makeSkill({ name: "ctx", type: "context" }),
+      makeSkill({ name: "cap", type: "skill" }),
+    ];
+    const { context, capability } = partitionSkillsByRole(pool);
+    const ctxNames = new Set(context.map((s) => s.manifest.name));
+    expect(capability.some((s) => ctxNames.has(s.manifest.name))).toBe(false);
+  });
+
+  test("context channel is sorted by priority ascending", () => {
+    const pool: Skill[] = [
+      makeSkill({ name: "p50", type: "context", priority: 50 }),
+      makeSkill({ name: "p0", type: "context", priority: 0 }),
+      makeSkill({ name: "p20", type: "context", priority: 20 }),
+    ];
+    expect(partitionSkillsByRole(pool).context.map((s) => s.manifest.name)).toEqual([
+      "p0",
+      "p20",
+      "p50",
+    ]);
+  });
+
+  test("disabled context skills are dropped from the always-on channel", () => {
+    const pool: Skill[] = [
+      makeSkill({ name: "active-ctx", type: "context", status: "active" }),
+      makeSkill({ name: "off-ctx", type: "context", status: "disabled" }),
+      makeSkill({ name: "no-status-ctx", type: "context" }),
+    ];
+    expect(partitionSkillsByRole(pool).context.map((s) => s.manifest.name).sort()).toEqual([
+      "active-ctx",
+      "no-status-ctx",
+    ]);
+  });
+
+  test("a workspace/user-tier context skill (non-boot sourcePath) still routes to context", () => {
+    // The guarantee: workspace/user context skills reach the prompt via the
+    // context channel regardless of where on disk they live — they are NOT
+    // gated to the boot-time set.
+    const pool: Skill[] = [
+      makeSkill({
+        name: "ws-rule",
+        type: "context",
+        sourcePath: "/work/workspaces/ws_x/skills/ws-rule.md",
+      }),
+    ];
+    const { context, capability } = partitionSkillsByRole(pool);
+    expect(context.map((s) => s.manifest.name)).toEqual(["ws-rule"]);
+    expect(capability).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What

Skill composition now routes by **role, not by a downstream filter.** A skill's `type` determines its prompt channel **by construction**:

- **`type: context`** (identity/voice, always-on) → the **context channel** (Layer 0/1), composed from **every tier** (core/builtin/org + workspace + user).
- **`type: skill`** (capability) → the **conditional channels**: tool-affinity Layer 3 (`selectLayer3Skills`) + the keyword matcher.

`partitionSkillsByRole(pool)` splits the per-turn pool into disjoint `{context, capability}` sets. Because the two are disjoint by `type`, a skill can never enter two channels — there is **nothing to de-duplicate**.

## Why (replaces the de-dup band-aid)

The earlier version of this PR added `excludeLayer01Skills` to filter context skills out of the Layer-3 pool. That was a patch over a **structural conflation**: the loader defaulted `type: context → loadingStrategy: "always"`, and `loadConversationSkills` fed context skills into the Layer-3 pool, so every always-on context skill was injected twice per turn. Reviewed with the chief architect; the conclusion was to fix the model, not filter its output.

The fix separates the two axes that were collapsed:
- **role** (`type`) → *which channel* (context vs. conditional)
- **loading-strategy** → *when*, and only for capability skills (`tool_affined` / future `retrieval` / `explicit`)

This also lines up with the volatility-tiered caching (#510): the context channel is the stable cached prefix; conditional skills are the on-demand tier — and it gives P3's Tier-1 catalog + `skills__activate` clean slots to build on.

## Changes

- `loader.ts` — drop the `type: context → always` default; `type` and `loading-strategy` are now orthogonal.
- `select.ts` — add `partitionSkillsByRole`; `selectLayer3Skills` unchanged.
- `runtime.ts` — partition once per turn at all sites (chat, task, `selectRequestLayer3`, `describeRequestSkills`); Layer 0/1 is now tier-aware (workspace/user context skills compose there, not via Layer 3). `activeContextSkills()` demoted to a boot-only audit helper (no longer the compose source).
- `compose.ts` — the live `compose_effective_context` trace partitions by role too, so it mirrors `chat`.
- `authoring-guide.md`, `automation-authoring.md` — reclassified `type: context → type: skill`: both declare tool-affinity but were wrongly forced always-on. (Consolidating the two authoring skills remains a separate follow-up.)

## Tests

- `partitionSkillsByRole` unit tests: role split, disjointness, priority sort, disabled-context dropped, and the **workspace/user-tier context skill is preserved** (routes to the context channel — the kill-always regression guard).
- Integration: a `type: context` skill composes into Layer 1 and is **absent from Layer 3**; a workspace-tier context skill is surfaced via `describeRequestSkills().context`; Layer-3 mechanism tests re-typed to `type: skill` (the role that actually uses Layer 3).

## Known follow-up (observability)

`skills.loaded` / `loading_log` are **Layer-3 telemetry only** — they do not yet record context-channel skills, so a run's persisted record omits which always-on context skills it composed. The live status surface (`describeRequestSkills().context`) does expose them. Recording context-channel loads in the per-run event (and extending the historical audit to cover them) is a clean, separable follow-up — intentionally out of scope here.

## Verify

`verify:static` ✓ · `test:unit` 3749/0 · `test:integration` 602/0 (12 skip) · `smoke` 23/0.
