### PR TITLE
Bring scripts/ under biome lint + format (completes #538's tsc move)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -31,7 +31,7 @@
     }
   },
   "files": {
-    "includes": ["src/**", "web/src/**", "instrument/**", "!**/dist/**", "!web/src/_generated/**"]
+    "includes": ["src/**", "web/src/**", "instrument/**", "scripts/**", "!**/dist/**", "!web/src/_generated/**"]
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
     "check": "bunx tsc --noEmit",
     "check:web": "cd web && bunx tsc --noEmit",
     "check:theme": "cd web && bun run check:theme",
-    "lint": "bunx @biomejs/biome check src/ instrument/",
-    "format": "bunx @biomejs/biome format --write src/ web/src/ instrument/",
-    "format:check": "bunx @biomejs/biome format src/ web/src/ instrument/",
+    "lint": "bunx @biomejs/biome check src/ instrument/ scripts/",
+    "format": "bunx @biomejs/biome format --write src/ web/src/ instrument/ scripts/",
+    "format:check": "bunx @biomejs/biome format src/ web/src/ instrument/ scripts/",
     "sync-models": "bun run src/model/sync-models.ts",
     "migrate:skill-frontmatter": "bun run scripts/migrate-skill-frontmatter.ts"
   },

--- a/scripts/check-bundle-transport.ts
+++ b/scripts/check-bundle-transport.ts
@@ -86,7 +86,12 @@ function hasAllowMarker(node: ts.Node, sourceFile: ts.SourceFile, src: string): 
     const lineText = lines[i] ?? "";
     if (lineText.includes(ALLOW_MARKER)) return true;
     const trimmed = lineText.trim();
-    if (trimmed === "" || trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) {
+    if (
+      trimmed === "" ||
+      trimmed.startsWith("//") ||
+      trimmed.startsWith("*") ||
+      trimmed.startsWith("/*")
+    ) {
       continue; // keep walking up through comments / blank lines
     }
     return false; // hit a code line without seeing the marker
@@ -143,9 +148,7 @@ async function main(): Promise<void> {
       console.error(`    ${v.snippet}\n`);
     }
     console.error("Bundle UIs must construct postMessage envelopes via @nimblebrain/synapse.");
-    console.error(
-      "Legitimate exceptions (e.g. internal-app cross-server calls) require a",
-    );
+    console.error("Legitimate exceptions (e.g. internal-app cross-server calls) require a");
     console.error(`  // ${ALLOW_MARKER}\n  comment on the line above the call.`);
     process.exit(1);
   }

