### PR TITLE
Make the runtime binary serve-only; move dev orchestration to scripts/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ src/
 ├── prompt/        System prompt composition (identity → core → apps → skill)
 ├── model/         LLM provider registry (AI SDK)
 ├── adapters/      EventSink implementations (logs, console, debug, telemetry)
-├── cli/           Process entry: serve (HTTP API) + dev (watch/HMR) launchers
+├── cli/           Process entry: the serve HTTP API server (dev tooling is in scripts/)
 └── files/         File context extraction
 web/               Vite + React + TypeScript SPA (separate package.json)
 ```

--- a/README.md
+++ b/README.md
@@ -458,12 +458,13 @@ src/
 ├── telemetry/            Anonymous product telemetry
 │   ├── posthog-sink.ts   PostHog event mapping
 │   └── manager.ts        TelemetryManager (opt-in/out, anonymous ID)
-└── cli/                  Process entry: serve + dev launchers
-    ├── index.ts          Entry point (argv dispatch: serve | dev)
+└── cli/                  Process entry: the serve HTTP API server
+    ├── index.ts          Entry point (boots the server)
     ├── serve.ts          HTTP API server boot
-    ├── dev.ts            dev-mode dual-process supervisor
     └── config.ts         nimblebrain.json loading
 ```
+
+Local dev orchestration (watch + web HMR) is tooling, not runtime: `scripts/dev.ts` (`bun run dev`).
 
 ## Deployment
 

--- a/docs/src/content/docs/cli/overview.mdx
+++ b/docs/src/content/docs/cli/overview.mdx
@@ -34,7 +34,7 @@ The server and dev mode share most flags:
 | `--debug` | serve, dev | Verbose event logging to stderr |
 | `--no-web` | dev | Skip the web dev server (API only) |
 
-The working directory is set with the `NB_WORK_DIR` environment variable, not a flag. Running `bun run src/cli/index.ts` with no command prints a one-line usage summary; an unrecognized command prints the same summary and exits with code 2.
+The working directory is set with the `NB_WORK_DIR` environment variable, not a flag. `bun run src/cli/index.ts` boots the server directly; a leading `serve` token is accepted (the deploy command passes it) but optional.
 
 See [Running the server](/cli/serve/) and [Dev mode](/cli/dev/) for each command's full flag set.
 

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "dev": "bun run src/cli/index.ts dev",
-    "dev:empty": "NB_API_PORT=27249 NB_WEB_PORT=27248 bun run src/cli/index.ts dev --port 27249 --config .environments/empty/nimblebrain.json",
-    "dev:minimal": "NB_API_PORT=27251 NB_WEB_PORT=27250 bun run src/cli/index.ts dev --port 27251 --config .environments/minimal/nimblebrain.json",
-    "dev:docs-demo": "NB_DEV_DISPLAY_NAME='Sarah Chen' NB_DEV_EMAIL='sarah@acme.co' NB_API_PORT=27253 NB_WEB_PORT=27252 bun run src/cli/index.ts dev --port 27253 --config .environments/docs-demo/nimblebrain.json",
+    "dev": "bun run scripts/dev.ts",
+    "dev:empty": "NB_API_PORT=27249 NB_WEB_PORT=27248 bun run scripts/dev.ts --port 27249 --config .environments/empty/nimblebrain.json",
+    "dev:minimal": "NB_API_PORT=27251 NB_WEB_PORT=27250 bun run scripts/dev.ts --port 27251 --config .environments/minimal/nimblebrain.json",
+    "dev:docs-demo": "NB_DEV_DISPLAY_NAME='Sarah Chen' NB_DEV_EMAIL='sarah@acme.co' NB_API_PORT=27253 NB_WEB_PORT=27252 bun run scripts/dev.ts --port 27253 --config .environments/docs-demo/nimblebrain.json",
     "dev:worktree": "bun run scripts/dev-worktree.ts",
     "dev:api": "bun --watch src/cli/index.ts serve -c .nimblebrain/nimblebrain.json",
     "dev:web": "cd web && bun run dev",

