### PR TITLE
web(connectors): adopt ui/Button for Browse/Detail action buttons (unification, slice 2)

### DIFF
--- a/web/src/pages/settings/ConnectorBrowsePage.tsx
+++ b/web/src/pages/settings/ConnectorBrowsePage.tsx
@@ -12,6 +12,7 @@ import {
 import { ComposioApiKeyModal } from "../../components/connectors/ComposioApiKeyModal";
 import { ConnectorIcon } from "../../components/connectors/ConnectorIcon";
 import { OperatorSetupModal } from "../../components/connectors/OperatorSetupModal";
+import { Button } from "../../components/ui/button";
 import { roleAtLeast, useScopedRole } from "../../hooks/useScopedRole";
 
 /**
@@ -363,9 +364,6 @@ function CardAction({
   // surfaces inside OperatorSetupModal, so the small `app.asana.com`
   // hint that used to live under each Set up button is intentionally
   // gone here.
-  const btnClass =
-    "text-xs px-3 py-1.5 rounded border border-border bg-background hover:bg-muted disabled:opacity-60";
-
   // Static-auth flow:
   //   - not configured + admin     → Set up
   //   - not configured + non-admin → "Operator setup required"
@@ -374,29 +372,29 @@ function CardAction({
     if (!operatorReady) {
       if (isWsAdmin) {
         return (
-          <button type="button" onClick={onSetUp} className={btnClass}>
+          <Button type="button" variant="outline" size="sm" onClick={onSetUp}>
             Set up
-          </button>
+          </Button>
         );
       }
       return <span className="text-xs text-muted-foreground">Operator setup required</span>;
     }
     return (
-      <button type="button" onClick={onInstall} disabled={busy} className={btnClass}>
+      <Button type="button" variant="outline" size="sm" onClick={onInstall} disabled={busy}>
         {busy ? "Installing…" : "Install"}
-      </button>
+      </Button>
     );
   }
   if (isMpakStub) {
     return (
-      <button type="button" onClick={onInstall} disabled={busy} className={btnClass}>
+      <Button type="button" variant="outline" size="sm" onClick={onInstall} disabled={busy}>
         {busy ? "Installing…" : "Install"}
-      </button>
+      </Button>
     );
   }
   return (
-    <button type="button" onClick={onInstall} disabled={busy} className={btnClass}>
+    <Button type="button" variant="outline" size="sm" onClick={onInstall} disabled={busy}>
       {busy ? "Installing…" : "Install"}
-    </button>
+    </Button>
   );
 }

--- a/web/src/pages/settings/ConnectorDetailPage.tsx
+++ b/web/src/pages/settings/ConnectorDetailPage.tsx
@@ -10,6 +10,7 @@ import { ConnectorStatusHero } from "../../components/connectors/ConnectorStatus
 import { OAuthConnectionSection } from "../../components/connectors/OAuthConnectionSection";
 import { OperatorOAuthSection } from "../../components/connectors/OperatorOAuthSection";
 import { ToolPermissionsTable } from "../../components/connectors/ToolPermissionsTable";
+import { Button } from "../../components/ui/button";
 import { roleAtLeast, useScopedRole } from "../../hooks/useScopedRole";
 
 /**
@@ -148,13 +149,14 @@ export function ConnectorDetailPage() {
             </a>
           )}
           {showHeaderConfigure && (
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="sm"
               onClick={() => setConfigureModalOpen(true)}
-              className="text-xs px-3 py-1.5 rounded border border-border bg-background hover:bg-muted"
             >
               Configure
-            </button>
+            </Button>
           )}
           {canManage && (
             <button


### PR DESCRIPTION
**Component-layer unification, slice 2.** The connector **Browse** and **Detail** pages (settings sub-pages). Same thesis as slice 1: *standard action buttons use the primitive; custom ones stay bespoke.*

Note: the settings *forms* are already largely on `<Button>` (10 of 13 files) — so the remaining clear action-button cluster in this area is the connector Browse/Detail pages.

## Changes
- **ConnectorBrowsePage** — the 4 Install / Set-up buttons shared a `btnClass` outline style → `<Button variant="outline" size="sm">`; dropped the now-unused `btnClass` const.
- **ConnectorDetailPage** — Configure → `<Button variant="outline" size="sm">`.

## Left bespoke (per the thesis)
`ConnectorDetailPage`'s **Uninstall** — a destructive text-link with a confirm-arm color toggle (`uninstallArmed` → `text-destructive`), the same custom pattern as the modal "Clear configuration" button left bespoke in slice 1.

## Verification — visual this time
Unlike slice 1's gated modals, the Browse page is **reachable in dev**:
- Navigated to it live → every "Install" button now renders as the `ui/Button` outline primitive (clean, consistent, correctly sized); the grid loads (the `isInstalled` `useCallback` works); **no console errors**.
- `tsc` · `build` · `lint` · `test:web` **575/0** — all green.

## Next
Slice 3: other modals / dialogs, then form inputs (`<input>` → `ui/Input`). Custom surfaces (nav/chat/FAB) stay bespoke throughout.