### PR TITLE
web(chat): tokenize the chat-CSS font sizes onto the type scale

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -142,6 +142,10 @@
 /* User messages: italic sans-serif */
 .presence-user-message {
   font-family: var(--font-sans);
+  /* Deliberate editorial size — sits between the type scale's sm (14px) and
+     base (16px) with no exact step; kept bespoke so the most-visible text in
+     the app isn't snapped for the sake of the rule. Assistant body below is
+     18px = the scale's lg, so it's tokenized. */
   font-size: 15px;
   font-weight: 500;
   line-height: 1.5;
@@ -152,7 +156,7 @@
 /* Assistant messages: serif typography base, Streamdown handles markdown rendering */
 .presence-assistant-message {
   font-family: var(--font-heading);
-  font-size: 18px;
+  font-size: var(--font-text-lg-size);
   font-weight: 400;
   line-height: 1.5;
   color: var(--foreground);
@@ -291,7 +295,7 @@
 
 .turn-pill {
   width: 100%;
-  font-size: 12px;
+  font-size: var(--font-text-xs-size);
   color: var(--muted-foreground);
 }
 
@@ -356,7 +360,7 @@
 .turn-pill__ms {
   color: var(--muted-foreground);
   opacity: 0.7;
-  font-size: 12px;
+  font-size: var(--font-text-xs-size);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
 }
@@ -421,7 +425,7 @@
   color: var(--muted-foreground);
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-text-xs-size);
   text-align: left;
   transition: color 150ms, background-color 150ms;
 }
@@ -443,14 +447,14 @@
 .turn-pill__row-count {
   color: var(--muted-foreground);
   opacity: 0.6;
-  font-size: 11px;
+  font-size: var(--font-text-2xs-size);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
 }
 .turn-pill__row-ms {
   color: var(--muted-foreground);
   opacity: 0.6;
-  font-size: 11px;
+  font-size: var(--font-text-2xs-size);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
 }
@@ -477,7 +481,7 @@
   color: var(--muted-foreground);
   cursor: pointer;
   font: inherit;
-  font-size: 11.5px;
+  font-size: var(--font-text-2xs-size);
   text-align: left;
   transition: color 150ms;
 }
@@ -490,7 +494,7 @@
   min-width: 0;
   color: var(--muted-foreground);
   font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 11px;
+  font-size: var(--font-text-2xs-size);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -498,7 +502,7 @@
 .turn-pill__call-ms {
   color: var(--muted-foreground);
   opacity: 0.6;
-  font-size: 11px;
+  font-size: var(--font-text-2xs-size);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
 }
@@ -518,7 +522,7 @@
   background: transparent;
   border: 0;
   color: var(--muted-foreground);
-  font-size: 12.5px;
+  font-size: var(--font-text-xs-size);
   line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
@@ -546,7 +550,7 @@
   padding: 0 2px 4px;
 }
 .turn-pill__section-label {
-  font-size: 10px;
+  font-size: var(--font-text-3xs-size);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--muted-foreground);
@@ -563,7 +567,7 @@
   border: 0;
   color: var(--primary);
   font: inherit;
-  font-size: 10px;
+  font-size: var(--font-text-3xs-size);
   cursor: pointer;
   border-radius: 4px;
   transition: background-color 120ms;
@@ -578,7 +582,7 @@
   background: var(--muted);
   overflow: hidden;
   font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 11.5px;
+  font-size: var(--font-text-2xs-size);
 }
 .turn-pill__kv-row {
   display: grid;
@@ -615,7 +619,7 @@
   border: 1px solid var(--border);
   border-radius: 6px;
   font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 11px;
+  font-size: var(--font-text-2xs-size);
   line-height: 1.55;
   color: var(--muted-foreground);
   overflow-x: auto;
@@ -647,7 +651,7 @@
   gap: 8px;
   padding: 2px 0;
   color: var(--muted-foreground);
-  font-size: 12px;
+  font-size: var(--font-text-xs-size);
 }
 .live-cursor__spinner {
   color: var(--processing);


### PR DESCRIPTION
## Why
Closes the type-scale thread. #539 wired the scale into the theme and #541 adopted it across the Tailwind className surface — but the hand-written chat CSS in `index.css` (`presence-*`, `turn-pill`, `live-cursor`) still set `font-size` as raw px literals. This points those at the same `--font-text-*` tokens, so the chat chrome now shares one source of truth with the rest of the shell.

## What changed (`index.css` only, 15 literals)
| Raw | → | Token | Note |
|---|---|---|---|
| `10px` | → | `var(--font-text-3xs-size)` | exact |
| `11px` | → | `var(--font-text-2xs-size)` | exact |
| `12px` | → | `var(--font-text-xs-size)` | exact |
| `18px` | → | `var(--font-text-lg-size)` | exact — assistant message body |
| `11.5px` | → | `var(--font-text-2xs-size)` | **snap −0.5px** (turn-pill call-head, kv table) |
| `12.5px` | → | `var(--font-text-xs-size)` | **snap −0.5px** (turn-pill reasoning) |

Only `font-size` values changed — existing `line-height` declarations are left as-is, so unlike the className utilities there's **no paired-line-height shift** here.

### Deliberate exception (please eyeball)
- **User-message body stays `15px`** (`.presence-user-message`). It sits between the scale's `sm` (14) and `base` (16) with no exact step, and it's the most-visible text in the app — snapping it ±1px to satisfy the rule isn't worth a visible change to every user turn. Left raw with a comment; the assistant body (18 = `lg`) is tokenized since it's exact.
- The two **−0.5px snaps** are turn-pill metadata chrome (call labels, kv table, reasoning) — sub-pixel, on-scale.

## Verification
- `rg 'font-size:\s*[0-9.]+px' web/src/index.css` → 1 (the documented user-message `15px`)
- `bun run build` green; confirmed the built CSS keeps the `var(--font-text-*-size)` refs and they resolve against `:root`
- `bun run test:web` → 569/0
- (Biome doesn't format CSS — `css.formatter` is disabled — so no format step applies here)

## What remains (the non-type-scale Tier-2 items)
- **Opacity-modifier soup** (11 ad-hoc `/N` steps → ~3 semantic foreground tokens)
- **Divergent radius scales** (shell multiplier scale vs. the ext `--border-radius-*` scale)