### PR TITLE
web: adopt the type scale shell-wide — migrate remaining text-[Npx] sites

### DIFF
--- a/web/src/components/FileAttachment.tsx
+++ b/web/src/components/FileAttachment.tsx
@@ -52,7 +52,7 @@ export function FileAttachment({ file }: Props) {
             } object-contain`}
           />
         </button>
-        <span className="block text-[10px] text-muted-foreground mt-1">
+        <span className="block text-3xs text-muted-foreground mt-1">
           {file.filename} ({formatFileSize(file.size)})
         </span>
       </div>
@@ -66,7 +66,7 @@ export function FileAttachment({ file }: Props) {
       <span className="truncate max-w-[200px]">{file.filename}</span>
       <span className="text-muted-foreground text-xs shrink-0">{formatFileSize(file.size)}</span>
       {file.extracted && (
-        <span className="text-[10px] text-success" title="Content extracted">
+        <span className="text-3xs text-success" title="Content extracted">
           extracted
         </span>
       )}

--- a/web/src/components/KeyboardShortcutsModal.tsx
+++ b/web/src/components/KeyboardShortcutsModal.tsx
@@ -139,7 +139,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
         <div className="px-5 py-3 border-t border-border bg-muted/50">
           <p className="text-xs text-muted-foreground text-center">
             Press{" "}
-            <kbd className="px-1 py-0.5 text-[10px] font-mono bg-card rounded border border-border">
+            <kbd className="px-1 py-0.5 text-3xs font-mono bg-card rounded border border-border">
               ?
             </kbd>{" "}
             anytime to show this

--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -250,21 +250,21 @@ export function MessageInput({
       </div>
 
       {/* Shortcut hints — status copy lives on the BlockTimeline / LiveCursor, not here. */}
-      <div className="flex items-center justify-center gap-3 mt-2 text-[10px] text-muted-foreground">
+      <div className="flex items-center justify-center gap-3 mt-2 text-3xs text-muted-foreground">
         {onNewConversation && (
           <button
             type="button"
             onClick={onNewConversation}
             className="hover:text-foreground transition-colors"
           >
-            <kbd className="px-1 py-0.5 font-mono bg-muted rounded border border-border text-[10px]">
+            <kbd className="px-1 py-0.5 font-mono bg-muted rounded border border-border text-3xs">
               /clear
             </kbd>{" "}
             reset
           </button>
         )}
         <span>
-          <kbd className="px-1 py-0.5 font-mono bg-muted rounded border border-border text-[10px]">
+          <kbd className="px-1 py-0.5 font-mono bg-muted rounded border border-border text-3xs">
             ⌘K
           </kbd>{" "}
           close

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -30,7 +30,7 @@ function UsageChip({ usage }: { usage: NonNullable<ChatMessage["usage"]> }) {
   if (cacheRead > 0) parts.push(`${formatTokens(cacheRead)} cached`);
 
   return (
-    <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground tabular-nums">
+    <span className="inline-flex items-center gap-1 text-3xs text-muted-foreground tabular-nums">
       <Zap style={{ width: 10, height: 10 }} className="opacity-70" />
       <span>{parts.join(" · ")}</span>
     </span>
@@ -334,7 +334,7 @@ export function MessageList({
                   >
                     {shouldShowSpeaker(msg, idx, messages, currentUserId) && (
                       <div
-                        className="flex items-center gap-1.5 mb-1 text-[11px] font-medium"
+                        className="flex items-center gap-1.5 mb-1 text-2xs font-medium"
                         style={{ color: participantColor(msg.userId!) }}
                       >
                         <span
@@ -346,10 +346,10 @@ export function MessageList({
                     )}
                     {contextPrefix && (
                       <details className="mb-1">
-                        <summary className="text-[10px] opacity-60 cursor-pointer select-none">
+                        <summary className="text-3xs opacity-60 cursor-pointer select-none">
                           App Context
                         </summary>
-                        <span className="block text-[10px] opacity-60 mt-0.5">{contextPrefix}</span>
+                        <span className="block text-3xs opacity-60 mt-0.5">{contextPrefix}</span>
                       </details>
                     )}
                     {msg.files && msg.files.length > 0 && (
@@ -447,7 +447,7 @@ export function MessageList({
                 >
                   <CopyButton content={displayContent} />
                   {showTimestamp && msg.timestamp && (
-                    <span className="text-[10px] text-muted-foreground">
+                    <span className="text-3xs text-muted-foreground">
                       {formatRelativeTime(msg.timestamp)}
                     </span>
                   )}

--- a/web/src/components/SkillsPopover.tsx
+++ b/web/src/components/SkillsPopover.tsx
@@ -112,7 +112,7 @@ export function SkillsPopover({ conversationId }: { conversationId: string | nul
             <div className="text-xs font-semibold">Active skills</div>
             <Link
               to={skillsPath}
-              className="text-[11px] text-muted-foreground hover:text-foreground"
+              className="text-2xs text-muted-foreground hover:text-foreground"
               onClick={() => setOpen(false)}
             >
               Manage →
@@ -138,16 +138,16 @@ export function SkillsPopover({ conversationId }: { conversationId: string | nul
                   <li key={s.id} className="px-3 py-2 space-y-0.5">
                     <div className="flex items-baseline justify-between gap-2">
                       <span className="text-xs font-medium truncate">{shortName(s.id)}</span>
-                      <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+                      <span className="text-3xs text-muted-foreground tabular-nums shrink-0">
                         {s.tokens} tok
                       </span>
                     </div>
-                    <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                    <div className="flex items-center gap-2 text-3xs text-muted-foreground">
                       <span className={SCOPE_COLOR[s.scope]}>{s.scope}</span>
                       <span>·</span>
                       <span>loaded: {s.loadedBy}</span>
                     </div>
-                    <div className="text-[10px] text-muted-foreground/80 truncate" title={s.reason}>
+                    <div className="text-3xs text-muted-foreground/80 truncate" title={s.reason}>
                       {s.reason}
                     </div>
                   </li>

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -152,7 +152,7 @@ export const UserMenu = memo(function UserMenu({
                 {label}
               </div>
               {displayName && email && displayName !== email && (
-                <div className="truncate text-[11px] text-sidebar-foreground/50 leading-tight">
+                <div className="truncate text-2xs text-sidebar-foreground/50 leading-tight">
                   {email}
                 </div>
               )}
@@ -184,7 +184,7 @@ export const UserMenu = memo(function UserMenu({
             <div className="px-3 py-2.5 border-b border-sidebar-border">
               <div className="truncate text-sm font-medium text-sidebar-foreground">{label}</div>
               {email && email !== label && (
-                <div className="truncate text-[11px] text-sidebar-foreground/50">{email}</div>
+                <div className="truncate text-2xs text-sidebar-foreground/50">{email}</div>
               )}
             </div>
           )}

--- a/web/src/components/briefing/BriefingView.tsx
+++ b/web/src/components/briefing/BriefingView.tsx
@@ -77,7 +77,7 @@ function formatInline(text: string): ReactNode[] {
 
 function Eyebrow() {
   return (
-    <div className="text-[11px] font-bold tracking-[0.08em] uppercase text-muted-foreground">
+    <div className="text-2xs font-bold tracking-[0.08em] uppercase text-muted-foreground">
       Briefing
     </div>
   );
@@ -105,7 +105,7 @@ function SectionGroup({
   if (items.length === 0) return null;
   return (
     <div className="mt-4 first:mt-3">
-      <div className="text-[11px] font-semibold tracking-[0.06em] uppercase text-muted-foreground/70">
+      <div className="text-2xs font-semibold tracking-[0.06em] uppercase text-muted-foreground/70">
         {label}
       </div>
       <ul className="mt-1.5 space-y-1.5">

--- a/web/src/components/chat/ComposerFooter.tsx
+++ b/web/src/components/chat/ComposerFooter.tsx
@@ -94,7 +94,7 @@ function ToolsFromLine({ workspaces }: { workspaces: readonly WorkspaceInfo[] })
       data-state="ready"
       data-workspace-count={workspaces.length}
     >
-      <span className="uppercase tracking-wider text-[10px] font-semibold">Tools from</span>
+      <span className="uppercase tracking-wider text-3xs font-semibold">Tools from</span>
       {workspaces.map((ws) => (
         <Badge
           key={ws.id}

--- a/web/src/components/connectors/BundleCredentialsModal.tsx
+++ b/web/src/components/connectors/BundleCredentialsModal.tsx
@@ -269,11 +269,11 @@ function BundleField({
         {label}
         {field.required && <span className="text-destructive">*</span>}
         {isPopulated && (
-          <span className="text-[10px] font-normal text-muted-foreground">✓ configured</span>
+          <span className="text-3xs font-normal text-muted-foreground">✓ configured</span>
         )}
       </span>
       {field.description && (
-        <span className="block text-[11px] text-muted-foreground mt-0.5">{field.description}</span>
+        <span className="block text-2xs text-muted-foreground mt-0.5">{field.description}</span>
       )}
       <input
         ref={inputRef}

--- a/web/src/components/connectors/ComposioApiKeyModal.tsx
+++ b/web/src/components/connectors/ComposioApiKeyModal.tsx
@@ -136,9 +136,7 @@ export function ComposioApiKeyModal({
                 className="mt-1 w-full text-sm font-mono px-2.5 py-1.5 rounded border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
               />
               {f.description && (
-                <span className="block text-[11px] text-muted-foreground mt-1">
-                  {f.description}
-                </span>
+                <span className="block text-2xs text-muted-foreground mt-1">{f.description}</span>
               )}
             </label>
           ))}

--- a/web/src/components/connectors/ConnectorStatusHero.tsx
+++ b/web/src/components/connectors/ConnectorStatusHero.tsx
@@ -166,7 +166,7 @@ export function ConnectorStatusHero({
           <div className="flex items-center gap-2 flex-wrap">
             <h1 className="text-xl font-semibold tracking-tight">{name}</h1>
             {installed.interactive && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent/40 text-accent-foreground font-medium">
+              <span className="text-3xs px-1.5 py-0.5 rounded bg-accent/40 text-accent-foreground font-medium">
                 Interactive
               </span>
             )}

--- a/web/src/components/connectors/OperatorSetupModal.tsx
+++ b/web/src/components/connectors/OperatorSetupModal.tsx
@@ -165,13 +165,13 @@ export function OperatorSetupModal({
               <span className="flex-1 min-w-0">
                 Add this redirect URI to the OAuth app's allowed redirect list:
                 <span className="mt-1 flex items-center gap-2">
-                  <code className="flex-1 min-w-0 truncate font-mono text-[11px] px-2 py-1 rounded border border-border bg-muted text-foreground">
+                  <code className="flex-1 min-w-0 truncate font-mono text-2xs px-2 py-1 rounded border border-border bg-muted text-foreground">
                     {redirectUri}
                   </code>
                   <button
                     type="button"
                     onClick={onCopyRedirectUri}
-                    className="text-[11px] px-2 py-1 rounded border border-border hover:bg-muted shrink-0"
+                    className="text-2xs px-2 py-1 rounded border border-border hover:bg-muted shrink-0"
                   >
                     {copied ? "Copied" : "Copy"}
                   </button>

--- a/web/src/components/connectors/ToolPermissionsTable.tsx
+++ b/web/src/components/connectors/ToolPermissionsTable.tsx
@@ -149,7 +149,7 @@ export function ToolPermissionsTable({ serverName }: { serverName: string }) {
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-mono">{tool.name}</span>
                     {savingTool === tool.name && (
-                      <span className="text-[10px] text-muted-foreground">saving…</span>
+                      <span className="text-3xs text-muted-foreground">saving…</span>
                     )}
                   </div>
                   {summary && (

--- a/web/src/components/palette/CommandPalette.tsx
+++ b/web/src/components/palette/CommandPalette.tsx
@@ -221,12 +221,12 @@ export function CommandPalette({ onLogout }: { onLogout: () => void }) {
               placeholder="Search workspaces, apps, or run a command…"
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={onInputKeyDown}
-              className="flex-1 bg-transparent border-0 outline-none text-[15px] text-foreground placeholder:text-muted-foreground"
+              className="flex-1 bg-transparent border-0 outline-none text-base text-foreground placeholder:text-muted-foreground"
             />
             {scopeId && (
               <span
                 data-testid="palette-scope"
-                className="shrink-0 text-[10.5px] font-mono px-1.5 py-0.5 rounded bg-accent text-accent-foreground border border-border"
+                className="shrink-0 text-3xs font-mono px-1.5 py-0.5 rounded bg-accent text-accent-foreground border border-border"
               >
                 {SCOPE_LABEL[scopeId]}
               </span>
@@ -245,7 +245,7 @@ export function CommandPalette({ onLogout }: { onLogout: () => void }) {
             ) : (
               groups.map((group) => (
                 <div key={group.source.id} className="pb-1.5">
-                  <div className="px-2.5 pt-2 pb-1 text-[9.5px] font-mono uppercase tracking-[0.12em] text-muted-foreground">
+                  <div className="px-2.5 pt-2 pb-1 text-3xs font-mono uppercase tracking-[0.12em] text-muted-foreground">
                     {group.label}
                   </div>
                   {group.items.map((item) => {
@@ -277,7 +277,7 @@ export function CommandPalette({ onLogout }: { onLogout: () => void }) {
           </div>
 
           {/* Footer */}
-          <div className="flex items-center gap-3.5 px-3.5 py-2.5 border-t border-border bg-muted/40 text-[10.5px] font-mono text-muted-foreground">
+          <div className="flex items-center gap-3.5 px-3.5 py-2.5 border-t border-border bg-muted/40 text-3xs font-mono text-muted-foreground">
             <span>
               <Kbd>↑↓</Kbd> navigate
             </span>

--- a/web/src/components/palette/CommandRow.tsx
+++ b/web/src/components/palette/CommandRow.tsx
@@ -20,7 +20,7 @@ function RowIcon({ icon }: { icon?: CommandIcon }) {
     return (
       <span
         aria-hidden="true"
-        className="shrink-0 flex items-center justify-center rounded-md text-white text-[11px] font-semibold"
+        className="shrink-0 flex items-center justify-center rounded-md text-white text-2xs font-semibold"
         style={{ width: 24, height: 24, backgroundColor: icon.color }}
       >
         {icon.letter}
@@ -44,7 +44,7 @@ function RowIcon({ icon }: { icon?: CommandIcon }) {
     <ConnectorIcon
       name={icon.fallbackLetter}
       iconUrl={icon.url}
-      className="h-6 w-6 rounded-md text-[11px]"
+      className="h-6 w-6 rounded-md text-2xs"
     />
   );
 }
@@ -79,13 +79,13 @@ export const CommandRow = memo(function CommandRow({
       <span className="flex-1 min-w-0 leading-tight">
         <span className="block text-sm truncate">{item.title}</span>
         {item.subtitle && (
-          <span className="block text-[11px] text-muted-foreground font-mono truncate">
+          <span className="block text-2xs text-muted-foreground font-mono truncate">
             {item.subtitle}
           </span>
         )}
       </span>
       {item.meta && (
-        <span className="shrink-0 text-[10.5px] font-mono text-muted-foreground">{item.meta}</span>
+        <span className="shrink-0 text-3xs font-mono text-muted-foreground">{item.meta}</span>
       )}
     </button>
   );

--- a/web/src/components/shell/SidebarSearch.tsx
+++ b/web/src/components/shell/SidebarSearch.tsx
@@ -28,7 +28,7 @@ export function SidebarSearch() {
           style={{ width: 14, height: 14 }}
         />
         <span className="flex-1 truncate text-sidebar-foreground/50">Search or run a command</span>
-        <kbd className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-sidebar-foreground/10 text-sidebar-foreground/60 border border-sidebar-border">
+        <kbd className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-medium bg-sidebar-foreground/10 text-sidebar-foreground/60 border border-sidebar-border">
           ⌘P
         </kbd>
       </button>

--- a/web/src/pages/GlobalHomePage.tsx
+++ b/web/src/pages/GlobalHomePage.tsx
@@ -44,7 +44,7 @@ export function GlobalHomePage() {
         </header>
 
         <section>
-          <h2 className="text-[11px] font-bold tracking-[0.08em] uppercase text-muted-foreground mb-3">
+          <h2 className="text-2xs font-bold tracking-[0.08em] uppercase text-muted-foreground mb-3">
             Your workspaces
           </h2>
           {wsCtx.loading ? (

--- a/web/src/pages/WorkspaceOverviewPage.tsx
+++ b/web/src/pages/WorkspaceOverviewPage.tsx
@@ -103,7 +103,7 @@ export function WorkspaceOverviewPage() {
         <header className="mb-8 flex items-start justify-between gap-4">
           <div className="min-w-0">
             <div
-              className="text-[11px] font-bold tracking-[0.08em] uppercase text-muted-foreground"
+              className="text-2xs font-bold tracking-[0.08em] uppercase text-muted-foreground"
               data-testid="workspace-overview-breadcrumb"
             >
               Workspace · {workspace.id}
@@ -138,7 +138,7 @@ export function WorkspaceOverviewPage() {
           />
         </div>
 
-        <div className="text-[11px] font-bold tracking-[0.08em] uppercase text-muted-foreground mb-3">
+        <div className="text-2xs font-bold tracking-[0.08em] uppercase text-muted-foreground mb-3">
           Available apps
         </div>
         {!appsReady ? (
@@ -229,10 +229,10 @@ function AppCard({
       )}
     >
       <div className="flex items-center gap-2">
-        <ConnectorIcon name={label} iconUrl={iconUrl} className="h-5 w-5 rounded text-[10px]" />
+        <ConnectorIcon name={label} iconUrl={iconUrl} className="h-5 w-5 rounded text-3xs" />
         <div className="truncate text-sm font-medium text-foreground">{label}</div>
       </div>
-      <div className="text-[10px] font-medium tracking-[0.04em] uppercase text-muted-foreground">
+      <div className="text-3xs font-medium tracking-[0.04em] uppercase text-muted-foreground">
         {describePlacementType(placement)}
       </div>
     </button>

--- a/web/src/pages/settings/OrgRegistriesTab.tsx
+++ b/web/src/pages/settings/OrgRegistriesTab.tsx
@@ -80,10 +80,10 @@ function RegistryRow({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">{registry.name}</span>
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+          <span className="text-3xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
             {registry.type}
           </span>
-          {registry.locked && <span className="text-[10px] text-muted-foreground">locked</span>}
+          {registry.locked && <span className="text-3xs text-muted-foreground">locked</span>}
         </div>
         {supportsUrl && (
           <div className="mt-1 font-mono text-xs text-muted-foreground">

--- a/web/src/pages/settings/ProfileTab.tsx
+++ b/web/src/pages/settings/ProfileTab.tsx
@@ -145,7 +145,7 @@ export function ProfileTab() {
                 <Icon className={cn("w-5 h-5", selected ? "text-warm" : "text-muted-foreground")} />
                 <div>
                   <div className="text-sm font-medium">{opt.label}</div>
-                  <div className="text-[11px] leading-tight text-muted-foreground mt-0.5">
+                  <div className="text-2xs leading-tight text-muted-foreground mt-0.5">
                     {opt.description}
                   </div>
                 </div>

--- a/web/src/pages/settings/components/CopyableWorkspaceId.tsx
+++ b/web/src/pages/settings/components/CopyableWorkspaceId.tsx
@@ -57,8 +57,8 @@ export function CopyableWorkspaceId({ workspaceId }: { workspaceId: string }) {
         </Button>
       </div>
       <p className="text-xs text-muted-foreground">
-        Use this ID as the <code className="text-[11px]">X-Workspace-Id</code> header when
-        connecting external MCP clients to this workspace.
+        Use this ID as the <code className="text-2xs">X-Workspace-Id</code> header when connecting
+        external MCP clients to this workspace.
       </p>
     </div>
   );

--- a/web/src/pages/settings/components/SettingsAppPanelPage.tsx
+++ b/web/src/pages/settings/components/SettingsAppPanelPage.tsx
@@ -49,7 +49,7 @@ export function SettingsAppPanelPage({ panel, children }: SettingsAppPanelPagePr
       </div>
       <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
       <p className="shrink-0 pt-2 text-right text-xs text-muted-foreground">
-        Provided by <code className="text-[11px]">{panel.serverName}</code>
+        Provided by <code className="text-2xs">{panel.serverName}</code>
       </p>
     </div>
   );


### PR DESCRIPTION
## Why
Follow-up to #539, which wired the type scale into the shell theme and migrated one component (`WorkspaceSection`) as the worked example. This finishes the **`text-[Npx]`** job: every remaining hand-set **px** font-size in the shell now uses a scale utility — no live `text-[Npx]` usages remain. Two non-px arbitrary sizes are intentionally left (see *What remains*).

## What changed
className swap across **22 files / 46 sites** — no token/theme change (the scale shipped in #539). One intended nuance, not pure no-op: the scale utilities carry a **paired line-height** the old `text-[Npx]` (font-size only) did not — see the *Line-height note* below.

| Old | → | Token | Sites |
|---|---|---|---|
| `text-[9.5px]` / `text-[10px]` / `text-[10.5px]` | → | `text-3xs` (10px) | most |
| `text-[11px]` | → | `text-2xs` (11px) | many |
| `text-[15px]` | → | `text-base` (16px) | 1 (command-palette search input) |

After this, `rg 'className="[^"]*text-\[[0-9.]+px\]' web/src` (live usages) returns **0**. The bare `rg 'text-\[[0-9.]+px\]'` still matches **2** — `text-[9px]`/`text-[11px]` inside `palette.ts` doc comments (not in this diff).

### Deliberate normalizations (please eyeball)
- **10.5→10px** (`text-3xs`) on three mono meta/badge labels in `CommandPalette`/`CommandRow` — sub-pixel, on-scale.
- **15→16px** (`text-base`) on the `CommandPalette` search input — nearest on-scale step; reads as a primary input and avoids mobile focus-zoom.
- Biome reflowed two lines (`ComposioApiKeyModal`, `CopyableWorkspaceId`) that the shorter class names let fit under 100 cols — whitespace only, text content identical.

### Line-height note
The scale utilities set a paired line-height (`3xs`→14px, `2xs`→16px, `base`→24px); the old `text-[Npx]` set font-size only and inherited the parent's (~1.5×). For the single-line majority (counts, badges, truncated labels) this is inert, and sites with explicit `leading-*` keep their leading (`--tw-leading` wins). The only visible effect is on a few genuinely multi-line micro-text blocks — the `MessageList` context-prefix and the `BundleCredentials`/`Composio` field descriptions — which tighten ~1.5×→1.4–1.45× (sub-pixel to ~1px). That's the scale doing its job (controlled vs. inherited line-height), not a regression.

## Verification
- `rg 'className="[^"]*text-\[[0-9.]+px\]' web/src` → 0 live usages (2 bare matches remain in `palette.ts` doc comments, not this diff)
- `bun run build` green
- `bun run test:unit` → 3799/0 · `bun run test:web` → 569/0
- `biome format` clean (after `--write` on the two reflows)
- No test pins any of the old class strings (checked)

## What remains (next PRs)
- **Non-px arbitrary text sizes** (out of this PR's px scope): `text-[0.85em]` (BriefingView inline `<code>`) is **relative-by-design** — keep it; `text-[0.8rem]` (vendored shadcn `sm` button variant, 12.8px) could fold to `text-xs` when that component is next touched.
- **index.css raw literals** — the hand-written chat CSS (`turn-pill`, `presence-*`) still uses ~16 raw `font-size:` px values; migrate those to the `--font-text-*` tokens.
- **Opacity-modifier soup** (11 ad-hoc `/N` steps → ~3 semantic foreground tokens).
- **Divergent radius scales** (shell multiplier scale vs. the ext `--border-radius-*` scale).
