### PR TITLE
web(settings): make the registry toggle visible in light mode

### DIFF
--- a/web/src/pages/settings/OrgRegistriesTab.tsx
+++ b/web/src/pages/settings/OrgRegistriesTab.tsx
@@ -113,6 +113,9 @@ function Toggle({
   label: string;
 }) {
   return (
+    // The off-state track and thumb must both stay visible on the off-white
+    // canvas: bg-input gives the track a form-control gray with real contrast in
+    // both themes, and shadow-sm lifts the thumb off whichever track it sits on.
     <button
       type="button"
       role="switch"
@@ -121,11 +124,11 @@ function Toggle({
       disabled={disabled}
       onClick={() => onChange(!checked)}
       className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
-        checked ? "bg-primary" : "bg-muted"
+        checked ? "bg-primary" : "bg-input"
       }`}
     >
       <span
-        className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
+        className={`inline-block h-4 w-4 transform rounded-full bg-background shadow-sm transition-transform ${
           checked ? "translate-x-4" : "translate-x-0.5"
         }`}
       />


### PR DESCRIPTION
## The bug
The registry enable/disable switch (Org → Settings → Registries) is **invisible in light mode** — surfaced during QA of #541 (but pre-existing on `main`, unrelated to that PR; #541 only changed a font size in this file).

The inline `Toggle` painted:
- off-state **track** `bg-muted` = `#f8f7f5`
- **thumb** `bg-background` = `#faf9f7`

…both within a shade of the page background (`#faf9f7`), so the control washes out. Locked rows add `disabled:opacity-60`, finishing the job.


## The fix
- Off-state track → **`bg-input`** (`#e5e5e5` light / `#262626` dark) — the semantic form-control token, which has real contrast against the page background in **both** themes.
- Thumb → add **`shadow-sm`** so the knob reads on either track state.

Two-line className change; added a short comment so it isn't "simplified" back to `bg-muted`.

## Verification
- `bun run check` (tsc) clean · `bun run build` green · `bun run test:web` 569/0 · `biome format` clean
- Eyeballed both states (on `bg-primary` blue, off `bg-input` gray) in light and dark, enabled and locked/disabled.
