### PR TITLE
security: SSRF redirect guard on remote transport + Secure auth cookies in prod

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1518,7 +1518,7 @@ export async function handleOidcAuthorize(provider: IdentityProvider): Promise<R
 export async function handleOidcCallback(
   request: Request,
   provider: IdentityProvider,
-  isLocalhost: boolean,
+  secureCookies: boolean,
   appOrigin?: string,
 ): Promise<Response> {
   if (!provider.capabilities.authCodeFlow || !provider.exchangeCode) {
@@ -1556,7 +1556,7 @@ export async function handleOidcCallback(
     const result = await provider.exchangeCode(code, pendingFlow.codeVerifier);
 
     const redirectUrl = appOrigin ?? url.origin;
-    const secure = !isLocalhost;
+    const secure = secureCookies;
 
     const sessionParts = [
       `nb_session=${result.accessToken}`,
@@ -1601,7 +1601,7 @@ export async function handleOidcCallback(
 export async function handleOidcRefresh(
   request: Request,
   provider: IdentityProvider,
-  isLocalhost: boolean,
+  secureCookies: boolean,
 ): Promise<Response> {
   if (!provider.capabilities.tokenRefresh || !provider.refreshToken) {
     return apiError(400, "not_configured", "OIDC auth not configured");
@@ -1624,7 +1624,7 @@ export async function handleOidcRefresh(
   try {
     const result = await provider.refreshToken(refreshToken);
 
-    const secure = !isLocalhost;
+    const secure = secureCookies;
     const sessionParts = [
       `nb_session=${result.accessToken}`,
       "HttpOnly",

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -21,12 +21,12 @@ export function authRoutes(ctx: AppContext) {
 
   app.get("/v1/auth/callback", (c) => {
     if (!ctx.provider) return apiError(400, "not_configured", "Auth provider not configured");
-    return handleOidcCallback(c.req.raw, ctx.provider, ctx.isLocalhost, ctx.appOrigin);
+    return handleOidcCallback(c.req.raw, ctx.provider, ctx.secureCookies, ctx.appOrigin);
   });
 
   app.post("/v1/auth/refresh", limit, (c) => {
     if (!ctx.provider) return apiError(400, "not_configured", "Auth provider not configured");
-    return handleOidcRefresh(c.req.raw, ctx.provider, ctx.isLocalhost);
+    return handleOidcRefresh(c.req.raw, ctx.provider, ctx.secureCookies);
   });
 
   // --- Authenticated ---

--- a/src/api/routes/composio-auth.ts
+++ b/src/api/routes/composio-auth.ts
@@ -293,7 +293,7 @@ export function composioAuthRoutes(ctx: AppContext) {
         "Path=/v1/composio-auth/callback",
         "Max-Age=900",
       ];
-      if (!ctx.isLocalhost) cookieParts.push("Secure");
+      if (ctx.secureCookies) cookieParts.push("Secure");
       c.header("Set-Cookie", cookieParts.join("; "));
 
       return c.json({
@@ -401,7 +401,7 @@ export function composioAuthRoutes(ctx: AppContext) {
       "Path=/v1/composio-auth/callback",
       "Max-Age=0",
     ];
-    if (!ctx.isLocalhost) expireParts.push("Secure");
+    if (ctx.secureCookies) expireParts.push("Secure");
     c.header("Set-Cookie", expireParts.join("; "));
 
     const returnUrl = workspaceConnectorsUrl(wsId);

--- a/src/api/routes/mcp-auth.ts
+++ b/src/api/routes/mcp-auth.ts
@@ -216,7 +216,7 @@ export function mcpAuthRoutes(ctx: AppContext) {
         "Path=/v1/mcp-auth/callback",
         "Max-Age=900",
       ];
-      if (!ctx.isLocalhost) cookieParts.push("Secure");
+      if (ctx.secureCookies) cookieParts.push("Secure");
       c.header("Set-Cookie", cookieParts.join("; "));
 
       return c.json({ authorizationUrl });
@@ -333,7 +333,7 @@ export function mcpAuthRoutes(ctx: AppContext) {
       "Path=/v1/mcp-auth/callback",
       "Max-Age=0",
     ];
-    if (!ctx.isLocalhost) expireParts.push("Secure");
+    if (ctx.secureCookies) expireParts.push("Secure");
     c.header("Set-Cookie", expireParts.join("; "));
 
     // Auto-redirect back to the workspace Connectors page. The user came

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -261,7 +261,12 @@ export function startServer(options: ServerOptions): ServerHandle {
     mcpLimiter,
     isDevMode,
     eventSink: runtime.getEventSink(),
-    isLocalhost: true, // Updated after Bun.serve starts
+    // Secure cookies whenever auth is configured (i.e. not dev mode). A
+    // configured deployment is always fronted by a TLS-terminating edge, so the
+    // browser↔edge leg is HTTPS regardless of the container's plain-HTTP listen
+    // address. Deriving this from the listen address is wrong: Bun binds
+    // `0.0.0.0` in production, which must NOT be read as localhost.
+    secureCookies: authConfigured,
     // Post-login landing — a user-facing browser destination, so it uses
     // webOrigin() like the connectors return (one rule: browser-facing →
     // webOrigin, vendor-facing → publicOrigin). Identical to publicOrigin() in
@@ -278,10 +283,6 @@ export function startServer(options: ServerOptions): ServerHandle {
     idleTimeout: 255, // seconds — max Bun allows; needed for SSE streams and long chat requests
     fetch: app.fetch,
   });
-
-  const host = server.hostname;
-  ctx.isLocalhost =
-    host === "127.0.0.1" || host === "::1" || host === "localhost" || host === "0.0.0.0";
 
   return {
     server,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -82,7 +82,17 @@ export interface AppContext {
    */
   isDevMode: boolean;
   eventSink: EventSink;
-  isLocalhost: boolean;
+  /**
+   * Whether auth cookies (`nb_session`, `nb_refresh`, OAuth-state) are issued
+   * with the `Secure` attribute. True for any auth-configured deployment — the
+   * browser↔edge leg is HTTPS even though the container itself is reached over
+   * plain HTTP behind the TLS-terminating edge. False only in dev mode, where
+   * the app is served over http://localhost and `Secure` would make the browser
+   * drop the cookie. Derived from a deployment property, never from the listen
+   * address or a client-supplied forwarded-scheme header (both spoofable /
+   * misleading — the listen address is `0.0.0.0` in production).
+   */
+  secureCookies: boolean;
   appOrigin: string | undefined;
   internalToken: string;
   mcpHost: McpServerHost;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -86,11 +86,15 @@ export interface AppContext {
    * Whether auth cookies (`nb_session`, `nb_refresh`, OAuth-state) are issued
    * with the `Secure` attribute. True for any auth-configured deployment — the
    * browser↔edge leg is HTTPS even though the container itself is reached over
-   * plain HTTP behind the TLS-terminating edge. False only in dev mode, where
-   * the app is served over http://localhost and `Secure` would make the browser
-   * drop the cookie. Derived from a deployment property, never from the listen
-   * address or a client-supplied forwarded-scheme header (both spoofable /
-   * misleading — the listen address is `0.0.0.0` in production).
+   * plain HTTP behind the TLS-terminating edge. False in dev mode, which serves
+   * plain HTTP with no TLS (localhost or a LAN IP), where a non-localhost origin
+   * would drop a `Secure` cookie. Derived from a deployment property, never from
+   * the listen address or a client-supplied forwarded-scheme header (both
+   * spoofable / misleading — the listen address is `0.0.0.0` in production).
+   *
+   * Edge case: running a real auth provider locally over http://localhost yields
+   * `Secure` cookies (auth is configured). That still works because modern
+   * browsers treat localhost as a secure context and accept Secure cookies there.
    */
   secureCookies: boolean;
   appOrigin: string | undefined;

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1398,7 +1398,10 @@ export class BundleLifecycleManager {
         type: "remote",
         url: new URL(ref.url),
         transportConfig: ref.transport,
-        allowInsecure: this.allowInsecureRemotes,
+        // Honor the per-call flag, same source the OAuth provider above and the
+        // startup-time validateBundleUrl use — not the manager default — so the
+        // transport's SSRF guard agrees with what this install was authorized for.
+        allowInsecure: opts.allowInsecureRemotes === true,
         authProvider: provider,
       },
       this.eventSink,

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1398,6 +1398,7 @@ export class BundleLifecycleManager {
         type: "remote",
         url: new URL(ref.url),
         transportConfig: ref.transport,
+        allowInsecure: this.allowInsecureRemotes,
         authProvider: provider,
       },
       this.eventSink,

--- a/src/bundles/startup.ts
+++ b/src/bundles/startup.ts
@@ -415,6 +415,7 @@ export async function startBundleSource(
         type: "remote",
         url: new URL(ref.url),
         transportConfig: ref.transport,
+        allowInsecure: opts?.allowInsecureRemotes === true,
         authProvider,
       },
       eventSink,

--- a/src/bundles/url-validator.ts
+++ b/src/bundles/url-validator.ts
@@ -9,8 +9,11 @@ const METADATA_HOSTNAMES = ["metadata.google.internal", "metadata.goog", "instan
 
 /**
  * IPv4 private/reserved range patterns (RFC 1918 + link-local + loopback).
- * Checked against the URL hostname string — no DNS resolution is performed
- * (intentionally avoids DNS rebinding bypass).
+ * Checked against the URL hostname string. No DNS resolution is performed: this
+ * avoids the TOCTOU rebinding race (resolve-then-connect can disagree), but it
+ * also does NOT catch a hostname whose A-record points at an internal IP. That
+ * residual gap is closed at the network layer — the tenant egress NetworkPolicy
+ * denies pod→link-local/RFC1918 — not here. See the SSRF follow-up.
  */
 const PRIVATE_IPV4_PATTERNS = [
   /^127\./, // loopback

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -135,6 +135,12 @@ export type McpTransportMode =
       url: URL;
       transportConfig?: RemoteTransportConfig;
       /**
+       * Dev-mode `allowInsecureRemotes` flag, threaded to the SSRF redirect
+       * guard in `createRemoteTransport` so http://localhost endpoints work in
+       * local development. Defaults to false (production posture).
+       */
+      allowInsecure?: boolean;
+      /**
        * Optional OAuth provider for the MCP SDK. When set and no static
        * `transportConfig.auth` is present, `createRemoteTransport` attaches
        * it to the client transport. If the server returns 401 on connect,
@@ -414,7 +420,10 @@ export class McpSource implements ToolSource {
         this.mode.url,
         this.mode.transportConfig,
         this.mode.authProvider,
-        { workspaceId: this.bundleContext?.workspaceId },
+        {
+          workspaceId: this.bundleContext?.workspaceId,
+          allowInsecure: this.mode.allowInsecure ?? false,
+        },
       );
 
       // Remote: watch for transport close — wired AFTER successful start
@@ -692,7 +701,10 @@ export class McpSource implements ToolSource {
       this.mode.url,
       this.mode.transportConfig,
       this.mode.authProvider,
-      { workspaceId: this.bundleContext?.workspaceId },
+      {
+        workspaceId: this.bundleContext?.workspaceId,
+        allowInsecure: this.mode.allowInsecure ?? false,
+      },
     );
     // onclose is wired in `start()` AFTER the connect succeeds — same
     // reason as the initial-construction site: a transport close that

--- a/src/tools/remote-transport.ts
+++ b/src/tools/remote-transport.ts
@@ -5,6 +5,7 @@ import type { FetchLike, Transport } from "@modelcontextprotocol/sdk/shared/tran
 import type { RemoteTransportConfig } from "../bundles/types.ts";
 import { getCredentialProvider } from "./credential-provider.ts";
 import { createOAuthRefreshFetch } from "./oauth-refresh-fetch.ts";
+import { createSsrfGuardedFetch } from "./ssrf-guarded-fetch.ts";
 
 /**
  * Resolve `${ENV_VAR}` placeholders against `process.env`.
@@ -56,6 +57,10 @@ export function createRemoteTransport(
      *  dimension a `provider`-auth token is scoped to). Threaded from the
      *  McpSource's `BundleMcpContext`. */
     workspaceId?: string;
+    /** Dev-mode flag (`allowInsecureRemotes`) threaded to the SSRF redirect
+     *  guard so http://localhost endpoints still work under local development.
+     *  Defaults to false (production posture). */
+    allowInsecure?: boolean;
   },
 ): Transport {
   const headers: Record<string, string> = { ...(config?.headers ?? {}) };
@@ -111,20 +116,33 @@ export function createRemoteTransport(
   const transportFetch: FetchLike | undefined =
     mintingFetch ?? (effectiveAuthProvider ? createOAuthRefreshFetch() : undefined);
 
+  // SSRF redirect guard: the SDK transports follow redirects automatically
+  // (fetch default `redirect: "follow"`). For a tenant-supplied remote URL,
+  // that would let a hostile server 30x our fetch into the cluster network or
+  // cloud metadata. Interpose manual, per-hop-validated redirect handling over
+  // whatever fetch the transport would otherwise use (minting / OAuth-refresh /
+  // global). A `provider`-auth source is the operator-vetted fleet rail and may
+  // point at an in-cluster `http://*.svc` endpoint, so its configured URL is
+  // validated with `fleetInternal` — redirect targets never are.
+  const guardedFetch: FetchLike = createSsrfGuardedFetch(transportFetch, {
+    allowInsecure: opts?.allowInsecure ?? false,
+    fleetInternal: config?.auth?.type === "provider",
+  });
+
   const requestInit: RequestInit = Object.keys(headers).length > 0 ? { headers } : {};
 
   if (config?.type === "sse") {
     return new SSEClientTransport(url, {
       requestInit,
       authProvider: effectiveAuthProvider,
-      fetch: transportFetch,
+      fetch: guardedFetch,
     });
   }
 
   return new StreamableHTTPClientTransport(url, {
     requestInit,
     authProvider: effectiveAuthProvider,
-    fetch: transportFetch,
+    fetch: guardedFetch,
     reconnectionOptions: config?.reconnection
       ? {
           maxReconnectionDelay: config.reconnection.maxReconnectionDelay ?? 30_000,

--- a/src/tools/ssrf-guarded-fetch.ts
+++ b/src/tools/ssrf-guarded-fetch.ts
@@ -1,0 +1,106 @@
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { validateBundleUrl } from "../bundles/url-validator.ts";
+
+/**
+ * Maximum redirect hops to follow before giving up. A legitimate remote MCP
+ * endpoint needs at most one or two (http→https upgrade, a trailing-slash
+ * normalization); a long chain is either misconfiguration or an attacker
+ * walking us around the network.
+ */
+const MAX_REDIRECT_HOPS = 5;
+
+/**
+ * Wrap a `FetchLike` so HTTP redirects are followed MANUALLY with an SSRF
+ * check on every hop.
+ *
+ * The MCP SDK's HTTP transports (`StreamableHTTPClientTransport`,
+ * `SSEClientTransport`) call `fetch` with its default `redirect: "follow"`.
+ * For a remote bundle whose URL is tenant-supplied (a self-service `dcr` /
+ * `static` connector install), that lets a hostile or compromised server
+ * answer the initial request with `30x Location: http://169.254.169.254/...`
+ * (cloud-metadata / IMDS) or an in-cluster service, and the SDK's fetch
+ * silently follows it — turning our outbound fetch into an internal-network
+ * probe. `validateBundleUrl` runs once on the configured URL at startup; it
+ * never sees the redirect target.
+ *
+ * This wrapper closes that gap by reusing the per-hop validation the headless
+ * OAuth probe already performs (see `workspace-oauth-provider.ts`): issue each
+ * request with `redirect: "manual"` and re-run `validateBundleUrl` on every
+ * hop. The primary control is stricter than the probe's, though: redirects are
+ * followed **same-origin only**. A cross-origin bounce is refused outright —
+ * it is the SSRF pivot, and re-issuing the request to a new origin would leak
+ * the connection's credential headers (Authorization / minted fleet token /
+ * API key) to a different trust scope, which WHATWG `fetch` strips for exactly
+ * this reason. Because every hop is same-origin as the configured endpoint, the
+ * connection's own opts (`fleetInternal` for an operator-vetted in-cluster
+ * source) apply unchanged throughout, and replaying credentials is safe.
+ *
+ * @param baseFetch The fetch the transport would otherwise use (a minting fetch,
+ *   the OAuth-refresh fetch, or `undefined` → the global `fetch`). Its behavior
+ *   is preserved; only redirect handling is interposed.
+ */
+export function createSsrfGuardedFetch(
+  baseFetch: FetchLike | undefined,
+  opts: { allowInsecure: boolean; fleetInternal: boolean },
+): FetchLike {
+  const doFetch: FetchLike = baseFetch ?? ((u, i) => fetch(u, i));
+
+  return async (input, init) => {
+    let currentUrl = typeof input === "string" ? new URL(input) : new URL(input.toString());
+    let currentInit: RequestInit = { ...init };
+
+    // Buffer a non-string body once so it can be replayed across redirect hops
+    // (a 307/308 re-sends the same body). JSON-RPC bodies are already strings,
+    // so this is a no-op on the hot path.
+    const rawBody = currentInit.body;
+    if (rawBody != null && typeof rawBody !== "string") {
+      currentInit.body = await new Response(rawBody).text();
+    }
+
+    for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+      // Redirects are same-origin only (enforced below), so the configured
+      // endpoint's opts — including `fleetInternal` for an operator-vetted
+      // in-cluster http source — apply unchanged on every hop. This validation
+      // is a backstop; the same-origin rule below is the primary control.
+      validateBundleUrl(currentUrl, {
+        allowInsecure: opts.allowInsecure,
+        fleetInternal: opts.fleetInternal,
+      });
+
+      const res = await doFetch(currentUrl, { ...currentInit, redirect: "manual" });
+
+      // Not a redirect — hand the response back as the SDK expects.
+      if (res.status < 300 || res.status >= 400) return res;
+
+      const location = res.headers.get("location");
+      if (!location) return res; // 3xx with no Location: nothing to follow.
+
+      const next = new URL(location, currentUrl);
+
+      // Follow SAME-ORIGIN redirects only; refuse anything cross-origin. A
+      // cross-origin bounce is both the SSRF pivot (to a host we don't control,
+      // or an internal one) AND a credential-leak vector: we re-issue the
+      // request with its original headers, which carry Authorization /
+      // minted-fleet / API-key credentials. WHATWG `fetch` strips those across
+      // origins precisely because the new origin is a different trust scope —
+      // this manual loop must not regress that protection. A legitimate
+      // JSON-RPC endpoint needs at most a same-origin redirect (trailing-slash
+      // or path normalization); same origin = same trust scope, so replaying
+      // credentials there is safe.
+      if (next.origin !== currentUrl.origin) {
+        throw new Error(
+          `SSRF guard: refusing cross-origin redirect from ${currentUrl.origin} to ${next.origin}`,
+        );
+      }
+
+      // Per fetch semantics, a 303 turns the follow-up into a bodyless GET;
+      // 307/308 preserve method and body. We only need to drop the body on 303.
+      if (res.status === 303) {
+        currentInit = { ...currentInit, method: "GET", body: undefined };
+      }
+      currentUrl = next;
+    }
+
+    throw new Error(`SSRF guard: remote endpoint exceeded ${MAX_REDIRECT_HOPS} redirect hops`);
+  };
+}

--- a/src/tools/ssrf-guarded-fetch.ts
+++ b/src/tools/ssrf-guarded-fetch.ts
@@ -3,9 +3,9 @@ import { validateBundleUrl } from "../bundles/url-validator.ts";
 
 /**
  * Maximum redirect hops to follow before giving up. A legitimate remote MCP
- * endpoint needs at most one or two (http→https upgrade, a trailing-slash
- * normalization); a long chain is either misconfiguration or an attacker
- * walking us around the network.
+ * endpoint needs at most one or two same-origin hops (a trailing-slash or path
+ * normalization — a scheme or host change is cross-origin and refused); a long
+ * chain is either misconfiguration or an attacker walking us around the network.
  */
 const MAX_REDIRECT_HOPS = 5;
 

--- a/test/integration/mcp-source-oauth-retry.test.ts
+++ b/test/integration/mcp-source-oauth-retry.test.ts
@@ -208,6 +208,9 @@ describe("McpSource — OAuth retry path", () => {
       {
         type: "remote",
         url: new URL(server.url),
+        // Mock runs on localhost; the transport's SSRF guard would otherwise
+        // reject the plain-http URL (matches the provider's allowInsecureRemotes).
+        allowInsecure: true,
         authProvider: provider,
       },
       new NoopEventSink(),

--- a/test/unit/api/mcp-auth-routes.test.ts
+++ b/test/unit/api/mcp-auth-routes.test.ts
@@ -53,7 +53,7 @@ function makeStubLifecycle(): StubLifecycle {
   };
 }
 
-function makeApp(lifecycle: StubLifecycle, isLocalhost = true): Hono<AppEnv> {
+function makeApp(lifecycle: StubLifecycle, secureCookies = false): Hono<AppEnv> {
   const ctx = {
     runtime: {
       getLifecycle: () => lifecycle,
@@ -65,7 +65,7 @@ function makeApp(lifecycle: StubLifecycle, isLocalhost = true): Hono<AppEnv> {
     // workspaceId. We set it ourselves in the wrapping middleware below.
     authOptions: { mode: { type: "dev" }, eventSink: { emit: () => {} } },
     workspaceStore: {},
-    isLocalhost,
+    secureCookies,
   } as unknown as AppContext;
 
   const app = new Hono<AppEnv>();
@@ -111,17 +111,17 @@ describe("POST /v1/mcp-auth/initiate", () => {
     expect(setCookie!).toContain("SameSite=Lax");
     expect(setCookie!).toContain("Path=/v1/mcp-auth/callback");
     expect(setCookie!).toContain("Max-Age=900");
-    // Localhost = no Secure flag
+    // secureCookies=false (dev) → no Secure flag
     expect(setCookie!).not.toContain("Secure");
   });
 
-  test("adds Secure flag when not on localhost", async () => {
+  test("adds Secure flag when secureCookies is set", async () => {
     lifecycle.instances.set(`granola|${WS_ID}`, { oauthScope: "workspace" });
     lifecycle.authUrls.set(
       `granola|${WS_ID}|_workspace`,
       "https://granola.test/auth?state=s",
     );
-    const prodApp = makeApp(lifecycle, /* isLocalhost */ false);
+    const prodApp = makeApp(lifecycle, /* secureCookies */ true);
 
     const res = await prodApp.request("http://api.example.com/v1/mcp-auth/initiate", {
       method: "POST",
@@ -248,7 +248,7 @@ describe("GET /v1/mcp-auth/callback", () => {
       },
       authOptions: { mode: { type: "dev" }, eventSink: { emit: () => {} } },
       workspaceStore: {},
-      isLocalhost: true,
+      secureCookies: false,
     } as unknown as AppContext;
     const wrapped = new Hono<AppEnv>();
     wrapped.use("*", securityHeaders());

--- a/test/unit/composio-auth.test.ts
+++ b/test/unit/composio-auth.test.ts
@@ -56,7 +56,7 @@ function sha256Hex(input: string): string {
 /**
  * Minimal AppContext stub. The composio-auth routes touch only the
  * runtime accessor for the connector directory + work dir, plus
- * `isLocalhost` for cookie scoping. requireAuth + requireWorkspace
+ * `secureCookies` for cookie scoping. requireAuth + requireWorkspace
  * are not exercised by tests below (the callback and proxy routes
  * are unauthenticated by design; the initiate route is covered
  * separately by the helper-function tests).
@@ -132,7 +132,7 @@ function stubCtx(
     runtime,
     workspaceStore: { get: async () => null } as unknown as AppContext["workspaceStore"],
     authOptions: {} as AppContext["authOptions"],
-    isLocalhost: true,
+    secureCookies: false,
     __lifecycleCalls: calls,
   } as unknown as AppContext & { __lifecycleCalls: StubLifecycleCalls };
 }

--- a/test/unit/ssrf-guarded-fetch.test.ts
+++ b/test/unit/ssrf-guarded-fetch.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { createSsrfGuardedFetch } from "../../src/tools/ssrf-guarded-fetch.ts";
+
+/**
+ * Build a stub fetch that returns canned responses keyed by URL. Each entry is
+ * either a terminal `{ status }` or a redirect `{ status, location }`. Records
+ * every call so tests can assert hop count and that `redirect: "manual"` is
+ * always used (the whole point — the SDK's default `follow` is what we replace).
+ */
+function stubFetch(routes: Record<string, { status: number; location?: string }>): {
+  fetch: FetchLike;
+  calls: Array<{ url: string; redirect: RequestRedirect | undefined }>;
+} {
+  const calls: Array<{ url: string; redirect: RequestRedirect | undefined }> = [];
+  const fetch: FetchLike = async (input, init) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, redirect: init?.redirect });
+    const route = routes[url];
+    if (!route) throw new Error(`stub fetch: no route for ${url}`);
+    const headers = route.location ? { location: route.location } : undefined;
+    return new Response(null, { status: route.status, headers });
+  };
+  return { fetch, calls };
+}
+
+describe("createSsrfGuardedFetch", () => {
+  test("passes a non-redirect response straight through (manual redirect mode)", async () => {
+    const { fetch, calls } = stubFetch({ "https://good.example.com/mcp": { status: 200 } });
+    const guarded = createSsrfGuardedFetch(fetch, { allowInsecure: false, fleetInternal: false });
+
+    const res = await guarded("https://good.example.com/mcp");
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.redirect).toBe("manual");
+  });
+
+  test("blocks a redirect to cloud metadata (IMDS)", async () => {
+    // Hop 0 is a public host that passes; it answers with a 307 into the
+    // link-local metadata range. The guard must reject the second hop.
+    const { fetch, calls } = stubFetch({
+      "https://evil.example.com/mcp": {
+        status: 307,
+        location: "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+      },
+    });
+    const guarded = createSsrfGuardedFetch(fetch, { allowInsecure: false, fleetInternal: false });
+
+    // Caught as a cross-origin redirect before the metadata URL is ever fetched.
+    await expect(guarded("https://evil.example.com/mcp")).rejects.toThrow(/cross-origin/);
+    expect(calls.map((c) => c.url)).toEqual(["https://evil.example.com/mcp"]);
+  });
+
+  test("blocks a redirect to a loopback address", async () => {
+    const { fetch } = stubFetch({
+      "https://evil.example.com/mcp": { status: 302, location: "http://127.0.0.1:8080/admin" },
+    });
+    const guarded = createSsrfGuardedFetch(fetch, { allowInsecure: false, fleetInternal: false });
+
+    await expect(guarded("https://evil.example.com/mcp")).rejects.toThrow(/cross-origin/);
+  });
+
+  test("refuses a cross-origin redirect even to another public HTTPS host", async () => {
+    // Cross-origin is refused regardless of the target's reputation: it is the
+    // SSRF pivot AND would leak the connection's credential headers to a new
+    // trust scope. The second host must never be contacted.
+    const { fetch, calls } = stubFetch({
+      "https://a.example.com/mcp": { status: 301, location: "https://b.example.com/mcp" },
+      "https://b.example.com/mcp": { status: 200 },
+    });
+    const guarded = createSsrfGuardedFetch(fetch, { allowInsecure: false, fleetInternal: false });
+
+    await expect(guarded("https://a.example.com/mcp")).rejects.toThrow(/cross-origin/);
+    expect(calls.map((c) => c.url)).toEqual(["https://a.example.com/mcp"]);
+  });
+
+  test("follows a same-origin redirect (path normalization)", async () => {
+    const { fetch, calls } = stubFetch({
+      "https://a.example.com/mcp": { status: 301, location: "https://a.example.com/mcp/" },
+      "https://a.example.com/mcp/": { status: 200 },
+    });
+    const guarded = createSsrfGuardedFetch(fetch, { allowInsecure: false, fleetInternal: false });
+
+    const res = await guarded("https://a.example.com/mcp");
+
+    expect(res.status).toBe(200);
+    expect(calls.map((c) => c.url)).toEqual([
+      "https://a.example.com/mcp",
+      "https://a.example.com/mcp/",
+    ]);
+  });
+
+  test("refuses a cross-origin (different in-cluster service) redirect from a fleet endpoint", async () => {
+    // The configured fleet URL is an in-cluster .svc over plain http — legal on
+    // hop 0 with fleetInternal. A 307 to a DIFFERENT in-cluster service is the
+    // SSRF we block: it is cross-origin, so the credential-bearing fleet token
+    // never reaches the second service.
+    const { fetch, calls } = stubFetch({
+      "http://people.fleet.svc.cluster.local/mcp": {
+        status: 307,
+        location: "http://billing.fleet.svc.cluster.local/admin",
+      },
+    });
+    const guarded = createSsrfGuardedFetch(fetch, { allowInsecure: false, fleetInternal: true });
+
+    await expect(guarded("http://people.fleet.svc.cluster.local/mcp")).rejects.toThrow(
+      /cross-origin/,
+    );
+    expect(calls).toHaveLength(1); // never reached the second service
+  });
+
+  test("follows a same-origin redirect on a fleet-internal http endpoint", async () => {
+    // A same-origin (same host:port) http→http normalization on a fleet source
+    // is benign and must still work — fleetInternal applies on every hop because
+    // the origin never changes.
+    const { fetch, calls } = stubFetch({
+      "http://people.fleet.svc.cluster.local/mcp": {
+        status: 308,
+        location: "http://people.fleet.svc.cluster.local/mcp/",
+      },
+      "http://people.fleet.svc.cluster.local/mcp/": { status: 200 },
+    });
+    const guarded = createSsrfGuardedFetch(fetch, { allowInsecure: false, fleetInternal: true });
+
+    const res = await guarded("http://people.fleet.svc.cluster.local/mcp");
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("rejects an over-long redirect chain", async () => {
+    // Same-origin bounces (distinct paths) — each hop is individually valid, but
+    // the chain length itself is the signal.
+    const routes: Record<string, { status: number; location?: string }> = {};
+    for (let i = 0; i < 12; i++) {
+      routes[`https://h.example.com/${i}`] = {
+        status: 302,
+        location: `https://h.example.com/${i + 1}`,
+      };
+    }
+    const { fetch } = stubFetch(routes);
+    const guarded = createSsrfGuardedFetch(fetch, { allowInsecure: false, fleetInternal: false });
+
+    await expect(guarded("https://h.example.com/0")).rejects.toThrow(/redirect hops/);
+  });
+
+  test("falls back to global fetch shape when no base fetch is given", () => {
+    // Smoke: undefined baseFetch must still yield a callable FetchLike.
+    const guarded = createSsrfGuardedFetch(undefined, { allowInsecure: false, fleetInternal: false });
+    expect(typeof guarded).toBe("function");
+  });
+});


### PR DESCRIPTION
Two findings from a security best-practices review of the runtime, both prod-reachable and grounded in code.

## H1 — SSRF via remote-MCP transport redirects (High)

The MCP SDK's HTTP transports follow redirects with fetch's default `redirect: "follow"`. A remote bundle URL can be tenant-supplied (a self-service `dcr`/`static` connector install), so a hostile/compromised server can answer the initial request with `30x Location: http://169.254.169.254/...` (cloud metadata / IMDS) or an in-cluster service, and the SDK's fetch silently follows it — turning our outbound fetch into an internal-network probe. `validateBundleUrl` only ran once, on the configured URL at startup; it never saw the redirect target.

**Fix:** `createSsrfGuardedFetch` (`src/tools/ssrf-guarded-fetch.ts`) wraps whatever fetch the transport uses (minting / OAuth-refresh / global) and follows redirects manually, **same-origin only**:
- A cross-origin bounce is refused outright. It is the SSRF pivot, **and** re-issuing the request to a new origin would leak the connection's credential headers (`Authorization` / minted fleet token / API key) to a different trust scope — WHATWG fetch strips those across origins for exactly this reason, and a manual loop must not regress it.
- Same-origin redirects (trailing-slash / path normalization) are followed, with the connection's own opts intact so an operator-vetted in-cluster `http://*.svc` fleet source keeps working. `validateBundleUrl` runs per-hop as a backstop.

This reuses the per-hop-validation pattern already proven in the headless OAuth probe (`workspace-oauth-provider.ts`). New unit suite covers IMDS/loopback/cross-origin rejection, same-origin follow (incl. fleet), and the hop cap.

## H2 — Auth cookies missing `Secure` in production (High)

`ctx.isLocalhost` was derived from `server.hostname` after `Bun.serve`. Bun binds the default `0.0.0.0` in production, and the check read `0.0.0.0` as localhost — so every cookie writer (`secure = !isLocalhost`) dropped `Secure` on `nb_session`, `nb_refresh`, `nb_oauth_state`, and `nb_composio_state` in the standard containerized deployment. The listen address is the production signal, not a localhost signal.

**Fix:** replace the misnamed, bind-derived flag with `ctx.secureCookies`, set once at context construction from `authConfigured`. A configured deployment is always fronted by a TLS-terminating edge (browser↔edge is HTTPS regardless of the container's plain-HTTP listen address), so the cookie carries `Secure`; dev mode (no auth, `http://localhost`) keeps it off. The signal is a deployment property — not the spoofable forwarded-scheme header, not the misleading listen address.

## Review

Reviewed by the chief-architect (kernel/trust-boundary lens) and platform-architect (trust-mesh/edge-topology lens) — both **APPROVE-WITH-CHANGES**, incorporated here:
- **Blocking (chief-architect):** the original loop forwarded credentials across cross-origin redirects. Fixed via the same-origin-only rule above.
- **Cookie signal (platform-architect):** confirmed `secureCookies = authConfigured` is correct for every supported topology — `public-origin.ts` already fails closed at boot for any deployed tenant not on HTTPS, so there is no auth-configured-but-plain-HTTP path. `X-Forwarded-Proto` was considered and rejected (wire value).
- **Fleet mesh:** confirmed no fleet/minted flow relies on following cross-origin redirects (connectors target stable ClusterIP service names directly; the OAuth authorize-302 path uses its own probe, not this transport fetch).

## Deferred — SSRF defense-in-depth (tracked follow-up, not this PR)

The string validator does not resolve DNS, so a public hostname whose A-record points at an internal IP still passes hop 0 (H1b). Per both reviews the authoritative fix is the network layer, not in-kernel DNS pinning:
- **infra:** add `169.254.0.0/16` + `127.0.0.0/8` to the `except` list in the tenant egress NetworkPolicy (`allow-https-egress`) to match the `apps` namespace policy — closes tenant-connector → IMDS.
- **infra:** set EKS node-group `metadata_options` (IMDSv2 required, hop limit 1) as defense-in-depth.
- **nice-to-have:** unify this redirect-guard loop with the OAuth probe's into one shared helper so the policy can't drift.

## Verification

`bun run check` (tsc) clean · biome clean · `bun run verify:static` exit 0 · `bun run test:unit` **3806 pass / 0 fail**.

Pre-merge: a smoke test against a real OAuth remote and one SSE remote is recommended (the guard now sits on those paths); I did not have a live external remote to exercise.