--- a/scripts/check-conversation-paths.ts
+++ b/scripts/check-conversation-paths.ts
@@ -202,9 +202,7 @@ function scanFile(absPath: string, violations: Violation[]): void {
 
   function record(node: ts.Node): void {
     if (hasAllowMarker(node, sourceFile, src)) return;
-    const { line, character } = sourceFile.getLineAndCharacterOfPosition(
-      node.getStart(sourceFile),
-    );
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
     violations.push({
       file: relative(ROOT, absPath),
       line: line + 1,
@@ -244,9 +242,7 @@ async function main(): Promise<void> {
   }
 
   if (violations.length > 0) {
-    console.error(
-      `✗ Found ${violations.length} workspace-scoped conversation path(s) in src/:\n`,
-    );
+    console.error(`✗ Found ${violations.length} workspace-scoped conversation path(s) in src/:\n`);
     for (const v of violations) {
       console.error(`  ${v.file}:${v.line}:${v.column}`);
       console.error(`    ${v.snippet}\n`);

--- a/scripts/check-credential-paths.ts
+++ b/scripts/check-credential-paths.ts
@@ -161,9 +161,7 @@ function scanFile(absPath: string, violations: Violation[]): void {
 
   function record(node: ts.Node, reason: string): void {
     if (hasAllowMarker(node, sourceFile, src)) return;
-    const { line, character } = sourceFile.getLineAndCharacterOfPosition(
-      node.getStart(sourceFile),
-    );
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
     violations.push({
       file: relative(ROOT, absPath),
       line: line + 1,

--- a/scripts/check-cycles.ts
+++ b/scripts/check-cycles.ts
@@ -20,7 +20,11 @@ interface Violation {
 
 const violations: Violation[] = [];
 
-function checkDir(dir: string, forbiddenPatterns: Array<{ pattern: RegExp; description: string }>, allowedFiles: Set<string>) {
+function checkDir(
+  dir: string,
+  forbiddenPatterns: Array<{ pattern: RegExp; description: string }>,
+  allowedFiles: Set<string>,
+) {
   let files: string[];
   try {
     files = readdirSync(dir, { recursive: true }) as unknown as string[];

--- a/scripts/check-file-paths.ts
+++ b/scripts/check-file-paths.ts
@@ -36,7 +36,9 @@ const ALLOW_MARKER = "lint-ok:file-path";
 // `runtime.ts` owns FileStore construction: the `getFileStore` method (the
 // sanctioned identity-scoped constructor) and the host-resources resolver
 // closure both legitimately call `createFileStore`.
-const CREATE_STORE_ALLOWED_FILES = new Set(["runtime/runtime.ts"].map((f) => f.split("/").join(sep)));
+const CREATE_STORE_ALLOWED_FILES = new Set(
+  ["runtime/runtime.ts"].map((f) => f.split("/").join(sep)),
+);
 
 interface Violation {
   file: string;
@@ -80,8 +82,7 @@ export function isWorkspaceScopedFilesJoin(node: ts.CallExpression): boolean {
     isGetWorkspaceScopedDirCall(args[0]);
   if (!firstIsWsScoped) return false;
   return args.some(
-    (a) =>
-      (ts.isStringLiteral(a) || ts.isNoSubstitutionTemplateLiteral(a)) && a.text === "files",
+    (a) => (ts.isStringLiteral(a) || ts.isNoSubstitutionTemplateLiteral(a)) && a.text === "files",
   );
 }
 
@@ -158,14 +159,14 @@ async function main(): Promise<void> {
   }
 
   if (violations.length > 0) {
-    console.error(`✗ Found ${violations.length} workspace-scoped / unsanctioned file path(s) in src/:\n`);
+    console.error(
+      `✗ Found ${violations.length} workspace-scoped / unsanctioned file path(s) in src/:\n`,
+    );
     for (const v of violations) {
       console.error(`  ${v.file}:${v.line}:${v.column} — ${v.reason}`);
       console.error(`    ${v.snippet}\n`);
     }
-    console.error(
-      "Phase B: files are identity-owned at `{workDir}/users/{userId}/files/`.",
-    );
+    console.error("Phase B: files are identity-owned at `{workDir}/users/{userId}/files/`.");
     console.error("Build a store only via `runtime.getFileStore(userId)`.");
     console.error(
       `Legitimate exceptions (rare) require a // ${ALLOW_MARKER} comment on the line above.`,

--- a/scripts/check-no-raw-console.ts
+++ b/scripts/check-no-raw-console.ts
@@ -92,7 +92,9 @@ async function main(): Promise<void> {
       console.error(`  ${v.file}:${v.line}`);
       console.error(`    ${v.snippet}\n`);
     }
-    console.error("Operational code must log through `log` from `src/observability/log.ts` so lines are");
+    console.error(
+      "Operational code must log through `log` from `src/observability/log.ts` so lines are",
+    );
     console.error("structured JSON with tenant_id + correlation_id in deployed pods. CLI command");
     console.error(`output is exempt; a rare exception needs a // ${ALLOW_MARKER} comment above.`);
     process.exit(1);

--- a/scripts/check-personal-workspace-id.ts
+++ b/scripts/check-personal-workspace-id.ts
@@ -134,9 +134,7 @@ function scanFile(absPath: string, violations: Violation[]): void {
 
   function record(node: ts.Node, reason: string): void {
     if (hasAllowMarker(node, sourceFile, src)) return;
-    const { line, character } = sourceFile.getLineAndCharacterOfPosition(
-      node.getStart(sourceFile),
-    );
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
     violations.push({
       file: relative(ROOT, absPath),
       line: line + 1,
@@ -174,9 +172,7 @@ async function main(): Promise<void> {
   }
 
   if (violations.length > 0) {
-    console.error(
-      `✗ Found ${violations.length} hand-built personal-workspace id(s) in src/:\n`,
-    );
+    console.error(`✗ Found ${violations.length} hand-built personal-workspace id(s) in src/:\n`);
     for (const v of violations) {
       console.error(`  ${v.file}:${v.line}:${v.column} — ${v.reason}`);
       console.error(`    ${v.snippet}\n`);

--- a/scripts/check-public-origin.ts
+++ b/scripts/check-public-origin.ts
@@ -80,7 +80,9 @@ async function main(): Promise<void> {
     console.error(
       "for vendor/OAuth callback URLs or `webOrigin()` for user-facing SPA returns — not raw",
     );
-    console.error(`NB_API_URL / NB_WEB_URL. Rare exceptions need a // ${ALLOW_MARKER} comment above.`);
+    console.error(
+      `NB_API_URL / NB_WEB_URL. Rare exceptions need a // ${ALLOW_MARKER} comment above.`,
+    );
     process.exit(1);
   }
 

--- a/scripts/check-tool-namespace.ts
+++ b/scripts/check-tool-namespace.ts
@@ -86,8 +86,7 @@ const ALLOWED_FILES = new Set(
  * `name`, the lint surfaces it via the construction predicates first;
  * splitting it back open is then trivially obvious in review.
  */
-const NAMESPACED_BINDING_RE =
-  /^(?:namespaced|qualified)[A-Za-z_]*name$|^fullToolName$|^toolName$/i;
+const NAMESPACED_BINDING_RE = /^(?:namespaced|qualified)[A-Za-z_]*name$|^fullToolName$|^toolName$/i;
 
 interface Violation {
   file: string;
@@ -139,7 +138,7 @@ export function isNamespacedToolTemplate(node: ts.TemplateExpression): boolean {
   // begins with `-`.
   if (node.head.text === "ws_") {
     const firstSpan = node.templateSpans[0];
-    if (firstSpan && firstSpan.literal.text.startsWith("-")) return true;
+    if (firstSpan?.literal.text.startsWith("-")) return true;
   }
   return false;
 }
@@ -174,8 +173,7 @@ export function isNamespacedToolBinaryConcat(node: ts.BinaryExpression): boolean
   for (let i = 0; i < operands.length; i++) {
     const op = operands[i];
     if (!op) continue;
-    const text =
-      ts.isStringLiteral(op) || ts.isNoSubstitutionTemplateLiteral(op) ? op.text : null;
+    const text = ts.isStringLiteral(op) || ts.isNoSubstitutionTemplateLiteral(op) ? op.text : null;
     if (text === null) continue;
     if (sawWsPrefix < 0) {
       // Either exactly "ws_" or a literal beginning with "ws_" and
@@ -255,9 +253,7 @@ function scanFile(absPath: string, scanRoot: string, violations: Violation[]): v
 
   function record(node: ts.Node, reason: string): void {
     if (hasAllowMarker(node, sourceFile, src)) return;
-    const { line, character } = sourceFile.getLineAndCharacterOfPosition(
-      node.getStart(sourceFile),
-    );
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
     violations.push({
       file: relative(ROOT, absPath),
       line: line + 1,
@@ -318,9 +314,7 @@ async function main(): Promise<void> {
     console.error(
       "Cross-workspace tool names must flow through `namespacedToolName(wsId, name)` /",
     );
-    console.error(
-      "`parseNamespacedToolName(s)` — `src/tools/namespace.ts` (platform) or",
-    );
+    console.error("`parseNamespacedToolName(s)` — `src/tools/namespace.ts` (platform) or");
     console.error("`web/src/lib/namespaced-tool.ts` (web mirror).");
     console.error(
       `Legitimate exceptions (rare) require a // ${ALLOW_MARKER} comment on the line above the construction.`,

--- a/scripts/check-workspace-paths.ts
+++ b/scripts/check-workspace-paths.ts
@@ -42,11 +42,9 @@ const ALLOW_MARKER = "lint-ok:workspace-path";
 // Files that legitimately define the workspace path layout. The lint
 // would otherwise flag the definitions it exists to protect.
 const ALLOWED_FILES = new Set(
-  [
-    "workspace/context.ts",
-    "workspace/workspace-store.ts",
-    "config/workspace-credentials.ts",
-  ].map((f) => f.split("/").join(sep)),
+  ["workspace/context.ts", "workspace/workspace-store.ts", "config/workspace-credentials.ts"].map(
+    (f) => f.split("/").join(sep),
+  ),
 );
 
 interface Violation {
@@ -169,9 +167,7 @@ async function main(): Promise<void> {
   }
 
   if (violations.length > 0) {
-    console.error(
-      `✗ Found ${violations.length} hand-built workspace-scoped path(s) in src/:\n`,
-    );
+    console.error(`✗ Found ${violations.length} hand-built workspace-scoped path(s) in src/:\n`);
     for (const v of violations) {
       console.error(`  ${v.file}:${v.line}:${v.column}`);
       console.error(`    ${v.snippet}\n`);
@@ -179,7 +175,9 @@ async function main(): Promise<void> {
     console.error(
       "Workspace-scoped paths must flow through WorkspaceContext (src/workspace/context.ts).",
     );
-    console.error("Use `ctx.getDataPath(scope, ...subpaths)` instead of `join(workDir, \"workspaces\", wsId, ...)`.");
+    console.error(
+      'Use `ctx.getDataPath(scope, ...subpaths)` instead of `join(workDir, "workspaces", wsId, ...)`.',
+    );
     console.error(
       `Legitimate exceptions (rare) require a // ${ALLOW_MARKER} comment on the line above the call.`,
     );

--- a/scripts/lib/migrate-skill-frontmatter.ts
+++ b/scripts/lib/migrate-skill-frontmatter.ts
@@ -82,9 +82,7 @@ function asStringArray(v: unknown): string[] | undefined {
  */
 function resolveStrategy(rawStrategy: unknown, type: unknown): SkillLoadingStrategy {
   if (typeof rawStrategy === "string" && rawStrategy.trim().length > 0) {
-    return rawStrategy.trim().toLowerCase().replace(/_/g, "-") === "always"
-      ? "always"
-      : "dynamic";
+    return rawStrategy.trim().toLowerCase().replace(/_/g, "-") === "always" ? "always" : "dynamic";
   }
   return type === "context" ? "always" : "dynamic";
 }
@@ -142,9 +140,7 @@ export function migrateFrontmatterToManifest(legacy: Record<string, unknown>): S
     ...(triggers ? { triggers } : {}),
     ...(allowedTools ? { allowedTools } : {}),
     ...(typeof legacy.license === "string" ? { license: legacy.license } : {}),
-    ...(typeof legacy.compatibility === "string"
-      ? { compatibility: legacy.compatibility }
-      : {}),
+    ...(typeof legacy.compatibility === "string" ? { compatibility: legacy.compatibility } : {}),
     ...(author ? { author } : {}),
     ...(version ? { version } : {}),
   };

--- a/scripts/repro-issue-116.ts
+++ b/scripts/repro-issue-116.ts
@@ -16,11 +16,11 @@
  * check.
  */
 
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { McpSource, type McpTransportMode } from "../src/tools/mcp-source.ts";
+import { join } from "node:path";
 import type { EngineEvent, EventSink } from "../src/engine/types.ts";
+import { McpSource, type McpTransportMode } from "../src/tools/mcp-source.ts";
 
 const RESET = "\x1b[0m";
 const GREEN = "\x1b[32m";
@@ -136,7 +136,10 @@ const crashes = events.filter(
 if (crashes.length === 0) {
   fail("No source.crashed event was emitted");
 } else if (crashes.length > 1) {
-  fail(`Expected exactly 1 source.crashed event, got ${crashes.length}`, "Dead-guard de-dup is broken.");
+  fail(
+    `Expected exactly 1 source.crashed event, got ${crashes.length}`,
+    "Dead-guard de-dup is broken.",
+  );
 } else {
   pass("Exactly one source.crashed event was emitted (dead-guard works)");
 }
@@ -145,7 +148,10 @@ if (crashes.length > 0) {
   const data = crashes[0]!.data as { stderrTail?: string };
   const tail = data.stderrTail ?? "";
   if (!tail) {
-    fail("source.crashed payload has empty stderrTail", "Ring buffer didn't capture pre-crash output.");
+    fail(
+      "source.crashed payload has empty stderrTail",
+      "Ring buffer didn't capture pre-crash output.",
+    );
   } else if (!tail.includes("ModuleNotFoundError")) {
     fail(
       "source.crashed.stderrTail is non-empty but doesn't contain 'ModuleNotFoundError'",
@@ -161,7 +167,9 @@ rmSync(bundleDir, { recursive: true, force: true });
 
 console.log("");
 if (failures > 0) {
-  console.log(`${RED}${BOLD}FAIL${RESET} — ${failures} contract violation(s). Issue #116 fix is broken.`);
+  console.log(
+    `${RED}${BOLD}FAIL${RESET} — ${failures} contract violation(s). Issue #116 fix is broken.`,
+  );
   process.exit(1);
 }
 console.log(`${GREEN}${BOLD}PASS${RESET} — issue #116 fix is wired end-to-end.`);


### PR DESCRIPTION
## Why

Completes the static-checking story for `scripts/`. #538 brought `scripts/` under **tsc** (the dev supervisor moved there and would otherwise have lost typecheck coverage), but biome's lint/format scope was still `src/` + `web/src/` + `instrument/` only — so the codegen, migration, guardrail, and dev-supervisor scripts could drift unformatted/unlinted. This closes that gap.

## What changed

- `biome.json`: add `scripts/**` to `files.includes`.
- `package.json`: add `scripts/` to `lint` / `format` / `format:check`, so `verify:static` and CI enforce biome on `scripts/`.
- Applied biome's fixes: 13 scripts reformatted (whitespace + import order) + one lint fix (optional chaining in `check-tool-namespace.ts`).

## Validation

- `bunx biome check scripts/` — 22 files, **0 errors, 0 warnings**.
- `bun run verify:static` — green. It runs the reformatted `check:*` and codegen scripts, so they're confirmed working post-format.
- No behavior change — pure formatting + one equivalent optional-chain rewrite.

## Blast radius

14 files, +63/−65 (net −2). The non-mechanical changes are confined to `biome.json`, `package.json`, and the one optional-chain line; everything else is biome line-wrapping + import sorting.