### PR TITLE
web(theme): single-source the shell's fonts + tokenize the glow (token federation, pt.1)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -12,9 +12,11 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-    --font-sans: 'Satoshi', system-ui, sans-serif;
-    --font-heading: 'Erode', Georgia, serif;
-    --font-mono: 'JetBrains Mono Variable', ui-monospace, SFMono-Regular, monospace;
+    /* Font stacks — single-sourced from src/theme/palette.ts (fonts), emitted
+       into :root as --nb-font-* by gen:theme. One source, same value. */
+    --font-sans: var(--nb-font-sans);
+    --font-heading: var(--nb-font-heading);
+    --font-mono: var(--nb-font-mono);
 
     /* Type scale — single-sourced from src/theme/palette.ts (typeScale),
        emitted into :root by gen:theme. Gives `text-3xs`/`text-2xs` for the
@@ -278,8 +280,8 @@
 }
 
 @keyframes breathing-glow {
-  0%, 100% { box-shadow: 0 0 0 1px var(--processing), 0 0 8px 0 rgba(124, 58, 237, 0.15); }
-  50% { box-shadow: 0 0 0 1px var(--processing), 0 0 16px 2px rgba(124, 58, 237, 0.08); }
+  0%, 100% { box-shadow: 0 0 0 1px var(--processing), 0 0 8px 0 color-mix(in oklch, var(--processing) 15%, transparent); }
+  50% { box-shadow: 0 0 0 1px var(--processing), 0 0 16px 2px color-mix(in oklch, var(--processing) 8%, transparent); }
 }
 
 /* Warm background shift — ambient state on scroll container */

--- a/web/src/theme/__tests__/palette.test.ts
+++ b/web/src/theme/__tests__/palette.test.ts
@@ -218,4 +218,14 @@ describe("paletteToRootCss — shell :root/.dark match current values", () => {
   test("dark block does not redefine the type scale (mode-independent, cascades)", () => {
     expect(darkBlock).not.toContain("--font-text-");
   });
+
+  test("light :root carries the font stacks (aliased to Tailwind --font-* in index.css)", () => {
+    expect(rootBlock).toContain("--nb-font-sans: 'Satoshi', system-ui, sans-serif;");
+    expect(rootBlock).toContain("--nb-font-heading: 'Erode', Georgia, serif;");
+    expect(rootBlock).toContain("--nb-font-mono: 'JetBrains Mono Variable'");
+  });
+
+  test("dark block does not redefine the font stacks (mode-independent, cascades)", () => {
+    expect(darkBlock).not.toContain("--nb-font-");
+  });
 });

--- a/web/src/theme/projections.ts
+++ b/web/src/theme/projections.ts
@@ -91,6 +91,10 @@ export function paletteToRootCss(): string {
   // Type scale is mode-independent — :root only, aliased to Tailwind `--text-*`
   // in index.css. Same single-source path as colors/radius/layout.
   for (const [k, v] of Object.entries(typeScale)) lightDecls.push(`  ${k}: ${v};`);
+  // Font stacks — single-sourced into the shell as `--nb-font-*`, aliased to
+  // Tailwind's `--font-*` in index.css (the shell previously restated these as
+  // literals). Mode-independent, :root only.
+  for (const [k, v] of Object.entries(fonts)) lightDecls.push(`  --nb-font-${k}: ${v};`);
 
   const darkDecls = names.map((n) => `  --${n}: ${pick(colors[n], "dark")};`);
 

--- a/web/src/theme/tokens.generated.css
+++ b/web/src/theme/tokens.generated.css
@@ -71,6 +71,9 @@
   --font-heading-md-line-height: 2rem;
   --font-heading-lg-size: 2rem;
   --font-heading-lg-line-height: 2.5rem;
+  --nb-font-sans: 'Satoshi', system-ui, sans-serif;
+  --nb-font-heading: 'Erode', Georgia, serif;
+  --nb-font-mono: 'JetBrains Mono Variable', ui-monospace, SFMono-Regular, monospace;
 }
 
 .dark {


### PR DESCRIPTION
First slice of **token federation** (the path to one source of UI-style truth). Closes the two single-source *escapes* where the shell restated values instead of consuming `palette.ts` — chosen because they're independent of the radius decision and carry **zero visual change**.

## Changes
- **Fonts** — `index.css @theme` restated the three font stacks as literals, duplicating `palette.ts::fonts`. Now emitted from palette into `:root` as `--nb-font-*` and aliased to Tailwind's `--font-*`. One source; palette already feeds the same stacks to the iframe apps, so both planes derive fonts from one place.
- **Glow** — the `breathing-glow` keyframe hardcoded `rgba(124,58,237,…)` (a literal of `--processing`). Replaced with `color-mix(in oklch, var(--processing) N%, transparent)` — single-sourced *and* now dark-mode-correct (the old literal didn't track the theme).

## Verification
- `gen:theme` emits `--nb-font-*`; built CSS resolves `font-sans → var(--nb-font-sans) → Satoshi`; no `rgba(124…)` remains
- `bun run build` green · `test:web` 571/0 · theme contract tests 10/10 (baseline + the 2 font-emission tests this PR adds) · biome clean
- Fonts: no visual change (identical values). Glow: dark mode now correctly tracks `--processing` (#a78bfa) instead of the hardcoded light-mode purple (#7c3aed). The light-mode glow is recomputed in oklch vs. the old sRGB `rgba()` — sub-perceptual at 8–15% alpha on a blur, and consistent with the file's other `color-mix(in oklch, …)` uses.

## Deferred (the meatier federation)
- **Radius** — a real design decision, not a swap: shadcn `rounded-lg`=8px collides *by name* with synapse `radiusLg`=16px, so naive value-unification would make the whole shell bubbly. Needs an element-level intent remap. *(Decision pending.)*
- **Shadows** — the shell has no shadow tokens (uses stock Tailwind); palette defines `sm/md/lg` but the shell also uses `xl/2xl`. Federating means extending the palette ramp + a minor shadow shift toward the design-system values.

