### PR TITLE
fix(tools): nb__search returns matches as data, never auto-promotes

### DIFF
--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -150,12 +150,12 @@ export const toolCallsTotal = new Counter({
 });
 
 /**
- * Tools promoted into the active set (progressive-disclosure discovery),
- * labeled by whether the promoted tool was actually called later in the same
- * run. `used="false"` is the wasted-promotion signal — a cache-prefix re-write
- * for a tool the model never used — that validates the auto-promote policy:
- * `used="false" / total` is the promoted-but-never-called rate. Counted at run
- * end (not at promote time) so the correlation is known.
+ * Tools promoted into the active set via nb__manage_tools (the model
+ * activating a tool it intends to call), labeled by whether the promoted tool
+ * was actually called later in the same run. `used="false"` is the
+ * wasted-promotion signal — a cache-prefix re-write for a tool the model never
+ * used — so `used="false" / total` is the promoted-but-never-called rate.
+ * Counted at run end (not at promote time) so the correlation is known.
  */
 export const toolPromotionsTotal = new Counter({
   name: "nb_tool_promotions_total",

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -94,7 +94,7 @@ export async function createSystemTools(
     {
       name: "search",
       description:
-        "Search installed tools by keyword, or search the mpak registry for bundles to install.",
+        "Search installed tools by keyword (scope: tools) or the mpak registry for bundles to install (scope: registry). Returns matches as a list; to call a matched tool, activate it first with nb__manage_tools.",
       inputSchema: {
         type: "object",
         properties: {
@@ -218,35 +218,22 @@ export async function createSystemTools(
             _meta: { [NON_ADVANCING_META_KEY]: true },
           };
         const shown = matches.slice(0, 25);
-        // Auto-promote the top matches straight into the active set, so the
-        // model can call them on the NEXT turn without a separate
-        // nb__manage_tools round-trip — which would re-send the whole cached
-        // prefix for zero state the model couldn't infer. The prefix
-        // cache-write on the next call is irreducible either way (tool
-        // definitions are wire position 0; changing them busts the prefix);
-        // this just removes one model round-trip per discovery. addTool is
-        // idempotent, eligibility-guarded, and LRU-bounded, and no-ops when
-        // there's no active run.
-        const AUTO_PROMOTE_LIMIT = 3;
-        const promoted: string[] = [];
-        if (toolPromotionCtx) {
-          for (const t of shown.slice(0, AUTO_PROMOTE_LIMIT)) {
-            if (toolPromotionCtx.addTool(t.name).ok) promoted.push(t.name);
-          }
-        }
+        // Return matches as DATA only — search never mutates the active tool
+        // set. Tool definitions are wire position 0 (before system and
+        // history), so adding one rewrites the whole cached prefix on the next
+        // call. Promoting speculatively pays that rewrite for tools the model
+        // may never call; instead the model activates a tool it commits to
+        // using via nb__manage_tools — one append-only round-trip (reads the
+        // warm prefix, writes a small delta) in place of a speculative
+        // full-prefix rewrite. This result rides the message tail, the
+        // cache-safe channel.
         const suffix = matches.length > shown.length ? ` (showing top ${shown.length})` : "";
         const lines = [`Found ${matches.length} tool(s) for "${query}"${suffix}:\n`];
         for (const t of shown) lines.push(`- **${t.name}**: ${t.description}`);
-        if (promoted.length > 0) {
-          const subj = promoted.length === 1 ? "This tool is" : `The top ${promoted.length} are`;
-          const obj = promoted.length === 1 ? "it" : "them";
-          lines.push(
-            `\n${subj} now active — call ${obj} directly. Use nb__manage_tools only to activate a different match from the list above.`,
-          );
-        }
+        lines.push("\nTo call one, activate it with nb__manage_tools first.");
         return {
           content: textContent(lines.join("\n")),
-          structuredContent: { tools: shown.map((t) => ({ name: t.name })), promoted },
+          structuredContent: { tools: shown.map((t) => ({ name: t.name })) },
           isError: false,
         };
       },

--- a/test/unit/system-tools.test.ts
+++ b/test/unit/system-tools.test.ts
@@ -124,7 +124,7 @@ describe("System Tools", () => {
 		]);
 	});
 
-	it("search auto-promotes its top matches into the active set", async () => {
+	it("search returns matches as data without promoting (append-only)", async () => {
 		const registry = await makeRegistry();
 		const added: string[] = [];
 		const toolPromotionCtx: ToolPromotionContext = {
@@ -157,12 +157,16 @@ describe("System Tools", () => {
 		const result = await systemTools.execute("search", { scope: "tools", query: "greet" });
 
 		expect(result.isError).toBe(false);
-		// The matched tool was promoted into the active set (one fewer round-trip
-		// than search → manage_tools → call).
-		expect(added).toContain("test__greet");
-		// The model is told it can call it directly, and the result reports it.
-		expect(extractText(result.content)).toContain("now active");
-		expect(getStructured<{ promoted?: string[] }>(result)?.promoted).toContain("test__greet");
+		// Search returns matches as data and never mutates the active set —
+		// adding a tool is wire position 0 and would bust the whole cached
+		// prefix. The model activates a committed tool via nb__manage_tools.
+		expect(added).toEqual([]);
+		expect(extractText(result.content)).not.toContain("now active");
+		expect(extractText(result.content)).toContain("nb__manage_tools");
+		expect(getStructured<{ tools?: Array<{ name: string }> }>(result)?.tools).toContainEqual({
+			name: "test__greet",
+		});
+		expect(getStructured<{ promoted?: string[] }>(result)?.promoted).toBeUndefined();
 	});
 
 	it("search with scope=tools preserves single-word prefix substring matches", async () => {
@@ -620,10 +624,10 @@ describe("System Tools", () => {
 			{ name: "test__tool.with.dot" },
 		]);
 
-		// search now auto-promotes its top match; clear the log to isolate the
-		// manage_tools call below (intent: manage_tools accepts the searched name).
-		expect(calls).toEqual(["add:test__tool.with.dot"]);
-		calls.length = 0;
+		// search no longer mutates the active set (append-only — promoting a tool
+		// would bust the cached prefix), so it added nothing; the manage_tools
+		// call below is the only promotion (intent: it accepts the searched name).
+		expect(calls).toEqual([]);
 
 		const result = await systemTools.execute("manage_tools", {
 			add: ["test__tool.with.dot"],


### PR DESCRIPTION
## What
`nb__search` no longer auto-promotes its top matches into the active tool set. It returns matches as **data**; the model activates a tool it intends to call via `nb__manage_tools`.

## Why
The prompt cache is a prefix in the order `tools → system → messages`. Tool definitions are the most upstream segment, so adding a tool mid-conversation invalidates the **entire** cached prefix — tools, system, and all message history. Speculative top-3 promotion paid that full-prefix rewrite on every search, and in practice a large fraction of promoted tools were never called, so most of those rewrites were wasted.

Returning matches as data keeps the result in the append-only **message tail** (the cache-safe region). The model promotes on commit, trading one cheap append-only round-trip for a speculative full-prefix bust. This restores the explicit-promotion posture (`nb__manage_tools`).

## Changes
- `src/tools/system-tools.ts` — `nb__search` returns matches as data only; description instructs activate-before-call.
- `src/api/metrics.ts` — `nb_tool_promotions_total` doc comment reflects explicit promotion.
- `test/unit/system-tools.test.ts` — assert no auto-promotion; matches returned as data.

## Verification
- `bun run verify:static` — clean (format, lint, tsc, cycles, custom guards).
- `bun run test:unit` — 3819 pass / 0 fail.

## Follow-up
First slice of a larger append-only-context change. The next slice adds on-demand tool definitions via deferred loading, so discovery never touches the cached prefix at all.