### PR TITLE
web(connectors): adopt the ui/Input primitive for credential fields

### DIFF
--- a/web/src/components/connectors/BundleCredentialsModal.tsx
+++ b/web/src/components/connectors/BundleCredentialsModal.tsx
@@ -6,6 +6,7 @@ import {
   setBundleUserConfig,
 } from "../../api/client";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 
 /**
  * Edit a stdio bundle's workspace `user_config` credentials, schema-
@@ -263,7 +264,7 @@ function BundleField({
   const inputType = field.sensitive ? "password" : "text";
   const label = field.title ?? fieldKey;
   return (
-    <label className="block">
+    <label className="block" htmlFor={`bundle-${fieldKey}`}>
       <span className="text-xs font-medium flex items-center gap-2">
         {label}
         {field.required && <span className="text-destructive">*</span>}
@@ -274,7 +275,8 @@ function BundleField({
       {field.description && (
         <span className="block text-2xs text-muted-foreground mt-0.5">{field.description}</span>
       )}
-      <input
+      <Input
+        id={`bundle-${fieldKey}`}
         ref={inputRef}
         type={inputType}
         value={value}
@@ -291,7 +293,7 @@ function BundleField({
         spellCheck={false}
         disabled={busy}
         placeholder={isPopulated ? "Leave blank to keep existing value" : ""}
-        className="mt-1 w-full text-sm font-mono px-2.5 py-1.5 rounded border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+        className="mt-1 font-mono"
       />
     </label>
   );

--- a/web/src/components/connectors/ComposioApiKeyModal.tsx
+++ b/web/src/components/connectors/ComposioApiKeyModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { type ComposioField, connectComposioApiKey } from "../../api/client";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 
 /**
  * Field-collection modal for a non-redirect (API-key) Composio connector.
@@ -113,12 +114,13 @@ export function ComposioApiKeyModal({
             browser's checkValidity pass, which we don't use.) */}
         <div className="mt-4 space-y-3">
           {fields.map((f, idx) => (
-            <label key={f.key} className="block">
+            <label key={f.key} className="block" htmlFor={`composio-${f.key}`}>
               <span className="text-xs font-medium">
                 {f.title}
                 {!isRequired(f) && <span className="text-muted-foreground"> (optional)</span>}
               </span>
-              <input
+              <Input
+                id={`composio-${f.key}`}
                 ref={idx === 0 ? firstFieldRef : undefined}
                 type={f.sensitive ? "password" : "text"}
                 value={values[f.key] ?? ""}
@@ -135,7 +137,7 @@ export function ComposioApiKeyModal({
                 spellCheck={false}
                 disabled={busy}
                 placeholder={f.placeholder}
-                className="mt-1 w-full text-sm font-mono px-2.5 py-1.5 rounded border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+                className="mt-1 font-mono"
               />
               {f.description && (
                 <span className="block text-2xs text-muted-foreground mt-1">{f.description}</span>

--- a/web/src/components/connectors/OperatorSetupModal.tsx
+++ b/web/src/components/connectors/OperatorSetupModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { type DirectoryEntry, getOAuthRedirectUri, setupConnectorOperator } from "../../api/client";
 import { safeHostname } from "../../lib/safe-url";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 
 /**
  * Workspace operator OAuth app setup. The form is the same whether
@@ -190,9 +191,10 @@ export function OperatorSetupModal({
         </ol>
 
         <form onSubmit={submit} className="mt-4 space-y-3">
-          <label className="block">
+          <label className="block" htmlFor="operator-client-id">
             <span className="text-xs font-medium">Client ID</span>
-            <input
+            <Input
+              id="operator-client-id"
               ref={firstFieldRef}
               type="text"
               value={clientId}
@@ -202,12 +204,13 @@ export function OperatorSetupModal({
               data-lpignore="true"
               spellCheck={false}
               disabled={busy}
-              className="mt-1 w-full text-sm font-mono px-2.5 py-1.5 rounded border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+              className="mt-1 font-mono"
             />
           </label>
-          <label className="block">
+          <label className="block" htmlFor="operator-client-secret">
             <span className="text-xs font-medium">Client Secret</span>
-            <input
+            <Input
+              id="operator-client-secret"
               type="password"
               value={clientSecret}
               onChange={(e) => setClientSecret(e.target.value)}
@@ -217,7 +220,7 @@ export function OperatorSetupModal({
               spellCheck={false}
               disabled={busy}
               placeholder={isEdit ? "Paste new secret to rotate" : ""}
-              className="mt-1 w-full text-sm font-mono px-2.5 py-1.5 rounded border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+              className="mt-1 font-mono"
             />
           </label>
           {error && <p className="text-xs text-destructive">{error}</p>}


### PR DESCRIPTION
## What

Migrate the last shell form-input sites still bypassing the design system — the connector **credential** fields — from bespoke `<input>` to the `ui/Input` primitive:

- `OperatorSetupModal` — Client ID + Client Secret (operator OAuth app setup)
- `ComposioApiKeyModal` — schema-driven API-key fields
- `BundleCredentialsModal` — stdio bundle `user_config` fields

Each previously carried the same ad-hoc class string (`w-full text-sm px-2.5 py-1.5 rounded border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60`). Routing through `ui/Input` single-sources the canonical focus ring, `border-input`, and disabled treatment. `font-mono` is preserved as the one deliberate per-field class (credentials read better monospaced).

Each field is now associated with its label explicitly via `htmlFor` + `id`, matching how the settings forms already pair `ui/Label` with `ui/Input`. The implicit label-wrapping these modals used is valid HTML but didn't expose the custom `Input` as the label's control to tooling (`a11y/noLabelWithoutControl`).

## Why

This closes the component-unification track on the form-input side. `<select>`/`<textarea>` have no bespoke shell sites left (only the primitives + the chat composer, which correctly stays bespoke). Remaining bespoke `<button>`/`<input>` are intentionally bespoke per the thesis (chat, nav, toggles, command palette, `type="search"` boxes).

## Scope notes

- **In scope:** connector credential/config fields only. `type="search"` boxes (ConnectorList, ConnectorBrowsePage), the command-palette and chat composer inputs, and the `ui/`-internal timezone-select input are distinct surfaces and stay bespoke.
- Pure primitive swap — no behavior change. All field props (`ref`, `type`, `value`, `onChange`, `onKeyDown`, `autoComplete`, `data-1p-ignore`/`data-lpignore`, `spellCheck`, `disabled`, `placeholder`) are forwarded unchanged.

## Verification

- `bun run check` (web tsc), `bun run build` (vite), root `bun run lint` (618 files), `bun run format:check`, `bun run test:web` (575/0) — all green.
- These three modals are install/OAuth-gated and not reachable in `dev:worktree`. Verified via the static gates + the `ui/Input` primitive's proven rendering on the reachable settings pages that already adopt it (ProfileTab, ModelTab, etc.) — consistent with how the connector slices (#558–#561) handled gated UI.