### PR TITLE
web(theme): converge the radius scale onto the design system (A)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -189,7 +189,7 @@ function BootstrappedShell({
         <span>Failed to load workspace: {error}</span>
         <button
           type="button"
-          className="px-4 py-2 text-sm bg-secondary text-secondary-foreground rounded-md hover:bg-accent transition-colors"
+          className="px-4 py-2 text-sm bg-secondary text-secondary-foreground rounded-sm hover:bg-accent transition-colors"
           onClick={() => window.location.reload()}
         >
           Retry

--- a/web/src/components/ArtifactChip.tsx
+++ b/web/src/components/ArtifactChip.tsx
@@ -44,10 +44,10 @@ export function ArtifactChip({ appName, uri, name, mimeType, description }: Arti
     <button
       type="button"
       onClick={() => openArtifact({ appName, uri, name, mimeType, description })}
-      className="group w-full my-2 flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted/50 hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="group w-full my-2 flex items-center gap-3 rounded-sm border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted/50 hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       aria-label={`Open ${title}`}
     >
-      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm bg-muted text-muted-foreground">
         <FileText className="h-4.5 w-4.5" />
       </span>
       <span className="min-w-0 flex-1">

--- a/web/src/components/ArtifactPanel.tsx
+++ b/web/src/components/ArtifactPanel.tsx
@@ -229,7 +229,7 @@ export function ArtifactPanel() {
                 type="button"
                 onClick={onCopy}
                 disabled={text == null}
-                className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
+                className="inline-flex items-center gap-1.5 rounded-sm border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
                 aria-label="Copy document to clipboard"
               >
                 {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
@@ -239,7 +239,7 @@ export function ArtifactPanel() {
                 type="button"
                 onClick={onDownload}
                 disabled={text == null}
-                className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
+                className="inline-flex items-center gap-1.5 rounded-sm border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-40"
                 aria-label="Download document"
               >
                 <Download className="h-3.5 w-3.5" />
@@ -249,7 +249,7 @@ export function ArtifactPanel() {
                 ref={closeButtonRef}
                 type="button"
                 onClick={closeArtifact}
-                className="ml-1 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                className="ml-1 inline-flex h-7 w-7 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
                 aria-label="Close document panel"
               >
                 <X className="h-4 w-4" />
@@ -266,7 +266,7 @@ export function ArtifactPanel() {
               )}
 
               {!loading && error && (
-                <div className="m-6 rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
+                <div className="m-6 rounded-sm border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
                   Failed to load {title}: {error}
                 </div>
               )}

--- a/web/src/components/ArtifactRenderer.tsx
+++ b/web/src/components/ArtifactRenderer.tsx
@@ -162,7 +162,7 @@ function DownloadFallback({
 }) {
   const label = title ?? downloadName ?? "artifact";
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-4 text-sm">
+    <div className="flex items-center gap-3 rounded-sm border border-border bg-card p-4 text-sm">
       <FileWarning className="h-5 w-5 shrink-0 text-muted-foreground" />
       <div className="min-w-0 flex-1">
         <p className="font-medium text-foreground">No preview available</p>
@@ -172,7 +172,7 @@ function DownloadFallback({
         <a
           href={objectUrl}
           download={downloadName ?? "artifact"}
-          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-sm border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
         >
           <Download className="h-3.5 w-3.5" />
           Download

--- a/web/src/components/ArtifactView.tsx
+++ b/web/src/components/ArtifactView.tsx
@@ -106,7 +106,7 @@ export function ArtifactView({ uri, appName, name, mimeType, description }: Arti
 
   if (loading) {
     return (
-      <div className="w-full my-2 rounded-lg border border-border bg-card p-3 flex items-center gap-2 text-sm text-muted-foreground">
+      <div className="w-full my-2 rounded-sm border border-border bg-card p-3 flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 className="w-4 h-4 text-processing animate-spin" />
         Loading {displayName}...
       </div>
@@ -115,7 +115,7 @@ export function ArtifactView({ uri, appName, name, mimeType, description }: Arti
 
   if (error || !content) {
     return (
-      <div className="w-full my-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
+      <div className="w-full my-2 rounded-sm border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
         Failed to load {displayName}: {error ?? "unknown error"}
       </div>
     );
@@ -153,7 +153,7 @@ export function ArtifactView({ uri, appName, name, mimeType, description }: Arti
   );
 
   return (
-    <div className="w-full my-2 rounded-lg border border-border bg-card overflow-hidden">
+    <div className="w-full my-2 rounded-sm border border-border bg-card overflow-hidden">
       {header}
       <div className="p-3 max-h-[32rem] overflow-y-auto">
         <ArtifactRenderer

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -139,7 +139,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
               onClick={onBack}
               type="button"
               aria-label="Back"
-              className="p-1.5 hover:bg-muted rounded-lg transition-all text-muted-foreground hover:text-foreground sm:hidden shrink-0"
+              className="p-1.5 hover:bg-muted rounded-sm transition-all text-muted-foreground hover:text-foreground sm:hidden shrink-0"
             >
               <ArrowLeft style={{ width: 18, height: 18 }} />
             </button>
@@ -167,7 +167,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
             type="button"
             disabled={isStreaming}
             aria-label="New conversation"
-            className="p-1.5 hover:bg-muted rounded-lg transition-all text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+            className="p-1.5 hover:bg-muted rounded-sm transition-all text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <RotateCcw style={{ width: 16, height: 16 }} />
           </button>
@@ -176,7 +176,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
             onClick={() => setShowShortcuts(true)}
             type="button"
             aria-label="Keyboard shortcuts"
-            className="p-1.5 hover:bg-muted rounded-lg transition-all text-muted-foreground hover:text-foreground"
+            className="p-1.5 hover:bg-muted rounded-sm transition-all text-muted-foreground hover:text-foreground"
           >
             <Keyboard style={{ width: 16, height: 16 }} />
           </button>
@@ -185,7 +185,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
               onClick={onFullscreen}
               type="button"
               aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-              className="p-1.5 hover:bg-muted rounded-lg transition-all text-muted-foreground hover:text-foreground"
+              className="p-1.5 hover:bg-muted rounded-sm transition-all text-muted-foreground hover:text-foreground"
             >
               {isFullscreen ? (
                 <Minimize2 style={{ width: 16, height: 16 }} />
@@ -199,7 +199,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
               onClick={onClose}
               type="button"
               aria-label="Close"
-              className="p-1.5 hover:bg-muted rounded-lg transition-all text-muted-foreground hover:text-foreground"
+              className="p-1.5 hover:bg-muted rounded-sm transition-all text-muted-foreground hover:text-foreground"
             >
               <X style={{ width: 16, height: 16 }} />
             </button>

--- a/web/src/components/FileAttachment.tsx
+++ b/web/src/components/FileAttachment.tsx
@@ -47,7 +47,7 @@ export function FileAttachment({ file }: Props) {
             alt={file.filename}
             loading="lazy"
             onError={() => setImgError(true)}
-            className={`rounded-lg border border-border transition-all duration-200 ${
+            className={`rounded-sm border border-border transition-all duration-200 ${
               expanded ? "max-w-full" : "max-w-[240px] max-h-[180px]"
             } object-contain`}
           />
@@ -61,7 +61,7 @@ export function FileAttachment({ file }: Props) {
 
   // Non-images, pending uploads, or failed image loads → file chip
   return (
-    <div className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-muted border border-border text-sm">
+    <div className="inline-flex items-center gap-2 px-3 py-2 rounded-sm bg-muted border border-border text-sm">
       <Icon style={{ width: 16, height: 16 }} className="text-muted-foreground shrink-0" />
       <span className="truncate max-w-[200px]">{file.filename}</span>
       <span className="text-muted-foreground text-xs shrink-0">{formatFileSize(file.size)}</span>

--- a/web/src/components/FileAttachmentChips.tsx
+++ b/web/src/components/FileAttachmentChips.tsx
@@ -37,7 +37,7 @@ export function FileAttachmentChips({ files, onRemove }: Props) {
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: composite key with idx to handle duplicate files
           key={`${file.name}-${file.size}-${idx}`}
-          className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-muted text-xs text-foreground border border-border"
+          className="flex items-center gap-1.5 px-2 py-1 rounded-sm bg-muted text-xs text-foreground border border-border"
         >
           {file.type.startsWith("image/") && <Thumbnail file={file} />}
           <span className="truncate max-w-[120px]">{file.name}</span>

--- a/web/src/components/InlineAppView.tsx
+++ b/web/src/components/InlineAppView.tsx
@@ -160,7 +160,7 @@ export function InlineAppView({ appName, resourceUri, toolResult }: InlineAppVie
   }, [appName, resourceUri]);
 
   return (
-    <div className="w-full max-w-full my-2 rounded-lg overflow-hidden border border-border bg-card">
+    <div className="w-full max-w-full my-2 rounded-sm overflow-hidden border border-border bg-card">
       <div
         className="relative w-full transition-[height] duration-150"
         style={{ height: `${height}px` }}

--- a/web/src/components/KeyboardShortcutsModal.tsx
+++ b/web/src/components/KeyboardShortcutsModal.tsx
@@ -92,14 +92,14 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
       <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" />
       <div
         ref={modalRef}
-        className="relative bg-card border border-border rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden"
+        className="relative bg-card border border-border rounded-md shadow-2xl w-full max-w-md mx-4 overflow-hidden"
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 className="font-heading text-lg font-medium text-foreground">Keyboard Shortcuts</h2>
           <button
             type="button"
             onClick={onClose}
-            className="p-1.5 hover:bg-muted rounded-lg transition-colors text-muted-foreground hover:text-foreground"
+            className="p-1.5 hover:bg-muted rounded-sm transition-colors text-muted-foreground hover:text-foreground"
           >
             <X style={{ width: 16, height: 16 }} />
           </button>

--- a/web/src/components/Logo.tsx
+++ b/web/src/components/Logo.tsx
@@ -23,7 +23,7 @@ export function Logo({ variant = "full", height = 24, className = "" }: LogoProp
           src={iconSquare}
           alt="NimbleBrain"
           style={{ height, width: height }}
-          className="rounded-sm"
+          className="rounded-xs"
         />
       </span>
     );
@@ -48,7 +48,7 @@ export function Logo({ variant = "full", height = 24, className = "" }: LogoProp
         alt=""
         aria-hidden="true"
         style={{ height, width: height }}
-        className="rounded-sm"
+        className="rounded-xs"
       />
       <span
         className="font-heading font-semibold tracking-tight text-foreground"

--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -163,7 +163,7 @@ export function MessageInput({
     <div className="py-3 shrink-0">
       {/* biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop container for file uploads */}
       <div
-        className={`rounded-2xl border transition-all duration-200 bg-card ${
+        className={`rounded-lg border transition-all duration-200 bg-card ${
           isDragOver
             ? "border-primary shadow-lg shadow-primary/20"
             : isActive && !isFocused
@@ -217,7 +217,7 @@ export function MessageInput({
               disabled={disabled}
               type="button"
               aria-label="Attach files"
-              className="shrink-0 flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-200 text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+              className="shrink-0 flex items-center justify-center w-8 h-8 rounded-sm transition-all duration-200 text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Paperclip style={{ width: 16, height: 16 }} />
             </button>
@@ -227,7 +227,7 @@ export function MessageInput({
               onClick={onStop}
               type="button"
               aria-label="Stop generating"
-              className="shrink-0 flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-200 bg-primary hover:bg-primary/80 text-primary-foreground"
+              className="shrink-0 flex items-center justify-center w-8 h-8 rounded-sm transition-all duration-200 bg-primary hover:bg-primary/80 text-primary-foreground"
             >
               <Square style={{ width: 14, height: 14 }} fill="currentColor" />
             </button>
@@ -237,7 +237,7 @@ export function MessageInput({
               disabled={!canSend}
               type="button"
               aria-label="Send message"
-              className={`shrink-0 flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-200 ${
+              className={`shrink-0 flex items-center justify-center w-8 h-8 rounded-sm transition-all duration-200 ${
                 canSend
                   ? "bg-primary hover:bg-primary/80 text-primary-foreground"
                   : "bg-muted text-muted-foreground cursor-not-allowed"

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -397,14 +397,14 @@ export function MessageList({
                     )}
                     {/* Stop reason notice */}
                     {msg.stopReason && (
-                      <div className="flex items-start gap-2 px-3 py-2 rounded-md bg-muted/50 border border-border text-sm text-muted-foreground">
+                      <div className="flex items-start gap-2 px-3 py-2 rounded-sm bg-muted/50 border border-border text-sm text-muted-foreground">
                         <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
                         <span>{stopReasonMessage(msg.stopReason)}</span>
                       </div>
                     )}
                     {/* Inline error notice */}
                     {msg.error && (
-                      <div className="px-3 py-2.5 rounded-md bg-destructive/10 border border-destructive/20 text-sm">
+                      <div className="px-3 py-2.5 rounded-sm bg-destructive/10 border border-destructive/20 text-sm">
                         <div className="flex items-center gap-2">
                           <AlertCircle className="w-4 h-4 shrink-0 text-destructive" />
                           <span className="flex-1 text-foreground">
@@ -414,7 +414,7 @@ export function MessageList({
                             <button
                               type="button"
                               onClick={onRetry}
-                              className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md border border-border bg-card hover:bg-muted text-foreground transition-colors shrink-0"
+                              className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-sm border border-border bg-card hover:bg-muted text-foreground transition-colors shrink-0"
                             >
                               <RotateCcw className="w-3 h-3" />
                               Try again

--- a/web/src/components/ReleaseUpdateBanner.tsx
+++ b/web/src/components/ReleaseUpdateBanner.tsx
@@ -49,7 +49,7 @@ export function ReleaseUpdateBanner({ collapsed = false }: { collapsed?: boolean
   return (
     <div
       role="status"
-      className="mx-2 mb-2 shrink-0 rounded-lg border border-warm/20 bg-warm/5 px-2.5 py-2 text-xs text-foreground"
+      className="mx-2 mb-2 shrink-0 rounded-sm border border-warm/20 bg-warm/5 px-2.5 py-2 text-xs text-foreground"
     >
       <div className="flex items-center justify-between gap-1">
         <span className="font-medium">New version available</span>

--- a/web/src/components/ResourceLinkView.tsx
+++ b/web/src/components/ResourceLinkView.tsx
@@ -99,7 +99,7 @@ export function ResourceLinkView({
 
   if (loading) {
     return (
-      <div className="w-full my-2 rounded-lg border border-border bg-card p-3 flex items-center gap-2 text-sm text-muted-foreground">
+      <div className="w-full my-2 rounded-sm border border-border bg-card p-3 flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 className="w-4 h-4 text-processing animate-spin" />
         Loading {displayName}...
       </div>
@@ -108,7 +108,7 @@ export function ResourceLinkView({
 
   if (error || !content) {
     return (
-      <div className="w-full my-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
+      <div className="w-full my-2 rounded-sm border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
         Failed to load {displayName}: {error ?? "unknown error"}
       </div>
     );
@@ -140,7 +140,7 @@ export function ResourceLinkView({
 
   if (resolvedMime === "application/pdf" && objectUrl) {
     return (
-      <div className="w-full my-2 rounded-lg border border-border bg-card overflow-hidden">
+      <div className="w-full my-2 rounded-sm border border-border bg-card overflow-hidden">
         {header}
         {/* No `sandbox` attribute by design. Chromium routes application/pdf
             to PDFium, which runs in a separate sandboxed renderer process
@@ -171,7 +171,7 @@ export function ResourceLinkView({
 
   if (resolvedMime.startsWith("image/") && objectUrl) {
     return (
-      <div className="w-full my-2 rounded-lg border border-border bg-card overflow-hidden">
+      <div className="w-full my-2 rounded-sm border border-border bg-card overflow-hidden">
         {header}
         <img src={objectUrl} alt={displayName} className="block max-w-full h-auto" />
         {description && (
@@ -185,7 +185,7 @@ export function ResourceLinkView({
 
   if (content.text !== undefined) {
     return (
-      <div className="w-full my-2 rounded-lg border border-border bg-card overflow-hidden">
+      <div className="w-full my-2 rounded-sm border border-border bg-card overflow-hidden">
         {header}
         <pre className="p-3 text-xs overflow-x-auto whitespace-pre-wrap break-words max-h-96">
           {content.text}
@@ -200,7 +200,7 @@ export function ResourceLinkView({
   }
 
   return (
-    <div className="w-full my-2 rounded-lg border border-border bg-card">
+    <div className="w-full my-2 rounded-sm border border-border bg-card">
       {header}
       <div className="p-3 text-sm">
         {objectUrl ? (

--- a/web/src/components/ShellLayout.tsx
+++ b/web/src/components/ShellLayout.tsx
@@ -339,7 +339,7 @@ const NavItem = memo(function NavItem({
         end={end}
         title={label}
         className={({ isActive }) =>
-          `flex items-center justify-center p-2.5 mx-2 rounded-lg text-sm font-medium transition-colors ${
+          `flex items-center justify-center p-2.5 mx-2 rounded-sm text-sm font-medium transition-colors ${
             isActive
               ? "bg-sidebar-foreground/10 text-sidebar-foreground"
               : "text-sidebar-foreground hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground"
@@ -356,7 +356,7 @@ const NavItem = memo(function NavItem({
       to={to}
       end={end}
       className={({ isActive }) =>
-        `flex items-center gap-3 px-3 py-2.5 mx-2 rounded-lg text-sm font-medium transition-colors ${
+        `flex items-center gap-3 px-3 py-2.5 mx-2 rounded-sm text-sm font-medium transition-colors ${
           isActive
             ? "bg-sidebar-foreground/10 text-sidebar-foreground"
             : "text-sidebar-foreground hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground"
@@ -387,7 +387,7 @@ function MobileNavItem({
       end={end}
       onClick={() => setDrawerOpen(false)}
       className={({ isActive }) =>
-        `flex items-center gap-3 px-3 py-2.5 mx-2 rounded-lg text-sm font-medium transition-colors ${
+        `flex items-center gap-3 px-3 py-2.5 mx-2 rounded-sm text-sm font-medium transition-colors ${
           isActive
             ? "bg-sidebar-foreground/10 text-sidebar-foreground"
             : "text-sidebar-foreground hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground"

--- a/web/src/components/SidebarToggle.tsx
+++ b/web/src/components/SidebarToggle.tsx
@@ -39,7 +39,7 @@ export const SidebarToggle = memo(function SidebarToggle() {
       onClick={toggle}
       aria-label={label}
       title={`${label} (⌘B)`}
-      className="p-2 rounded-lg text-sidebar-foreground/50 hover:text-sidebar-foreground/60 hover:bg-sidebar-hover transition-colors shrink-0"
+      className="p-2 rounded-sm text-sidebar-foreground/50 hover:text-sidebar-foreground/60 hover:bg-sidebar-hover transition-colors shrink-0"
     >
       {icon}
     </button>

--- a/web/src/components/SkillsPopover.tsx
+++ b/web/src/components/SkillsPopover.tsx
@@ -101,13 +101,13 @@ export function SkillsPopover({ conversationId }: { conversationId: string | nul
         aria-label="Active skills"
         aria-expanded={open}
         title="Skills loaded for this conversation"
-        className="p-1.5 hover:bg-muted rounded-lg transition-all text-muted-foreground hover:text-foreground"
+        className="p-1.5 hover:bg-muted rounded-sm transition-all text-muted-foreground hover:text-foreground"
       >
         <Lightbulb style={{ width: 16, height: 16 }} />
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full mt-1 z-50 w-80 rounded-md border bg-popover text-popover-foreground shadow-md">
+        <div className="absolute right-0 top-full mt-1 z-50 w-80 rounded-sm border bg-popover text-popover-foreground shadow-md">
           <div className="px-3 py-2 border-b flex items-center justify-between">
             <div className="text-xs font-semibold">Active skills</div>
             <Link

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -130,7 +130,7 @@ export const UserMenu = memo(function UserMenu({
         aria-label={`Account: ${label}`}
         aria-expanded={open}
         className={cn(
-          "flex items-center w-full rounded-lg transition-all duration-150 text-sm",
+          "flex items-center w-full rounded-sm transition-all duration-150 text-sm",
           "text-sidebar-foreground hover:bg-sidebar-foreground/5",
           open && "bg-sidebar-foreground/5",
           collapsed ? "justify-center p-1.5" : "gap-2.5 px-2 py-2",
@@ -138,7 +138,7 @@ export const UserMenu = memo(function UserMenu({
       >
         <span
           className={cn(
-            "inline-flex items-center justify-center font-semibold shrink-0 select-none rounded-md",
+            "inline-flex items-center justify-center font-semibold shrink-0 select-none rounded-sm",
             "w-7 h-7 text-xs",
           )}
           style={{ backgroundColor: bg, color: fg }}
@@ -170,7 +170,7 @@ export const UserMenu = memo(function UserMenu({
       {open && (
         <div
           className={cn(
-            "absolute z-50 rounded-lg border border-sidebar-border bg-sidebar shadow-lg ws-dropdown-enter",
+            "absolute z-50 rounded-sm border border-sidebar-border bg-sidebar shadow-lg ws-dropdown-enter",
             collapsed
               ? cn("left-full ml-2 w-56", dropdownDirection === "up" ? "bottom-0" : "top-0")
               : cn(
@@ -192,7 +192,7 @@ export const UserMenu = memo(function UserMenu({
             <button
               type="button"
               onClick={goToProfile}
-              className="flex items-center gap-2.5 w-full rounded-md px-2 py-2 text-sm text-left transition-all duration-150 text-sidebar-foreground hover:bg-sidebar-foreground/5"
+              className="flex items-center gap-2.5 w-full rounded-sm px-2 py-2 text-sm text-left transition-all duration-150 text-sidebar-foreground hover:bg-sidebar-foreground/5"
             >
               <UserCog className="w-4 h-4 text-sidebar-foreground/60" />
               <span>Profile settings</span>
@@ -201,7 +201,7 @@ export const UserMenu = memo(function UserMenu({
               <button
                 type="button"
                 onClick={goToOrgSettings}
-                className="flex items-center gap-2.5 w-full rounded-md px-2 py-2 text-sm text-left transition-all duration-150 text-sidebar-foreground hover:bg-sidebar-foreground/5"
+                className="flex items-center gap-2.5 w-full rounded-sm px-2 py-2 text-sm text-left transition-all duration-150 text-sidebar-foreground hover:bg-sidebar-foreground/5"
               >
                 <Building2 className="w-4 h-4 text-sidebar-foreground/60" />
                 <span>Organization</span>
@@ -210,7 +210,7 @@ export const UserMenu = memo(function UserMenu({
             <button
               type="button"
               onClick={handleLogout}
-              className="flex items-center gap-2.5 w-full rounded-md px-2 py-2 text-sm text-left transition-all duration-150 text-sidebar-foreground hover:bg-sidebar-foreground/5"
+              className="flex items-center gap-2.5 w-full rounded-sm px-2 py-2 text-sm text-left transition-all duration-150 text-sidebar-foreground hover:bg-sidebar-foreground/5"
             >
               <LogOut className="w-4 h-4 text-sidebar-foreground/60" />
               <span>Sign out</span>

--- a/web/src/components/briefing/BriefingView.tsx
+++ b/web/src/components/briefing/BriefingView.tsx
@@ -148,7 +148,7 @@ export function BriefingView({ briefing, loading, error, onRetry, onAction }: Br
 
       {error && (
         <div
-          className="mt-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+          className="mt-3 rounded-sm border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive"
           data-testid="workspace-briefing-error"
         >
           <p>{error}</p>

--- a/web/src/components/charts/CostChart.tsx
+++ b/web/src/components/charts/CostChart.tsx
@@ -181,7 +181,7 @@ export function CostChart({ data }: CostChartProps) {
       {/* Tooltip */}
       {hoveredIndex !== null && data[hoveredIndex] && (
         <div
-          className="absolute bg-popover border border-border rounded-md shadow-md px-3 py-2 text-xs pointer-events-none z-20"
+          className="absolute bg-popover border border-border rounded-sm shadow-md px-3 py-2 text-xs pointer-events-none z-20"
           style={{
             left: `${tooltipCenterPct}%`,
             top: 0,
@@ -219,7 +219,7 @@ export function CostChart({ data }: CostChartProps) {
         {Object.entries(COLORS).map(([key, color]) => (
           <span key={key} className="flex items-center gap-1">
             <span
-              className="inline-block w-2.5 h-2.5 rounded-sm"
+              className="inline-block w-2.5 h-2.5 rounded-xs"
               style={{ backgroundColor: color }}
             />
             {LABELS[key]}

--- a/web/src/components/connectors/BundleCredentialsModal.tsx
+++ b/web/src/components/connectors/BundleCredentialsModal.tsx
@@ -146,7 +146,7 @@ export function BundleCredentialsModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="bundle-credentials-title"
-        className="bg-background border border-border rounded-lg shadow-xl w-full max-w-md p-5"
+        className="bg-background border border-border rounded-sm shadow-xl w-full max-w-md p-5"
       >
         <h2 id="bundle-credentials-title" className="text-base font-semibold">
           Configure {connectorName}

--- a/web/src/components/connectors/ComposioApiKeyModal.tsx
+++ b/web/src/components/connectors/ComposioApiKeyModal.tsx
@@ -95,7 +95,7 @@ export function ComposioApiKeyModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="composio-apikey-title"
-        className="bg-background border border-border rounded-lg shadow-xl w-full max-w-md p-5"
+        className="bg-background border border-border rounded-sm shadow-xl w-full max-w-md p-5"
       >
         <h2 id="composio-apikey-title" className="text-base font-semibold">
           Connect {connectorName}

--- a/web/src/components/connectors/ConnectorStatusHero.tsx
+++ b/web/src/components/connectors/ConnectorStatusHero.tsx
@@ -160,7 +160,7 @@ export function ConnectorStatusHero({
         <ConnectorIcon
           name={name}
           iconUrl={installed.iconUrl}
-          className="h-12 w-12 rounded-md text-base"
+          className="h-12 w-12 rounded-sm text-base"
         />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
@@ -193,7 +193,7 @@ export function ConnectorStatusHero({
           When `ready`, the page reads as quiet settings; when any
           other status applies, this block is the visual anchor. */}
       {installed.status !== "ready" && (
-        <div className="flex items-start justify-between gap-4 px-4 py-3 border border-border/60 rounded-md bg-muted/20">
+        <div className="flex items-start justify-between gap-4 px-4 py-3 border border-border/60 rounded-sm bg-muted/20">
           <div className="flex items-start gap-3 min-w-0">
             <StatusDot status={installed.status} />
             <div className="min-w-0">

--- a/web/src/components/connectors/OperatorSetupModal.tsx
+++ b/web/src/components/connectors/OperatorSetupModal.tsx
@@ -132,7 +132,7 @@ export function OperatorSetupModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="operator-setup-title"
-        className="bg-background border border-border rounded-lg shadow-xl w-full max-w-md p-5"
+        className="bg-background border border-border rounded-sm shadow-xl w-full max-w-md p-5"
       >
         <h2 id="operator-setup-title" className="text-base font-semibold">
           {isEdit ? `Edit ${entry.name} OAuth app` : `Set up ${entry.name}`}

--- a/web/src/components/palette/CommandPalette.tsx
+++ b/web/src/components/palette/CommandPalette.tsx
@@ -199,7 +199,7 @@ export function CommandPalette({ onLogout }: { onLogout: () => void }) {
           aria-modal="true"
           aria-label="Command palette"
           data-testid="command-palette"
-          className="relative mt-[12vh] w-[min(580px,calc(100vw-2rem))] bg-card border border-border rounded-xl shadow-2xl overflow-hidden animate-in"
+          className="relative mt-[12vh] w-[min(580px,calc(100vw-2rem))] bg-card border border-border rounded-md shadow-2xl overflow-hidden animate-in"
         >
           {/* Input */}
           <div className="flex items-center gap-3 px-4 py-3.5 border-b border-border">

--- a/web/src/components/palette/CommandRow.tsx
+++ b/web/src/components/palette/CommandRow.tsx
@@ -20,7 +20,7 @@ function RowIcon({ icon }: { icon?: CommandIcon }) {
     return (
       <span
         aria-hidden="true"
-        className="shrink-0 flex items-center justify-center rounded-md text-white text-2xs font-semibold"
+        className="shrink-0 flex items-center justify-center rounded-sm text-white text-2xs font-semibold"
         style={{ width: 24, height: 24, backgroundColor: icon.color }}
       >
         {icon.letter}
@@ -32,7 +32,7 @@ function RowIcon({ icon }: { icon?: CommandIcon }) {
     return (
       <span
         aria-hidden="true"
-        className="shrink-0 flex items-center justify-center rounded-md bg-muted text-muted-foreground"
+        className="shrink-0 flex items-center justify-center rounded-sm bg-muted text-muted-foreground"
         style={{ width: 24, height: 24 }}
       >
         <Icon style={{ width: 14, height: 14 }} />
@@ -44,7 +44,7 @@ function RowIcon({ icon }: { icon?: CommandIcon }) {
     <ConnectorIcon
       name={icon.fallbackLetter}
       iconUrl={icon.url}
-      className="h-6 w-6 rounded-md text-2xs"
+      className="h-6 w-6 rounded-sm text-2xs"
     />
   );
 }
@@ -71,7 +71,7 @@ export const CommandRow = memo(function CommandRow({
       onClick={onSelect}
       onMouseMove={onHover}
       className={cn(
-        "w-full flex items-center gap-3 px-2.5 py-2 rounded-md text-left transition-colors",
+        "w-full flex items-center gap-3 px-2.5 py-2 rounded-sm text-left transition-colors",
         selected ? "bg-accent text-accent-foreground" : "text-foreground hover:bg-accent/50",
       )}
     >

--- a/web/src/components/shell/SidebarSearch.tsx
+++ b/web/src/components/shell/SidebarSearch.tsx
@@ -20,7 +20,7 @@ export function SidebarSearch() {
         onClick={() => openPalette()}
         aria-label="Open command palette"
         aria-keyshortcuts="Meta+P Control+P"
-        className="w-full h-8 flex items-center gap-2.5 pl-2.5 pr-1.5 rounded-md text-sm bg-sidebar-foreground/5 border border-transparent hover:bg-sidebar-foreground/10 hover:border-sidebar-foreground/20 transition-colors text-left"
+        className="w-full h-8 flex items-center gap-2.5 pl-2.5 pr-1.5 rounded-sm text-sm bg-sidebar-foreground/5 border border-transparent hover:bg-sidebar-foreground/10 hover:border-sidebar-foreground/20 transition-colors text-left"
       >
         <Search
           aria-hidden="true"

--- a/web/src/components/shell/WorkspaceSection.tsx
+++ b/web/src/components/shell/WorkspaceSection.tsx
@@ -118,7 +118,7 @@ export function WorkspaceSection({ collapsed = false }: WorkspaceSectionProps) {
             aria-label="Add workspace"
             title="Add workspace"
             data-testid="sidebar-workspace-add"
-            className="p-1 rounded-md text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-foreground/10 transition-colors"
+            className="p-1 rounded-sm text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-foreground/10 transition-colors"
           >
             <Plus className="size-3.5" />
           </button>
@@ -207,7 +207,7 @@ function WorkspaceInlineApps({ workspaceId }: { workspaceId: string }) {
             data-app-route={p.route ?? ""}
             data-is-active={isActive ? "true" : "false"}
             className={cn(
-              "flex items-center gap-2 text-sm transition-colors rounded-md px-2 py-1",
+              "flex items-center gap-2 text-sm transition-colors rounded-sm px-2 py-1",
               isActive
                 ? "bg-sidebar-foreground/10 text-sidebar-foreground"
                 : "text-sidebar-foreground/80 hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground",
@@ -216,7 +216,7 @@ function WorkspaceInlineApps({ workspaceId }: { workspaceId: string }) {
             <ConnectorIcon
               name={label}
               iconUrl={iconFor(p.serverName)}
-              className="size-[18px] rounded-sm text-3xs"
+              className="size-[18px] rounded-xs text-3xs"
             />
             <span className="flex-1 truncate">{label}</span>
           </Link>
@@ -265,7 +265,7 @@ function WorkspaceItem({
       data-is-active={isActive ? "true" : "false"}
       data-is-personal={workspace.isPersonal === true ? "true" : "false"}
       className={cn(
-        "flex items-center text-sm transition-colors text-left rounded-md mx-2 my-px",
+        "flex items-center text-sm transition-colors text-left rounded-sm mx-2 my-px",
         collapsed ? "justify-center p-1.5" : "gap-2 px-3 py-1.5",
         isActive
           ? "bg-sidebar-foreground/10 text-sidebar-foreground"
@@ -275,7 +275,7 @@ function WorkspaceItem({
       <span
         aria-hidden="true"
         data-testid="workspace-avatar"
-        className="size-[18px] shrink-0 flex items-center justify-center rounded-md text-white text-3xs font-semibold"
+        className="size-[18px] shrink-0 flex items-center justify-center rounded-sm text-white text-3xs font-semibold"
         style={{ backgroundColor: avatar.color }}
       >
         {avatar.letter}

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-sm border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -23,14 +23,13 @@ const buttonVariants = cva(
       size: {
         default:
           "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-6 gap-1 rounded-sm px-2 text-xs in-data-[slot=button-group]:rounded-sm has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-sm px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-sm has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
         icon: "size-8",
         "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+          "size-6 rounded-sm in-data-[slot=button-group]:rounded-sm [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7 rounded-sm in-data-[slot=button-group]:rounded-sm",
         "icon-lg": "size-9",
       },
     },

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-md bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-md *:[img:last-child]:rounded-b-md",
         className,
       )}
       {...props}
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-md px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
         className,
       )}
       {...props}
@@ -81,7 +81,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        "flex items-center rounded-b-md border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
         className,
       )}
       {...props}

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-8 w-full min-w-0 rounded-sm border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -16,7 +16,7 @@ function Select({ className, children, ...props }: React.ComponentProps<"select"
     <select
       data-slot="select"
       className={cn(
-        "flex h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "flex h-8 w-full min-w-0 rounded-sm border border-input bg-transparent px-2.5 py-1 text-sm transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "flex field-sizing-content min-h-16 w-full rounded-sm border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/web/src/components/ui/timezone-select.tsx
+++ b/web/src/components/ui/timezone-select.tsx
@@ -87,7 +87,7 @@ export function TimezoneSelect({ value, onChange }: TimezoneSelectProps) {
           }
         }}
         className={cn(
-          "flex h-8 w-full items-center justify-between rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm transition-colors",
+          "flex h-8 w-full items-center justify-between rounded-sm border border-input bg-transparent px-2.5 py-1 text-sm transition-colors",
           "hover:border-ring focus-visible:outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
           !value && "text-muted-foreground",
         )}
@@ -106,7 +106,7 @@ export function TimezoneSelect({ value, onChange }: TimezoneSelectProps) {
 
       {/* Dropdown */}
       {open && (
-        <div className="absolute z-50 mt-1 w-full rounded-lg border border-border bg-card shadow-lg animate-in fade-in-0 zoom-in-95 duration-100">
+        <div className="absolute z-50 mt-1 w-full rounded-sm border border-border bg-card shadow-lg animate-in fade-in-0 zoom-in-95 duration-100">
           {/* Search */}
           <div className="p-2 border-b border-border">
             <input

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -81,13 +81,15 @@
     --color-processing-foreground: var(--processing-foreground);
     --color-processing-light: var(--processing-light);
     --color-info-light: var(--info-light);
-    --radius-sm: calc(var(--radius) * 0.6);
-    --radius-md: calc(var(--radius) * 0.8);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) * 1.4);
-    --radius-2xl: calc(var(--radius) * 1.8);
-    --radius-3xl: calc(var(--radius) * 2.2);
-    --radius-4xl: calc(var(--radius) * 2.6);
+    /* Radius scale — single-sourced from src/theme/palette.ts (radiusScale),
+       emitted to :root as --border-radius-* (the ext-apps / synapse-ui names)
+       and aliased here so shell `rounded-*` and the iframe apps round
+       equivalent elements identically: controls 8px (sm), cards 12px (md). */
+    --radius-xs: var(--border-radius-xs);
+    --radius-sm: var(--border-radius-sm);
+    --radius-md: var(--border-radius-md);
+    --radius-lg: var(--border-radius-lg);
+    --radius-xl: var(--border-radius-xl);
 }
 
 /* ─────────────────────────────────────────────────────────────────────────

--- a/web/src/pages/GlobalHomePage.tsx
+++ b/web/src/pages/GlobalHomePage.tsx
@@ -78,13 +78,13 @@ function WorkspaceTile({ workspace }: { workspace: WorkspaceInfo }) {
       data-testid="home-workspace-tile"
       data-workspace-id={workspace.id}
       className={cn(
-        "group flex items-center gap-3 p-4 rounded-lg border border-border bg-card",
+        "group flex items-center gap-3 p-4 rounded-sm border border-border bg-card",
         "hover:border-foreground/20 hover:bg-foreground/[0.02] transition-colors",
       )}
     >
       <span
         aria-hidden="true"
-        className="shrink-0 flex items-center justify-center rounded-md text-white text-sm font-semibold"
+        className="shrink-0 flex items-center justify-center rounded-sm text-white text-sm font-semibold"
         style={{ width: 32, height: 32, backgroundColor: avatar.color }}
       >
         {avatar.letter}
@@ -105,7 +105,7 @@ function NewWorkspaceTile() {
       to="/org/workspaces"
       data-testid="home-new-workspace-tile"
       className={cn(
-        "flex flex-col items-center justify-center gap-2 p-4 rounded-lg border border-dashed border-border",
+        "flex flex-col items-center justify-center gap-2 p-4 rounded-sm border border-dashed border-border",
         "text-muted-foreground hover:text-foreground hover:border-foreground/20 hover:bg-foreground/[0.02] transition-colors",
         "min-h-[100px]",
       )}

--- a/web/src/pages/WorkspaceOverviewPage.tsx
+++ b/web/src/pages/WorkspaceOverviewPage.tsx
@@ -118,7 +118,7 @@ export function WorkspaceOverviewPage() {
           <Link
             to={`/w/${toSlug(workspace.id)}/settings/general`}
             data-testid="workspace-overview-settings"
-            className="shrink-0 inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm text-muted-foreground hover:text-foreground hover:bg-foreground/[0.02] hover:border-foreground/20 transition-colors"
+            className="shrink-0 inline-flex items-center gap-2 px-3 py-2 rounded-sm border border-border text-sm text-muted-foreground hover:text-foreground hover:bg-foreground/[0.02] hover:border-foreground/20 transition-colors"
           >
             <Settings className="w-4 h-4" />
             <span className="hidden sm:inline">Settings</span>
@@ -145,7 +145,7 @@ export function WorkspaceOverviewPage() {
           <AppGridSkeleton />
         ) : apps.length === 0 ? (
           <div
-            className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground"
+            className="rounded-sm border border-dashed border-border p-8 text-center text-sm text-muted-foreground"
             data-testid="workspace-overview-empty"
           >
             No apps installed in this workspace yet.
@@ -195,7 +195,7 @@ function AppGridSkeleton() {
       aria-hidden
     >
       {[0, 1, 2].map((i) => (
-        <div key={i} className="flex flex-col gap-2 p-4 rounded-lg border border-border bg-card">
+        <div key={i} className="flex flex-col gap-2 p-4 rounded-sm border border-border bg-card">
           <div className="flex items-center gap-2">
             <div className="h-4 w-4 shrink-0 rounded bg-muted-foreground/20 animate-pulse" />
             <div className="h-3.5 w-2/3 rounded bg-muted-foreground/20 animate-pulse" />
@@ -224,7 +224,7 @@ function AppCard({
       data-testid="workspace-overview-app-card"
       data-app-route={placement.route ?? ""}
       className={cn(
-        "group flex flex-col gap-2 p-4 rounded-lg border border-border bg-card text-left",
+        "group flex flex-col gap-2 p-4 rounded-sm border border-border bg-card text-left",
         "hover:border-foreground/20 hover:bg-foreground/[0.02] transition-colors",
       )}
     >

--- a/web/src/pages/settings/ConnectorBrowsePage.tsx
+++ b/web/src/pages/settings/ConnectorBrowsePage.tsx
@@ -308,7 +308,7 @@ function DirectoryCard({
   const operatorReady = entry.operatorConfigured === true;
 
   return (
-    <div className="flex flex-col gap-3 p-4 border border-border/60 rounded-md bg-background h-full">
+    <div className="flex flex-col gap-3 p-4 border border-border/60 rounded-sm bg-background h-full">
       <div className="flex items-start gap-3">
         <ConnectorIcon name={entry.name} iconUrl={entry.iconUrl} />
         <div className="flex-1 min-w-0">

--- a/web/src/pages/settings/ProfileTab.tsx
+++ b/web/src/pages/settings/ProfileTab.tsx
@@ -136,7 +136,7 @@ export function ProfileTab() {
                 type="button"
                 onClick={() => handleThemeChange(opt.value)}
                 className={cn(
-                  "flex flex-col items-center gap-2 rounded-lg border-2 p-4 text-center transition-all",
+                  "flex flex-col items-center gap-2 rounded-sm border-2 p-4 text-center transition-all",
                   selected
                     ? "border-warm bg-warm/5 text-foreground"
                     : "border-border bg-card text-muted-foreground hover:border-muted-foreground/20 hover:bg-muted/50",

--- a/web/src/pages/settings/SettingsShell.tsx
+++ b/web/src/pages/settings/SettingsShell.tsx
@@ -44,7 +44,7 @@ export interface SettingsShellProps {
 
 const navItemClass = (isActive: boolean) =>
   cn(
-    "px-3 py-2 text-sm font-medium rounded-md transition-colors whitespace-nowrap",
+    "px-3 py-2 text-sm font-medium rounded-sm transition-colors whitespace-nowrap",
     isActive
       ? "bg-accent text-accent-foreground"
       : "text-muted-foreground hover:text-foreground hover:bg-muted",

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -579,7 +579,7 @@ function Toggle({
       disabled={disabled}
       aria-label={`${on ? "Turn off" : "Turn on"} ${label}`}
       className={cn(
-        "inline-flex items-center gap-2 px-2 py-1 rounded-md text-xs font-medium select-none",
+        "inline-flex items-center gap-2 px-2 py-1 rounded-sm text-xs font-medium select-none",
         disabled ? "text-muted-foreground/60 cursor-not-allowed" : "text-foreground hover:bg-muted",
       )}
     >

--- a/web/src/pages/settings/WorkspaceDetailPage.tsx
+++ b/web/src/pages/settings/WorkspaceDetailPage.tsx
@@ -382,7 +382,7 @@ export function WorkspaceDetailPage() {
         header switcher and use Settings → This Workspace → General.
       */}
       <Section>
-        <div className="rounded-md border border-dashed p-4">
+        <div className="rounded-sm border border-dashed p-4">
           <p className="text-sm text-muted-foreground">
             To view or edit this workspace's custom instructions, switch into{" "}
             <span className="font-medium">{workspace?.name}</span> via the header workspace

--- a/web/src/pages/settings/components/EmptyState.tsx
+++ b/web/src/pages/settings/components/EmptyState.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 /**
  * Dashed-border centered placeholder. Lifted from five copies in the
- * settings tabs that all rendered the same `rounded-md border border-dashed
+ * settings tabs that all rendered the same `rounded-sm border border-dashed
  * p-8 text-center` shape with slightly different copy.
  *
  * `action` is optional — for empty list states a "Create the first X"
@@ -11,7 +11,7 @@ import type { ReactNode } from "react";
  */
 export function EmptyState({ message, action }: { message: ReactNode; action?: ReactNode }) {
   return (
-    <div className="rounded-md border border-dashed p-8 text-center">
+    <div className="rounded-sm border border-dashed p-8 text-center">
       <p className="text-sm text-muted-foreground">{message}</p>
       {action ? <div className="mt-3 flex justify-center">{action}</div> : null}
     </div>

--- a/web/src/pages/settings/components/InlineError.tsx
+++ b/web/src/pages/settings/components/InlineError.tsx
@@ -18,7 +18,7 @@ export function InlineError({
 }) {
   return (
     <div
-      className="flex items-center justify-between gap-3 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2"
+      className="flex items-center justify-between gap-3 rounded-sm border border-destructive/20 bg-destructive/5 px-3 py-2"
       role={role}
     >
       <p className="text-sm text-destructive">{message}</p>

--- a/web/src/pages/settings/components/SettingsPageHeader.tsx
+++ b/web/src/pages/settings/components/SettingsPageHeader.tsx
@@ -55,7 +55,7 @@ export function SettingsPageHeader({
   onBack,
 }: SettingsPageHeaderProps) {
   const backButtonClass =
-    "-ml-1 shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50";
+    "-ml-1 shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50";
   return (
     <header className="flex items-start justify-between gap-4">
       <div className="flex items-start gap-2 min-w-0">

--- a/web/src/theme/__tests__/palette.test.ts
+++ b/web/src/theme/__tests__/palette.test.ts
@@ -228,4 +228,15 @@ describe("paletteToRootCss — shell :root/.dark match current values", () => {
   test("dark block does not redefine the font stacks (mode-independent, cascades)", () => {
     expect(darkBlock).not.toContain("--nb-font-");
   });
+
+  test("light :root carries the radius scale (aliased to Tailwind --radius-* in index.css)", () => {
+    expect(rootBlock).toContain("--border-radius-xs: 0.25rem;");
+    expect(rootBlock).toContain("--border-radius-sm: 0.5rem;");
+    expect(rootBlock).toContain("--border-radius-md: 0.75rem;");
+    expect(rootBlock).toContain("--border-radius-lg: 1rem;");
+  });
+
+  test("dark block does not redefine the radius scale (mode-independent, cascades)", () => {
+    expect(darkBlock).not.toContain("--border-radius-");
+  });
 });

--- a/web/src/theme/projections.ts
+++ b/web/src/theme/projections.ts
@@ -88,6 +88,11 @@ export function paletteToRootCss(): string {
   const lightDecls = names.map((n) => `  --${n}: ${pick(colors[n], "light")};`);
   lightDecls.push(`  --radius: ${radiusBase};`);
   for (const [k, v] of Object.entries(layout)) lightDecls.push(`  ${k}: ${v};`);
+  // Radius scale — the ONE radius source, shared with the iframe apps. Emitted
+  // as `--border-radius-*` (the ext-apps / synapse-ui names) and aliased to
+  // Tailwind's `--radius-*` in index.css, so the shell and the apps round
+  // equivalent elements identically.
+  for (const [k, v] of Object.entries(radiusScale)) lightDecls.push(`  ${k}: ${v};`);
   // Type scale is mode-independent — :root only, aliased to Tailwind `--text-*`
   // in index.css. Same single-source path as colors/radius/layout.
   for (const [k, v] of Object.entries(typeScale)) lightDecls.push(`  ${k}: ${v};`);

--- a/web/src/theme/tokens.generated.css
+++ b/web/src/theme/tokens.generated.css
@@ -49,6 +49,12 @@
   --radius: 0.5rem;
   --sidebar-width: 240px;
   --sidebar-width-collapsed: 64px;
+  --border-radius-xs: 0.25rem;
+  --border-radius-sm: 0.5rem;
+  --border-radius-md: 0.75rem;
+  --border-radius-lg: 1rem;
+  --border-radius-xl: 1.5rem;
+  --border-width-regular: 1px;
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;


### PR DESCRIPTION
**Part A of the design-system convergence.** One radius scale, shared by the shell and the fleet apps.

## The problem
The shell ran a *multiplier* radius scale (`--radius-sm..4xl` = ×0.6..2.6 of `--radius`) that diverged **by name** from the `synapse/ui` scale the fleet services use — shadcn `rounded-lg`=8px collided with synapse `radiusLg`=16px. Same palette, two hand-maintained scales.

## What changed
1. **One scale, single-sourced from `palette.ts`** (`radiusScale` — the absolute `4/8/12/16/24` the iframe apps already receive). Emitted to `:root` as `--border-radius-*` and aliased to Tailwind's `--radius-*`. The multiplier scale is gone.
2. **Remapped every shell `rounded-*` to the synapse element intent** — px-preserving, so the change is subtle (the shell was already close):

   | Element | → | token | px |
   |---|---|---|---|
   | buttons, inputs, rows, search | → | `sm` | 8px |
   | cards, panels | → | `md` | 12px |
   | small chips, avatars | → | `xs` | 4px |
   | badges | → | `full` | pill |

   Deterministic single-pass remap (`sm→xs, md→sm, lg→sm, xl→md, 2xl→lg`, directional-aware) + manual fixes for the button radius-clamps and card corners.

## The one brand call: badges stay pills
`synapse/ui` 0.11 squares its badge (`radiusXs`); the shell — and the mockup — use **pills**. Per your call, the shell keeps `rounded-full` and the SDK should follow the brand (a `synapse/ui` follow-up), not the reverse.

## Result
Shell and fleet apps round equivalent elements identically. Visual delta is **sub-2px** (cards 11→12, rows 6.4→8); **controls unchanged** at 8px. Verified live — the shell reads refined, not bubbly.

## Verification
- One scale: `rg 'rounded-(2xl|3xl|4xl)'` → 0; built CSS resolves `rounded-md → --radius-md → --border-radius-md → 0.75rem` (12px)
- `bun run build` green · `test:web` 573/0 · theme contract tests 12/12 (added 2 radius-emission tests pinning the :root scale, per the #548 lesson) · biome clean
- Ran the shell locally (home + settings) — cards/avatars/toggles render correctly on the new scale

## Side finding (separate fix)
`scripts/dev-worktree.ts` is **broken on main** — it still spawns the removed `dev` subcommand (#538 made the runtime `serve`-only and moved web orchestration to `scripts/dev.ts`). One-line fix: delegate to `scripts/dev.ts`. Not in this PR; flagging for a standalone fix.
