### PR TITLE
web: standardize opacity modifiers onto a documented 6-step ramp

### DIFF
--- a/web/src/components/ArtifactChip.tsx
+++ b/web/src/components/ArtifactChip.tsx
@@ -44,7 +44,7 @@ export function ArtifactChip({ appName, uri, name, mimeType, description }: Arti
     <button
       type="button"
       onClick={() => openArtifact({ appName, uri, name, mimeType, description })}
-      className="group w-full my-2 flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted/40 hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="group w-full my-2 flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted/50 hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       aria-label={`Open ${title}`}
     >
       <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -266,7 +266,7 @@ export function ArtifactPanel() {
               )}
 
               {!loading && error && (
-                <div className="m-6 rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                <div className="m-6 rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
                   Failed to load {title}: {error}
                 </div>
               )}

--- a/web/src/components/ArtifactView.tsx
+++ b/web/src/components/ArtifactView.tsx
@@ -115,7 +115,7 @@ export function ArtifactView({ uri, appName, name, mimeType, description }: Arti
 
   if (error || !content) {
     return (
-      <div className="w-full my-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+      <div className="w-full my-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
         Failed to load {displayName}: {error ?? "unknown error"}
       </div>
     );
@@ -129,7 +129,7 @@ export function ArtifactView({ uri, appName, name, mimeType, description }: Arti
   const isRenderable = kind !== "unsupported" && content.text !== undefined;
 
   const header = (
-    <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border bg-muted/30 text-xs">
+    <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border bg-muted/20 text-xs">
       <div className="flex items-center gap-2 min-w-0">
         <FileText className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
         <span className="truncate font-medium">{displayName}</span>

--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -227,7 +227,7 @@ export function MessageInput({
               onClick={onStop}
               type="button"
               aria-label="Stop generating"
-              className="shrink-0 flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-200 bg-primary hover:bg-primary/90 text-primary-foreground"
+              className="shrink-0 flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-200 bg-primary hover:bg-primary/80 text-primary-foreground"
             >
               <Square style={{ width: 14, height: 14 }} fill="currentColor" />
             </button>
@@ -239,7 +239,7 @@ export function MessageInput({
               aria-label="Send message"
               className={`shrink-0 flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-200 ${
                 canSend
-                  ? "bg-primary hover:bg-primary/90 text-primary-foreground"
+                  ? "bg-primary hover:bg-primary/80 text-primary-foreground"
                   : "bg-muted text-muted-foreground cursor-not-allowed"
               }`}
             >

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -404,7 +404,7 @@ export function MessageList({
                     )}
                     {/* Inline error notice */}
                     {msg.error && (
-                      <div className="px-3 py-2.5 rounded-md bg-destructive/8 border border-destructive/20 text-sm">
+                      <div className="px-3 py-2.5 rounded-md bg-destructive/10 border border-destructive/20 text-sm">
                         <div className="flex items-center gap-2">
                           <AlertCircle className="w-4 h-4 shrink-0 text-destructive" />
                           <span className="flex-1 text-foreground">

--- a/web/src/components/ReleaseUpdateBanner.tsx
+++ b/web/src/components/ReleaseUpdateBanner.tsx
@@ -49,7 +49,7 @@ export function ReleaseUpdateBanner({ collapsed = false }: { collapsed?: boolean
   return (
     <div
       role="status"
-      className="mx-2 mb-2 shrink-0 rounded-lg border border-warm/30 bg-warm/5 px-2.5 py-2 text-xs text-foreground"
+      className="mx-2 mb-2 shrink-0 rounded-lg border border-warm/20 bg-warm/5 px-2.5 py-2 text-xs text-foreground"
     >
       <div className="flex items-center justify-between gap-1">
         <span className="font-medium">New version available</span>

--- a/web/src/components/ResourceLinkView.tsx
+++ b/web/src/components/ResourceLinkView.tsx
@@ -108,14 +108,14 @@ export function ResourceLinkView({
 
   if (error || !content) {
     return (
-      <div className="w-full my-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+      <div className="w-full my-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
         Failed to load {displayName}: {error ?? "unknown error"}
       </div>
     );
   }
 
   const header = (
-    <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border bg-muted/30 text-xs">
+    <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border bg-muted/20 text-xs">
       <div className="flex items-center gap-2 min-w-0">
         <FileText className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
         <span className="truncate font-medium">{displayName}</span>

--- a/web/src/components/SidebarToggle.tsx
+++ b/web/src/components/SidebarToggle.tsx
@@ -39,7 +39,7 @@ export const SidebarToggle = memo(function SidebarToggle() {
       onClick={toggle}
       aria-label={label}
       title={`${label} (⌘B)`}
-      className="p-2 rounded-lg text-sidebar-foreground/40 hover:text-sidebar-foreground/60 hover:bg-sidebar-hover transition-colors shrink-0"
+      className="p-2 rounded-lg text-sidebar-foreground/50 hover:text-sidebar-foreground/60 hover:bg-sidebar-hover transition-colors shrink-0"
     >
       {icon}
     </button>

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -159,7 +159,7 @@ export const UserMenu = memo(function UserMenu({
             </div>
             <ChevronUp
               className={cn(
-                "shrink-0 w-4 h-4 text-sidebar-foreground/40 transition-transform duration-200",
+                "shrink-0 w-4 h-4 text-sidebar-foreground/50 transition-transform duration-200",
                 open ? "rotate-0" : "rotate-180",
               )}
             />

--- a/web/src/components/briefing/BriefingView.tsx
+++ b/web/src/components/briefing/BriefingView.tsx
@@ -105,12 +105,12 @@ function SectionGroup({
   if (items.length === 0) return null;
   return (
     <div className="mt-4 first:mt-3">
-      <div className="text-2xs font-semibold tracking-[0.06em] uppercase text-muted-foreground/70">
+      <div className="text-2xs font-semibold tracking-[0.06em] uppercase text-muted-foreground/60">
         {label}
       </div>
       <ul className="mt-1.5 space-y-1.5">
         {items.map((item) => (
-          <li key={item.id} className="flex items-start gap-2.5 text-sm text-foreground/90">
+          <li key={item.id} className="flex items-start gap-2.5 text-sm text-foreground/80">
             <span
               className={cn("mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full", dotClass(item.type))}
               aria-hidden
@@ -148,7 +148,7 @@ export function BriefingView({ briefing, loading, error, onRetry, onAction }: Br
 
       {error && (
         <div
-          className="mt-3 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+          className="mt-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive"
           data-testid="workspace-briefing-error"
         >
           <p>{error}</p>

--- a/web/src/components/chat/ComposerFooter.tsx
+++ b/web/src/components/chat/ComposerFooter.tsx
@@ -34,7 +34,7 @@ export function ComposerFooter() {
 
   return (
     <div
-      className="px-3 py-2 text-xs text-muted-foreground border-t border-border/40 space-y-1"
+      className="px-3 py-2 text-xs text-muted-foreground border-t border-border/60 space-y-1"
       data-testid="composer-footer"
     >
       <ViewingLine activeWorkspace={wsCtx.activeWorkspace} activeAppDisplayName={activeApp} />

--- a/web/src/components/connectors/BundleCredentialsModal.tsx
+++ b/web/src/components/connectors/BundleCredentialsModal.tsx
@@ -208,7 +208,7 @@ export function BundleCredentialsModal({
               <button
                 type="submit"
                 disabled={busy || clearing}
-                className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+                className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-60"
               >
                 {busy ? "Saving…" : "Save"}
               </button>

--- a/web/src/components/connectors/ComposioApiKeyModal.tsx
+++ b/web/src/components/connectors/ComposioApiKeyModal.tsx
@@ -155,7 +155,7 @@ export function ComposioApiKeyModal({
               type="button"
               onClick={() => void submit()}
               disabled={busy}
-              className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+              className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-60"
             >
               {busy ? "Connecting…" : "Connect"}
             </button>

--- a/web/src/components/connectors/ConnectorStatusHero.tsx
+++ b/web/src/components/connectors/ConnectorStatusHero.tsx
@@ -166,7 +166,7 @@ export function ConnectorStatusHero({
           <div className="flex items-center gap-2 flex-wrap">
             <h1 className="text-xl font-semibold tracking-tight">{name}</h1>
             {installed.interactive && (
-              <span className="text-3xs px-1.5 py-0.5 rounded bg-accent/40 text-accent-foreground font-medium">
+              <span className="text-3xs px-1.5 py-0.5 rounded bg-accent/50 text-accent-foreground font-medium">
                 Interactive
               </span>
             )}
@@ -179,7 +179,7 @@ export function ConnectorStatusHero({
             <p className="text-xs text-muted-foreground font-mono mt-0.5">
               v{shownVersion}
               {versionDrift && (
-                <span className="ml-2 text-muted-foreground/70">catalog v{versionDrift}</span>
+                <span className="ml-2 text-muted-foreground/60">catalog v{versionDrift}</span>
               )}
             </p>
           )}
@@ -193,7 +193,7 @@ export function ConnectorStatusHero({
           When `ready`, the page reads as quiet settings; when any
           other status applies, this block is the visual anchor. */}
       {installed.status !== "ready" && (
-        <div className="flex items-start justify-between gap-4 px-4 py-3 border border-border/60 rounded-md bg-muted/30">
+        <div className="flex items-start justify-between gap-4 px-4 py-3 border border-border/60 rounded-md bg-muted/20">
           <div className="flex items-start gap-3 min-w-0">
             <StatusDot status={installed.status} />
             <div className="min-w-0">

--- a/web/src/components/connectors/OperatorSetupModal.tsx
+++ b/web/src/components/connectors/OperatorSetupModal.tsx
@@ -232,7 +232,7 @@ export function OperatorSetupModal({
             <button
               type="submit"
               disabled={busy}
-              className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+              className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-60"
             >
               {busy ? "Saving…" : isEdit ? "Save changes" : "Save"}
             </button>

--- a/web/src/components/palette/CommandPalette.tsx
+++ b/web/src/components/palette/CommandPalette.tsx
@@ -277,7 +277,7 @@ export function CommandPalette({ onLogout }: { onLogout: () => void }) {
           </div>
 
           {/* Footer */}
-          <div className="flex items-center gap-3.5 px-3.5 py-2.5 border-t border-border bg-muted/40 text-3xs font-mono text-muted-foreground">
+          <div className="flex items-center gap-3.5 px-3.5 py-2.5 border-t border-border bg-muted/50 text-3xs font-mono text-muted-foreground">
             <span>
               <Kbd>↑↓</Kbd> navigate
             </span>

--- a/web/src/components/shell/WorkspaceSection.tsx
+++ b/web/src/components/shell/WorkspaceSection.tsx
@@ -109,7 +109,7 @@ export function WorkspaceSection({ collapsed = false }: WorkspaceSectionProps) {
     >
       {!collapsed && (
         <div className="flex items-center justify-between px-4 pt-1 pb-1">
-          <div className="text-2xs font-bold tracking-[0.08em] text-sidebar-foreground/70 uppercase">
+          <div className="text-2xs font-bold tracking-[0.08em] text-sidebar-foreground/60 uppercase">
             Workspaces
           </div>
           <button
@@ -226,7 +226,7 @@ function WorkspaceInlineApps({ workspaceId }: { workspaceId: string }) {
         <Link
           to={`/w/${slug}/`}
           data-testid="sidebar-workspace-view-all"
-          className="flex items-center gap-1.5 px-2 py-1 text-xs text-sidebar-foreground/55 hover:text-sidebar-foreground transition-colors"
+          className="flex items-center gap-1.5 px-2 py-1 text-xs text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors"
         >
           <ArrowRight className="size-3 shrink-0" />
           <span className="truncate">View all {apps.length} apps</span>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -88,6 +88,23 @@
     --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+/* ─────────────────────────────────────────────────────────────────────────
+ * Opacity ramp — the canonical opacity modifiers for color utilities (the
+ * `/N` suffix on `text-`, `bg-`, and `border-` colors). Six steps; pick by
+ * intent, don't invent in-between values (no /55, /70, /8…).
+ *
+ *   /5   passive hover · resting subtle fill (nav rows, search box at rest)
+ *   /10  active / selected fill · stronger hover for a discrete control
+ *   /20  soft border (foreground / sidebar-foreground) · faint surface (muted header strips)
+ *   /50  faint text (placeholder / disabled) · default muted surface (muted cards)
+ *   /60  muted / secondary text · softened border token (border-border)
+ *   /80  emphasized text · primary action hover (bg-primary)
+ *
+ * Two intentional two-level pairs — keep them distinct: /5 vs /10 (passive vs
+ * control fill) and /20 vs /50 (faint vs default muted surface). shadcn
+ * primitives under components/ui/* keep their vendored values.
+ * ───────────────────────────────────────────────────────────────────────── */
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/web/src/pages/settings/ConnectorBrowsePage.tsx
+++ b/web/src/pages/settings/ConnectorBrowsePage.tsx
@@ -308,7 +308,7 @@ function DirectoryCard({
   const operatorReady = entry.operatorConfigured === true;
 
   return (
-    <div className="flex flex-col gap-3 p-4 border border-border/50 rounded-md bg-background h-full">
+    <div className="flex flex-col gap-3 p-4 border border-border/60 rounded-md bg-background h-full">
       <div className="flex items-start gap-3">
         <ConnectorIcon name={entry.name} iconUrl={entry.iconUrl} />
         <div className="flex-1 min-w-0">

--- a/web/src/pages/settings/ProfileTab.tsx
+++ b/web/src/pages/settings/ProfileTab.tsx
@@ -139,7 +139,7 @@ export function ProfileTab() {
                   "flex flex-col items-center gap-2 rounded-lg border-2 p-4 text-center transition-all",
                   selected
                     ? "border-warm bg-warm/5 text-foreground"
-                    : "border-border bg-card text-muted-foreground hover:border-muted-foreground/30 hover:bg-muted/50",
+                    : "border-border bg-card text-muted-foreground hover:border-muted-foreground/20 hover:bg-muted/50",
                 )}
               >
                 <Icon className={cn("w-5 h-5", selected ? "text-warm" : "text-muted-foreground")} />

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -580,7 +580,7 @@ function Toggle({
       aria-label={`${on ? "Turn off" : "Turn on"} ${label}`}
       className={cn(
         "inline-flex items-center gap-2 px-2 py-1 rounded-md text-xs font-medium select-none",
-        disabled ? "text-muted-foreground/70 cursor-not-allowed" : "text-foreground hover:bg-muted",
+        disabled ? "text-muted-foreground/60 cursor-not-allowed" : "text-foreground hover:bg-muted",
       )}
     >
       <span

--- a/web/src/pages/settings/WorkspaceAppsTab.tsx
+++ b/web/src/pages/settings/WorkspaceAppsTab.tsx
@@ -37,7 +37,7 @@ function Inner() {
           {panels.map((panel) => {
             const Icon = panel.icon ? resolveIcon(panel.icon) : null;
             return (
-              <Card key={panel.serverName} className="hover:bg-muted/40 transition-colors">
+              <Card key={panel.serverName} className="hover:bg-muted/50 transition-colors">
                 <CardContent className="py-3 px-4">
                   <Link
                     to={panel.serverName}

--- a/web/src/pages/settings/components/InlineError.tsx
+++ b/web/src/pages/settings/components/InlineError.tsx
@@ -18,7 +18,7 @@ export function InlineError({
 }) {
   return (
     <div
-      className="flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2"
+      className="flex items-center justify-between gap-3 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2"
       role={role}
     >
       <p className="text-sm text-destructive">{message}</p>


### PR DESCRIPTION
## Why
The shell used **11 ad-hoc opacity steps** (`/5 /10 /20 /30 /40 /50 /55 /60 /70 /80 /90`, ~183 occurrences) for muted text, subtle fills, and soft borders. No system — so the *same intent* drifted across steps (sidebar hover was `/5` in 9 places and `/10` in 3; `border-border` was `/60` ×6 and `/50` ×2). This snaps everything onto a canonical ramp and, more importantly, **writes down what each step means** so it stays consistent.

## The ramp (documented at the top of `index.css`)
| Step | Meaning |
|---|---|
| `/5` | passive hover · resting subtle fill (nav rows, search box at rest) |
| `/10` | active / selected fill · stronger hover for a discrete control |
| `/20` | soft border · faint muted surface (header strips) |
| `/50` | faint text (placeholder/disabled) · default muted surface (cards) |
| `/60` | muted / secondary text · softened `border-border` |
| `/80` | emphasized text · primary action hover (`bg-primary`) |

**Two intentional two-level pairs** kept distinct (not flattened): `/5` vs `/10` (passive vs control fill) and `/20` vs `/50` (faint vs default muted surface). These looked like "inconsistency" but are real element-type distinctions — so they're now *documented* rather than erased.

## Changes
- **Snapped** the 5 off-ramp steps to nearest: `30→20, 40→50, 55→50, 70→60, 90→80` (each ≤15% opacity, on near-neutral bases). `bg-primary/90 → /80` also unifies the primary-button hover with shadcn's `ui/button` `/80`.
- **Fixed 2 true inconsistencies**: `bg-destructive/8 → /10` (off-ramp error-banner fill) and **`border-border` unified to `/60`** — it existed at `/40` (ComposerFooter), `/50` (ConnectorBrowsePage), and `/60` (×6); the `/40` flows `40→50→60` through both passes, so all 8 non-ui `border-border` sites are now `/60`.
- **Documented** the ramp + semantics in `index.css`.

## Scope (deliberately excluded)
- `components/ui/*` — vendored shadcn primitives keep their values.
- Literal `bg-black` overlay **scrims** — a modal-backdrop concern, not semantic-color emphasis (the perl initially caught `bg-black/40`→`/50`; reverted).
- Numeric shade tints (`bg-blue-500/15` avatars) — never matched (semantic bases only).

## Verification
- `bun run build` green (caught a `*/`-in-CSS-comment bug in the ramp doc — fixed)
- `bun run test:web` → 569/0
- `biome format` clean on changed files
- Confirmed every changed line is a semantic-color opacity swap (no over-match)
