### PR TITLE
docs: update env example defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ POSTHOG_API_KEY=
 # fallback for `bun run dev`; unset ⇒ each feature disabled.
 
 # API base URL for the web client in development.
-# Default: /v1 (proxied to :3000 by Vite dev server)
+# Default: /v1 (proxied to :27247 by Vite dev server)
 # VITE_API_BASE=/v1
 
 # PostHog write-only API key for web client analytics. If unset, disabled.

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 # At least one LLM provider key is required.
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
-GEMINI_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEY=
 
 # ── Telemetry (optional) ───────────────────────────────────────────────────────
 
@@ -24,8 +24,8 @@ POSTHOG_API_KEY=
 
 # ── Server (optional) ─────────────────────────────────────────────────────────
 
-# HTTP port for the API server. Default: 3000
-# PORT=3000
+# HTTP port for the API server. Default: 27247
+# PORT=27247
 
 # Host URL used for generating absolute URLs (e.g. MCP server callbacks).
 # Default: http://localhost:${PORT}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ cd web && bun install && cd ..
 
 # Copy the environment template and fill in at least one LLM provider key
 cp .env.example .env
-# Edit .env — set ANTHROPIC_API_KEY (or OPENAI_API_KEY / GEMINI_API_KEY)
+# Edit .env — set ANTHROPIC_API_KEY (or OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY)
 ```
 
 ## Running Locally


### PR DESCRIPTION
## Summary
- Replace stale `GEMINI_API_KEY` references with `GOOGLE_GENERATIVE_AI_API_KEY`.
- Update the API server port example from `3000` to the runtime default `27247`.

## Test plan
- Not run; documentation/example-only change.

Closes #448