### PR TITLE
feat(connectors): surface the running serverInfo.version per connector

### DIFF
--- a/src/tools/connector-tools.ts
+++ b/src/tools/connector-tools.ts
@@ -33,6 +33,7 @@ import { canWriteWorkspaceScoped } from "../workspace/authz.ts";
 import type { Workspace } from "../workspace/types.ts";
 import { FileCredentialStore } from "./credential-store.ts";
 import type { InProcessTool } from "./in-process-app.ts";
+import { McpSource } from "./mcp-source.ts";
 
 /**
  * `manage_connectors` tool — single surface for the Connectors UI
@@ -517,6 +518,14 @@ async function handleListInstalled(
     serverName: string;
     bundleName: string;
     version: string;
+    /**
+     * The version the running server reports in its MCP `initialize` handshake
+     * (serverInfo.version), sanitized. Distinct from `version`, which is the
+     * catalog/manifest's *declared* version: this is what's actually connected.
+     * Untrusted (the server sets it) and display-only. Absent when the source is
+     * stopped or the server reports none.
+     */
+    handshakeVersion?: string;
     type: "remote" | "local";
     state: string;
     // Stage 2: only workspace-scope connectors exist. Personal connectors
@@ -657,11 +666,18 @@ async function handleListInstalled(
         cat = catalogById.get(composioConnectorId);
       }
 
-      // Tool count + interactive — best-effort (a stopped source returns []).
+      // Tool count + reported version — best-effort (a stopped source returns []
+      // and has no version). Both read from the same live source. getReportedVersion
+      // is McpSource-specific (not on the ToolSource interface), reached by the
+      // same `instanceof` narrowing the system-prompt composer uses for instructions.
       let toolCount = 0;
+      let handshakeVersion: string | undefined;
       try {
         const src = registry.getSource(instance.serverName);
-        if (src) toolCount = (await src.tools()).length;
+        if (src) {
+          toolCount = (await src.tools()).length;
+          if (src instanceof McpSource) handshakeVersion = src.getReportedVersion();
+        }
       } catch {
         // ignore
       }
