### PR TITLE
web(theme): federate shell shadows from palette; drop the vestigial --radius (Part B)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -94,7 +94,10 @@
     /* Shadow ramp — single-sourced from src/theme/palette.ts (shadows),
        emitted to :root/.dark as --nb-shadow-* and aliased so shell `shadow-*`
        matches the design system the iframe apps share. The ramp tops out at
-       `lg`; `shadow-xl`/`shadow-2xl` (modals) keep Tailwind's defaults. */
+       `lg`; `shadow-xl`/`shadow-2xl` (modals) keep Tailwind's defaults. The
+       palette also emits `--nb-shadow-hairline`, intentionally left unaliased
+       here — there's no Tailwind `shadow-hairline` utility; it's consumed only
+       on the iframe path (bridge/theme.ts). */
     --shadow-sm: var(--nb-shadow-sm);
     --shadow-md: var(--nb-shadow-md);
     --shadow-lg: var(--nb-shadow-lg);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -90,6 +90,14 @@
     --radius-md: var(--border-radius-md);
     --radius-lg: var(--border-radius-lg);
     --radius-xl: var(--border-radius-xl);
+
+    /* Shadow ramp — single-sourced from src/theme/palette.ts (shadows),
+       emitted to :root/.dark as --nb-shadow-* and aliased so shell `shadow-*`
+       matches the design system the iframe apps share. The ramp tops out at
+       `lg`; `shadow-xl`/`shadow-2xl` (modals) keep Tailwind's defaults. */
+    --shadow-sm: var(--nb-shadow-sm);
+    --shadow-md: var(--nb-shadow-md);
+    --shadow-lg: var(--nb-shadow-lg);
 }
 
 /* ─────────────────────────────────────────────────────────────────────────

--- a/web/src/theme/__tests__/palette.test.ts
+++ b/web/src/theme/__tests__/palette.test.ts
@@ -193,7 +193,6 @@ describe("paletteToRootCss — shell :root/.dark match current values", () => {
       "--processing: #7c3aed;",
       "--sidebar-accent: #eff6ff;",
       "--chart-1: #0055FF;",
-      "--radius: 0.5rem;",
       "--sidebar-width: 240px;",
     ]) {
       expect(rootBlock).toContain(decl);
@@ -238,5 +237,16 @@ describe("paletteToRootCss — shell :root/.dark match current values", () => {
 
   test("dark block does not redefine the radius scale (mode-independent, cascades)", () => {
     expect(darkBlock).not.toContain("--border-radius-");
+  });
+
+  test("shadow ramp lands in :root (light) and .dark (mode-dependent), aliased to --shadow-* in index.css", () => {
+    expect(rootBlock).toContain("--nb-shadow-sm: 0 1px 2px rgba(0,0,0,0.05);");
+    expect(rootBlock).toContain("--nb-shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.1);");
+    // shadows are mode-dependent, so .dark carries its own values
+    expect(darkBlock).toContain("--nb-shadow-sm: 0 1px 2px rgba(0,0,0,0.3);");
+  });
+
+  test("the --radius base is no longer emitted (vestigial after the radius convergence)", () => {
+    expect(rootBlock).not.toContain("--radius:");
   });
 });

--- a/web/src/theme/palette.ts
+++ b/web/src/theme/palette.ts
@@ -29,9 +29,6 @@ export const fonts = {
   mono: "'JetBrains Mono Variable', ui-monospace, SFMono-Regular, monospace",
 } as const;
 
-/** Base corner radius (the shadcn `--radius`; scale multiples derive in index.css `@theme`). */
-export const radiusBase = "0.5rem";
-
 /** Layout constants (mode-independent; `:root` only). */
 export const layout = {
   "--sidebar-width": "240px",

--- a/web/src/theme/projections.ts
+++ b/web/src/theme/projections.ts
@@ -77,9 +77,11 @@ export function paletteToExtAppsTokens(mode: Mode): Record<string, string> {
 /**
  * Build the shell's `:root` (light) and `.dark` (dark) CSS blocks. The values
  * and selectors match what Tailwind v4's `@theme inline` already references
- * (`--background`, `--sidebar-*`, `--chart-*`, `--radius`, `--font-text-*`, …).
- * `:root` also carries the mode-independent layout constants, base radius, and
- * type scale; `.dark` redefines colors only (the rest cascade from `:root`).
+ * (`--background`, `--sidebar-*`, `--chart-*`, `--border-radius-*`,
+ * `--font-text-*`, `--nb-shadow-*`, …). `:root` also carries the
+ * mode-independent layout constants, radius scale, type scale, and fonts;
+ * `.dark` redefines colors and shadows (both mode-dependent), the rest cascade
+ * from `:root`.
  */
 export function paletteToRootCss(): string {
   const names = Object.keys(colors) as (keyof typeof colors)[];

--- a/web/src/theme/projections.ts
+++ b/web/src/theme/projections.ts
@@ -17,7 +17,6 @@ import {
   layout,
   type Mode,
   pick,
-  radiusBase,
   radiusScale,
   shadows,
   typeScale,
@@ -86,7 +85,6 @@ export function paletteToRootCss(): string {
   const names = Object.keys(colors) as (keyof typeof colors)[];
 
   const lightDecls = names.map((n) => `  --${n}: ${pick(colors[n], "light")};`);
-  lightDecls.push(`  --radius: ${radiusBase};`);
   for (const [k, v] of Object.entries(layout)) lightDecls.push(`  ${k}: ${v};`);
   // Radius scale — the ONE radius source, shared with the iframe apps. Emitted
   // as `--border-radius-*` (the ext-apps / synapse-ui names) and aliased to
@@ -100,8 +98,16 @@ export function paletteToRootCss(): string {
   // Tailwind's `--font-*` in index.css (the shell previously restated these as
   // literals). Mode-independent, :root only.
   for (const [k, v] of Object.entries(fonts)) lightDecls.push(`  --nb-font-${k}: ${v};`);
+  // Shadows — mode-dependent, so emitted into both :root and .dark. Renamed to
+  // `--nb-shadow-*` (Tailwind owns the `--shadow-*` key) and aliased to it in
+  // index.css. The shell shares the design system's shadow ramp the iframe apps
+  // already use; the shell-only `shadow-xl`/`2xl` (modals) keep Tailwind's
+  // values — the ramp tops out at `lg` in the shared design system.
+  const shadowDecl = (k: string, v: string) => `  ${k.replace("--shadow-", "--nb-shadow-")}: ${v};`;
+  for (const [k, v] of Object.entries(shadows.light)) lightDecls.push(shadowDecl(k, v));
 
   const darkDecls = names.map((n) => `  --${n}: ${pick(colors[n], "dark")};`);
+  for (const [k, v] of Object.entries(shadows.dark)) darkDecls.push(shadowDecl(k, v));
 
   return `:root {\n${lightDecls.join("\n")}\n}\n\n.dark {\n${darkDecls.join("\n")}\n}\n`;
 }

--- a/web/src/theme/tokens.generated.css
+++ b/web/src/theme/tokens.generated.css
@@ -46,7 +46,6 @@
   --sidebar-border: #e5e5e5;
   --sidebar-ring: #0055FF;
   --sidebar-hover: #faf9f7;
-  --radius: 0.5rem;
   --sidebar-width: 240px;
   --sidebar-width-collapsed: 64px;
   --border-radius-xs: 0.25rem;
@@ -80,6 +79,10 @@
   --nb-font-sans: 'Satoshi', system-ui, sans-serif;
   --nb-font-heading: 'Erode', Georgia, serif;
   --nb-font-mono: 'JetBrains Mono Variable', ui-monospace, SFMono-Regular, monospace;
+  --nb-shadow-hairline: 0 0 0 1px rgba(0,0,0,0.06);
+  --nb-shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --nb-shadow-md: 0 4px 6px -1px rgba(0,0,0,0.1);
+  --nb-shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.1);
 }
 
 .dark {
@@ -127,4 +130,8 @@
   --sidebar-border: #262626;
   --sidebar-ring: #3b8eff;
   --sidebar-hover: #141413;
+  --nb-shadow-hairline: 0 0 0 1px rgba(255,255,255,0.06);
+  --nb-shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --nb-shadow-md: 0 4px 6px -1px rgba(0,0,0,0.4);
+  --nb-shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.4);
 }


### PR DESCRIPTION
**Finishes the token convergence** — every shell token now derives from `palette.ts`. Two small token-system changes.

## 1. Shadows (the last divergence)
The shell had **no shadow tokens** — `shadow-*` utilities used stock Tailwind defaults, while the iframe apps consume the palette's designed ramp. Federated:
- `paletteToRootCss` emits `palette.shadows` into `:root`/`.dark` as `--nb-shadow-*` (Tailwind owns the `--shadow-*` key, so the `--nb-` rename + alias pattern, same as fonts).
- `index.css` aliases Tailwind's `shadow-sm/md/lg` → `var(--nb-shadow-*)`.
- The shared design system's ramp **tops out at `lg`** (`synapse/ui` defines `hairline/sm/md/lg` only), so the shell-only `shadow-xl`/`shadow-2xl` (modals) **keep Tailwind's values** — there's nothing to converge them to. No `palette.shadows` extension → **no ext-apps contract-test churn.**

**Visual delta:** `shadow-sm/md/lg` go from Tailwind's two-layer to the palette's single-layer ramp (slightly lighter/flatter); modals unchanged. Verified live — menus/dropdowns render clean, no console errors.

## 2. Drop the vestigial `--radius` base (#549 QA note)
The radius convergence (#549) re-pointed `--radius-*` at `--border-radius-*`, leaving the `--radius` base **unreferenced** — confirmed: `rg 'var(--radius)' web/src` → 0, and bare `.rounded` is a *static* Tailwind `0.25rem` utility (verified in the built CSS), not a var read. Removed its `:root` emission and the now-unused `radiusBase` const.

## Verification
- `gen:theme` diff = `--radius` removed, `--nb-shadow-*` added to `:root`+`.dark`
- built CSS: `.rounded{border-radius:.25rem}` unchanged (confirms `--radius` was dead); `shadow-lg` resolves through `--nb-shadow-lg`
- `bun run build` green · `test:web` **575/0** · theme contract tests **14/14** (added shadow + radius-removal pins) · `lint` (incl. `web/src`) + `format:check` clean
- Ran the app — user-menu dropdown (`shadow-lg`, a changed shadow) renders correctly

## Scope
Runtime only (`code/web/`). `synapse/ui` untouched — it's the read-only reference.

## Convergence status after this
✅ Type scale · ✅ Opacity ramp · ✅ Fonts/glow · ✅ Radius · ✅ **Shadows** — token federation complete. Remaining: the component-layer unification (shell's bespoke Tailwind vs shadcn `ui/*`) + the `synapse/ui` badge→pill follow-up.