### PR TITLE
web(connectors): adopt ui/Button for modal footer actions (component unification, slice 1)

### DIFF
--- a/web/src/components/connectors/BundleCredentialsModal.tsx
+++ b/web/src/components/connectors/BundleCredentialsModal.tsx
@@ -5,6 +5,7 @@ import {
   type InstalledConnector,
   setBundleUserConfig,
 } from "../../api/client";
+import { Button } from "../ui/button";
 
 /**
  * Edit a stdio bundle's workspace `user_config` credentials, schema-
@@ -198,21 +199,18 @@ export function BundleCredentialsModal({
               <span />
             )}
             <div className="flex items-center gap-2">
-              <button
+              <Button
                 type="button"
+                variant="outline"
+                size="sm"
                 onClick={onClose}
                 disabled={busy || clearing}
-                className="text-xs px-3 py-1.5 rounded border border-border hover:bg-muted disabled:opacity-60"
               >
                 Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={busy || clearing}
-                className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-60"
-              >
+              </Button>
+              <Button type="submit" size="sm" disabled={busy || clearing}>
                 {busy ? "Saving…" : "Save"}
-              </button>
+              </Button>
             </div>
           </div>
         </form>

--- a/web/src/components/connectors/ComposioApiKeyModal.tsx
+++ b/web/src/components/connectors/ComposioApiKeyModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { type ComposioField, connectComposioApiKey } from "../../api/client";
+import { Button } from "../ui/button";
 
 /**
  * Field-collection modal for a non-redirect (API-key) Composio connector.
@@ -144,22 +145,12 @@ export function ComposioApiKeyModal({
           {error && <p className="text-xs text-destructive">{error}</p>}
 
           <div className="flex items-center justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={busy}
-              className="text-xs px-3 py-1.5 rounded border border-border hover:bg-muted disabled:opacity-60"
-            >
+            <Button type="button" variant="outline" size="sm" onClick={onClose} disabled={busy}>
               Cancel
-            </button>
-            <button
-              type="button"
-              onClick={() => void submit()}
-              disabled={busy}
-              className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-60"
-            >
+            </Button>
+            <Button type="button" size="sm" onClick={() => void submit()} disabled={busy}>
               {busy ? "Connecting…" : "Connect"}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/web/src/components/connectors/OperatorSetupModal.tsx
+++ b/web/src/components/connectors/OperatorSetupModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { type DirectoryEntry, getOAuthRedirectUri, setupConnectorOperator } from "../../api/client";
 import { safeHostname } from "../../lib/safe-url";
+import { Button } from "../ui/button";
 
 /**
  * Workspace operator OAuth app setup. The form is the same whether
@@ -222,21 +223,12 @@ export function OperatorSetupModal({
           {error && <p className="text-xs text-destructive">{error}</p>}
 
           <div className="flex items-center justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={busy}
-              className="text-xs px-3 py-1.5 rounded border border-border hover:bg-muted disabled:opacity-60"
-            >
+            <Button type="button" variant="outline" size="sm" onClick={onClose} disabled={busy}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={busy}
-              className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-60"
-            >
+            </Button>
+            <Button type="submit" size="sm" disabled={busy}>
               {busy ? "Saving…" : isEdit ? "Save changes" : "Save"}
-            </button>
+            </Button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
**First slice of the component-layer unification** — your "converge shadcn + Tailwind in the runtime" goal. *Focused, pattern-first* (the option you picked).

## The problem
The shell hand-rolls **~72 bespoke `<button>`** vs only **7 `<Button>`** — the full-featured `ui/Button` primitive (variants `default/outline/secondary/ghost/destructive/link` × `xs/sm/lg/icon`) sits nearly unused. This is an *adoption* gap, not a missing-primitive one.

## The thesis (the judgment that scopes this)
**Standard action buttons → `ui/Button`. Genuinely-custom/utility surfaces stay bespoke.** Not all 72 should migrate — nav rows, the chat composer, the FAB, etc. are custom components, not design-system buttons. Forcing them into `<Button>` makes things worse.

## This slice: the connector modals' footer actions
The clearest, most consistent pattern to start with.

| Button | → |
|---|---|
| Cancel (`border hover:bg-muted`) | `<Button variant="outline" size="sm">` |
| Connect / Save (`bg-primary`) | `<Button size="sm">` |

**Left bespoke, deliberately** (no clean primitive mapping):
- `BundleCredentialsModal`'s "Clear configuration" — a destructive **link** with a confirm-state color toggle (`ui/Button`'s `link` variant is primary-colored, not destructive).
- `OperatorSetupModal`'s inline "Copy" utility button.

So `ComposioApiKeyModal` is fully migrated; the other two keep exactly one bespoke button each (the custom ones) — which is the thesis in miniature.

## Verification
- `tsc` · `build` · `lint` (incl. `web/src`) · `test:web` **575/0** — all green
- Variant mapping derived from the bespoke classNames by **intent, not pixel-identity** (outline = border+hover:bg-muted; default = bg-primary). `size="sm"` is the design-system small button — slightly different metrics (h-7/12.8px vs the bespoke 12px, disabled:opacity-50 vs /60), as intended by adoption. Note: the `default` variant`s hover is anchor-scoped in the primitive (`[a]:hover`), so primary buttons don`t darken on hover until that design-system bug is fixed (1-line, separate)
- The `ui/Button` outline/default variants render cleanly — confirmed live via existing settings usage (the `+ Add a rule` outline button). The connector modals themselves are gated behind real configure/OAuth flows not reachable in dev, so I verified the shared primitive rather than each modal.

## Next slices (if the pattern looks right)
Settings dialogs, then other modals — same thesis, surface by surface. Custom surfaces (nav/chat/FAB) stay bespoke by design.
