### PR TITLE
ci: bump deprecated Node 20 actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       # layer cache used by ./.github/actions/build-push-image. The cache
       # restores the base layers (apt deps, node, bun, mpak) that don't change
       # between commits, so a warm build skips them.
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -189,7 +189,7 @@ jobs:
       - name: Mint deploy-repo token
         if: steps.cfg.outputs.enabled == 'true'
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EDGE_BUMP_APP_ID }}
           private-key: ${{ secrets.EDGE_BUMP_APP_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -293,7 +293,7 @@ jobs:
       - name: Mint prod-promote token
         if: steps.cfg.outputs.enabled == 'true'
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.PROD_PROMOTE_APP_ID }}
           private-key: ${{ secrets.PROD_PROMOTE_APP_KEY }}


### PR DESCRIPTION
## What

The `v0.6.0` release run flagged a Node 20 deprecation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `docker/setup-buildx-action@v3` … `actions/create-github-app-token@v2`.

Bump both to their Node 24 majors:

| Action | Before | After | `runs.using` |
|---|---|---|---|
| `docker/setup-buildx-action` | `@v3` | `@v4` | `node24` ✓ |
| `actions/create-github-app-token` | `@v2` | `@v3` | `node24` ✓ |

Applied in the only two workflows that use them — `release.yml` (buildx in the retag job, app-token in promote-to-prod) and `ci.yml` (buildx in build-and-push, app-token in roll-staging-edge). 4 lines total.

## Verified

- Confirmed both target versions are `runs.using: node24` (checked their `action.yml`).
- `setup-bun@v2` and `checkout@v6` already run on Node 24 — left as-is.
- No other workflow uses these two actions (grep across `.github/workflows/`).
- Both files still parse as valid YAML.

Pure version bump — no behavior change. Clears the deprecation warning so the actions aren't force-migrated unpredictably when GitHub drops the Node 20 shim.