### PR TITLE
feat(oauth): decouple authorizer token endpoint from issuer identity

### DIFF
--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -56,8 +56,12 @@ export interface RemoteTransportConfig {
      * its `config` are opaque to the kernel — for a catalog connector they come
      * from the operator-published catalog entry, never tenant input. The
      * built-in `"minted"` provider mints a short-lived, workspace-scoped service
-     * token against the fleet authorizer (config: `{ audience, scope, issuer? }`)
-     * and re-mints on expiry. No interactive OAuth, no static secret. The
+     * token against the fleet authorizer (config:
+     * `{ audience, scope, tokenUrl?, issuer? }`) and re-mints on expiry. The
+     * endpoint resolves via `resolveAuthorizerTokenUrl`: `tokenUrl` is an explicit
+     * per-connection endpoint override; `issuer` is the legacy identity from which
+     * `${issuer}/token` is derived. Per-connection config wins over the global env.
+     * No interactive OAuth, no static secret. The
      * workspace dimension is the connection's own workspace.
      */
     | { type: "provider"; provider: string; config: Record<string, unknown> };

--- a/src/host-resources/artifacts/data-plane-read-client.ts
+++ b/src/host-resources/artifacts/data-plane-read-client.ts
@@ -1,6 +1,7 @@
 import {
   createMintingFetch,
   getDefaultServiceTokenCache,
+  resolveAuthorizerTokenUrl,
   type ServiceTokenCache,
 } from "../../oauth/tenant-key-mint.ts";
 
@@ -78,8 +79,8 @@ export class ArtifactReadError extends Error {
 export interface ArtifactDataPlaneConfig {
   /** Base URL of the artifacts data-plane service (the read API root). */
   baseUrl: string;
-  /** mcp-authorizer issuer the tenant-key exchange mints against. */
-  issuer: string;
+  /** Authorizer token endpoint (POST target) the tenant-key exchange mints against. */
+  tokenUrl: string;
 }
 
 /**
@@ -97,13 +98,16 @@ export function readArtifactDataPlaneConfigFromEnv(
       "NB_ARTIFACTS_DATA_PLANE_URL is not set; cannot resolve artifact:// references",
     );
   }
-  const issuer = env.NB_FLEET_AUTHORIZER_ISSUER;
-  if (!issuer) {
+  const tokenUrl = resolveAuthorizerTokenUrl({
+    tokenUrl: env.NB_FLEET_AUTHORIZER_TOKEN_URL,
+    issuer: env.NB_FLEET_AUTHORIZER_ISSUER,
+  });
+  if (!tokenUrl) {
     throw new ArtifactReadError(
-      "NB_FLEET_AUTHORIZER_ISSUER is not set; cannot mint an artifacts read token",
+      "authorizer token endpoint is not set; cannot mint an artifacts read token (set NB_FLEET_AUTHORIZER_TOKEN_URL, or NB_FLEET_AUTHORIZER_ISSUER for the legacy `${issuer}/token` fallback)",
     );
   }
-  return { baseUrl, issuer };
+  return { baseUrl, tokenUrl };
 }
 
 export interface ArtifactReadClientOptions {
@@ -216,7 +220,7 @@ export class ArtifactReadClient {
     // identity-only, scoped to (tenant, workspace, aud=artifacts, read).
     const authedFetch = createMintingFetch({
       cache: this.cache,
-      issuer: this.config.issuer,
+      tokenUrl: this.config.tokenUrl,
       workspace: workspaceId,
       audience: ARTIFACTS_AUDIENCE,
       scope: ARTIFACTS_READ_SCOPE,
@@ -332,7 +336,7 @@ export class ArtifactReadClient {
     }
     const authedFetch = createMintingFetch({
       cache: this.cache,
-      issuer: this.config.issuer,
+      tokenUrl: this.config.tokenUrl,
       workspace: workspaceId,
       audience: ARTIFACTS_AUDIENCE,
       scope: ARTIFACTS_READ_SCOPE,

--- a/src/oauth/minted-credential-provider.ts
+++ b/src/oauth/minted-credential-provider.ts
@@ -4,7 +4,11 @@ import {
   type TransportCredential,
   type TransportCredentialProvider,
 } from "../tools/credential-provider.ts";
-import { createMintingFetch, getDefaultServiceTokenCache } from "./tenant-key-mint.ts";
+import {
+  createMintingFetch,
+  getDefaultServiceTokenCache,
+  resolveAuthorizerTokenUrl,
+} from "./tenant-key-mint.ts";
 
 /** The provider name a catalog/source auth config selects: `{ type: "provider";
  *  provider: "minted"; config: { audience, scope, issuer? } }`. */
@@ -19,9 +23,11 @@ export const MINTED_PROVIDER = "minted";
  * read path uses it too), but `remote-transport.ts` reaches it only through this
  * registered provider, never by import.
  *
- * `config`: `{ audience: string; scope: string; issuer?: string }`. `issuer`
- * defaults to `NB_FLEET_AUTHORIZER_ISSUER`. Workspace comes from the connection
- * (the dimension the token is scoped to), NOT from config.
+ * `config`: `{ audience: string; scope: string; tokenUrl?: string; issuer?: string }`.
+ * The authorizer token endpoint resolves via `resolveAuthorizerTokenUrl`: an explicit
+ * `tokenUrl` (config or `NB_FLEET_AUTHORIZER_TOKEN_URL`) wins, else `${issuer}/token`
+ * from `NB_FLEET_AUTHORIZER_ISSUER` (legacy fallback). Workspace comes from the
+ * connection (the dimension the token is scoped to), NOT from config.
  */
 export const mintedCredentialProvider: TransportCredentialProvider = {
   credentialFor(
@@ -38,12 +44,13 @@ export const mintedCredentialProvider: TransportCredentialProvider = {
         "minted transport credential requires a config object ({ audience, scope }); got a `provider` auth with no `config`",
       );
     }
-    const issuer =
-      (typeof config.issuer === "string" && config.issuer) ||
-      process.env.NB_FLEET_AUTHORIZER_ISSUER;
-    if (!issuer) {
+    const tokenUrl = resolveAuthorizerTokenUrl({
+      tokenUrl: typeof config.tokenUrl === "string" ? config.tokenUrl : undefined,
+      issuer: typeof config.issuer === "string" ? config.issuer : undefined,
+    });
+    if (!tokenUrl) {
       throw new Error(
-        "minted transport credential requires NB_FLEET_AUTHORIZER_ISSUER (the mcp-authorizer issuer)",
+        "minted transport credential requires the authorizer token endpoint (set NB_FLEET_AUTHORIZER_TOKEN_URL, or NB_FLEET_AUTHORIZER_ISSUER for the legacy `${issuer}/token` fallback)",
       );
     }
     const { audience, scope } = config;
@@ -55,7 +62,7 @@ export const mintedCredentialProvider: TransportCredentialProvider = {
     }
     const fetch = createMintingFetch({
       cache: getDefaultServiceTokenCache(),
-      issuer,
+      tokenUrl,
       workspace: workspaceId,
       audience,
       scope,

--- a/src/oauth/tenant-key-mint.ts
+++ b/src/oauth/tenant-key-mint.ts
@@ -181,10 +181,32 @@ export function readTenantIdentityFromEnv(env: NodeJS.ProcessEnv = process.env):
   return { tid, tenantKey };
 }
 
+/**
+ * Resolve the authorizer's token endpoint (the POST target) — decoupled from the
+ * `iss` identity. An explicit `tokenUrl` wins (a per-connection override, or
+ * `NB_FLEET_AUTHORIZER_TOKEN_URL`); otherwise it is derived from the legacy,
+ * identity-overloaded issuer as `${issuer}/token` for backward-compat. Because the
+ * mint never inspects `iss` (only verifiers do), the endpoint can move
+ * (namespace/cluster) with ZERO token-contract change — set the new var and the
+ * POST target moves while `iss` stays put. Returns `undefined` when neither is
+ * configured; the caller decides whether that is an error.
+ */
+export function resolveAuthorizerTokenUrl(
+  opts: { tokenUrl?: string; issuer?: string } = {},
+): string | undefined {
+  const explicit = opts.tokenUrl ?? process.env.NB_FLEET_AUTHORIZER_TOKEN_URL;
+  if (explicit) return explicit;
+  const issuer = opts.issuer ?? process.env.NB_FLEET_AUTHORIZER_ISSUER;
+  return issuer ? new URL("/token", issuer).toString() : undefined;
+}
+
 export interface MintServiceTokenOptions {
-  /** Authorizer issuer, e.g. `https://mcp-authorizer.mcp-shared.svc`. The mint
-   *  POST goes to `${issuer}/token`. */
-  issuer: string;
+  /** The authorizer's token endpoint, e.g. `http://mcp-authorizer.mcp-shared.svc/token`.
+   *  This is the physical POST target — deployment plumbing, NOT the `iss` identity.
+   *  The mint never inspects `iss` (only verifiers do), so location and identity are
+   *  decoupled: the endpoint can move (namespace/cluster) without any token-contract
+   *  change. Resolve via `resolveAuthorizerTokenUrl()`. */
+  tokenUrl: string;
   workspace: string;
   audience: string;
   scope: string;
@@ -210,7 +232,7 @@ export async function mintServiceToken(opts: MintServiceTokenOptions): Promise<S
     now: nowSeconds,
   });
 
-  const tokenUrl = new URL("/token", opts.issuer).toString();
+  const tokenUrl = opts.tokenUrl;
   const body = new URLSearchParams({ grant_type: TENANT_KEY_GRANT, tenant_assertion: wire });
   const doFetch = opts.fetchImpl ?? fetch;
 
@@ -260,17 +282,17 @@ export async function mintServiceToken(opts: MintServiceTokenOptions): Promise<S
   return { accessToken: json.access_token, expiresAt: nowSeconds + json.expires_in };
 }
 
-/** Cache key — one minted token per distinct `(issuer, tid, workspace, audience,
+/** Cache key — one minted token per distinct `(tokenUrl, tid, workspace, audience,
  *  scope)`. tid is included so a key-rotation that changes identity can't serve a
- *  stale token. */
+ *  stale token; tokenUrl namespaces by authorizer endpoint. */
 function cacheKey(
-  issuer: string,
+  tokenUrl: string,
   tid: string,
   workspace: string,
   audience: string,
   scope: string,
 ): string {
-  return [issuer, tid, workspace, audience, scope].join("|");
+  return [tokenUrl, tid, workspace, audience, scope].join("|");
 }
 
 interface CacheSlot {
@@ -280,7 +302,8 @@ interface CacheSlot {
 }
 
 export interface TokenRequest {
-  issuer: string;
+  /** Authorizer token endpoint (POST target), not the `iss` identity. */
+  tokenUrl: string;
   workspace: string;
   audience: string;
   scope: string;
@@ -314,7 +337,7 @@ export class ServiceTokenCache {
    * fresh. `forceRefresh` discards any cached token first — the 401-retry path.
    */
   async getToken(req: TokenRequest, opts: { forceRefresh?: boolean } = {}): Promise<string> {
-    const key = cacheKey(req.issuer, this.identity.tid, req.workspace, req.audience, req.scope);
+    const key = cacheKey(req.tokenUrl, this.identity.tid, req.workspace, req.audience, req.scope);
     const slot = this.slots.get(key) ?? {};
 
     if (opts.forceRefresh) {
@@ -330,7 +353,7 @@ export class ServiceTokenCache {
     }
 
     const inflight = mintServiceToken({
-      issuer: req.issuer,
+      tokenUrl: req.tokenUrl,
       workspace: req.workspace,
       audience: req.audience,
       scope: req.scope,
@@ -367,8 +390,8 @@ export function getDefaultServiceTokenCache(): ServiceTokenCache {
 
 export interface MintingFetchOptions {
   cache: ServiceTokenCache;
-  /** Authorizer issuer the cache mints against. */
-  issuer: string;
+  /** Authorizer token endpoint the cache mints against (POST target, not `iss`). */
+  tokenUrl: string;
   workspace: string;
   audience: string;
   scope: string;
@@ -389,7 +412,7 @@ export interface MintingFetchOptions {
 export function createMintingFetch(opts: MintingFetchOptions): typeof fetch {
   const base = opts.baseFetch ?? fetch;
   const req: TokenRequest = {
-    issuer: opts.issuer,
+    tokenUrl: opts.tokenUrl,
     workspace: opts.workspace,
     audience: opts.audience,
     scope: opts.scope,

--- a/src/oauth/tenant-key-mint.ts
+++ b/src/oauth/tenant-key-mint.ts
@@ -194,10 +194,17 @@ export function readTenantIdentityFromEnv(env: NodeJS.ProcessEnv = process.env):
 export function resolveAuthorizerTokenUrl(
   opts: { tokenUrl?: string; issuer?: string } = {},
 ): string | undefined {
-  const explicit = opts.tokenUrl ?? process.env.NB_FLEET_AUTHORIZER_TOKEN_URL;
-  if (explicit) return explicit;
-  const issuer = opts.issuer ?? process.env.NB_FLEET_AUTHORIZER_ISSUER;
-  return issuer ? new URL("/token", issuer).toString() : undefined;
+  // Per-connection config (opts) is more specific than global env, so it wins
+  // OUTRIGHT — a connection pinned to its own authorizer via `config.issuer` /
+  // `config.tokenUrl` is never silently redirected to the global endpoint once
+  // Item 2 sets NB_FLEET_AUTHORIZER_TOKEN_URL. Within each tier, an explicit
+  // endpoint beats the issuer-derived one.
+  if (opts.tokenUrl) return opts.tokenUrl;
+  if (opts.issuer) return new URL("/token", opts.issuer).toString();
+  const envTokenUrl = process.env.NB_FLEET_AUTHORIZER_TOKEN_URL;
+  if (envTokenUrl) return envTokenUrl;
+  const envIssuer = process.env.NB_FLEET_AUTHORIZER_ISSUER;
+  return envIssuer ? new URL("/token", envIssuer).toString() : undefined;
 }
 
 export interface MintServiceTokenOptions {
@@ -312,7 +319,7 @@ export interface TokenRequest {
 /**
  * Expiry-aware, single-flight cache over `mintServiceToken`. One instance backs
  * all tenant-key connections in a runtime: it dedupes concurrent mints for the
- * same `(issuer, workspace, audience, scope)` and re-mints just before expiry
+ * same `(tokenUrl, tid, workspace, audience, scope)` and re-mints just before expiry
  * (or on demand after a 401).
  *
  * Identity (`tid` + key) is read once from the env at construction and reused —

--- a/test/unit/artifact-resolver.test.ts
+++ b/test/unit/artifact-resolver.test.ts
@@ -28,6 +28,7 @@ import { ServiceTokenCache, type TenantIdentity } from "../../src/oauth/tenant-k
 
 const TID = "tenant-a";
 const ISSUER = "https://authorizer.test";
+const TOKEN_URL = `${ISSUER}/token`;
 const DATA_PLANE = "https://artifacts.test";
 
 // A 32-byte tenant key (the cache validates length, not content, when the
@@ -154,7 +155,7 @@ function makeResolver(
   const dataPlaneFetch = makeDataPlaneFetch(rows, presigned);
   const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl: dataPlaneFetch });
   const client = new ArtifactReadClient({
-    config: { baseUrl: DATA_PLANE, issuer: ISSUER },
+    config: { baseUrl: DATA_PLANE, tokenUrl: TOKEN_URL },
     cache,
     fetchImpl: dataPlaneFetch,
   });
@@ -277,7 +278,7 @@ function makeReadClient(
   const dataPlaneFetch = makeDataPlaneFetch(rows, presigned);
   const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl: dataPlaneFetch });
   return new ArtifactReadClient({
-    config: { baseUrl: DATA_PLANE, issuer: ISSUER },
+    config: { baseUrl: DATA_PLANE, tokenUrl: TOKEN_URL },
     cache,
     fetchImpl: dataPlaneFetch,
   });
@@ -382,7 +383,7 @@ function makeListFetch(byWorkspace: Record<string, ListRow[]>): typeof fetch {
 function makeListClient(byWorkspace: Record<string, ListRow[]>): ArtifactReadClient {
   const fetchImpl = makeListFetch(byWorkspace);
   const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl });
-  return new ArtifactReadClient({ config: { baseUrl: DATA_PLANE, issuer: ISSUER }, cache, fetchImpl });
+  return new ArtifactReadClient({ config: { baseUrl: DATA_PLANE, tokenUrl: TOKEN_URL }, cache, fetchImpl });
 }
 
 describe("ArtifactReadClient.list — discovery as the viewing user", () => {
@@ -474,7 +475,7 @@ describe("ArtifactReadClient.list — discovery as the viewing user", () => {
     }) as typeof fetch;
     const cache = new ServiceTokenCache({ identity: IDENTITY, fetchImpl });
     const client = new ArtifactReadClient({
-      config: { baseUrl: DATA_PLANE, issuer: ISSUER },
+      config: { baseUrl: DATA_PLANE, tokenUrl: TOKEN_URL },
       cache,
       fetchImpl,
     });

--- a/test/unit/tenant-key-mint.test.ts
+++ b/test/unit/tenant-key-mint.test.ts
@@ -6,6 +6,7 @@ import {
   MintError,
   mintServiceToken,
   readTenantIdentityFromEnv,
+  resolveAuthorizerTokenUrl,
   ServiceTokenCache,
   type TenantIdentity,
 } from "../../src/oauth/tenant-key-mint.ts";
@@ -217,7 +218,7 @@ describe("mintServiceToken", () => {
   it("mints a token and computes absolute expiry from expires_in", async () => {
     const { fetchImpl } = fakeAuthorizer({ expiresIn: 300, now: () => 1000 });
     const tok = await mintServiceToken({
-      issuer: "https://authz.test",
+      tokenUrl: "https://authz.test/token",
       workspace: "ws_smoke",
       audience: "artifacts",
       scope: "artifacts:write",
@@ -245,7 +246,7 @@ describe("mintServiceToken", () => {
 });
 
 describe("ServiceTokenCache", () => {
-  const req = { issuer: "https://authz.test", workspace: "ws_smoke", audience: "artifacts", scope: "artifacts:write" };
+  const req = { tokenUrl: "https://authz.test/token", workspace: "ws_smoke", audience: "artifacts", scope: "artifacts:write" };
 
   it("serves a cached token until the renew skew, then re-mints", async () => {
     let clock = 1000;
@@ -297,7 +298,7 @@ describe("ServiceTokenCache", () => {
 });
 
 describe("createMintingFetch", () => {
-  const req = { issuer: "https://authz.test", workspace: "ws_smoke", audience: "artifacts", scope: "artifacts:write" };
+  const req = { tokenUrl: "https://authz.test/token", workspace: "ws_smoke", audience: "artifacts", scope: "artifacts:write" };
 
   it("attaches a freshly-minted bearer to each outbound request", async () => {
     const authz = fakeAuthorizer({ now: () => 1000 });
@@ -347,5 +348,70 @@ describe("createMintingFetch", () => {
     const res = await f("https://artifacts.test/v1/artifacts");
     expect(res.status).toBe(500);
     expect(serviceCalls).toBe(1); // 500 is surfaced, not retried
+  });
+});
+
+describe("resolveAuthorizerTokenUrl (issuer/endpoint decoupling)", () => {
+  const ENV = ["NB_FLEET_AUTHORIZER_TOKEN_URL", "NB_FLEET_AUTHORIZER_ISSUER"] as const;
+  function withEnv(
+    vals: Partial<Record<(typeof ENV)[number], string | undefined>>,
+    fn: () => void,
+  ): void {
+    const saved = Object.fromEntries(ENV.map((k) => [k, process.env[k]]));
+    try {
+      for (const k of ENV) {
+        const v = vals[k];
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      fn();
+    } finally {
+      for (const k of ENV) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k] as string;
+      }
+    }
+  }
+
+  it("uses an explicit tokenUrl verbatim, ignoring the issuer (location != identity)", () => {
+    // The whole point: a moved endpoint never disturbs the `iss` identity.
+    expect(
+      resolveAuthorizerTokenUrl({
+        tokenUrl: "http://mcp-authorizer.auth.svc/token",
+        issuer: "http://mcp-authorizer.mcp-shared.svc",
+      }),
+    ).toBe("http://mcp-authorizer.auth.svc/token");
+  });
+
+  it("derives `${issuer}/token` when no explicit tokenUrl (legacy fallback)", () => {
+    expect(resolveAuthorizerTokenUrl({ issuer: "http://mcp-authorizer.mcp-shared.svc" })).toBe(
+      "http://mcp-authorizer.mcp-shared.svc/token",
+    );
+  });
+
+  it("prefers NB_FLEET_AUTHORIZER_TOKEN_URL over the issuer-derived endpoint", () => {
+    withEnv(
+      {
+        NB_FLEET_AUTHORIZER_TOKEN_URL: "http://mcp-authorizer.auth.svc/token",
+        NB_FLEET_AUTHORIZER_ISSUER: "http://mcp-authorizer.mcp-shared.svc",
+      },
+      () => expect(resolveAuthorizerTokenUrl()).toBe("http://mcp-authorizer.auth.svc/token"),
+    );
+  });
+
+  it("falls back to `${NB_FLEET_AUTHORIZER_ISSUER}/token` when the token-url var is unset", () => {
+    withEnv(
+      {
+        NB_FLEET_AUTHORIZER_TOKEN_URL: undefined,
+        NB_FLEET_AUTHORIZER_ISSUER: "http://mcp-authorizer.mcp-shared.svc",
+      },
+      () => expect(resolveAuthorizerTokenUrl()).toBe("http://mcp-authorizer.mcp-shared.svc/token"),
+    );
+  });
+
+  it("returns undefined when neither is configured", () => {
+    withEnv({ NB_FLEET_AUTHORIZER_TOKEN_URL: undefined, NB_FLEET_AUTHORIZER_ISSUER: undefined }, () =>
+      expect(resolveAuthorizerTokenUrl()).toBeUndefined(),
+    );
   });
 });

--- a/test/unit/tenant-key-mint.test.ts
+++ b/test/unit/tenant-key-mint.test.ts
@@ -414,4 +414,23 @@ describe("resolveAuthorizerTokenUrl (issuer/endpoint decoupling)", () => {
       expect(resolveAuthorizerTokenUrl()).toBeUndefined(),
     );
   });
+
+  it("per-connection config wins over global env (a pinned authorizer is never silently redirected)", () => {
+    withEnv(
+      {
+        NB_FLEET_AUTHORIZER_TOKEN_URL: "http://global-authorizer.svc/token",
+        NB_FLEET_AUTHORIZER_ISSUER: "http://global-authorizer.svc",
+      },
+      () => {
+        // A connection pinned via config.issuer must beat the global TOKEN_URL env...
+        expect(resolveAuthorizerTokenUrl({ issuer: "http://pinned.example" })).toBe(
+          "http://pinned.example/token",
+        );
+        // ...and an explicit config.tokenUrl likewise.
+        expect(resolveAuthorizerTokenUrl({ tokenUrl: "http://pinned.example/token" })).toBe(
+          "http://pinned.example/token",
+        );
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Why

The fleet token-mint path overloads a single value — `NB_FLEET_AUTHORIZER_ISSUER` — as **both** the `iss` identity **and** the physical endpoint: `tenant-key-mint.ts` built the POST target as `new URL("/token", issuer)`. That ties a deployment detail (where the authorizer runs) to an identity contract (what minted tokens claim). Consequence: relocating the authorizer (new namespace/cluster) would change its DNS → change `iss` → force a coordinated update across **every** verifier and consumer.

This is a leaky-interface fix. The verifiers (mcp-edge) already hold the public key out-of-band and check `iss` by **exact string match** against their own `expectedIssuer` — they never derive anything from it. And `nimbletasks` already models the right shape: separate `authorizerIssuer` (identity) + `authorizerTokenUrl` (endpoint). This brings the runtime in line, and matches the OAuth spec separation of `issuer` vs `token_endpoint` (RFC 8414).

## What

- `mintServiceToken` / `TokenRequest` / `MintingFetchOptions` take an explicit **`tokenUrl`** (POST target) instead of `issuer`. The mint never inspects `iss`.
- New **`resolveAuthorizerTokenUrl()`**: explicit `tokenUrl` wins (`NB_FLEET_AUTHORIZER_TOKEN_URL` or per-connection `config.tokenUrl`); otherwise derive `${issuer}/token` from `NB_FLEET_AUTHORIZER_ISSUER` — the legacy fallback.
- `minted-credential-provider` and the artifacts data-plane read client resolve through it.

## Additive — zero token-contract change

Until `NB_FLEET_AUTHORIZER_TOKEN_URL` is set, the issuer fallback reproduces today's URL **exactly**, so `iss` never moves and no deploy needs to change. Setting the new var later points the **endpoint** elsewhere while `iss` stays put. **Rollback = unset the var.**

This is the foundational step (Item 1) that makes a future authorizer **namespace move (Item 2)** a config-only change — flip `…_TOKEN_URL` + netpols, `iss` untouched, 300 s token TTL covers any window. No flag day.

## Verification

- `bun run verify:static` — clean (format, lint, tsc strict, cycles, code-style, no-raw-console, no-sentry-in-kernel, codegen).
- `bun run test:unit` — **3757 pass / 0 fail**, incl. 5 new `resolveAuthorizerTokenUrl` tests pinning the decoupling (explicit endpoint ignores issuer; env precedence; legacy fallback; unset → undefined) and the updated mint/artifact tests.

## Follow-ons (not in this PR)

- Plumb `NB_FLEET_AUTHORIZER_TOKEN_URL` through `charts/runtime` + `charts/artifacts` (split `authorizerIssuer`/`authorizerTokenUrl` like nimbletasks) so operators can set it. Deploy-side only; this runtime change is safe without it.
- Item 2: relocate the authorizer to its own namespace (a config + netpol change, on top of this).