### PR TITLE
web(conversations): scope the conversation list to the focused room

### DIFF
--- a/src/bundles/conversations/src/index-cache.ts
+++ b/src/bundles/conversations/src/index-cache.ts
@@ -48,6 +48,10 @@ export interface ListOptions {
   sortBy?: "created" | "updated";
   dateFrom?: string; // ISO 8601
   dateTo?: string; // ISO 8601
+  /** Scope to one room. Applied before pagination so the limit applies to the room's set. */
+  workspaceId?: string;
+  /** With `workspaceId`, include roomless (legacy) entries — they belong to the personal room. */
+  includeUnstamped?: boolean;
 }
 
 /**
@@ -155,6 +159,18 @@ export class ConversationIndex {
     // reflects the caller's visible set, not the global one.
     if (access) {
       items = items.filter((e) => e.ownerId === access.userId);
+    }
+
+    // Room filter — scope to one workspace BEFORE pagination, so the limit
+    // applies to the room's set rather than slicing a global page and then
+    // dropping out-of-room entries (which under-counts a room whose chats
+    // aren't in the global most-recent page). A roomless (legacy) entry
+    // belongs to the personal room, so it's included only when the caller
+    // asks for it via `includeUnstamped` (set when the focused room is personal).
+    if (options?.workspaceId) {
+      const wsId = options.workspaceId;
+      const includeUnstamped = options.includeUnstamped ?? false;
+      items = items.filter((e) => (e.workspaceId ? e.workspaceId === wsId : includeUnstamped));
     }
 
     // Search filter: case-insensitive substring on title + preview

--- a/src/bundles/conversations/src/index-cache.ts
+++ b/src/bundles/conversations/src/index-cache.ts
@@ -33,6 +33,12 @@ export interface IndexEntry {
    * and the dispatcher treats `null` as inaccessible (no synthesis).
    */
   ownerId: string | null;
+  /**
+   * The room (workspace) the conversation ran in. `null` for legacy files
+   * with no stamped workspace — a consumer reads that as the owner's
+   * personal room. The room-scoped conversation list keys off this.
+   */
+  workspaceId: string | null;
 }
 
 export interface ListOptions {
@@ -230,6 +236,7 @@ export class ConversationIndex {
       preview: header.preview,
       filePath,
       ownerId: header.meta.ownerId ?? null,
+      workspaceId: header.meta.workspaceId ?? null,
     };
 
     this.entries.set(entry.id, entry);
@@ -262,6 +269,7 @@ export class ConversationIndex {
           preview: header.preview,
           filePath,
           ownerId: header.meta.ownerId ?? null,
+          workspaceId: header.meta.workspaceId ?? null,
         };
         this.entries.set(entry.id, entry);
         this.fileToId.set(filename, entry.id);

--- a/src/bundles/conversations/src/jsonl-reader.ts
+++ b/src/bundles/conversations/src/jsonl-reader.ts
@@ -26,6 +26,13 @@ export interface ConversationMeta {
   totalCostUsd: number;
   lastModel: string | null;
   ownerId?: string;
+  /**
+   * The room (workspace) the conversation ran in — the breadcrumb the
+   * runtime stamps on the line-1 header at create time. Absent on legacy
+   * files written before workspace stamping; a consumer treats absent as
+   * the owner's personal room.
+   */
+  workspaceId?: string;
 }
 
 /**
@@ -283,6 +290,7 @@ function parseMeta(raw: Record<string, unknown>): ConversationMeta | null {
     totalCostUsd: (raw.totalCostUsd as number) ?? 0,
     lastModel: (raw.lastModel as string | null) ?? null,
     ...(raw.ownerId ? { ownerId: raw.ownerId as string } : {}),
+    ...(raw.workspaceId ? { workspaceId: raw.workspaceId as string } : {}),
   };
 }
 

--- a/src/bundles/conversations/src/tools/list.ts
+++ b/src/bundles/conversations/src/tools/list.ts
@@ -15,6 +15,10 @@ export interface ListInput {
   sortBy?: "created" | "updated";
   dateFrom?: string;
   dateTo?: string;
+  /** Scope to one room. Applied before the limit so the page reflects the room's set. */
+  workspaceId?: string;
+  /** With `workspaceId`, also include roomless (legacy) chats — they belong to the personal room. */
+  includeUnstamped?: boolean;
 }
 
 export async function handleList(
@@ -30,6 +34,8 @@ export async function handleList(
       sortBy: input.sortBy,
       dateFrom: input.dateFrom,
       dateTo: input.dateTo,
+      workspaceId: input.workspaceId,
+      includeUnstamped: input.includeUnstamped,
     },
     access,
   );