--- a/scripts/check-cycles.ts
+++ b/scripts/check-cycles.ts
@@ -42,7 +42,7 @@ function checkDir(dir: string, forbiddenPatterns: Array<{ pattern: RegExp; descr
       const line = lines[i]!;
       if (!line.includes("from ")) continue;
 
-      for (const { pattern, description } of forbiddenPatterns) {
+      for (const { pattern } of forbiddenPatterns) {
         if (pattern.test(line)) {
           violations.push({
             file: relPath,

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,10 +1,21 @@
+#!/usr/bin/env bun
+/**
+ * `bun run dev` — supervised dual-process development mode.
+ *
+ * Local developer tooling, not part of the runtime. Spawns the API server in
+ * watch mode (`bun --watch src/cli/index.ts serve`) plus the Vite web dev
+ * server, with unified prefixed output and readiness gating. The runtime binary
+ * (`src/cli/index.ts`) only serves; this script orchestrates the dev loop on top
+ * of it, alongside the other `scripts/dev-*.ts` tooling.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { parseArgs } from "node:util";
 import { type Subprocess, spawn } from "bun";
-import { log } from "../observability/log.ts";
-import { setAppDevMode } from "../runtime/dev-registry.ts";
+import { log } from "../src/observability/log.ts";
+import { setAppDevMode } from "../src/runtime/dev-registry.ts";
 
-export interface DevOptions {
+interface DevOptions {
   port: number;
   noWeb: boolean;
   config: string | undefined;
@@ -74,19 +85,12 @@ async function waitForHealth(port: number, opts: { timeoutMs: number }): Promise
   throw new Error(`API did not become ready within ${opts.timeoutMs}ms`);
 }
 
-/**
- * `bun run dev` — supervised dual-process development mode.
- *
- * Starts the API server with bun --watch (auto-restart on source changes)
- * and optionally the Vite web dev server. Both share a single terminal
- * with prefixed output.
- */
-export async function runDev(options: DevOptions): Promise<void> {
+async function runDev(options: DevOptions): Promise<void> {
   const { port, noWeb, config, debug, app: appPath, appPort = 5173 } = options;
   const children: Subprocess[] = [];
 
-  // Resolve the CLI entry point relative to this file's location
-  const cliEntry = join(import.meta.dir, "index.ts");
+  // The runtime entry, relative to this script (scripts/ -> ../src/cli/index.ts).
+  const cliEntry = join(import.meta.dir, "..", "src", "cli", "index.ts");
 
   // --- API server with bun --watch ---
   const apiArgs = ["bun", "--watch", cliEntry, "serve", "--port", String(port)];
@@ -250,3 +254,33 @@ export async function runDev(options: DevOptions): Promise<void> {
 
   process.exit(apiExitCode ?? 0);
 }
+
+async function main(): Promise<void> {
+  const rest = process.argv.slice(2);
+  const { values } = parseArgs({
+    args: rest,
+    // strict:false so the `--no-web` negation token passes through; we read it
+    // off argv directly since parseArgs has no boolean-negation support.
+    strict: false,
+    options: {
+      config: { type: "string", short: "c" },
+      port: { type: "string" },
+      app: { type: "string" },
+      "app-port": { type: "string" },
+      debug: { type: "boolean" },
+    },
+  });
+  await runDev({
+    port: values.port ? Number(values.port) : 27247,
+    noWeb: rest.includes("--no-web"),
+    config: values.config as string | undefined,
+    debug: (values.debug as boolean | undefined) ?? false,
+    app: values.app as string | undefined,
+    appPort: values["app-port"] ? Number(values["app-port"]) : undefined,
+  });
+}
+
+main().catch((err) => {
+  log.error(`[dev] Fatal: ${err}`);
+  process.exit(1);
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,37 @@ import { TelemetryManager } from "../telemetry/manager.ts";
 import { runServe } from "./serve.ts";
 
 /**
+ * Parse server flags, accepting (and ignoring) a leading `serve` token so the
+ * image/chart command `bun run src/cli/index.ts serve` is unchanged. A bad flag
+ * or stray positional is a usage error (exit 2), distinct from a runtime failure
+ * (exit 1). NOTE: the only behavioral difference between the `serve` strip being
+ * present vs. absent is whether a *bare* `serve` boots — `serve <garbage>` exits
+ * non-zero either way — so the deploy contract is pinned by the integration boot
+ * smoke, not by an arg-parse assertion.
+ */
+function parseServeArgs(argv: string[]) {
+  const args = argv[0] === "serve" ? argv.slice(1) : argv;
+  try {
+    return parseArgs({
+      args,
+      options: {
+        config: { type: "string", short: "c" },
+        model: { type: "string" },
+        port: { type: "string" },
+        debug: { type: "boolean" },
+      },
+      allowPositionals: false,
+    }).values;
+  } catch (err) {
+    process.stderr.write(
+      `${err instanceof Error ? err.message : String(err)}\n` +
+        "Usage: bun run src/cli/index.ts [serve] [--config <path>] [--port <n>] [--model <id>] [--debug]\n",
+    );
+    process.exit(2);
+  }
+}
+
+/**
  * Process entry point: boot the HTTP API server. Serving is the one thing the
  * runtime binary does — the web shell and `/mcp` are its UIs. Local dev
  * orchestration (watch + web HMR) is tooling, not runtime: it lives in
@@ -22,20 +53,7 @@ async function main(): Promise<void> {
   // (nothing exported) unless OTEL_EXPORTER_OTLP_ENDPOINT is set.
   initTracing();
 
-  // Accept (and ignore) a leading `serve` token for deploy-command stability.
-  const argv = process.argv.slice(2);
-  if (argv[0] === "serve") argv.shift();
-
-  const { values } = parseArgs({
-    args: argv,
-    options: {
-      config: { type: "string", short: "c" },
-      model: { type: "string" },
-      port: { type: "string" },
-      debug: { type: "boolean" },
-    },
-    allowPositionals: false,
-  });
+  const values = parseServeArgs(process.argv.slice(2));
 
   const telemetry = TelemetryManager.create({ workDir: join(homedir(), ".nimblebrain") });
   try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,93 +5,55 @@ import { parseArgs } from "node:util";
 import { initTracing } from "../observability/index.ts";
 import { log } from "../observability/log.ts";
 import { TelemetryManager } from "../telemetry/manager.ts";
-import { runDev } from "./dev.ts";
 import { runServe } from "./serve.ts";
 
-const USAGE = "Usage: bun run src/cli/index.ts <serve|dev> [options]\n";
-
 /**
- * Process entry point. Dispatches the two server-side commands the platform
- * runs — `serve` (the managed-services HTTP server) and `dev` (the local
- * watch/HMR loop). No interactive terminal client; the web shell and `/mcp`
- * are the runtime's UIs. Kept at this path so the image/chart command
- * (`bun run src/cli/index.ts serve`) is unchanged.
+ * Process entry point: boot the HTTP API server. Serving is the one thing the
+ * runtime binary does — the web shell and `/mcp` are its UIs. Local dev
+ * orchestration (watch + web HMR) is tooling, not runtime: it lives in
+ * `scripts/dev.ts` (`bun run dev`), which spawns this entry in watch mode.
+ *
+ * The image/chart invoke this as `bun run src/cli/index.ts serve [flags]`; the
+ * leading `serve` token is accepted and ignored so the deploy command is
+ * unchanged. Flags: --config/-c, --model, --port, --debug.
  */
 async function main(): Promise<void> {
   // Install vendor-neutral OTel tracing once, before anything runs. No-op
   // (nothing exported) unless OTEL_EXPORTER_OTLP_ENDPOINT is set.
   initTracing();
 
-  const command = process.argv[2];
-  const rest = process.argv.slice(3);
+  // Accept (and ignore) a leading `serve` token for deploy-command stability.
+  const argv = process.argv.slice(2);
+  if (argv[0] === "serve") argv.shift();
 
-  if (command === "serve") {
-    // Telemetry is created only here. `serve` is the long-running runtime that
-    // emits product usage. `dev` spawns its own `serve` child (which inits its
-    // own telemetry), so initializing it in the dev parent would print the
-    // first-run notice and write the anon-id file while capturing nothing.
-    const telemetry = TelemetryManager.create({ workDir: join(homedir(), ".nimblebrain") });
-    try {
-      const { values } = parseArgs({
-        args: rest,
-        options: {
-          config: { type: "string", short: "c" },
-          model: { type: "string" },
-          port: { type: "string" },
-          debug: { type: "boolean" },
-        },
-        allowPositionals: false,
-      });
-      await runServe(
-        {
-          config: values.config,
-          model: values.model,
-          port: values.port ? Number(values.port) : undefined,
-          debug: values.debug ?? false,
-        },
-        telemetry,
-      );
-    } catch (err) {
-      log.error(`Fatal: ${err}`);
-      await telemetry.shutdown();
-      process.exit(1);
-    }
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      config: { type: "string", short: "c" },
+      model: { type: "string" },
+      port: { type: "string" },
+      debug: { type: "boolean" },
+    },
+    allowPositionals: false,
+  });
+
+  const telemetry = TelemetryManager.create({ workDir: join(homedir(), ".nimblebrain") });
+  try {
+    await runServe(
+      {
+        config: values.config,
+        model: values.model,
+        port: values.port ? Number(values.port) : undefined,
+        debug: values.debug ?? false,
+      },
+      telemetry,
+    );
+  } catch (err) {
+    log.error(`Fatal: ${err}`);
     await telemetry.shutdown();
-    return;
+    process.exit(1);
   }
-
-  if (command === "dev") {
-    try {
-      const { values } = parseArgs({
-        args: rest,
-        // strict:false so the `--no-web` negation token passes through; we read
-        // it off argv directly since parseArgs has no boolean-negation support.
-        strict: false,
-        options: {
-          config: { type: "string", short: "c" },
-          port: { type: "string" },
-          app: { type: "string" },
-          "app-port": { type: "string" },
-          debug: { type: "boolean" },
-        },
-      });
-      await runDev({
-        port: values.port ? Number(values.port) : 27247,
-        noWeb: rest.includes("--no-web"),
-        config: values.config as string | undefined,
-        debug: (values.debug as boolean | undefined) ?? false,
-        app: values.app as string | undefined,
-        appPort: values["app-port"] ? Number(values["app-port"]) : undefined,
-      });
-    } catch (err) {
-      log.error(`Fatal: ${err}`);
-      process.exit(1);
-    }
-    return;
-  }
-
-  process.stderr.write(command ? `Unknown command: ${command}\n${USAGE}` : USAGE);
-  process.exit(command ? 2 : 0);
+  await telemetry.shutdown();
 }
 
 main().catch((err) => {

--- a/src/oauth/public-origin.ts
+++ b/src/oauth/public-origin.ts
@@ -65,7 +65,7 @@ const TENANT_ID_ENV = "NB_TENANT_ID";
  * User-facing SPA origin for post-callback returns. In production the API and
  * the SPA share one origin (Caddy proxies `/v1/*` to the API), so this equals
  * `publicOrigin()`. In dev they split — API on :27247, SPA on :27246 — and
- * `src/cli/dev.ts` sets `NB_WEB_URL` so a connector return lands on the SPA,
+ * `scripts/dev.ts` sets `NB_WEB_URL` so a connector return lands on the SPA,
  * not a JSON error page on the API port. This module is the only sanctioned
  * reader of `NB_WEB_URL` — `check:public-origin` rejects it elsewhere.
  */

--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -1,20 +1,14 @@
-import { describe, expect, it } from "bun:test";
 import { spawnSync } from "bun";
+import { describe, expect, it } from "bun:test";
 
-// The CLI is a thin argv dispatcher over two commands (serve, dev). These tests
-// exercise the dispatch/usage edges without booting a server.
+// The runtime binary's one job is to serve. It accepts (and ignores) a leading
+// `serve` token for deploy-command stability and rejects other positionals
+// before booting anything.
 const CLI = "src/cli/index.ts";
 
-describe("nb dispatcher", () => {
-  it("no command prints usage and exits 0", () => {
-    const result = spawnSync(["bun", "run", CLI], { stdout: "pipe", stderr: "pipe" });
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr.toString()).toContain("Usage:");
-  });
-
-  it("unknown command exits 2 with an error", () => {
+describe("serve entry", () => {
+  it("rejects an unrecognized positional argument", () => {
     const result = spawnSync(["bun", "run", CLI, "fakecmd"], { stdout: "pipe", stderr: "pipe" });
-    expect(result.exitCode).toBe(2);
-    expect(result.stderr.toString()).toContain("Unknown command");
+    expect(result.exitCode).not.toBe(0);
   });
 });

--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -1,14 +1,63 @@
-import { spawnSync } from "bun";
+import { spawn, spawnSync } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
 
-// The runtime binary's one job is to serve. It accepts (and ignores) a leading
-// `serve` token for deploy-command stability and rejects other positionals
-// before booting anything.
+// The runtime binary's one job is to serve. The deploy command is
+// `bun run src/cli/index.ts serve` (Dockerfile CMD; `start` and `dev:api` also
+// pass `serve`), and the entry strips that leading token. A parse-only assertion
+// can't guard the strip — `serve <garbage>` exits non-zero with or without it.
+// The only behavioral difference is whether a *bare* `serve` boots, so the boot
+// smoke below is what actually pins the deploy contract.
 const CLI = "src/cli/index.ts";
 
+async function waitForHealth(port: number, opts: { timeoutMs: number }): Promise<boolean> {
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://localhost:${port}/v1/health`);
+      if (res.ok) return true;
+    } catch {
+      // Port not listening yet — expected during boot.
+    }
+    await Bun.sleep(150);
+  }
+  return false;
+}
+
 describe("serve entry", () => {
-  it("rejects an unrecognized positional argument", () => {
+  it("the deploy command (`serve`) boots and serves /v1/health", async () => {
+    const workDir = mkdtempSync(join(tmpdir(), "nb-serve-"));
+    const port = 27991;
+    const proc = spawn(
+      [
+        "bun",
+        "run",
+        CLI,
+        "serve",
+        "--port",
+        String(port),
+        "--config",
+        ".environments/empty/nimblebrain.json",
+      ],
+      {
+        env: { ...process.env, NB_WORK_DIR: workDir, NB_TELEMETRY_DISABLED: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    try {
+      expect(await waitForHealth(port, { timeoutMs: 20_000 })).toBe(true);
+    } finally {
+      proc.kill();
+      await proc.exited;
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("rejects an unrecognized positional as a usage error (exit 2)", () => {
     const result = spawnSync(["bun", "run", CLI, "fakecmd"], { stdout: "pipe", stderr: "pipe" });
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(2);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "instrument/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "instrument/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["node_modules", "src/bundles/*/ui", "src/bundles/*/src/ui"]
 }


### PR DESCRIPTION
## Why

Follow-up to #536. With the TUI / operator subcommands / `nb` binary gone, the runtime entry was still a 2-command argv dispatcher (`serve` | `dev`). But `serve` and `dev` are different *kinds* of thing:

- **`serve`** = the runtime: one process, the product, what the container runs.
- **`dev`** = a local two-process supervisor (watch-mode serve + Vite HMR) — build tooling.

Mixing them in one binary made the runtime "know about" dev tooling. This makes the runtime binary **serve-only** and moves dev orchestration to `scripts/dev.ts`, next to the existing `scripts/dev-worktree.ts`. The split now matches what the code already is: `serve` = product, `dev` = tooling. (Camp-wise: this moves us from the framework-CLI pattern — `next dev`/`next start` — to the app-server pattern, where the binary serves and dev is a separate tool. We're an app server.)

## What changed

- **`src/cli/index.ts`** → serve-only. No subcommand dispatch. It accepts (and ignores) a leading `serve` token so the deploy command is byte-for-byte unchanged, and parses `--config`/`-c`, `--model`, `--port`, `--debug`.
- **`scripts/dev.ts`** (new) ← the dual-process dev supervisor, moved from `src/cli/dev.ts` (import paths + the resolved CLI-entry path adjusted for the new location; an argv-parsing `main()` added).
- **`src/cli/dev.ts`** deleted.
- **package.json**: `dev` / `dev:empty` / `dev:minimal` / `dev:docs-demo` point at `scripts/dev.ts`. `bun run dev` is unchanged for developers. `dev:api`, `start`, `dev:worktree` untouched.
- Docs (README tree, AGENTS structure line, `cli/overview` usage note) and one stale code comment updated.

After this, `src/cli/` is just the serve surface: `index.ts` (boot), `serve.ts`, `config.ts`.

## Deploy safety

The image/chart command `bun run src/cli/index.ts serve` is **unchanged** — the entry accepts the `serve` token and ignores it. No Dockerfile/Helm change.

One behavior delta: `bun run src/cli/index.ts` with *no* args now boots the server (it previously printed usage and exited 0). No in-repo caller invokes it bare — every deploy path (Dockerfile `CMD`, `start`, `dev:api`, the dev supervisor) passes `serve` — and booting on bare invoke is the correct app-server behavior (the binary's job is to serve). Documented in `cli/overview`.

## scripts/ is now typechecked

The relocation raised the obvious question: was `scripts/` ever typechecked? It wasn't — tsconfig `include` was `src/**` + `instrument/**`, so the codegen, migration, guardrail, and (now) dev-supervisor scripts all ran unchecked. This PR closes that: `scripts/**/*.ts` is added to the tsc program, so `bun run check` / verify:static / CI typecheck them under the same strict options as `src/`. Blast radius across all 19 scripts was a single pre-existing error (an unused destructured var in `check-cycles.ts`), fixed here. Biome-lint scope is unchanged — a separate, optional follow-up.

## Validation

- `bun run verify:static` — green (tsc, lint, all kernel checks, codegen)
- unit 3799/0 · integration 590/0 (incl. the `serve` boot smoke; ~12 env-gated skips) · smoke 21/0
- `scripts/dev.ts` bundles cleanly (relocated imports resolve)
- **Deploy-contract boot smoke:** an integration test boots the deploy command (`serve`) and polls `/v1/health`; mutation-verified (it fails if the `serve`-strip is removed). Parse errors exit 2 (usage), distinct from runtime exit 1.
- serve entry fast-fails correctly **with and without** the `serve` token; rejects unrecognized positionals
- **Live boot:** `bun run scripts/dev.ts --no-web` spawns the watch-mode serve child via the relocated path and reaches `[dev] API ready` (with `[api] Runtime ready` → listening on the chosen port)

