### PR TITLE
fix(mcp): log ui:// resource-read failures instead of masking them as 404

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -3946,16 +3946,22 @@ export class Runtime {
   ): Promise<ResourceData | null> {
     if (!(source instanceof McpSource)) return null;
 
+    // This is the app-surface (resource-proxy) read path — its only callers are
+    // readAppResource / readIdentityAppResource serving a `ui://` resource for a
+    // mounted app. A failure here is anomalous, so opt into logging; discovery
+    // probes that read directly from a source stay silent.
+    const opts = { logFailures: true } as const;
+
     if (resourcePath.includes("://")) {
-      return source.readResource(resourcePath);
+      return source.readResource(resourcePath, opts);
     }
 
     const exactUri = `ui://${resourcePath}`;
     const namespacedUri = `ui://${appName}/${resourcePath}`;
 
-    const result = await source.readResource(exactUri);
+    const result = await source.readResource(exactUri, opts);
     if (result !== null) return result;
-    if (exactUri !== namespacedUri) return source.readResource(namespacedUri);
+    if (exactUri !== namespacedUri) return source.readResource(namespacedUri, opts);
     return null;
   }
 

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -1292,8 +1292,22 @@ export class McpSource implements ToolSource {
    * spec attaches ui metadata at the content level, so that's the load-bearing
    * source for iframe CSP / permissions / layout hints.
    */
-  async readResource(uri: string): Promise<ResourceData | null> {
-    if (!this.client) return null;
+  async readResource(uri: string, opts?: { logFailures?: boolean }): Promise<ResourceData | null> {
+    if (!this.client) {
+      // A torn-down client (a source degraded/crashed without re-creation)
+      // returns null HERE, before the catch below — the persistent silent-404
+      // shape this change exists to surface, and the most likely cause of a read
+      // that stays broken until a full runtime restart. Log it on the app-surface
+      // path; the probe path stays silent because a not-yet-started or tearing-down
+      // source legitimately has no client during composition.
+      if (opts?.logFailures) {
+        log.warn("[mcp] readResource: source has no active client connection", {
+          uri,
+          source: this.name,
+        });
+      }
+      return null;
+    }
     try {
       const result = await this.client.readResource({ uri });
       if (!result.contents || result.contents.length === 0) return null;
@@ -1312,8 +1326,25 @@ export class McpSource implements ToolSource {
         return { blob: bytes, mimeType: first.mimeType, meta };
       }
       return { text: JSON.stringify(first), meta };
-    } catch {
-      // Resource not found is expected (e.g., skill:// on servers that don't have one)
+    } catch (err) {
+      // A genuine MCP miss is expected and stays a silent null — e.g. a skill://
+      // or app://instructions probe against a server that has neither.
+      if (isMcpResourceMiss(err)) return null;
+      // Anything else — a torn transport, a dropped connection, a timeout — is a
+      // real failure, NOT a missing resource. The old bare `catch { return null }`
+      // masked every such failure as a 404 with no log to say why, so a degraded
+      // source was undiagnosable. Log it ONLY for app-surface reads (the resource
+      // proxy passes `logFailures`), where a failure is anomalous. Discovery
+      // probes stay silent, so a bundle that simply lacks a probed resource never
+      // spams — whatever non-standard error shape it returns. The null (404) is
+      // preserved either way; this only makes the anomalous case visible.
+      if (opts?.logFailures) {
+        log.warn("[mcp] readResource failed", {
+          uri,
+          source: this.name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       return null;
     }
   }
@@ -1946,6 +1977,33 @@ export class McpSource implements ToolSource {
       return false;
     }
   }
+}
+
+/**
+ * Distinguish a genuine "the resource is not here" outcome from a transport /
+ * connection failure, for `readResource`'s catch.
+ *
+ * A JSON-RPC application error means the server received the request and
+ * answered — it is alive, the resource simply isn't (or isn't readable) there,
+ * and restarting the transport would not change the answer:
+ *   - `-32002` ResourceNotFound (the spec code; see host-resources/resolver.ts),
+ *   - `-32601` MethodNotFound (server advertises no resources capability),
+ *   - `-32602` InvalidParams (unknown / unsupported URI).
+ * Some servers signal a miss only in the message, so match that as a fallback.
+ *
+ * A torn transport (connection closed `-32000`, timeout, fetch failure) is none
+ * of these — it carries no application error code — so it returns `false` and
+ * must NOT be masked as a missing resource.
+ */
+export function isMcpResourceMiss(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === -32002 || code === -32601 || code === -32602) return true;
+  const message = (err as { message?: unknown }).message;
+  return (
+    typeof message === "string" &&
+    /resource not found|unknown resource|no such resource/i.test(message)
+  );
 }
 
 /** Type guard: does this unknown value match Tool.execution's shape? */

--- a/test/unit/mcp-source-resource-errors.test.ts
+++ b/test/unit/mcp-source-resource-errors.test.ts
@@ -1,0 +1,131 @@
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, spyOn } from "bun:test";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { isMcpResourceMiss, McpSource } from "../../src/tools/mcp-source.ts";
+
+/**
+ * `readResource` must distinguish a genuine "resource not here" from a transport
+ * failure. The old `catch { return null }` masked every error as a 404 with no
+ * log, so a degraded source was undiagnosable. The contract now: a genuine MCP
+ * miss stays a silent null; a real failure is logged — but ONLY on the
+ * app-surface proxy path (`logFailures`), so discovery probes against a bundle
+ * that simply lacks a `skill://` / `app://instructions` resource never spam,
+ * whatever non-standard error shape that bundle returns.
+ */
+describe("isMcpResourceMiss — allowlist of genuine misses", () => {
+  it("treats resource/method/params JSON-RPC errors as misses", () => {
+    expect(isMcpResourceMiss(new McpError(-32002, "Resource not found"))).toBe(true);
+    expect(isMcpResourceMiss(new McpError(-32601, "Method not found"))).toBe(true);
+    expect(isMcpResourceMiss(new McpError(-32602, "Invalid params"))).toBe(true);
+  });
+
+  it("treats a not-found message (no code) as a miss", () => {
+    expect(isMcpResourceMiss(new Error("Unknown resource ui://x"))).toBe(true);
+    expect(isMcpResourceMiss(new Error("no such resource"))).toBe(true);
+  });
+
+  it("does NOT treat transport failures as misses", () => {
+    expect(isMcpResourceMiss(new Error("Connection closed"))).toBe(false);
+    expect(isMcpResourceMiss(new McpError(-32000, "Connection closed"))).toBe(false);
+    expect(isMcpResourceMiss(new Error("fetch failed"))).toBe(false);
+    expect(isMcpResourceMiss(new Error("request timed out"))).toBe(false);
+  });
+
+  it("is null/undefined safe", () => {
+    expect(isMcpResourceMiss(null)).toBe(false);
+    expect(isMcpResourceMiss(undefined)).toBe(false);
+    expect(isMcpResourceMiss("nope")).toBe(false);
+  });
+});
+
+describe("McpSource.readResource — log scoping (no probe spam)", () => {
+  function makeSourceWithThrowingClient(err: unknown): McpSource {
+    const source = new McpSource(
+      "stub",
+      { type: "remote", url: new URL("http://localhost:0/mcp") },
+      new NoopEventSink(),
+    );
+    (source as unknown as { client: { readResource: () => Promise<unknown> } }).client = {
+      readResource: async () => {
+        throw err;
+      },
+    };
+    return source;
+  }
+
+  /** Did any `log.warn` (→ console.error, pretty mode) mention readResource? */
+  function loggedReadFailure(spy: ReturnType<typeof spyOn>): boolean {
+    return spy.mock.calls.some((call) => String(call[0]).includes("readResource"));
+  }
+
+  it("does NOT log a transport failure on a probe read (no logFailures)", async () => {
+    const source = makeSourceWithThrowingClient(new Error("Connection closed"));
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await source.readResource("skill://x/usage")).toBeNull();
+      expect(loggedReadFailure(spy)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("logs a transport failure on the app-surface path (logFailures)", async () => {
+    const source = makeSourceWithThrowingClient(new Error("Connection closed"));
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await source.readResource("ui://x", { logFailures: true })).toBeNull();
+      expect(loggedReadFailure(spy)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("does NOT log a genuine miss even on the app-surface path", async () => {
+    const source = makeSourceWithThrowingClient(new McpError(-32002, "Resource not found"));
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await source.readResource("ui://x", { logFailures: true })).toBeNull();
+      expect(loggedReadFailure(spy)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  /** A source whose MCP client was torn down (or never started): client === null. */
+  function makeSourceWithNoClient(): McpSource {
+    return new McpSource(
+      "stub",
+      { type: "remote", url: new URL("http://localhost:0/mcp") },
+      new NoopEventSink(),
+    );
+  }
+
+  it("does NOT log a torn-down client on the probe path", async () => {
+    const source = makeSourceWithNoClient();
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await source.readResource("skill://x/usage")).toBeNull();
+      expect(loggedReadFailure(spy)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("logs a torn-down client on the app-surface path (the persistent-404 incident)", async () => {
+    const source = makeSourceWithNoClient();
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await source.readResource("ui://x", { logFailures: true })).toBeNull();
+      expect(loggedReadFailure(spy)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("never throws — the 404 (null) contract holds for every caller", async () => {
+    const miss = makeSourceWithThrowingClient(new McpError(-32002, "Resource not found"));
+    const transport = makeSourceWithThrowingClient(new Error("Connection closed"));
+    expect(await miss.readResource("ui://x")).toBeNull();
+    expect(await transport.readResource("ui://x", { logFailures: true })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

A `ui://` resource read (the `/v1/apps/:name/resources/*` proxy that mounts an app's UI) could return a silent **404 `resource_not_found`** when the backing MCP source's connection degraded — e.g. after a deploy/roll — and stay that way until the **entire runtime was restarted**. There was no log to say why, because the error was thrown away.

## Root cause

`McpSource.readResource` had a bare `catch { return null }`. It collapsed two different outcomes into one answer:

- the resource is **genuinely absent** (expected — a `skill://` / `app://instructions` probe against a server that has neither), and
- the read itself **failed** (torn transport, dropped connection, timeout).

Both became `null` → a 404, with nothing logged. So a degraded source was undiagnosable.

## Fix (scoped deliberately small)

Classify the error in the catch:

- a genuine MCP miss (`-32002` / `-32601` / `-32602`, or a "not found" message) stays a **silent null** — `isMcpResourceMiss` is an allowlist with everything-else-falls-through;
- a real failure is **logged** (`[mcp] readResource(...) failed: ...`).

The 404 is **unchanged** — this only makes the cause visible.

### Logging is scoped to the app-surface path (no probe spam)

The log fires **only** on the resource-proxy path (`readResourceFromSource`, whose sole callers are `readAppResource` / `readIdentityAppResource` serving a mounted app's `ui://` resource), where a failure is anomalous and low-volume. **Discovery probes** (`skill://`, `app://instructions`, facets) read a source directly and stay silent — because absence there is the *normal* case, runs against every bundle on every turn, and isn't actionable. This holds **regardless of the error code a bundle returns** for an unknown resource (which isn't standardized across MCP server implementations), so a bundle that simply lacks a probed resource can never spam the log.

## Why not the self-heal too?

The resource-read path also lacks the self-heal the tool-dispatch path has (`recoverWorkspaceSource` / restart a degraded source in `src/orchestrator/route.ts`). That asymmetry is real — but **I have not confirmed which failure mode caused the incident** (the masking destroyed the evidence, and the source was restarted before it could be captured). The plausible mechanisms — torn transport, a source that didn't re-register its resources after a roll, or a boot-time connection failure — call for **different** fixes, and a speculative recovery branch is extra kernel surface for a guess. This PR adds the log that will identify the real mechanism; the targeted recovery follows once it's confirmed. Tracked in #533.

## Tests

`test/unit/mcp-source-resource-errors.test.ts`: the `isMcpResourceMiss` allowlist (miss codes / message → miss; transport errors → not a miss; null-safe), and the log scoping — a transport failure is **silent** on a probe read but **logged** on the app-surface path, a genuine miss is silent on both, and `readResource` never throws (the null/404 contract holds for every caller).

`bun run verify` passes (static + unit + bundles + integration + smoke, 0 failures).