### PR TITLE
fix(web): lint web/src/ and clear the 16 pre-existing violations

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,6 +23,9 @@
     }
   },
   "css": {
+    "parser": {
+      "tailwindDirectives": true
+    },
     "formatter": {
       "enabled": false
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "check": "bunx tsc --noEmit",
     "check:web": "cd web && bunx tsc --noEmit",
     "check:theme": "cd web && bun run check:theme",
-    "lint": "bunx @biomejs/biome check src/ instrument/ scripts/",
+    "lint": "bunx @biomejs/biome check src/ instrument/ scripts/ web/src/",
     "format": "bunx @biomejs/biome format --write src/ web/src/ instrument/ scripts/",
     "format:check": "bunx @biomejs/biome format src/ web/src/ instrument/ scripts/",
     "sync-models": "bun run src/model/sync-models.ts",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,8 +19,8 @@ import { CommandPalette } from "./components/palette/CommandPalette";
 import { RouteGuard } from "./components/RouteGuard";
 import { ShellLayout } from "./components/ShellLayout";
 import { WorkspaceRouteGuard } from "./components/WorkspaceRouteGuard";
-import { ChatProvider, useChatConfigContext, useChatContext } from "./context/ChatContext";
 import { ArtifactPanelProvider } from "./context/ArtifactPanelContext";
+import { ChatProvider, useChatConfigContext, useChatContext } from "./context/ChatContext";
 import { ChatPanelProvider, useChatPanelContext } from "./context/ChatPanelContext";
 import { FocusedAppProvider } from "./context/FocusedAppContext";
 import { PaletteProvider } from "./context/PaletteContext";
@@ -36,17 +36,15 @@ import {
 } from "./context/WorkspaceContext";
 import { chatStore } from "./hooks/chat-store";
 import { useDataSync } from "./hooks/useDataSync";
-import { forwardConversationTitleToIframes } from "./lib/forward-conversation-title";
 import { useEvents } from "./hooks/useEvents";
 import { useShell } from "./hooks/useShell";
 import { bootstrapWorkspacesToInfo } from "./lib/bootstrap";
+import { forwardConversationTitleToIframes } from "./lib/forward-conversation-title";
 import { identityAppRoute, isIdentityApp } from "./lib/identity-apps";
 import { recoverFromWorkspaceError } from "./lib/workspace-recovery";
 import { toSlug } from "./lib/workspace-slug";
 import { GlobalHomePage } from "./pages/GlobalHomePage";
 import { ProfilePage } from "./pages/ProfilePage";
-import { ProfileSkillsTab } from "./pages/settings/ProfileSkillsTab";
-import { ProfileTab } from "./pages/settings/ProfileTab";
 import { ConnectorBrowsePage } from "./pages/settings/ConnectorBrowsePage";
 import { ConnectorDetailPage } from "./pages/settings/ConnectorDetailPage";
 import { ModelTab } from "./pages/settings/ModelTab";
@@ -55,6 +53,8 @@ import { OrgRegistriesTab } from "./pages/settings/OrgRegistriesTab";
 import { OrgSettingsPage } from "./pages/settings/OrgSettingsPage";
 import { OrgSkillsTab } from "./pages/settings/OrgSkillsTab";
 import { OrgUsageTab } from "./pages/settings/OrgUsageTab";
+import { ProfileSkillsTab } from "./pages/settings/ProfileSkillsTab";
+import { ProfileTab } from "./pages/settings/ProfileTab";
 import { SettingsAppPanel } from "./pages/settings/SettingsAppPanel";
 import { SkillsTab } from "./pages/settings/SkillsTab";
 import { UsersTab } from "./pages/settings/UsersTab";
@@ -448,7 +448,7 @@ function AuthenticatedAppContent({
               <Route
                 path="model"
                 element={
-                  <RouteGuard role="org_admin">
+                  <RouteGuard requireRole="org_admin">
                     <ModelTab />
                   </RouteGuard>
                 }
@@ -456,7 +456,7 @@ function AuthenticatedAppContent({
               <Route
                 path="workspaces"
                 element={
-                  <RouteGuard role="org_admin">
+                  <RouteGuard requireRole="org_admin">
                     <WorkspacesTab />
                   </RouteGuard>
                 }
@@ -464,7 +464,7 @@ function AuthenticatedAppContent({
               <Route
                 path="workspaces/:slug"
                 element={
-                  <RouteGuard role="org_admin">
+                  <RouteGuard requireRole="org_admin">
                     <WorkspaceDetailPage />
                   </RouteGuard>
                 }
@@ -472,7 +472,7 @@ function AuthenticatedAppContent({
               <Route
                 path="users"
                 element={
-                  <RouteGuard role="org_admin">
+                  <RouteGuard requireRole="org_admin">
                     <UsersTab />
                   </RouteGuard>
                 }
@@ -480,7 +480,7 @@ function AuthenticatedAppContent({
               <Route
                 path="usage"
                 element={
-                  <RouteGuard role="org_admin">
+                  <RouteGuard requireRole="org_admin">
                     <OrgUsageTab />
                   </RouteGuard>
                 }
@@ -488,7 +488,7 @@ function AuthenticatedAppContent({
               <Route
                 path="registries"
                 element={
-                  <RouteGuard role="org_admin">
+                  <RouteGuard requireRole="org_admin">
                     <OrgRegistriesTab />
                   </RouteGuard>
                 }
@@ -496,7 +496,7 @@ function AuthenticatedAppContent({
               <Route
                 path="skills"
                 element={
-                  <RouteGuard role="org_admin">
+                  <RouteGuard requireRole="org_admin">
                     <OrgSkillsTab />
                   </RouteGuard>
                 }

--- a/web/src/__tests__/events-client.test.ts
+++ b/web/src/__tests__/events-client.test.ts
@@ -111,7 +111,6 @@ describe("events-client — event routing", () => {
     subscribe("config.changed", c);
 
     // Drive an event through the fake's captured onEvent.
-    // biome-ignore lint/style/noNonNullAssertion: lastOptions is set by the first subscribe()
     lastOptions!.onEvent("data.changed", { server: "x", tool: "y" });
 
     expect(a).toHaveBeenCalledTimes(1);
@@ -127,7 +126,6 @@ describe("events-client — event routing", () => {
     subscribe("data.changed", thrower);
     subscribe("data.changed", good);
 
-    // biome-ignore lint/style/noNonNullAssertion: see prior
     lastOptions!.onEvent("data.changed", { server: "x" });
 
     expect(thrower).toHaveBeenCalledTimes(1);
@@ -136,7 +134,6 @@ describe("events-client — event routing", () => {
 
   test("events for types with no subscribers are dropped without error", () => {
     subscribe("data.changed", () => {});
-    // biome-ignore lint/style/noNonNullAssertion: see prior
     expect(() => lastOptions!.onEvent("skill.created", { id: "x" })).not.toThrow();
   });
 });
@@ -149,7 +146,6 @@ describe("events-client — onReconnect", () => {
     onReconnect(a);
     onReconnect(b);
 
-    // biome-ignore lint/style/noNonNullAssertion: see prior
     lastOptions!.onReconnect?.();
 
     expect(a).toHaveBeenCalledTimes(1);
@@ -162,7 +158,6 @@ describe("events-client — onReconnect", () => {
     const unsub = onReconnect(a);
 
     unsub();
-    // biome-ignore lint/style/noNonNullAssertion: see prior
     lastOptions!.onReconnect?.();
 
     expect(a).toHaveBeenCalledTimes(0);

--- a/web/src/__tests__/t009-acceptance.test.ts
+++ b/web/src/__tests__/t009-acceptance.test.ts
@@ -32,9 +32,9 @@
 // trick required.
 // ---------------------------------------------------------------------------
 
+import { describe, expect, mock, test } from "bun:test";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { describe, expect, mock, test } from "bun:test";
 
 // Real exports under test — asserted as values/types below.
 import {

--- a/web/src/__tests__/useEvents.test.tsx
+++ b/web/src/__tests__/useEvents.test.tsx
@@ -47,7 +47,6 @@ function fakeConnectEvents(options: ConnectEventsOptions): EventConnection {
   return new FakeConnection();
 }
 
-const React = await import("react");
 const ReactDOMClient = await import("react-dom/client");
 const { act } = await import("react");
 const { useEvents } = await import("../hooks/useEvents");
@@ -96,7 +95,6 @@ describe("useEvents", () => {
     act(() => {
       root.render(<Probe onReconnect={onReconnect} />);
     });
-    // biome-ignore lint/style/noNonNullAssertion: ensureOpen ran on first subscribe()
     expect(lastOptions!.onReconnect).toBeDefined();
 
     // Simulate the singleton firing reconnect (as it does after a

--- a/web/src/api/conversation-stream.test.ts
+++ b/web/src/api/conversation-stream.test.ts
@@ -102,7 +102,7 @@ describe("conversation-stream watchdog", () => {
 
   test("does not reconnect after close()", async () => {
     let calls = 0;
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
       calls++;
       return silentStreamResponse(init?.signal as AbortSignal);
     }) as typeof fetch;

--- a/web/src/api/events-client.ts
+++ b/web/src/api/events-client.ts
@@ -33,7 +33,7 @@
 
 import type { SseEventMap, SseEventType } from "../types";
 import { addAuthLifecycleHandler, getAuthToken } from "./client";
-import { connectEvents, type ConnectEventsOptions, type EventConnection } from "./sse";
+import { type ConnectEventsOptions, connectEvents, type EventConnection } from "./sse";
 
 type Handler<K extends SseEventType> = (data: SseEventMap[K]) => void;
 type ReconnectHandler = () => void;

--- a/web/src/bridge/__tests__/iframe-csp.test.ts
+++ b/web/src/bridge/__tests__/iframe-csp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock, spyOn } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { buildCSP, isValidCspDomain } from "../iframe.ts";
 
 describe("buildCSP", () => {

--- a/web/src/components/RouteGuard.tsx
+++ b/web/src/components/RouteGuard.tsx
@@ -4,8 +4,8 @@ import { roleAtLeast, type ScopedRole, useScopedRole } from "../hooks/useScopedR
 
 interface RouteGuardProps {
   /** Minimum role required to render `children`. Insufficient → redirect. */
-  role: ScopedRole;
-  /** Where to send users who don't meet `role`. Defaults to /profile. */
+  requireRole: ScopedRole;
+  /** Where to send users who don't meet `requireRole`. Defaults to /profile. */
   fallback?: string;
   children: ReactNode;
 }
@@ -20,9 +20,9 @@ interface RouteGuardProps {
  * backend tool enforces roles independently. None of these alone is the
  * security boundary; together they're defense in depth.
  */
-export function RouteGuard({ role, fallback = "/profile", children }: RouteGuardProps) {
+export function RouteGuard({ requireRole, fallback = "/profile", children }: RouteGuardProps) {
   const current = useScopedRole();
-  if (!roleAtLeast(current, role)) {
+  if (!roleAtLeast(current, requireRole)) {
     return <Navigate to={fallback} replace />;
   }
   return <>{children}</>;

--- a/web/src/components/SlotRenderer.tsx
+++ b/web/src/components/SlotRenderer.tsx
@@ -78,6 +78,7 @@ export function SlotRenderer({
   // Stable key: only re-mount iframes when the actual placements change
   const placementKey = filtered.map((p) => p.resourceUri).join(",");
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-mount iframes only when placementKey changes — `filtered` is read at run time but changes identity every render (depending on it would thrash iframes), and mode/streaming/forceRefresh are read through refs
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -148,7 +149,6 @@ export function SlotRenderer({
     };
     // Only re-mount iframes when placements change, not when callbacks change.
     // Callbacks are accessed via refs so bridges always call the latest version.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: callbacks accessed via refs
   }, [placementKey]);
 
   // Propagate host-context changes (theme + workspace) to mounted iframes

--- a/web/src/components/charts/CostChart.tsx
+++ b/web/src/components/charts/CostChart.tsx
@@ -125,8 +125,8 @@ export function CostChart({ data }: CostChartProps) {
           const x = paddingLeft + gap + i * (barWidth + gap);
           let yOffset = 0;
 
-          // biome-ignore lint/a11y/noStaticElementInteractions: SVG hover for tooltip, no keyboard equivalent needed
           return (
+            // biome-ignore lint/a11y/noStaticElementInteractions: SVG hover for tooltip, no keyboard equivalent needed
             <g
               key={d.key}
               onMouseEnter={() => setHoveredIndex(i)}

--- a/web/src/components/chat/ComposerFooter.tsx
+++ b/web/src/components/chat/ComposerFooter.tsx
@@ -24,8 +24,8 @@ import { useMatch } from "react-router-dom";
 import { useShellContext } from "../../context/ShellContext";
 import { useToolWorkspaces } from "../../context/ToolWorkspacesContext";
 import { useWorkspaceContext, type WorkspaceInfo } from "../../context/WorkspaceContext";
-import { workspaceBadgeVariant } from "./ToolCallProvenance";
 import { Badge } from "../ui/badge";
+import { workspaceBadgeVariant } from "./ToolCallProvenance";
 
 export function ComposerFooter() {
   const wsCtx = useWorkspaceContext();

--- a/web/src/components/connectors/BundleCredentialsModal.tsx
+++ b/web/src/components/connectors/BundleCredentialsModal.tsx
@@ -135,6 +135,7 @@ export function BundleCredentialsModal({
   const connectorName = installed.catalog?.name ?? installed.serverName;
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-dismiss is a mouse convenience; keyboard users dismiss via ESC
     <div
       className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
       role="presentation"

--- a/web/src/components/connectors/ComposioApiKeyModal.tsx
+++ b/web/src/components/connectors/ComposioApiKeyModal.tsx
@@ -84,6 +84,7 @@ export function ComposioApiKeyModal({
   };
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-dismiss is a mouse convenience; keyboard users dismiss via ESC
     <div
       className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
       role="presentation"

--- a/web/src/components/connectors/ConnectorIcon.tsx
+++ b/web/src/components/connectors/ConnectorIcon.tsx
@@ -77,6 +77,5 @@ const TINTS = [
 function pickTint(seed: string): string {
   let h = 0;
   for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) | 0;
-  // biome-ignore lint/style/noNonNullAssertion: TINTS is a non-empty literal
   return TINTS[Math.abs(h) % TINTS.length]!;
 }

--- a/web/src/components/connectors/OperatorSetupModal.tsx
+++ b/web/src/components/connectors/OperatorSetupModal.tsx
@@ -121,6 +121,7 @@ export function OperatorSetupModal({
   };
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-dismiss is a mouse convenience; keyboard users dismiss via ESC
     <div
       className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
       role="presentation"

--- a/web/src/components/connectors/ToolPermissionsTable.tsx
+++ b/web/src/components/connectors/ToolPermissionsTable.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import {
   type ConnectorTool,
   listConnectorToolsWithPermissions,
-  type ToolPolicy,
   setConnectorPermissions,
+  type ToolPolicy,
 } from "../../api/client";
 
 /**
@@ -247,7 +247,7 @@ function PolicyButton({
 
 function CheckIcon() {
   return (
-    <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden>
+    <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
       <path
         d="M2.5 6.5L5 9L9.5 3.5"
         stroke="currentColor"
@@ -262,7 +262,7 @@ function CheckIcon() {
 
 function DenyIcon() {
   return (
-    <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden>
+    <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
       <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.4" fill="none" />
       <path d="M3 9L9 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
     </svg>

--- a/web/src/context/SidebarContext.tsx
+++ b/web/src/context/SidebarContext.tsx
@@ -80,7 +80,7 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
 
   const value = useMemo<SidebarContextValue>(
     () => ({ state, isDrawerOpen, toggle, setDrawerOpen }),
-    [state, isDrawerOpen, toggle, setDrawerOpen],
+    [state, isDrawerOpen, toggle],
   );
 
   return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>;

--- a/web/src/hooks/useDataSync.test.ts
+++ b/web/src/hooks/useDataSync.test.ts
@@ -7,8 +7,8 @@
 // the null-origin problem (sandbox-proxy work in iframe.ts).
 // ---------------------------------------------------------------------------
 
-import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
 import { useDataSync } from "./useDataSync";
 
 interface CapturedPost {

--- a/web/src/lib/forward-conversation-title.test.ts
+++ b/web/src/lib/forward-conversation-title.test.ts
@@ -71,7 +71,7 @@ describe("forwardConversationTitleToIframes", () => {
     // No matching iframe in the DOM — querySelectorAll returns empty for any
     // selector. Forward must not throw and must post nothing.
     originalQSA = document.querySelectorAll.bind(document);
-    let posted = false;
+    const posted = false;
     document.querySelectorAll = (() =>
       [] as unknown as NodeListOf<Element>) as typeof document.querySelectorAll;
     // Guard: if forward somehow posted, this would flip — but with zero

--- a/web/src/lib/workspace-avatar.ts
+++ b/web/src/lib/workspace-avatar.ts
@@ -51,6 +51,5 @@ function pickColor(id: string): string {
     hash = (hash * 31 + id.charCodeAt(i)) | 0;
   }
   const idx = Math.abs(hash) % PALETTE.length;
-  // biome-ignore lint/style/noNonNullAssertion: idx is `% PALETTE.length`, so always in-range
   return PALETTE[idx]!;
 }

--- a/web/src/pages/settings/ConnectorBrowsePage.tsx
+++ b/web/src/pages/settings/ConnectorBrowsePage.tsx
@@ -93,12 +93,18 @@ export function ConnectorBrowsePage() {
     return { byUrl, byBundleName };
   }, [installed]);
 
-  function isInstalled(entry: DirectoryEntry): boolean {
-    if (entry.install.kind === "remote-oauth") return installedByKey.byUrl.has(entry.install.url);
-    if (entry.install.kind === "mpak-bundle")
-      return installedByKey.byBundleName.has(entry.install.package);
-    return false;
-  }
+  // useCallback so the visibleEntries memo can depend on a stable isInstalled
+  // (its identity changes only when installedByKey does — the same trigger the
+  // memo needs to drop newly-installed connectors from the list).
+  const isInstalled = useCallback(
+    (entry: DirectoryEntry): boolean => {
+      if (entry.install.kind === "remote-oauth") return installedByKey.byUrl.has(entry.install.url);
+      if (entry.install.kind === "mpak-bundle")
+        return installedByKey.byBundleName.has(entry.install.package);
+      return false;
+    },
+    [installedByKey],
+  );
 
   // One unified browse list: every connector is installable into any
   // workspace, so the only filtering is dropping already-installed
@@ -113,9 +119,7 @@ export function ConnectorBrowsePage() {
         e.description.toLowerCase().includes(q) ||
         (e.tags ?? []).some((t) => t.toLowerCase().includes(q)),
     );
-    // installedByKey is captured by isInstalled via closure; re-running
-    // when it changes is what lets newly-installed connectors disappear.
-  }, [entries, query, installedByKey]);
+  }, [entries, query, isInstalled]);
 
   // Install into the workspace the user is already in. The page is
   // mounted under `/w/<slug>/...`, so the route names an unambiguous

--- a/web/src/pages/settings/OrgRegistriesTab.tsx
+++ b/web/src/pages/settings/OrgRegistriesTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { listRegistries, type RegistryConfig, setRegistryEnabled } from "../../api/client";
 import { SettingsPageHeader } from "./components";
 
@@ -15,7 +15,10 @@ export function OrgRegistriesTab() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const refresh = async () => {
+  // useCallback so the load-on-mount effect can depend on it without
+  // re-running every render (refresh captures only stable setters + the
+  // module-level listRegistries, so its dep array is empty).
+  const refresh = useCallback(async () => {
     setError(null);
     try {
       const res = await listRegistries();
@@ -25,11 +28,11 @@ export function OrgRegistriesTab() {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     refresh();
-  }, []);
+  }, [refresh]);
 
   const onToggle = async (id: string, next: boolean) => {
     setError(null);

--- a/web/src/pages/settings/OrgSkillsTab.tsx
+++ b/web/src/pages/settings/OrgSkillsTab.tsx
@@ -4,7 +4,7 @@ import { SkillsBrowser } from "./SkillsTab";
  * Org-admin skills tab — `/org/skills`.
  *
  * Renders the shared `SkillsBrowser` locked to org-tier. The route guard
- * (`RouteGuard role="org_admin"` in App.tsx) is the access gate; this tab
+ * (`RouteGuard requireRole="org_admin"` in App.tsx) is the access gate; this tab
  * assumes it has been passed before mount. Backend `checkPathAccess` is
  * the source of truth — UI gating is defense in depth, not the security
  * boundary.

--- a/web/src/pages/settings/SkillsTab.tsx
+++ b/web/src/pages/settings/SkillsTab.tsx
@@ -3,6 +3,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { Streamdown } from "streamdown";
 import type { ToolInput } from "../../_generated/platform-schemas/catalog";
+import type {
+  SkillSummary as ListedSkill,
+  SkillDetail as ReadSkill,
+  SkillScope as Scope,
+  SkillsListOutput,
+} from "../../_generated/platform-schemas/skills";
 import { callTool } from "../../api/client";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
@@ -11,13 +17,6 @@ import { Textarea } from "../../components/ui/textarea";
 import { parseToolResponse } from "../../lib/tool-response";
 import { cn } from "../../lib/utils";
 import { RequireActiveWorkspace, Section, SettingsPageHeader } from "./components";
-
-import type {
-  SkillDetail as ReadSkill,
-  SkillScope as Scope,
-  SkillsListOutput,
-  SkillSummary as ListedSkill,
-} from "../../_generated/platform-schemas/skills";
 
 // ── Wrappers ─────────────────────────────────────────────────────────────
 
@@ -465,6 +464,10 @@ function Rule({
 }) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const [shellH, setShellH] = useState(0);
+  // `detail` isn't read in the effect, but its async content renders inside
+  // bodyRef — so when it loads the measured scrollHeight changes. Keeping it as
+  // a dependency re-measures on load; it's a deliberate trigger, not dead code.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: detail changes the measured DOM height
   useEffect(() => {
     if (!expanded) {
       setShellH(0);
@@ -711,6 +714,7 @@ function PersonalFooter({ count }: { count: number }) {
 // ── Edit view ────────────────────────────────────────────────────────────
 
 type CreateInput = ToolInput<"skills", "create">;
+
 export type { CreateInput };
 
 /**

--- a/web/src/theme/projections.ts
+++ b/web/src/theme/projections.ts
@@ -11,11 +11,11 @@
  */
 
 import {
-  type Mode,
   colors,
   extOnlyColors,
   fonts,
   layout,
+  type Mode,
   pick,
   radiusBase,
   radiusScale,


### PR DESCRIPTION
## Why
`web/src/` is in `biome.json`'s `files.includes` but was **absent from the `lint` script** (`biome check src/ instrument/ scripts/`) — so it was *formatted* but **never lint-checked**. 16 errors had quietly accumulated. Surfaced by QA on #549. (This also closes the class of bug from #548 — a silent regression that passes every gate because `web/src` lint never ran.)

## What changed
Added `web/src/` to `lint` and fixed all 16 — each correctly, not silenced:

**Config**
- `biome.json`: `parser.tailwindDirectives: true` so biome's CSS parser accepts Tailwind v4 at-rules (`@theme`, `@custom-variant`) in `index.css`. CSS linter/formatter stay disabled. *(5 of the 16 "errors" were CSS parse failures, not lint rules.)*

**API footgun fix**
- `RouteGuard`: renamed the `role` prop → **`requireRole`**. It's an authorization level, not an ARIA role — the name shadowed the HTML concept and tripped `a11y/useValidAriaRole` ×7. The rename clears the false-positive *and* removes the footgun.

**Hooks (`useExhaustiveDependencies`) — fixed for correctness, not just lint**
- `OrgRegistriesTab` / `ConnectorBrowsePage`: the missing deps (`refresh`, `isInstalled`) were functions recreated every render — wrapped in `useCallback` so the effect/memo depends on a *stable* identity. **Not** a blind dep-add (that loops).
- `SidebarContext`: dropped the stable `setDrawerOpen` setter from the memo deps (unnecessary).
- `SlotRenderer` (`[placementKey]`) and `SkillsTab` (`[expanded, detail]`): kept, with documented `biome-ignore`s — these are deliberate re-run triggers biome can't infer (`detail`'s async content changes the measured DOM height).

**a11y (real, fixed properly)**
- 3 modal backdrops (`BundleCredentials`/`Composio`/`OperatorSetup`): verified each wires `Escape`, then documented the backdrop-click `noStaticElementInteractions` (mouse convenience; ESC = keyboard path).
- `CostChart`: a misplaced existing suppression sat above `return (` instead of the `<g>` — moved it (clears both the dead-suppression and the interaction error).
- `ToolPermissionsTable` Check/Deny icons: confirmed decorative (parent `<button>` has `aria-label`) → explicit `aria-hidden`.

**Mechanical:** removed 5 stale `noNonNullAssertion` suppressions (rule is `off`) + unused imports/vars/params.

## Verification
- `bun run lint` (now incl. `web/src/`) → **exit 0** · `format:check` clean · project `tsc` clean · `test:web` **573/0**
- Ran the app: `/org/registries` (the one *effect*-based hook change) loads its data with **zero console errors/warnings** — no loop. The other hook changes are `useMemo` (can't loop) or behavior-unchanged.

Now `web/src` lint runs in CI on every PR.