### PR TITLE
web(connectors): finish the detail-page action buttons (slice 2 follow-up)

### DIFF
--- a/web/src/components/connectors/ConnectorStatusHero.tsx
+++ b/web/src/components/connectors/ConnectorStatusHero.tsx
@@ -6,6 +6,7 @@ import {
   initiateComposioOAuth,
   initiateMcpOAuth,
 } from "../../api/client";
+import { Button } from "../ui/button";
 import { BundleCredentialsModal } from "./BundleCredentialsModal";
 import { ComposioApiKeyModal } from "./ComposioApiKeyModal";
 import { ConnectorIcon } from "./ConnectorIcon";
@@ -204,14 +205,16 @@ export function ConnectorStatusHero({
             </div>
           </div>
           {action && canManageAction(action, canManage) && (
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
               onClick={onPrimary}
               disabled={acting}
-              className="text-xs px-3 py-1.5 rounded border border-border bg-background hover:bg-muted disabled:opacity-60 shrink-0"
             >
               {acting ? "Working…" : action.label}
-            </button>
+            </Button>
           )}
         </div>
       )}

--- a/web/src/components/connectors/OperatorOAuthSection.tsx
+++ b/web/src/components/connectors/OperatorOAuthSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import type { DirectoryEntry, InstalledConnector } from "../../api/client";
+import { Button } from "../ui/button";
 import { OperatorSetupModal } from "./OperatorSetupModal";
 
 /**
@@ -78,13 +79,15 @@ export function OperatorOAuthSection({
           </div>
         </div>
         {canManage && (
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
             onClick={() => setEditing(true)}
-            className="text-xs px-3 py-1.5 rounded border border-border hover:bg-muted shrink-0"
           >
             Edit OAuth app
-          </button>
+          </Button>
         )}
       </div>
       {editing && (


### PR DESCRIPTION
Addresses the optional-polish item QA raised on #560 (merged before I could fold it in — so, a small follow-up).

## The orphan
`ConnectorStatusHero`'s primary CTA carried the **identical** retired `btnClass` outline shape, but it lives in a *child component* of `ConnectorDetailPage` — so slice 2 (which scoped to the two page files directly) missed it. By the thesis ("standard action buttons use the primitive") it qualifies, and my "Next" plan (modals → inputs) wouldn't have caught it. So it'd be orphaned — exactly as QA noted.

## This PR — finish the connector-detail surface
Swept *all* standard action buttons in the detail page's children, not just the one flagged:
- `ConnectorStatusHero` primary CTA → `<Button variant="outline" size="sm">`
- `OperatorOAuthSection` "Edit OAuth app" → `<Button variant="outline" size="sm">`

## Left bespoke (classified, per the thesis)
- `OAuthConnectionSection` **Disconnect** + `ConnectorDetailPage` **Uninstall** — destructive text-links with confirm-arm color toggles (same custom pattern as the modal "Clear" button).
- `ToolPermissionsTable` **Allow all / Disallow all** + per-row toggle — custom muted-link toggles (not standard actions; `link` variant is primary-colored, wrong fit).

## Result
**`rg 'text-xs px-3 py-1.5 rounded border border-border bg-background hover:bg-muted' web/src/{components/connectors,pages/settings}` → 0** — the `btnClass` action-button shape is fully retired.

## Verification
- `tsc` · `build` · `lint` · `test:web` **575/0**
- These buttons render on the detail page (gated behind an installed connector in dev), but they're the *same* `outline/sm` pattern visually confirmed on the reachable Browse page in #560 — and the hover fix (#559) is merged, so they darken on hover.