### PR TITLE
fix(scripts): dev:worktree delegates to scripts/dev.ts (runtime is serve-only)

### DIFF
--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -92,9 +92,13 @@ if (envResult.path) {
   console.log(`[dev:worktree]   Loaded .env from ${envResult.path}${note}`);
 }
 
+// Delegate to the shared dev orchestrator (serve API + Vite web). The runtime
+// binary is serve-only — it no longer has a `dev` subcommand — so worktree dev
+// goes through `scripts/dev.ts`, the same launcher `bun run dev` uses, with the
+// worktree's ports/workdir threaded via env below.
 const child = spawn(
   "bun",
-  ["run", "src/cli/index.ts", "dev", "--port", API_PORT, "--config", CONFIG_PATH],
+  ["run", "scripts/dev.ts", "--port", API_PORT, "--config", CONFIG_PATH],
   {
     stdio: "inherit",
     cwd: WORKTREE_ROOT,

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -96,20 +96,16 @@ if (envResult.path) {
 // binary is serve-only — it no longer has a `dev` subcommand — so worktree dev
 // goes through `scripts/dev.ts`, the same launcher `bun run dev` uses, with the
 // worktree's ports/workdir threaded via env below.
-const child = spawn(
-  "bun",
-  ["run", "scripts/dev.ts", "--port", API_PORT, "--config", CONFIG_PATH],
-  {
-    stdio: "inherit",
-    cwd: WORKTREE_ROOT,
-    env: {
-      ...process.env,
-      NB_API_PORT: API_PORT,
-      NB_WEB_PORT: WEB_PORT,
-      NB_WORK_DIR: WORKDIR,
-    },
+const child = spawn("bun", ["run", "scripts/dev.ts", "--port", API_PORT, "--config", CONFIG_PATH], {
+  stdio: "inherit",
+  cwd: WORKTREE_ROOT,
+  env: {
+    ...process.env,
+    NB_API_PORT: API_PORT,
+    NB_WEB_PORT: WEB_PORT,
+    NB_WORK_DIR: WORKDIR,
   },
-);
+});
 
 child.on("error", (err) => {
   console.error(`[dev:worktree] Failed to spawn bun: ${err.message}`);


### PR DESCRIPTION
## The bug
`bun run dev:worktree` is **broken on `main`** — it dies immediately with:

```
Unexpected argument 'dev'. This command does not take positional arguments
Usage: bun run src/cli/index.ts [serve] ...
```

When the runtime binary became **serve-only** and dev orchestration moved to `scripts/dev.ts` (#538), `dev-worktree.ts` was missed — it still spawned `src/cli/index.ts dev`. So nobody can spin up a worktree to QA a feature branch (I hit this trying to preview #549 and had to patch it locally).

## The fix
Delegate to `scripts/dev.ts` — the same launcher `bun run dev` uses, which orchestrates `serve` (API) + Vite (web) — threading the worktree's ports/workdir through env (`NB_API_PORT` / `NB_WEB_PORT` / `NB_WORK_DIR`), unchanged.

## Verification
Ran `bun run dev:worktree` from a fresh worktree:
- API up on `:27271` (serve mode), Vite web up on `:27270` → **HTTP 200**
- isolated `.nimblebrain-worktree/` workdir, no auth gate (dev mode) — exactly the documented behavior
- `biome check scripts/` clean · `tsc` clean