### PR TITLE
feat(web): API-key connect form for Composio connectors

### DIFF
--- a/docs/src/content/docs/config/connectors-catalog.mdx
+++ b/docs/src/content/docs/config/connectors-catalog.mdx
@@ -166,10 +166,39 @@ NimbleBrain-specific fields under `_meta["ai.nimblebrain/connector"]`:
 | `requiredScopes` | no | List of OAuth scope strings. |
 | `additionalAuthorizationParams` | no | Extra authorize-URL params (e.g. Google's `access_type: offline`). Reserved keys (`client_id`, `state`, `redirect_uri`, `response_type`, `code_challenge`, `code_challenge_method`, `scope`, etc.) are rejected. |
 | `operatorSetup` | required when `auth: static` | `{ portalUrl, hint, clientSecretKey }`. |
-| `composio` | required when `auth: composio` | `{ toolkit, authConfigEnv, tools? }`. `tools` is an optional allowlist of upstream tool names — strongly recommended to keep agent context bounded. |
+| `composio` | required when `auth: composio` | `{ toolkit, authConfigEnv, tools?, authScheme?, fields? }`. `tools` is an optional allowlist of upstream tool names — strongly recommended to keep agent context bounded. `authScheme` defaults to `OAUTH2` (the redirect flow); set it to `API_KEY` for toolkits that authenticate by key (see below). `fields` is required for `API_KEY` — the inputs collected from the user at connect. |
 | `tags` | no | Strings used for filter / search in the Browse page. |
 | `interactive` | no | Sets the "Interactive" badge. |
 | `docsUrl` | no | Connector-specific docs link surfaced on the Configure page. Must be http(s). |
+
+### auth: composio with API keys
+
+Some Composio toolkits authenticate by **API key** rather than OAuth. They skip the redirect: the user pastes the key (and any region/host) into a form, the platform hands it to Composio at connect time, and only an opaque account pointer is persisted — never the key.
+
+Set `authScheme: API_KEY` and declare the `fields` to collect:
+
+```yaml
+    _meta:
+      ai.nimblebrain/connector:
+        auth: composio
+        composio:
+          toolkit: posthog
+          authConfigEnv: COMPOSIO_POSTHOG_AUTH_CONFIG_ID
+          authScheme: API_KEY        # default is OAUTH2 (the redirect flow)
+          fields:
+            - key: generic_api_key   # MUST match Composio's connection field name
+              title: Personal API Key
+              sensitive: true        # rendered as a password input
+              required: true         # required unless explicitly false
+            - key: subdomain
+              title: Region / subdomain
+              required: true
+          tools:
+            - POSTHOG_CREATE_QUERY_IN_PROJECT_BY_ID
+            # ...curated allowlist
+```
+
+Each `fields[].key` is sent to Composio verbatim, so it **must** match the toolkit's connection-initiation field name — which is often **not** what the REST tool catalog suggests (e.g. PostHog's key field is `generic_api_key`, not `api_key`). The same namespace caveat applies to `tools` slugs. The operator runbook for creating the `API_KEY` auth config and verifying field keys + tool slugs is in [Composio Aggregator Setup → API-key toolkits](/deploy/composio/#api-key-toolkits-no-oauth).
 
 ### Offline access & refresh tokens
 

--- a/docs/src/content/docs/deploy/composio.mdx
+++ b/docs/src/content/docs/deploy/composio.mdx
@@ -109,6 +109,29 @@ The full procedure to add (say) Slack to a Composio-backed deployment:
 4. **Catalog YAML**: add a `auth: composio` entry with `composio.toolkit: slack` and `composio.authConfigEnv: COMPOSIO_SLACK_AUTH_CONFIG_ID`. Curate `composio.tools` aggressively — Slack publishes 100+ tools, and the agent's first-turn tool search will spend tens of thousands of tokens listing them all if you let it. See [Connectors Catalog → auth: composio](/config/connectors-catalog/#2-add-the-yaml-entry).
 5. **Roll the deployment**: bump the platform image (or restart pods). The new env var and catalog entry are picked up on next start.
 
+## API-key toolkits (no OAuth)
+
+Some toolkits in Composio's directory authenticate by **API key**, not OAuth (PostHog, among others). There's no vendor OAuth app and no consent redirect: when a user connects, they paste the toolkit's API key (plus any region/host) into a short form, the platform hands it to Composio, and only the opaque `connectedAccountId` is persisted. **The platform never stores the key.** It's the same trust posture as the OAuth path — Composio custodies the credential.
+
+Setup differs from the OAuth procedure above in three ways:
+
+### 1. Create the auth config with the API_KEY scheme
+
+In the Composio dashboard → **Authentication management → Create Auth Config**, pick the toolkit and choose the **API Key** auth scheme. There is **no** "use your own developer credentials" step — API-key toolkits have no OAuth client. Save and copy the `ac_…` id, then wire it into the pod as `COMPOSIO_<TOOLKIT>_AUTH_CONFIG_ID` exactly as for OAuth toolkits. (It is **not** a secret on its own — inert without `COMPOSIO_API_KEY`.)
+
+### 2. Declare authScheme + fields in the catalog
+
+The catalog entry sets `authScheme: API_KEY` and lists the `fields` the connect form collects from the user. See [Connectors Catalog → auth: composio with API keys](/config/connectors-catalog/#auth-composio-with-api-keys) for the YAML shape.
+
+### 3. Verify field keys and tool slugs against Composio
+
+Composio exposes **three** slightly different slug namespaces — the REST tool catalog, the connection-initiation fields, and the tool-router session filter — so two values must be confirmed against Composio's own naming rather than guessed:
+
+- **`fields[].key`** must be the connection-initiation field name. Confirm with `getConnectedAccountInitiationFields("<toolkit>", "API_KEY")` (or the toolkit's auth page on composio.dev). It is often not the obvious name — e.g. PostHog's key field is `generic_api_key` (not `api_key`) plus a `subdomain`.
+- **`tools[]`** must be the tool-router `config.tools` names, which differ from the REST catalog (`GET /api/v3/tools`). The authoritative check is to **install the connector with your candidate list**: session-create returns `400 Invalid tool slugs in config.tools: …` naming every wrong one. Iterate until it installs clean. (A no-filter install's exposed tool list is a *third* namespace — also not authoritative for the filter.)
+
+Everything else — `COMPOSIO_API_KEY`, env wiring, the `[composio] integration: configured` startup check, the egress allowlist — is identical to the OAuth setup above.
+
 ## Disconnect / revocation semantics
 
 When a user clicks Disconnect on a Composio-backed connector:
@@ -118,7 +141,7 @@ When a user clicks Disconnect on a Composio-backed connector:
 3. The bundle's MCP source is stopped and removed from the registry.
 4. Bundle state transitions to `not_authenticated`. The UI shows **Connect** again.
 
-Reconnect after disconnect runs a fresh OAuth flow at the vendor — there's no adopt-existing shortcut because the upstream account was deleted in step 1.
+Reconnect after disconnect runs a fresh OAuth flow at the vendor — there's no adopt-existing shortcut because the upstream account was deleted in step 1. For **API-key** toolkits there's no OAuth flow: reconnect re-opens the key form. Re-connecting an already-connected API-key toolkit (key rotation) replaces and revokes the prior Composio account and is gated to workspace admins, since it swaps the credential every member's agent runs under.
 
 ## Migrating off Composio (per toolkit)
 
@@ -147,6 +170,8 @@ The catalog `name` (`com.google/gmail`) stays stable across the migration. Compo
 | Install returns "Installed … click Connect to retry" | Eager source-start failed (transient upstream / network). The install itself succeeded — workspace.json has the entry, the bundle just couldn't kick its tool list. | Click **Connect** on the connector. If retries keep failing, check pod logs for `[bundles] <serverName> start failed:` |
 | Connect returns 502 `composio_adopt_source_start_failed` | The adopt-existing path matched a Composio account but couldn't bring the local MCP source online. No partial state was persisted. | Click **Disconnect** then **Connect** to run a fresh OAuth flow. Investigate pod logs if it persists. |
 | Install fails with `400 Invalid auth config IDs` from Composio | `COMPOSIO_<TOOLKIT>_AUTH_CONFIG_ID` points at an `ac_…` that doesn't exist in the Composio dashboard | Confirm the id in `platform.composio.dev → Auth Configs`; update your secret; refresh the in-pod value; roll the deployment |
+| Install fails with `400 Invalid tool slugs in config.tools: …` (API-key toolkit) | The `tools` allowlist uses REST-catalog names, not the tool-router `config.tools` namespace | Replace the named slugs with their tool-router equivalents and reinstall to re-validate — see [API-key toolkits](#api-key-toolkits-no-oauth) |
+| Connect form rejects a field or the connection 401s on first tool call (API-key toolkit) | A `fields[].key` doesn't match Composio's connection-initiation field name (e.g. `api_key` vs `generic_api_key`), or the wrong key type was entered | Verify keys via `getConnectedAccountInitiationFields`; confirm the user pasted the correct key type (e.g. PostHog needs a `phx_` personal key, not a `phc_` project key) |
 | Agent returns "model returned an error" on first tool call | Tool allowlist missing or too broad — `nb__search` returns hundreds of tool descriptions and blows past the input-token cap | Add or tighten `composio.tools` in the catalog entry; reinstall |
 | Composio API errors after deploy | API key not propagated through the secret pipeline | `kubectl exec` (or equivalent) into the pod and check `printenv COMPOSIO_API_KEY` |
 | Multiple connected accounts piling up in the Composio dashboard | Legacy state from before the adopt-existing path landed. New connects auto-dedup against the active account. | Manual cleanup in the Composio dashboard for old duplicates |

--- a/docs/src/content/docs/using/connectors.mdx
+++ b/docs/src/content/docs/using/connectors.mdx
@@ -36,13 +36,13 @@ Connectors authenticate in one of three ways. As an end user you rarely need to 
 |------|---------------|-------------|
 | **dcr** | Dynamic Client Registration. The platform registers an OAuth client with the vendor on the fly. | Click **Install**, sign in. No setup. |
 | **static** | The vendor requires a pre-registered OAuth app. A workspace admin configures the app's client ID and secret once. | An admin clicks **Set up** first; after that, everyone connects with **Install**. |
-| **composio** | The service is brokered through Composio, a managed-connector provider. | Click **Install**, sign in through Composio's flow. Requires the platform operator to have configured Composio. |
+| **composio** | The service is brokered through Composio, a managed-connector provider. | Click **Install**. OAuth toolkits send you through the vendor's sign-in; API-key toolkits open a short form where you paste the service's API key (and any region/host it needs). Requires the platform operator to have configured Composio. |
 
 For a **static**-auth connector that hasn't been set up yet, non-admins see "Operator setup required" until an admin completes the one-time **Set up** step.
 
 ## Where your secrets live
 
-Tokens and credentials for a connector are stored in the workspace, at `workspaces/<wsId>/credentials/` on the platform — never echoed back to the UI. For **static**-auth connectors, the admin-configured OAuth client ID is recorded on the workspace; the client secret goes into the same credential store and is never returned in any API response. For **composio** connectors, the platform-wide Composio API key lives in the platform environment, not in the workspace.
+Tokens and credentials for a connector are stored in the workspace, at `workspaces/<wsId>/credentials/` on the platform — never echoed back to the UI. For **static**-auth connectors, the admin-configured OAuth client ID is recorded on the workspace; the client secret goes into the same credential store and is never returned in any API response. For **composio** connectors, the platform-wide Composio API key lives in the platform environment, not in the workspace. For an API-key Composio toolkit, the key you paste into the connect form is sent to Composio and **never stored by the platform** — only an opaque account pointer is kept.
 
 Because credentials are workspace-scoped, connecting a service in one workspace never exposes it to another. See [Credentials](/config/credentials/) for the full storage model.
 

--- a/web/src/__tests__/connector-sections.test.tsx
+++ b/web/src/__tests__/connector-sections.test.tsx
@@ -60,6 +60,11 @@ const setupConnectorOperator = mock(async () => ({
   catalogId: "io.asana/mcp",
   clientId: "cid-rotated",
 }));
+const connectComposioApiKey = mock(async () => ({
+  connected: true,
+  serverName: "com-posthog-analytics",
+  status: "ACTIVE",
+}));
 
 // Spread the preload's real-module snapshot (see web/test/setup.ts) so this
 // whole-module mock exposes every api/client export; only these five are
@@ -72,6 +77,7 @@ mock.module("../api/client", () => ({
   clearBundleUserConfig,
   setBundleUserConfig,
   setupConnectorOperator,
+  connectComposioApiKey,
 }));
 
 const React = await import("react");
@@ -80,8 +86,9 @@ const { act } = await import("react");
 
 const { OAuthConnectionSection } = await import("../components/connectors/OAuthConnectionSection");
 const { OperatorOAuthSection } = await import("../components/connectors/OperatorOAuthSection");
+const { ComposioApiKeyModal } = await import("../components/connectors/ComposioApiKeyModal");
 
-import type { InstalledConnector } from "../api/client";
+import type { ComposioField, InstalledConnector } from "../api/client";
 
 // ── Mount helper (mirrors ResourceLinkView.test.tsx) ────────────────
 
@@ -130,6 +137,7 @@ beforeEach(() => {
   clearBundleUserConfig.mockClear();
   setBundleUserConfig.mockClear();
   setupConnectorOperator.mockClear();
+  connectComposioApiKey.mockClear();
 });
 
 // ── InstalledConnector fixtures ─────────────────────────────────────
@@ -562,5 +570,94 @@ describe("ConnectorStatusHero", () => {
       />,
     );
     expect(findButton(mounted.container, "Connect")).not.toBeNull();
+  });
+});
+
+// ── ComposioApiKeyModal — API-key connect form ──────────────────────
+
+const POSTHOG_FIELDS: ComposioField[] = [
+  { key: "generic_api_key", title: "Personal API Key", sensitive: true, required: true },
+  { key: "subdomain", title: "Region", required: true },
+];
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const WindowEvent = (globalThis as unknown as { window: { Event: typeof Event } }).window.Event;
+  const setVal = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  setVal?.call(input, value);
+  input.dispatchEvent(new WindowEvent("input", { bubbles: true }));
+}
+
+describe("ComposioApiKeyModal", () => {
+  test("renders the declared fields; sensitive field is a password input", async () => {
+    mounted = await mount(
+      <ComposioApiKeyModal
+        catalogId="com.posthog/analytics"
+        connectorName="PostHog"
+        fields={POSTHOG_FIELDS}
+        open={true}
+        onClose={() => {}}
+        onConnected={() => {}}
+      />,
+    );
+    expect(mounted.container.textContent).toContain("Connect PostHog");
+    expect(mounted.container.textContent).toContain("Personal API Key");
+    expect(mounted.container.textContent).toContain("Region");
+    const inputs = Array.from(mounted.container.getElementsByTagName("input"));
+    expect(inputs.length).toBe(2);
+    expect(inputs[0]?.type).toBe("password"); // generic_api_key (sensitive)
+    expect(inputs[1]?.type).toBe("text"); // subdomain
+  });
+
+  test("a missing required field blocks submit (no connect call, shows error)", async () => {
+    mounted = await mount(
+      <ComposioApiKeyModal
+        catalogId="com.posthog/analytics"
+        connectorName="PostHog"
+        fields={POSTHOG_FIELDS}
+        open={true}
+        onClose={() => {}}
+        onConnected={() => {}}
+      />,
+    );
+    await act(async () => {
+      findButton(mounted!.container, "Connect")?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(connectComposioApiKey).not.toHaveBeenCalled();
+    expect(mounted.container.textContent).toContain("required");
+  });
+
+  test("filled fields submit → connectComposioApiKey(catalogId, values) + onConnected", async () => {
+    const onConnected = mock(() => {});
+    mounted = await mount(
+      <ComposioApiKeyModal
+        catalogId="com.posthog/analytics"
+        connectorName="PostHog"
+        fields={POSTHOG_FIELDS}
+        open={true}
+        onClose={() => {}}
+        onConnected={onConnected}
+      />,
+    );
+    const inputs = Array.from(mounted.container.getElementsByTagName("input"));
+    await act(async () => {
+      setInputValue(inputs[0]!, "phx_secret");
+      setInputValue(inputs[1]!, "us");
+    });
+    await act(async () => {
+      findButton(mounted!.container, "Connect")?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(connectComposioApiKey).toHaveBeenCalledTimes(1);
+    expect(connectComposioApiKey.mock.calls[0]).toEqual([
+      "com.posthog/analytics",
+      { generic_api_key: "phx_secret", subdomain: "us" },
+    ]);
+    expect(onConnected).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,6 @@
 import type { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps";
 import type { ToolInput } from "../_generated/platform-schemas/catalog";
+import { addAuthBreadcrumb, captureLogout, setSentryWorkspace } from "../sentry";
 import type {
   ApiError,
   BootstrapResponse,
@@ -9,7 +10,6 @@ import type {
   PlacementEntry,
   ToolCallResult,
 } from "../types";
-import { addAuthBreadcrumb, captureLogout, setSentryWorkspace } from "../sentry";
 import { createFetchWithRefresh } from "./fetch-with-refresh";
 
 // ---------------------------------------------------------------------------
@@ -576,6 +576,31 @@ export async function initiateComposioOAuth(
  * Connectors catalog entry — one card on Settings → Connectors.
  * Mirrors the server-side `ConnectorCatalogEntry` shape.
  */
+/**
+ * One field collected from the user when connecting a non-redirect
+ * (API-key) Composio connector. `key` is the Composio connection-field
+ * name, sent verbatim; the value is handed to Composio at connect time
+ * and never persisted by the platform. `sensitive` → render password.
+ */
+export interface ComposioField {
+  key: string;
+  title: string;
+  description?: string;
+  sensitive?: boolean;
+  required?: boolean;
+  placeholder?: string;
+}
+
+/** Composio connector config carried on catalog + directory entries. */
+export interface ComposioConfig {
+  toolkit: string;
+  authConfigEnv: string;
+  tools?: string[];
+  /** Defaults to OAUTH2 (the redirect flow). API_KEY connectors collect `fields`. */
+  authScheme?: "OAUTH2" | "API_KEY";
+  fields?: ComposioField[];
+}
+
 export interface ConnectorCatalogEntry {
   id: string;
   name: string;
@@ -588,7 +613,7 @@ export interface ConnectorCatalogEntry {
   additionalAuthorizationParams?: Record<string, string>;
   operatorSetup?: { portalUrl: string; hint: string; clientSecretKey: string };
   /** Composio-backed connectors: toolkit slug + auth-config env var + optional tool allowlist. */
-  composio?: { toolkit: string; authConfigEnv: string; tools?: string[] };
+  composio?: ComposioConfig;
   tags?: string[];
   /** When true, the connector exposes a UI surface — render the "Interactive" badge. */
   interactive?: boolean;
@@ -888,7 +913,7 @@ export interface DirectoryEntry {
         requiredScopes?: string[];
         additionalAuthorizationParams?: Record<string, string>;
         operatorSetup?: { portalUrl: string; hint: string; clientSecretKey: string };
-        composio?: { toolkit: string; authConfigEnv: string; tools?: string[] };
+        composio?: ComposioConfig;
       }
     | { kind: "mpak-bundle"; package: string }
     | { kind: "direct-url"; url: string };
@@ -921,6 +946,25 @@ export async function setupConnectorOperator(
     clientSecret,
   });
   return unwrapStructured(result, "setup_operator");
+}
+
+/**
+ * Connect a non-redirect (API-key) Composio connector. Collects the
+ * connector's declared `fields` (e.g. generic_api_key, subdomain) and
+ * hands them to Composio at connect time; the platform persists only the
+ * opaque connectedAccountId. A first connect is member-level; re-connect
+ * (rotation, when a connection already exists) is ws_admin gated server-side.
+ */
+export async function connectComposioApiKey(
+  catalogId: string,
+  fields: Record<string, string>,
+): Promise<{ connected: boolean; serverName: string; status: string }> {
+  const result = await callTool("nb", "manage_connectors", {
+    action: "connect_api_key",
+    catalogId,
+    fields,
+  });
+  return unwrapStructured(result, "connect_api_key");
 }
 
 /**

--- a/web/src/components/connectors/ComposioApiKeyModal.tsx
+++ b/web/src/components/connectors/ComposioApiKeyModal.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from "react";
+import { type ComposioField, connectComposioApiKey } from "../../api/client";
+
+/**
+ * Field-collection modal for a non-redirect (API-key) Composio connector.
+ * The sibling of {@link OperatorSetupModal}: instead of an OAuth round-trip,
+ * the user pastes the connector's declared `fields` (e.g. a PostHog personal
+ * API key + region), which are handed to Composio at connect time and never
+ * persisted by the platform. Used for both first connect and reconnect/rotation
+ * (the rotation case is ws_admin gated server-side; the error surfaces inline).
+ *
+ * Form shape is driven entirely by `fields` so any API-key toolkit reuses it —
+ * the component knows nothing PostHog-specific.
+ */
+export function ComposioApiKeyModal({
+  catalogId,
+  connectorName,
+  fields,
+  open,
+  onClose,
+  onConnected,
+}: {
+  catalogId: string;
+  connectorName: string;
+  fields: ComposioField[];
+  open: boolean;
+  onClose: () => void;
+  onConnected: () => void;
+}) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const firstFieldRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset on open so a reconnect/rotation never shows stale values.
+  useEffect(() => {
+    if (open) {
+      setValues({});
+      setError(null);
+      setBusy(false);
+      setTimeout(() => firstFieldRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  // Esc closes; transient overlay, not navigation.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, busy, onClose]);
+
+  if (!open) return null;
+
+  // Required unless explicitly opted out — mirrors the server's
+  // `required !== false` default-deny in connect_api_key.
+  const isRequired = (f: ComposioField) => f.required !== false;
+
+  const submit = async () => {
+    if (busy) return;
+    const payload: Record<string, string> = {};
+    for (const f of fields) {
+      const v = (values[f.key] ?? "").trim();
+      if (!v) {
+        if (isRequired(f)) {
+          setError(`${f.title} is required.`);
+          return;
+        }
+        continue;
+      }
+      payload[f.key] = v;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await connectComposioApiKey(catalogId, payload);
+      onConnected();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="composio-apikey-title"
+        className="bg-background border border-border rounded-lg shadow-xl w-full max-w-md p-5"
+      >
+        <h2 id="composio-apikey-title" className="text-base font-semibold">
+          Connect {connectorName}
+        </h2>
+        <p className="text-xs text-muted-foreground mt-1">
+          Enter your credentials below. They're sent to the connector provider and never stored by
+          the platform.
+        </p>
+
+        {/* Not a <form>: validation lives in JS (`submit`) and the primary
+            button drives it via onClick. Enter-to-submit is preserved by the
+            per-input keydown handler. (Native form submission triggers the
+            browser's checkValidity pass, which we don't use.) */}
+        <div className="mt-4 space-y-3">
+          {fields.map((f, idx) => (
+            <label key={f.key} className="block">
+              <span className="text-xs font-medium">
+                {f.title}
+                {!isRequired(f) && <span className="text-muted-foreground"> (optional)</span>}
+              </span>
+              <input
+                ref={idx === 0 ? firstFieldRef : undefined}
+                type={f.sensitive ? "password" : "text"}
+                value={values[f.key] ?? ""}
+                onChange={(e) => setValues((prev) => ({ ...prev, [f.key]: e.target.value }))}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void submit();
+                  }
+                }}
+                autoComplete="off"
+                data-1p-ignore="true"
+                data-lpignore="true"
+                spellCheck={false}
+                disabled={busy}
+                placeholder={f.placeholder}
+                className="mt-1 w-full text-sm font-mono px-2.5 py-1.5 rounded border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+              />
+              {f.description && (
+                <span className="block text-[11px] text-muted-foreground mt-1">
+                  {f.description}
+                </span>
+              )}
+            </label>
+          ))}
+          {error && <p className="text-xs text-destructive">{error}</p>}
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={busy}
+              className="text-xs px-3 py-1.5 rounded border border-border hover:bg-muted disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void submit()}
+              disabled={busy}
+              className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+            >
+              {busy ? "Connecting…" : "Connect"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/connectors/ConnectorStatusHero.tsx
+++ b/web/src/components/connectors/ConnectorStatusHero.tsx
@@ -2,11 +2,12 @@ import { useMemo, useState } from "react";
 import {
   type DirectoryEntry,
   disconnectConnector,
+  type InstalledConnector,
   initiateComposioOAuth,
   initiateMcpOAuth,
-  type InstalledConnector,
 } from "../../api/client";
 import { BundleCredentialsModal } from "./BundleCredentialsModal";
+import { ComposioApiKeyModal } from "./ComposioApiKeyModal";
 import { ConnectorIcon } from "./ConnectorIcon";
 import { OperatorSetupModal } from "./OperatorSetupModal";
 
@@ -49,6 +50,7 @@ export function ConnectorStatusHero({
   const [error, setError] = useState<string | null>(null);
   const [bundleModalOpen, setBundleModalOpen] = useState(false);
   const [operatorModalOpen, setOperatorModalOpen] = useState(false);
+  const [apiKeyModalOpen, setApiKeyModalOpen] = useState(false);
 
   const cat = installed.catalog;
   const name = cat?.name ?? installed.serverName;
@@ -110,6 +112,13 @@ export function ConnectorStatusHero({
       return;
     }
     if (action.kind === "oauth") {
+      // API-key Composio connectors have no redirect — collect the declared
+      // fields in a modal and call connect_api_key (rotation is admin-gated
+      // server-side). Branch before the OAuth dispatch below.
+      if (cat?.auth === "composio" && cat.composio?.authScheme === "API_KEY") {
+        setApiKeyModalOpen(true);
+        return;
+      }
       setActing(true);
       try {
         // Composio-backed connectors route through their own
@@ -208,6 +217,19 @@ export function ConnectorStatusHero({
           onClose={() => setOperatorModalOpen(false)}
           onSaved={() => {
             setOperatorModalOpen(false);
+            onChanged();
+          }}
+        />
+      )}
+      {apiKeyModalOpen && cat && (
+        <ComposioApiKeyModal
+          catalogId={cat.id}
+          connectorName={name}
+          fields={cat.composio?.fields ?? []}
+          open={apiKeyModalOpen}
+          onClose={() => setApiKeyModalOpen(false)}
+          onConnected={() => {
+            setApiKeyModalOpen(false);
             onChanged();
           }}
         />

--- a/web/src/pages/settings/ConnectorBrowsePage.tsx
+++ b/web/src/pages/settings/ConnectorBrowsePage.tsx
@@ -3,12 +3,13 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   type DirectoryEntry,
   getInstalledConnectors,
-  installConnector,
   type InstalledConnector,
   initiateComposioOAuth,
   initiateMcpOAuth,
+  installConnector,
   listDirectory,
 } from "../../api/client";
+import { ComposioApiKeyModal } from "../../components/connectors/ComposioApiKeyModal";
 import { ConnectorIcon } from "../../components/connectors/ConnectorIcon";
 import { OperatorSetupModal } from "../../components/connectors/OperatorSetupModal";
 import { roleAtLeast, useScopedRole } from "../../hooks/useScopedRole";
@@ -31,6 +32,13 @@ export function ConnectorBrowsePage() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [setupModalEntry, setSetupModalEntry] = useState<DirectoryEntry | null>(null);
+  // API-key Composio connector: after install we collect the key fields in a
+  // modal (no OAuth redirect), then call connect_api_key. Holds the entry +
+  // its installed serverName so success can route to Configure.
+  const [apiKeyModal, setApiKeyModal] = useState<{
+    entry: DirectoryEntry;
+    serverName: string;
+  } | null>(null);
 
   const role = useScopedRole();
   const isWsAdmin = roleAtLeast(role, "ws_admin");
@@ -136,6 +144,14 @@ export function ConnectorBrowsePage() {
           navigate(`${configureBasePath}/${result.serverName}`);
           return;
         }
+        // API-key Composio connectors have no OAuth redirect — collect the
+        // declared fields in a modal and call connect_api_key. The install
+        // above already created the bundle ref the connect step needs.
+        if (entry.install.auth === "composio" && entry.install.composio?.authScheme === "API_KEY") {
+          setApiKeyModal({ entry, serverName: result.serverName });
+          setBusyId(null);
+          return;
+        }
         // Composio-backed connectors route through their own initiate
         // endpoint (keyed on catalog id, not server name). Everything
         // else (dcr + static) stays on /v1/mcp-auth.
@@ -226,6 +242,21 @@ export function ConnectorBrowsePage() {
           onSaved={() => {
             setSetupModalEntry(null);
             fetchDirectory();
+          }}
+        />
+      )}
+
+      {apiKeyModal && apiKeyModal.entry.install.kind === "remote-oauth" && (
+        <ComposioApiKeyModal
+          catalogId={apiKeyModal.entry.id}
+          connectorName={apiKeyModal.entry.name}
+          fields={apiKeyModal.entry.install.composio?.fields ?? []}
+          open={true}
+          onClose={() => setApiKeyModal(null)}
+          onConnected={() => {
+            const serverName = apiKeyModal.serverName;
+            setApiKeyModal(null);
+            navigate(`${configureBasePath}/${serverName}`);
           }}
         />
       )}


### PR DESCRIPTION
## What

Adds the web UI so a client can **Install an API-key Composio connector and enter its credentials in-app** — the missing front end for the `connect_api_key` backend that landed in #515. Until now, clicking Install on an `authScheme: "API_KEY"` connector (e.g. PostHog) routed into the OAuth redirect path, which has no redirect to follow, and failed.

## How

- **`client.ts`** — the server already ships `authScheme` + `fields` on `install.composio` / `catalog.composio`; widen the two web types to expose them (new `ComposioField` / `ComposioConfig`). Add `connectComposioApiKey(catalogId, fields)` → `manage_connectors.connect_api_key`.
- **`ComposioApiKeyModal.tsx`** (new) — a field-driven form rendered from the connector's declared `fields`: titles, descriptions, password inputs for `sensitive`, required-field validation mirroring the server's `required !== false` default. Reuses the `OperatorSetupModal` chrome. Submits via an `onClick` handler (Enter-to-submit preserved via a keydown handler) rather than native form submission.
- **Connect flow branch** — in `ConnectorBrowsePage` (post-install) and `ConnectorStatusHero` (connect/reconnect), when `authScheme === "API_KEY"` open the modal instead of `initiateComposioOAuth`. First connect is member-level; reconnect/rotation is admin-gated server-side and the error surfaces inline.

## Trust posture

Unchanged from the backend: field values flow to `connect_api_key` → Composio and are **never persisted** by the platform (only the opaque `connectedAccountId`). `sensitive` fields render as password inputs and aren't logged.

## Testing

- `bun run verify` green (static + 3763 unit + web + smoke).
- New tests in `connector-sections.test.tsx`: `connectComposioApiKey` wiring, modal field rendering (+ password for sensitive), required-field validation (no call on empty), and filled-submit calls the helper with the right `(catalogId, values)` + fires `onConnected`.

## Notes

- A small UX detail worth a look: the modal intentionally is **not** a `<form>` — happy-dom crashes on `requestSubmit`/`checkValidity`, and we do validation in JS, so the primary button drives submit via `onClick` with Enter handled per-input. Same end-user behavior, testable.
- This unblocks **deployments#96** (the PostHog catalog entry), which was held in draft pending this form. Sequence after merge: roll the runtime image → undraft + merge #96 → provision `COMPOSIO_POSTHOG_AUTH_CONFIG_ID` per env.
- Validated end-to-end locally against real PostHog via the same `connect_api_key` action this form calls (install → connect ACTIVE → live tool read).
