### PR TITLE
web(ui): primary Button darkens on hover (not only as an anchor)

### DIFF
--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
Fixes the design-system bug QA surfaced on #558.

## The bug
The `default` Button variant scoped its hover to anchor elements:
```
default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80"
```
So a primary **`<button>`** (the overwhelming case) **never darkened on hover** — uniquely among the variants. Every other variant (`outline`, `ghost`, `secondary`, `destructive`, `warm`, `link`) hovers unconditionally on buttons. No rationale for "primary buttons alone don't hover"; it's an inconsistency.

This silently affected **every** primary `<Button>` in the app, and #558's adoption surfaced it — the connector-modal Save/Connect CTAs lost the hover-darken their bespoke versions had.

## The fix
Drop the `[a]:` scope — one line:
```
default: "bg-primary text-primary-foreground hover:bg-primary/80"
```
Kept at `/80`, the canonical primary-emphasis step (#546 standardized it; it's what every bespoke primary button used). So this *restores* the prior hover, now via the primitive, for #558's CTAs and the other ~7 default `<Button>` call sites.

## Verification
- Built CSS: the rule is now `.hover\:bg-primary\/80:hover{…}` (plain `:hover`, button-applicable); **0** anchor-scoped primary-hover rules remain
- `tsc` · `build` · `lint` · `test:web` **575/0** — green
- Purely additive (a hover style) — can't break functionality; affects only hover appearance of default Buttons (the intended correction)