@@ -680,6 +696,7 @@ async function handleListInstalled(
         serverName: instance.serverName,
         bundleName: instance.bundleName,
         version: instance.version,
+        ...(handshakeVersion ? { handshakeVersion } : {}),
         type: isRemote ? "remote" : "local",
         state: instance.state,
         // Provisional — overwritten by deriveConnectorStatus below

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -238,15 +238,17 @@ function deferred<T>(): Deferred<T> {
  * remains.
  */
 export function sanitizeReportedVersion(raw: string): string | undefined {
-  const cleaned = Array.from(raw)
+  const printable = Array.from(raw)
     .filter((ch) => {
       const cp = ch.codePointAt(0) ?? 0;
       return cp > 0x1f && !(cp >= 0x7f && cp <= 0x9f);
     })
     .join("")
-    .trim()
-    .slice(0, 64);
-  return cleaned || undefined;
+    .trim();
+  // Cap by code points, not UTF-16 units: slicing the string directly could cut
+  // an astral character at the 64-unit boundary and leave a lone surrogate.
+  const capped = Array.from(printable).slice(0, 64).join("");
+  return capped || undefined;
 }
 
 /**

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -231,6 +231,25 @@ function deferred<T>(): Deferred<T> {
 }
 
 /**
+ * Sanitize an untrusted `serverInfo.version` before we store or surface it. The
+ * string comes from the MCP server — a Composio gateway or a third-party OAuth
+ * server controls it — so drop C0/C1 control characters and cap the length.
+ * Display-only; never a security signal. Returns undefined if nothing usable
+ * remains.
+ */
+export function sanitizeReportedVersion(raw: string): string | undefined {
+  const cleaned = Array.from(raw)
+    .filter((ch) => {
+      const cp = ch.codePointAt(0) ?? 0;
+      return cp > 0x1f && !(cp >= 0x7f && cp <= 0x9f);
+    })
+    .join("")
+    .trim()
+    .slice(0, 64);
+  return cleaned || undefined;
+}
+
+/**
  * ToolSource wrapping a single MCP server (stdio subprocess or remote HTTP/SSE).
  * Lazy tool loading: first tools() call triggers listTools(), then caches.
  * Crash recovery: on execute failure, attempts one restart + retry.
@@ -245,6 +264,10 @@ export class McpSource implements ToolSource {
    *  `initialize`. Captured after connect so callers (e.g. the system
    *  prompt composer) can surface per-bundle guidance to the LLM. */
   private _instructions: string | undefined;
+  /** Sanitized `serverInfo.version` reported in the `initialize` response.
+   *  Untrusted (the server sets it); display-only. Undefined until start()
+   *  completes, if the server reports none, or after stop(). */
+  private _serverVersion: string | undefined;
   /**
    * For `inProcess` mode only — the linked-pair MCP server that this source
    * speaks to. Owned by McpSource (constructed in `start()` via
@@ -549,6 +572,17 @@ export class McpSource implements ToolSource {
     // the system prompt composer can render it in the apps list.
     const instructions = this.client.getInstructions();
     this._instructions = typeof instructions === "string" ? instructions : undefined;
+
+    // Capture the server's reported version (serverInfo.version, from the same
+    // initialize response). The server is untrusted — a Composio gateway or a
+    // third-party OAuth server controls this string — so strip control chars and
+    // cap length before storing. Display-only; never a security signal. A server
+    // that sets no version reports its framework's instead; that's still what it
+    // claims, so we keep it and let the UI decide (running version primary,
+    // catalog version shown only on drift).
+    const reportedVersion = this.client.getServerVersion()?.version;
+    this._serverVersion =
+      typeof reportedVersion === "string" ? sanitizeReportedVersion(reportedVersion) : undefined;
 
     this.startTaskSweeper();
 
@@ -937,12 +971,20 @@ export class McpSource implements ToolSource {
     this.inProcessServer = null;
     this.cachedTools = null;
     this._instructions = undefined;
+    this._serverVersion = undefined;
   }
 
   /** Server `instructions` string from the MCP `initialize` response.
    *  Undefined until start() completes; cleared by stop(). */
   getInstructions(): string | undefined {
     return this._instructions;
+  }
+
+  /** Sanitized `serverInfo.version` from the MCP `initialize` response.
+   *  Undefined until start() completes, if the server reports none, or after
+   *  stop(). Display-only — the server is untrusted. */
+  getReportedVersion(): string | undefined {
+    return this._serverVersion;
   }
 
   /**

--- a/test/unit/mcp-source-version.test.ts
+++ b/test/unit/mcp-source-version.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { sanitizeReportedVersion } from "../../src/tools/mcp-source.ts";
+
+/**
+ * `sanitizeReportedVersion` is the trust boundary for the connector-version
+ * display: `serverInfo.version` comes from an untrusted MCP server (a Composio
+ * gateway, a third-party OAuth server), so it is neutralized before the runtime
+ * stores or the UI renders it. Pure function — test the boundary directly.
+ *
+ * Control / non-ASCII inputs are built with `String.fromCharCode` so this source
+ * file stays pure ASCII (no raw control bytes, no high bytes).
+ */
+const ch = (code: number) => String.fromCharCode(code);
+
+describe("sanitizeReportedVersion", () => {
+  it("passes a normal version through untouched", () => {
+    expect(sanitizeReportedVersion("0.2.0")).toBe("0.2.0");
+    expect(sanitizeReportedVersion("1.4.2+build.7")).toBe("1.4.2+build.7");
+    expect(sanitizeReportedVersion("a1b2c3d")).toBe("a1b2c3d");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeReportedVersion("  0.2.0  ")).toBe("0.2.0");
+  });
+
+  it("strips C0/C1 control characters (newline, tab, DEL, APC)", () => {
+    expect(sanitizeReportedVersion(`0.2${ch(0x0a)}.0`)).toBe("0.2.0"); // newline
+    expect(sanitizeReportedVersion(`${ch(0x09)}1.0`)).toBe("1.0"); // tab
+    expect(sanitizeReportedVersion(`1.0${ch(0x7f)}${ch(0x9f)}`)).toBe("1.0"); // DEL + APC
+  });
+
+  it("caps length at 64 characters", () => {
+    expect(sanitizeReportedVersion("9".repeat(200))).toBe("9".repeat(64));
+  });
+
+  it("returns undefined when nothing usable remains", () => {
+    expect(sanitizeReportedVersion("")).toBeUndefined();
+    expect(sanitizeReportedVersion("   ")).toBeUndefined();
+    expect(sanitizeReportedVersion(`${ch(0x00)}${ch(0x1f)}`)).toBeUndefined();
+  });
+
+  it("preserves printable non-ASCII (>= U+00A0)", () => {
+    const v = `2.0-${ch(0xe9)}`; // 0xE9 = a printable Latin-1 letter
+    expect(sanitizeReportedVersion(v)).toBe(v);
+  });
+});

--- a/test/unit/mcp-source-version.test.ts
+++ b/test/unit/mcp-source-version.test.ts
@@ -33,6 +33,15 @@ describe("sanitizeReportedVersion", () => {
     expect(sanitizeReportedVersion("9".repeat(200))).toBe("9".repeat(64));
   });
 
+  it("caps by code points, never splitting a surrogate pair at the boundary", () => {
+    // U+1F600 is one code point / two UTF-16 units. Placed so the naive
+    // string.slice(0, 64) boundary would fall mid-pair (after 63 ASCII chars).
+    const astral = String.fromCodePoint(0x1f600);
+    const out = sanitizeReportedVersion(`${"a".repeat(63)}${astral}xx`);
+    expect(out).toBe(`${"a".repeat(63)}${astral}`);
+    expect(Array.from(out ?? "")).toHaveLength(64);
+  });
+
   it("returns undefined when nothing usable remains", () => {
     expect(sanitizeReportedVersion("")).toBeUndefined();
     expect(sanitizeReportedVersion("   ")).toBeUndefined();

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -650,7 +650,15 @@ export interface BundleUserConfigField {
 export interface InstalledConnector {
   serverName: string;
   bundleName: string;
+  /** Declared version — the catalog/manifest's stated version. */
   version: string;
+  /**
+   * The version the running server reports in its MCP `initialize` handshake
+   * (serverInfo.version). What's *actually* connected, vs `version` (declared).
+   * Absent when the source is stopped or the server reports none. Untrusted,
+   * display-only.
+   */
+  handshakeVersion?: string;
   type: "remote" | "local";
   state: string;
   scope: "workspace";

--- a/web/src/components/connectors/ConnectorStatusHero.tsx
+++ b/web/src/components/connectors/ConnectorStatusHero.tsx
@@ -84,6 +84,18 @@ export function ConnectorStatusHero({
 
   const action = resolveAction(installed, !!directoryEntry);
 
+  // Connector version, two axes: the running serverInfo.version (handshakeVersion —
+  // what's actually connected) takes precedence over the declared catalog/manifest
+  // version (installed.version; "remote" is the placeholder for a remote bundle that
+  // declares none, not a real version). When both exist and differ, the declared one
+  // is surfaced as a small drift note rather than silently hidden.
+  const declaredVersion = installed.version !== "remote" ? installed.version : undefined;
+  const shownVersion = installed.handshakeVersion ?? declaredVersion;
+  const versionDrift =
+    installed.handshakeVersion && declaredVersion && installed.handshakeVersion !== declaredVersion
+      ? declaredVersion
+      : undefined;
+
   const onPrimary = async () => {
     if (!action) return;
     setError(null);
@@ -159,10 +171,17 @@ export function ConnectorStatusHero({
               </span>
             )}
           </div>
-          {/* Version for stdio bundles (registry/local). Remote connectors have
-              no meaningful bundle version (`installed.version === "remote"`). */}
-          {installed.type !== "remote" && installed.version && (
-            <p className="text-xs text-muted-foreground font-mono mt-0.5">v{installed.version}</p>
+          {/* Version: running serverInfo.version primary, declared (catalog/manifest)
+              version shown only when it drifts from what's running. Covers remote
+              connectors (fleet, Composio, OAuth) — which report a handshake version
+              but carry no meaningful bundle version — as well as local bundles. */}
+          {shownVersion && (
+            <p className="text-xs text-muted-foreground font-mono mt-0.5">
+              v{shownVersion}
+              {versionDrift && (
+                <span className="ml-2 text-muted-foreground/70">catalog v{versionDrift}</span>
+              )}
+            </p>
           )}
           {cat?.description && (
             <p className="text-sm text-muted-foreground mt-1">{cat.description}</p>


### PR DESCRIPTION
## What

Surfaces a **version** on the connector detail page. Today the page shows a version only for stdio/local bundles; the in-scope connectors (platform fleet, Composio, remote OAuth) are all `type: "remote"` and show nothing.

The standards-based source is **MCP `serverInfo.version`** — a required field every server returns in the `initialize` handshake, so one uniform path covers all three connector types with no per-type special-casing. The runtime already captured `instructions` from that same handshake; the SDK's `getServerVersion()` was sitting unused right next to it.

## Two version axes, surfaced with provenance

| | Source | Trust |
|---|---|---|
| **declared** | catalog/manifest version (`InstalledConnector.version`) | ours |
| **running** | live `serverInfo.version` (`handshakeVersion`, new) | the server's |

The hero renders the **running** version primary and the **declared** version only when it *drifts* from what's connected (`catalog v0.1.9`), rather than collapsing the two with a silent fallback. Drift is then legible instead of hidden.

## Trust boundary

`serverInfo.version` is attacker-controlled (a Composio gateway or a third-party OAuth server sets the string), so it's **sanitized at the capture boundary** in `mcp-source.ts` — C0/C1 control characters stripped, length-capped to 64, `undefined` if nothing usable remains — and treated as **display-only**, never a policy/security signal. The sanitizer (`sanitizeReportedVersion`) is exported and unit-tested directly (`test/unit/mcp-source-version.test.ts`).

## Changes

- **`mcp-source.ts`** — capture + sanitize `getServerVersion()?.version` into `_serverVersion` next to the existing `_instructions` capture; expose `getReportedVersion()`; clear on `stop()`.
- **`connector-tools.ts`** — read `getReportedVersion()` off the live source (same lookup that already counts tools; `instanceof McpSource` narrowing, mirroring the system-prompt composer's `getInstructions()` access); add `handshakeVersion` to the projected entry.
- **`web/api/client.ts`** — `handshakeVersion?: string` on `InstalledConnector`.
- **`ConnectorStatusHero.tsx`** — running-primary / catalog-on-drift version line; replaces the stdio-only version display.

## Sequencing

Read-side only. Depends on **platform#151** (fleet runners reporting a real version) for the fleet connectors to show something meaningful — without it, fleet servers report the FastMCP library version (`3.4.2`). Composio / remote-OAuth connectors surface their server's reported version immediately.

## Verification

- backend `tsc --noEmit` ✅
- web `tsc --noEmit` ✅
- `biome check` on touched files ✅
- `bun test` — sanitizer unit test, 6/6 ✅