--- a/src/bundles/conversations/ui/src/Dashboard.tsx
+++ b/src/bundles/conversations/ui/src/Dashboard.tsx
@@ -4,7 +4,7 @@ import { ConversationList } from "./ConversationList";
 import { groupByDate } from "./dateUtils";
 import { Header } from "./Header";
 import { SearchResults } from "./SearchResults";
-import type { FilterKey, ListResult, SearchResultData } from "./types";
+import type { FilterKey, ListResult, RoomScope, SearchResultData } from "./types";
 
 type View = "list" | "search";
 
@@ -13,7 +13,13 @@ export function Dashboard() {
   const action = useAction();
   // Conversations with an in-flight assistant turn in this tab — pushed by the
   // host via hostContext. Drives a live per-row streaming indicator.
-  const { streamingConversationIds } = useHostContext<{ streamingConversationIds?: string[] }>();
+  // `workspace` is the room the shell is focused on — the binding for the
+  // default room-scoped list. `streamingConversationIds` drives the live
+  // per-row indicator. Both are pushed by the host via hostContext.
+  const { streamingConversationIds, workspace } = useHostContext<{
+    streamingConversationIds?: string[];
+    workspace?: { id: string; name: string; isPersonal?: boolean };
+  }>();
   const streamingIds = useMemo(
     () => new Set(streamingConversationIds ?? []),
     [streamingConversationIds],
@@ -22,6 +28,9 @@ export function Dashboard() {
   const [view, setView] = useState<View>("list");
   const [conversations, setConversations] = useState<ListResult["conversations"]>([]);
   const [activeFilter, setActiveFilter] = useState<FilterKey>("all");
+  // Default to the focused room — the list matches where you are. "All rooms"
+  // is the deliberate cross-room escape hatch.
+  const [roomScope, setRoomScope] = useState<RoomScope>("current");
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResultData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -176,21 +185,31 @@ export function Dashboard() {
     [action],
   );
 
-  const groups = useMemo(
-    () => (loading ? [] : groupByDate(conversations)),
-    [loading, conversations],
-  );
+  // Scope the list to the focused room by default. A chat with no stamped
+  // room belongs to the personal room, so it shows only when the focused room
+  // IS personal. "All rooms" bypasses the filter for the cross-room view.
+  const roomScoped = useMemo(() => {
+    if (roomScope === "all" || !workspace) return conversations;
+    return conversations.filter((c) =>
+      c.workspaceId ? c.workspaceId === workspace.id : workspace.isPersonal === true,
+    );
+  }, [conversations, roomScope, workspace]);
+
+  const groups = useMemo(() => (loading ? [] : groupByDate(roomScoped)), [loading, roomScoped]);
   const isSearching = view === "search";
 
   return (
     <>
       <Header
-        totalCount={conversations.length}
+        totalCount={roomScoped.length}
         loading={loading}
         groups={groups}
         activeFilter={activeFilter}
         isSearching={isSearching}
         searchQuery={searchQuery}
+        roomName={workspace?.name}
+        roomScope={roomScope}
+        onSelectRoomScope={setRoomScope}
         onSelectFilter={handleSelectFilter}
         onSearchInput={handleSearchInput}
         onSearchSubmit={handleSearchSubmit}
@@ -210,7 +229,7 @@ export function Dashboard() {
             loading={loading}
             groups={groups}
             activeFilter={activeFilter}
-            totalConversations={conversations.length}
+            totalConversations={roomScoped.length}
             streamingIds={streamingIds}
             onOpen={handleOpenConversation}
           />

--- a/src/bundles/conversations/ui/src/Dashboard.tsx
+++ b/src/bundles/conversations/ui/src/Dashboard.tsx
@@ -11,11 +11,10 @@ type View = "list" | "search";
 export function Dashboard() {
   const synapse = useSynapse();
   const action = useAction();
-  // Conversations with an in-flight assistant turn in this tab — pushed by the
-  // host via hostContext. Drives a live per-row streaming indicator.
-  // `workspace` is the room the shell is focused on — the binding for the
-  // default room-scoped list. `streamingConversationIds` drives the live
-  // per-row indicator. Both are pushed by the host via hostContext.
+  // Both pushed by the host via hostContext: `workspace` is the room the shell
+  // is focused on (the binding for the default room-scoped list);
+  // `streamingConversationIds` are the chats with an in-flight assistant turn
+  // in this tab (drive the live per-row indicator).
   const { streamingConversationIds, workspace } = useHostContext<{
     streamingConversationIds?: string[];
     workspace?: { id: string; name: string; isPersonal?: boolean };
@@ -24,6 +23,10 @@ export function Dashboard() {
     () => new Set(streamingConversationIds ?? []),
     [streamingConversationIds],
   );
+  // Primitives (not the workspace object, whose identity churns per push) so the
+  // room-scoped `loadList` only re-runs when the room actually changes.
+  const roomId = workspace?.id;
+  const roomIsPersonal = workspace?.isPersonal === true;
 
   const [view, setView] = useState<View>("list");
   const [conversations, setConversations] = useState<ListResult["conversations"]>([]);
@@ -45,7 +48,15 @@ export function Dashboard() {
       if (!opts?.background) setLoading(true);
       setError(null);
       try {
-        const result = await synapse.callTool<Record<string, never>, ListResult>("list", {});
+        // Scope to the focused room server-side, so the limit applies to the
+        // room's set rather than slicing a global page we'd then filter down.
+        // "All rooms" omits the params; legacy roomless chats belong to the
+        // personal room, so include them only when the focused room is personal.
+        const args: { workspaceId?: string; includeUnstamped?: boolean } =
+          roomScope === "current" && roomId
+            ? { workspaceId: roomId, ...(roomIsPersonal ? { includeUnstamped: true } : {}) }
+            : {};
+        const result = await synapse.callTool<typeof args, ListResult>("list", args);
         if (result.isError) {
           setError("Failed to load conversations");
           return;
@@ -57,7 +68,7 @@ export function Dashboard() {
         if (!opts?.background) setLoading(false);
       }
     },
-    [synapse],
+    [synapse, roomScope, roomId, roomIsPersonal],
   );
 
   const runSearch = useCallback(
@@ -87,7 +98,8 @@ export function Dashboard() {
     [synapse],
   );
 
-  // Initial load
+  // Initial load — and reloads whenever the room scope or focused room
+  // changes, since `loadList` now carries the room params (it's in its deps).
   useEffect(() => {
     loadList();
   }, [loadList]);
@@ -185,23 +197,18 @@ export function Dashboard() {
     [action],
   );
 
-  // Scope the list to the focused room by default. A chat with no stamped
-  // room belongs to the personal room, so it shows only when the focused room
-  // IS personal. "All rooms" bypasses the filter for the cross-room view.
-  const roomScoped = useMemo(() => {
-    if (roomScope === "all" || !workspace) return conversations;
-    return conversations.filter((c) =>
-      c.workspaceId ? c.workspaceId === workspace.id : workspace.isPersonal === true,
-    );
-  }, [conversations, roomScope, workspace]);
-
-  const groups = useMemo(() => (loading ? [] : groupByDate(roomScoped)), [loading, roomScoped]);
+  // `conversations` is already room-scoped by the server (see `loadList`), so
+  // group it directly.
+  const groups = useMemo(
+    () => (loading ? [] : groupByDate(conversations)),
+    [loading, conversations],
+  );
   const isSearching = view === "search";
 
   return (
     <>
       <Header
-        totalCount={roomScoped.length}
+        totalCount={conversations.length}
         loading={loading}
         groups={groups}
         activeFilter={activeFilter}
@@ -229,7 +236,7 @@ export function Dashboard() {
             loading={loading}
             groups={groups}
             activeFilter={activeFilter}
-            totalConversations={roomScoped.length}
+            totalConversations={conversations.length}
             streamingIds={streamingIds}
             onOpen={handleOpenConversation}
           />

--- a/src/bundles/conversations/ui/src/Header.tsx
+++ b/src/bundles/conversations/ui/src/Header.tsx
@@ -1,5 +1,5 @@
 import { FILTER_GROUPS, FILTER_LABELS } from "./dateUtils";
-import type { DateGroup, FilterKey } from "./types";
+import type { DateGroup, FilterKey, RoomScope } from "./types";
 
 interface HeaderProps {
   totalCount: number;
@@ -8,6 +8,10 @@ interface HeaderProps {
   activeFilter: FilterKey;
   isSearching: boolean;
   searchQuery: string;
+  /** Display name of the focused room; absent until the host handshake lands. */
+  roomName?: string;
+  roomScope: RoomScope;
+  onSelectRoomScope: (scope: RoomScope) => void;
   onSelectFilter: (key: FilterKey) => void;
   onSearchInput: (value: string) => void;
   onSearchSubmit: () => void;
@@ -25,6 +29,9 @@ export function Header({
   activeFilter,
   isSearching,
   searchQuery,
+  roomName,
+  roomScope,
+  onSelectRoomScope,
   onSelectFilter,
   onSearchInput,
   onSearchSubmit,
@@ -34,7 +41,20 @@ export function Header({
 
   return (
     <div className="header">
-      <div className="header-title">Conversations</div>
+      <div className="header-top">
+        <div className="header-title">Conversations</div>
+        {roomName && (
+          <select
+            className="room-select"
+            value={roomScope}
+            onChange={(e) => onSelectRoomScope(e.target.value as RoomScope)}
+            aria-label="Scope conversations by room"
+          >
+            <option value="current">{roomName}</option>
+            <option value="all">All rooms</option>
+          </select>
+        )}
+      </div>
       {!loading && totalCount > 0 && (
         <div className="header-lede">
           You have {totalCount} conversation{totalCount === 1 ? "" : "s"}

--- a/src/bundles/conversations/ui/src/index.css
+++ b/src/bundles/conversations/ui/src/index.css
@@ -43,6 +43,34 @@ body {
   margin: 0 auto;
   width: 100%;
 }
+.header-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.room-select {
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  border: 1px solid var(--color-border-primary, #e5e5e5);
+  border-radius: var(--border-radius-sm, 6px);
+  background: var(--color-background-secondary, #ffffff);
+  color: var(--color-text-secondary, #737373);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  max-width: 160px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.room-select:hover {
+  border-color: var(--color-text-accent, #0055FF);
+  color: var(--color-text-accent, #0055FF);
+}
+.room-select:focus {
+  outline: none;
+  border-color: var(--color-text-accent, #0055FF);
+}
 .header-title {
   font-family: var(--nb-font-heading, Georgia, 'Times New Roman', serif);
   font-size: 22px;

--- a/src/bundles/conversations/ui/src/types.ts
+++ b/src/bundles/conversations/ui/src/types.ts
@@ -4,7 +4,19 @@ export interface ConversationSummary {
   preview?: string;
   createdAt?: string;
   updatedAt?: string;
+  /**
+   * The room (workspace) the conversation ran in. Absent on legacy chats
+   * with no stamped room — read as the owner's personal room.
+   */
+  workspaceId?: string | null;
 }
+
+/**
+ * Which room's chats the list shows. "current" scopes to the room the shell
+ * is focused on (the default — a chat list that matches where you are);
+ * "all" is the deliberate cross-room view.
+ */
+export type RoomScope = "current" | "all";
 
 export interface ListResult {
   conversations: ConversationSummary[];

--- a/src/tools/platform/schemas/conversations.ts
+++ b/src/tools/platform/schemas/conversations.ts
@@ -22,6 +22,18 @@ export const ConversationsListInput = Type.Object({
       description: "Filter: only conversations created on or before this ISO 8601 date.",
     }),
   ),
+  workspaceId: Type.Optional(
+    Type.String({
+      description:
+        "Filter: only conversations that ran in this room (workspace). Applied before the limit, so the page reflects the room's set. Omit for all rooms.",
+    }),
+  ),
+  includeUnstamped: Type.Optional(
+    Type.Boolean({
+      description:
+        "When workspaceId is set, also include conversations with no stamped room — legacy chats belong to the personal room. Default false.",
+    }),
+  ),
 });
 export type ConversationsListInput = Static<typeof ConversationsListInput>;
 

--- a/test/unit/bundles/conversations/index-cache.test.ts
+++ b/test/unit/bundles/conversations/index-cache.test.ts
@@ -17,6 +17,8 @@ interface ConvSpec {
 	totalInputTokens?: number;
 	totalOutputTokens?: number;
 	lastModel?: string | null;
+	ownerId?: string;
+	workspaceId?: string | null;
 	messages?: Array<{ role: string; content: string; timestamp: string }>;
 }
 
@@ -27,6 +29,8 @@ function writeConvFile(spec: ConvSpec): string {
 		updatedAt: spec.updatedAt,
 		title: spec.title,
 		lastModel: spec.lastModel ?? null,
+		...(spec.ownerId ? { ownerId: spec.ownerId } : {}),
+		...(spec.workspaceId ? { workspaceId: spec.workspaceId } : {}),
 	};
 
 	// Bundle no longer reads line-1 totals — attach the requested totals
@@ -283,6 +287,120 @@ describe("list search", () => {
 		const r4 = index.list({ search: "nonexistent" });
 		expect(r4.conversations).toHaveLength(0);
 		expect(r4.totalCount).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// list() — room (workspace) filtering
+// ---------------------------------------------------------------------------
+
+describe("list room filtering", () => {
+	// One owner's chats across two rooms, a roomless (legacy) chat, and another
+	// owner's chat in one of the rooms (to prove the room filter composes with
+	// the ownership filter).
+	async function buildRoomIndex(): Promise<ConversationIndex> {
+		writeConvFile({
+			id: "helix1",
+			createdAt: "2025-01-01T00:00:00.000Z",
+			updatedAt: "2025-01-01T00:00:00.000Z",
+			title: "Helix chat",
+			ownerId: "u1",
+			workspaceId: "ws_helix",
+			messages: [{ role: "user", content: "hi", timestamp: "2025-01-01T00:01:00.000Z" }],
+		});
+		writeConvFile({
+			id: "acme1",
+			createdAt: "2025-01-02T00:00:00.000Z",
+			updatedAt: "2025-01-02T00:00:00.000Z",
+			title: "Acme chat",
+			ownerId: "u1",
+			workspaceId: "ws_acme",
+			messages: [{ role: "user", content: "hi", timestamp: "2025-01-02T00:01:00.000Z" }],
+		});
+		writeConvFile({
+			id: "legacy1",
+			createdAt: "2025-01-03T00:00:00.000Z",
+			updatedAt: "2025-01-03T00:00:00.000Z",
+			title: "Roomless legacy chat",
+			ownerId: "u1",
+			// no workspaceId — belongs to the personal room
+			messages: [{ role: "user", content: "hi", timestamp: "2025-01-03T00:01:00.000Z" }],
+		});
+		writeConvFile({
+			id: "helix_other",
+			createdAt: "2025-01-04T00:00:00.000Z",
+			updatedAt: "2025-01-04T00:00:00.000Z",
+			title: "Another owner in Helix",
+			ownerId: "u2",
+			workspaceId: "ws_helix",
+			messages: [{ role: "user", content: "hi", timestamp: "2025-01-04T00:01:00.000Z" }],
+		});
+		const index = new ConversationIndex();
+		await index.build(TMP_DIR);
+		return index;
+	}
+
+	test("workspaceId scopes to that room, excluding other rooms and roomless chats", async () => {
+		const index = await buildRoomIndex();
+		const r = index.list({ workspaceId: "ws_helix" }, { userId: "u1" });
+		expect(r.conversations.map((c) => c.id)).toEqual(["helix1"]);
+		expect(r.totalCount).toBe(1);
+	});
+
+	test("includeUnstamped folds roomless (legacy) chats into the personal room", async () => {
+		const index = await buildRoomIndex();
+		const r = index.list({ workspaceId: "ws_user_u1", includeUnstamped: true }, { userId: "u1" });
+		expect(r.conversations.map((c) => c.id)).toEqual(["legacy1"]);
+	});
+
+	test("a non-personal room does not pick up roomless chats", async () => {
+		const index = await buildRoomIndex();
+		const r = index.list({ workspaceId: "ws_helix", includeUnstamped: false }, { userId: "u1" });
+		expect(r.conversations.map((c) => c.id)).toEqual(["helix1"]);
+	});
+
+	test("no workspaceId returns all of the owner's rooms", async () => {
+		const index = await buildRoomIndex();
+		const r = index.list({}, { userId: "u1" });
+		expect(r.conversations.map((c) => c.id).sort()).toEqual(["acme1", "helix1", "legacy1"]);
+	});
+
+	test("the room filter runs before the limit (no post-pagination under-count)", async () => {
+		// 25 Acme chats newer than one older Helix chat. A global most-recent
+		// page of 20 is all Acme, so post-pagination filtering would return the
+		// Helix room empty. Filtering server-side before the slice returns it.
+		for (let i = 0; i < 25; i++) {
+			const day = String(i + 1).padStart(2, "0");
+			writeConvFile({
+				id: `acme_${i}`,
+				createdAt: `2025-02-${day}T00:00:00.000Z`,
+				updatedAt: `2025-02-${day}T00:00:00.000Z`,
+				title: `Acme ${i}`,
+				ownerId: "u1",
+				workspaceId: "ws_acme",
+				messages: [{ role: "user", content: "hi", timestamp: `2025-02-${day}T00:01:00.000Z` }],
+			});
+		}
+		writeConvFile({
+			id: "helix_old",
+			createdAt: "2025-01-01T00:00:00.000Z",
+			updatedAt: "2025-01-01T00:00:00.000Z",
+			title: "Old Helix chat",
+			ownerId: "u1",
+			workspaceId: "ws_helix",
+			messages: [{ role: "user", content: "hi", timestamp: "2025-01-01T00:01:00.000Z" }],
+		});
+		const index = new ConversationIndex();
+		await index.build(TMP_DIR);
+
+		// The Helix chat is NOT in the global most-recent page of 20.
+		const globalPage = index.list({ limit: 20 }, { userId: "u1" });
+		expect(globalPage.conversations.map((c) => c.id)).not.toContain("helix_old");
+
+		// Room-scoped: the limit applies to Helix's set, so its chat is returned.
+		const helix = index.list({ limit: 20, workspaceId: "ws_helix" }, { userId: "u1" });
+		expect(helix.conversations.map((c) => c.id)).toEqual(["helix_old"]);
+		expect(helix.totalCount).toBe(1);
 	});
 });
 

--- a/web/src/_generated/platform-schemas/catalog.d.ts
+++ b/web/src/_generated/platform-schemas/catalog.d.ts
@@ -224,6 +224,8 @@ export declare const PlatformToolCatalog: {
                 sortBy: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"created" | "updated">>;
                 dateFrom: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
                 dateTo: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
+                workspaceId: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
+                includeUnstamped: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TBoolean>;
             }>;
         };
         readonly get: {

--- a/web/src/_generated/platform-schemas/conversations.d.ts
+++ b/web/src/_generated/platform-schemas/conversations.d.ts
@@ -10,6 +10,8 @@ export declare const ConversationsListInput: import("@sinclair/typebox").TObject
     sortBy: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TUnsafe<"created" | "updated">>;
     dateFrom: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
     dateTo: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
+    workspaceId: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TString>;
+    includeUnstamped: import("@sinclair/typebox").TOptional<import("@sinclair/typebox").TBoolean>;
 }>;
 export type ConversationsListInput = Static<typeof ConversationsListInput>;
 export declare const ConversationsGetInput: import("@sinclair/typebox").TObject<{

--- a/web/src/bridge/host-extensions.ts
+++ b/web/src/bridge/host-extensions.ts
@@ -17,7 +17,18 @@
 
 import { getThemeTokens } from "./theme";
 
-export type WorkspaceForHostContext = { id: string; name: string } | null;
+export type WorkspaceForHostContext = {
+  id: string;
+  name: string;
+  /**
+   * Whether the active room is the user's personal room. Apps that scope a
+   * view to the current room read this to fold legacy artifacts with no
+   * stamped room into Personal (absent room === personal, per the
+   * permission-boundaries spec). This is the app's OWN active room — not a
+   * roster of other rooms — so it crosses no wall.
+   */
+  isPersonal?: boolean;
+} | null;
 
 /**
  * Non-spec extension keys to merge into the `ui/initialize` hostContext
@@ -34,7 +45,13 @@ export function buildHostExtensions(
   streamingConversationIds: string[] = [],
 ): Record<string, unknown> {
   const ext: Record<string, unknown> = workspace
-    ? { workspace: { id: workspace.id, name: workspace.name } }
+    ? {
+        workspace: {
+          id: workspace.id,
+          name: workspace.name,
+          isPersonal: workspace.isPersonal ?? false,
+        },
+      }
     : {};
   if (forceRefresh) ext.forceRefresh = true;
   // Conversations with an in-flight assistant turn in this browser tab. Apps


### PR DESCRIPTION
## What

The conversations app rendered **every** chat the identity owns, across all rooms, with no room scoping — the undifferentiated "where did this run?" list. The runtime already walls each chat session to one workspace; the list should match.

This scopes the conversation list to the **focused room by default**, with a room selector at the panel head that toggles to **"All rooms"** for the deliberate cross-room view.

| Layer | Change |
|---|---|
| **conversations bundle** | Surface the `workspaceId` breadcrumb (already persisted on the JSONL line-1 header) through `ConversationMeta` → `IndexEntry` → the `list` result. Filter by room **server-side** in `ConversationIndex.list()` — beside the ownership filter, **before the limit** — via new `workspaceId` + `includeUnstamped` params on the `list` tool. |
| **host** | Include `isPersonal` on the active-room `hostContext.workspace` payload, so the app folds legacy chats with no stamped room into Personal. **The active room only** — no cross-room roster crosses the iframe boundary. |
| **ui** | Default room-scoped list + room selector (`{room} ▾` / `All rooms`); `loadList` passes the focused room (and `includeUnstamped` when it's personal) and reloads on scope/room change. Count lede and date buckets follow the active scope. |

## Behavior

- **In a room:** the list shows that room's chats. Because the filter runs before the limit, a room whose chats aren't in the global most-recent page still returns its set (no under-count).
- **"All rooms":** the full cross-room list (the previous behavior), now opt-in.
- Legacy chats with no stamped room show only when the focused room is Personal.
- Live `data.changed` refreshes and title updates respect the scope.

## Scope notes

- Pure presentation + a surfaced breadcrumb + a server-side filter — **no storage migration**, no change to where conversations live or how they're authorized (still owner-scoped identity tools).
- **Pre-migration deployments:** until `migrate-personal-workspaces` runs, `WorkspaceInfo.isPersonal` is `false` for every workspace, so legacy roomless chats match no scoped room and appear only under "All rooms". Acceptable degradation given the escape hatch; not a bug.
- **Search** stays cross-room for now (search results aren't room-tagged); the selector governs the list view. Follow-up.
- **Per-item room chips** in the All-rooms view are deferred to the next slice — they need the room roster, which must be gated so it reaches only first-party identity apps (not every sandboxed iframe).

## Verification

- `bun run verify` (format + lint + tsc + cycles + codegen + unit + web 575/0 + bundles) — green. Schema change regenerated via `bun run codegen`.
- New `list room filtering` unit tests (5 cases, incl. the pre-vs-post-pagination case). Conversations bundle `vite build` + UI `tsc` + web `vite build` — green.
- Bundle `dist/` is gitignored (rebuilt by the pipeline); source only here.