### PR TITLE
docs: require a closing keyword (Closes #N) when a PR resolves an issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,12 @@
 
 <!-- What does this change, and why? -->
 
+## Related issue
+
+<!-- If this PR resolves an issue, link it with a closing keyword so it auto-closes on merge, e.g. "Closes #123". Use "Related to #123" for issues this PR touches but doesn't fully resolve. Delete this section if neither applies. -->
+
 ## Checklist
 
+- [ ] Linked the resolved issue with a closing keyword (`Closes #N`), if this PR fixes one.
 - [ ] Updated `docs/` for any user- or operator-facing change (CLI, config, API, behavior). Docs live in this repo now — keep them in lockstep with the code.
 - [ ] Ran `bun run verify` (or the relevant subset).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ LLM evals (`test/eval/`) send real messages to Claude and assert on agent behavi
 
 - Keep PRs focused — one logical change per PR.
 - Describe *why* the change is needed, not just what it does.
-- Reference any related issues.
+- If the PR resolves an issue, link it with a closing keyword (`Closes #123`) so it auto-closes on merge. Use `Related to #123` for issues the PR touches but doesn't fully resolve.
 
 ## Reporting Issues
 


### PR DESCRIPTION
## Summary

Make issue auto-closing the default by documenting it in the two places contributors look: the PR template and CONTRIBUTING.

- **PR template** — adds a `Related issue` section (with a `Closes #123` example) and a checklist item.
- **CONTRIBUTING** — upgrades the vague "Reference any related issues" bullet to require a closing keyword for resolved issues, and `Related to #N` for issues a PR touches but does not fully resolve.

## Why

A triage sweep found a large share of open issues were already fixed but never closed — the fixes had landed under a different PR number or with no closing keyword, so GitHub never auto-closed the issue. This bakes the `Closes #N` habit into the contributor flow so the backlog stays honest.

## Related issue

None — process change.

## Checklist

- [x] Docs-only; no `docs/` (Astro) or code change, so `bun run verify` is not affected.