### PR TITLE
web(nav): room-centric sidebar — the room you're in is the parent

### DIFF
--- a/web/src/__tests__/current-room-nav.test.tsx
+++ b/web/src/__tests__/current-room-nav.test.tsx
@@ -1,0 +1,304 @@
+// ---------------------------------------------------------------------------
+// CurrentRoomNav — the room you're in, as the parent of its contents.
+//
+// Pins:
+//   1. The focused room renders as the current-room header; its identity
+//      views (Conversations / Automations / Files) + Connectors + its apps
+//      nest beneath it.
+//   2. Identity apps route top-level (`/conversations`); Connectors routes to
+//      the room's settings tab; apps route into `/w/<slug>/app/<route>`.
+//   3. When focused on a SHARED room, a compact Personal way-home row appears
+//      above it (and navigates to `/` on click). When focused on Personal,
+//      there is no separate home row — the header IS Personal.
+//   4. The app quick-list is capped at MAX_INLINE_APPS with a View-all
+//      overflow link to the room overview.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { realClient } from "../../test/setup";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let mockedActiveId: string | null = null;
+const setActiveSpy = mock((id: string | null) => {
+  if (mockedActiveId === id) return;
+  mockedActiveId = id;
+});
+
+mock.module("../api/client", () => ({
+  ...realClient,
+  setActiveWorkspaceId: setActiveSpy,
+  getActiveWorkspaceId: (): string | null => mockedActiveId,
+  callTool: mock(async () => ({ structuredContent: null, content: [] })),
+}));
+
+const React = await import("react");
+const ReactDOMClient = await import("react-dom/client");
+const { act } = await import("react");
+const { MemoryRouter, Route, Routes, useLocation } = await import("react-router-dom");
+const { WorkspaceProvider } = await import("../context/WorkspaceContext");
+const { ShellProvider } = await import("../context/ShellContext");
+const { CurrentRoomNav } = await import("../components/shell/CurrentRoomNav");
+
+import type { WorkspaceInfo } from "../context/WorkspaceContext";
+import type { PlacementEntry } from "../types";
+
+interface Mounted {
+  container: HTMLDivElement;
+  unmount(): void;
+  navigationTarget(): string;
+}
+
+let mounted: Mounted | null = null;
+let navTarget = "/";
+
+function NavigationProbe() {
+  const location = useLocation();
+  navTarget = location.pathname;
+  return null;
+}
+
+// Mirror useShell's forSlot: prefix-match `slot` + `slot.`, priority asc.
+function makeForSlot(placements: PlacementEntry[]) {
+  return (slot: string): PlacementEntry[] =>
+    placements
+      .filter((p) => p.slot === slot || p.slot.startsWith(`${slot}.`))
+      .sort((a, b) => a.priority - b.priority);
+}
+
+async function mount({
+  workspaces,
+  activeId,
+  initialPath = "/",
+  placements = [],
+}: {
+  workspaces: WorkspaceInfo[];
+  activeId?: string;
+  initialPath?: string;
+  placements?: PlacementEntry[];
+}): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  const root = ReactDOMClient.createRoot(container);
+  await act(async () => {
+    root.render(
+      <React.StrictMode>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <WorkspaceProvider initialWorkspaces={workspaces} initialActiveId={activeId}>
+            <NavigationProbe />
+            <ShellProvider
+              value={{
+                forSlot: makeForSlot(placements),
+                mainRoutes: () => [],
+                // The shell reflects the focused workspace; the app quick-list
+                // gates on shellWorkspaceId === focused.id.
+                shellWorkspaceId: activeId,
+              }}
+            >
+              <Routes>
+                <Route path="*" element={<CurrentRoomNav />} />
+              </Routes>
+            </ShellProvider>
+          </WorkspaceProvider>
+        </MemoryRouter>
+      </React.StrictMode>,
+    );
+  });
+
+  return {
+    container,
+    unmount() {
+      act(() => root.unmount());
+      container.remove();
+    },
+    navigationTarget: () => navTarget,
+  };
+}
+
+beforeEach(() => {
+  mockedActiveId = null;
+  setActiveSpy.mockClear();
+  navTarget = "/";
+});
+
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+});
+
+function ws(overrides: Partial<WorkspaceInfo> & { id: string; name: string }): WorkspaceInfo {
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    bundles: [],
+    memberCount: 1,
+    isPersonal: overrides.isPersonal ?? false,
+    userRole: overrides.userRole ?? "admin",
+    ...overrides,
+  };
+}
+
+function identityPlacement(serverName: string, priority: number): PlacementEntry {
+  return {
+    serverName,
+    slot: "sidebar",
+    resourceUri: `ui://${serverName}/main`,
+    priority,
+    label: serverName[0]!.toUpperCase() + serverName.slice(1),
+    route: serverName,
+  };
+}
+
+function appPlacement(serverName: string, over: Partial<PlacementEntry> = {}): PlacementEntry {
+  return {
+    serverName,
+    slot: "sidebar.apps",
+    resourceUri: `ui://${serverName}/main`,
+    priority: 100,
+    label: serverName,
+    route: serverName,
+    ...over,
+  };
+}
+
+const IDENTITY_PLACEMENTS: PlacementEntry[] = [
+  identityPlacement("conversations", 1),
+  identityPlacement("automations", 2),
+  identityPlacement("files", 3),
+];
+
+function byTestId(container: HTMLElement, testid: string): HTMLElement[] {
+  return Array.from(container.getElementsByTagName("*")).filter(
+    (el) => el.getAttribute("data-testid") === testid,
+  ) as HTMLElement[];
+}
+
+function anchorHrefs(container: HTMLElement): string[] {
+  return Array.from(container.getElementsByTagName("a")).map((a) => a.getAttribute("href") ?? "");
+}
+
+const PERSONAL = ws({ id: "ws_user_u1", name: "Personal", isPersonal: true });
+const HELIX = ws({ id: "ws_helix", name: "Helix" });
+
+// ---------------------------------------------------------------------------
+// (1) Focused on Personal (home)
+// ---------------------------------------------------------------------------
+
+describe("CurrentRoomNav — focused on Personal (home)", () => {
+  test("renders the Personal header (no separate home row) + nested identity views", async () => {
+    mounted = await mount({
+      workspaces: [PERSONAL, HELIX],
+      activeId: "ws_user_u1",
+      placements: IDENTITY_PLACEMENTS,
+    });
+
+    // Exactly one room header — the Personal header — and it's the focused one.
+    const headers = byTestId(mounted.container, "sidebar-room-header");
+    expect(headers).toHaveLength(1);
+    expect(headers[0]?.getAttribute("data-room-id")).toBe("ws_user_u1");
+    expect(headers[0]?.getAttribute("data-focused")).toBe("true");
+    expect(headers[0]?.textContent).toContain("Personal");
+
+    // Identity views route top-level, and Connectors routes to the room's
+    // settings tab (toSlug strips `ws_`: ws_user_u1 → user_u1).
+    const hrefs = anchorHrefs(mounted.container);
+    expect(hrefs).toContain("/conversations");
+    expect(hrefs).toContain("/automations");
+    expect(hrefs).toContain("/files");
+    expect(hrefs).toContain("/w/user_u1/settings/connectors");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) Focused on a shared room
+// ---------------------------------------------------------------------------
+
+describe("CurrentRoomNav — focused on a shared room", () => {
+  test("shows a Personal way-home row above the focused room, and the room's apps nest under it", async () => {
+    mounted = await mount({
+      workspaces: [PERSONAL, HELIX],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      placements: [...IDENTITY_PLACEMENTS, appPlacement("people"), appPlacement("tasks")],
+    });
+
+    // Two headers: the Personal way-home row + the focused Helix header.
+    const headers = byTestId(mounted.container, "sidebar-room-header");
+    const byId = Object.fromEntries(headers.map((h) => [h.getAttribute("data-room-id"), h]));
+    expect(byId["ws_user_u1"]?.getAttribute("data-focused")).toBe("false");
+    expect(byId["ws_helix"]?.getAttribute("data-focused")).toBe("true");
+
+    // Helix's apps nest under it, routed into the room.
+    const appRows = byTestId(mounted.container, "sidebar-room-app");
+    expect(appRows.map((r) => r.getAttribute("data-app-route")).sort()).toEqual([
+      "people",
+      "tasks",
+    ]);
+    expect(anchorHrefs(mounted.container)).toContain("/w/helix/app/people");
+    // Connectors is the focused room's.
+    expect(anchorHrefs(mounted.container)).toContain("/w/helix/settings/connectors");
+  });
+
+  test("clicking the Personal way-home row navigates home (/) and focuses Personal", async () => {
+    mounted = await mount({
+      workspaces: [PERSONAL, HELIX],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      placements: IDENTITY_PLACEMENTS,
+    });
+    setActiveSpy.mockClear();
+
+    const homeRow = byTestId(mounted.container, "sidebar-room-header").find(
+      (h) => h.getAttribute("data-room-id") === "ws_user_u1",
+    ) as HTMLButtonElement | undefined;
+    await act(async () => {
+      homeRow?.click();
+    });
+
+    expect(setActiveSpy).toHaveBeenCalledTimes(1);
+    expect(setActiveSpy.mock.calls[0]?.[0]).toBe("ws_user_u1");
+    expect(mounted.navigationTarget()).toBe("/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3) App quick-list cap + overflow
+// ---------------------------------------------------------------------------
+
+describe("CurrentRoomNav — app quick-list", () => {
+  test("caps apps at MAX_INLINE_APPS with a View-all overflow link to the room overview", async () => {
+    mounted = await mount({
+      workspaces: [HELIX],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      placements: [
+        appPlacement("collateral", { priority: 10 }),
+        appPlacement("salesforce", { priority: 20 }),
+        appPlacement("apollo", { priority: 30 }),
+        appPlacement("gong", { priority: 40 }),
+        appPlacement("knowledge", { priority: 50 }),
+      ],
+    });
+
+    // 5 installed, capped at 4 shown.
+    expect(byTestId(mounted.container, "sidebar-room-app")).toHaveLength(4);
+
+    const viewAll = byTestId(mounted.container, "sidebar-room-view-all");
+    expect(viewAll).toHaveLength(1);
+    expect(viewAll[0]?.textContent).toContain("View all 5 apps");
+    expect(viewAll[0]?.getAttribute("href")).toBe("/w/helix/");
+  });
+
+  test("no overflow link when apps fit within the cap", async () => {
+    mounted = await mount({
+      workspaces: [HELIX],
+      activeId: "ws_helix",
+      initialPath: "/w/helix/",
+      placements: [appPlacement("collateral"), appPlacement("salesforce")],
+    });
+
+    expect(byTestId(mounted.container, "sidebar-room-app")).toHaveLength(2);
+    expect(byTestId(mounted.container, "sidebar-room-view-all")).toHaveLength(0);
+  });
+});

--- a/web/src/__tests__/workspace-section.test.tsx
+++ b/web/src/__tests__/workspace-section.test.tsx
@@ -1,18 +1,17 @@
 // ---------------------------------------------------------------------------
-// WorkspaceSection — load-bearing UI contract.
+// WorkspaceSection — load-bearing UI contract (the OTHER rooms).
 //
-// Four pins:
-//   1. Renders the user's workspaces in personal-first then shared
-//      alphabetical order.
-//   2. The active marker follows the ROUTE: a workspace row is active
-//      only on `/w/<slug>/...`; on global routes (`/`, `/conversations`)
-//      no workspace row is active (it must not double-light with Home).
-//   3. Cross-workspace click fires `setActiveWorkspaceId` exactly once;
-//      re-clicking the active workspace's row is a no-op for the
-//      setter (T009 equality guard). Topology pin — a regression that
-//      lost the guard would silently invalidate the REST cache on
-//      every click.
-//   4. Click navigates to `/w/<slug>/`.
+// The focused room and the Personal room are shown above in CurrentRoomNav;
+// this list is every other room. Pins:
+//   1. Lists the OTHER rooms only — Personal (home) and the focused room
+//      (promoted into the current-room section) are excluded — alphabetically.
+//   2. Clicking a row fires `setActiveWorkspaceId` exactly once — always a
+//      cross-room switch, since the focused room is never in this list — and
+//      navigates to `/w/<slug>/`.
+//   3. The `+ add workspace` affordance is present.
+//
+// The focused room's apps + the active-route highlight moved to CurrentRoomNav
+// (see current-room-nav.test.tsx).
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -48,10 +47,8 @@ const { act } = await import("react");
 const { MemoryRouter, Route, Routes, useLocation } = await import("react-router-dom");
 const { WorkspaceProvider } = await import("../context/WorkspaceContext");
 const { WorkspaceSection } = await import("../components/shell/WorkspaceSection");
-const { ShellProvider } = await import("../context/ShellContext");
 
 import type { WorkspaceInfo } from "../context/WorkspaceContext";
-import type { PlacementEntry } from "../types";
 
 interface Mounted {
   container: HTMLDivElement;
@@ -68,35 +65,17 @@ function NavigationProbe() {
   return null;
 }
 
-// Mirror useShell's forSlot: prefix-match `slot` + `slot.`, priority asc.
-function makeForSlot(placements: PlacementEntry[]) {
-  return (slot: string): PlacementEntry[] =>
-    placements
-      .filter((p) => p.slot === slot || p.slot.startsWith(`${slot}.`))
-      .sort((a, b) => a.priority - b.priority);
-}
-
 async function mount({
   workspaces,
   activeId,
   initialPath = "/",
-  placements,
 }: {
   workspaces: WorkspaceInfo[];
   activeId?: string;
   initialPath?: string;
-  /** When provided, wrap in a ShellProvider so the inline app quick-list
-   *  has placements to render. Omit to exercise the null-shell path. */
-  placements?: PlacementEntry[];
 }): Promise<Mounted> {
   const container = document.createElement("div");
   document.body.appendChild(container);
-
-  const routes = (
-    <Routes>
-      <Route path="*" element={<WorkspaceSection />} />
-    </Routes>
-  );
 
   const root = ReactDOMClient.createRoot(container);
   await act(async () => {
@@ -105,21 +84,9 @@ async function mount({
         <MemoryRouter initialEntries={[initialPath]}>
           <WorkspaceProvider initialWorkspaces={workspaces} initialActiveId={activeId}>
             <NavigationProbe />
-            {placements ? (
-              <ShellProvider
-                value={{
-                  forSlot: makeForSlot(placements),
-                  mainRoutes: () => [],
-                  // The shell reflects the focused (active) workspace; the
-                  // inline app list gates on shellWorkspaceId === workspaceId.
-                  shellWorkspaceId: activeId,
-                }}
-              >
-                {routes}
-              </ShellProvider>
-            ) : (
-              routes
-            )}
+            <Routes>
+              <Route path="*" element={<WorkspaceSection />} />
+            </Routes>
           </WorkspaceProvider>
         </MemoryRouter>
       </React.StrictMode>,
@@ -178,20 +145,38 @@ function findRow(container: HTMLElement, wsId: string): HTMLButtonElement | null
 // ---------------------------------------------------------------------------
 
 describe("WorkspaceSection — render + ordering", () => {
-  test("renders the user's workspaces in personal-first then shared alphabetical order", async () => {
+  test("lists the OTHER rooms only — Personal excluded — alphabetically", async () => {
     mounted = await mount({
       workspaces: [
         ws({ id: "ws_helix", name: "Helix" }),
         ws({ id: "ws_user_u1", name: "Personal", isPersonal: true }),
         ws({ id: "ws_acme", name: "Acme" }),
       ],
-      activeId: "ws_user_u1",
+      activeId: "ws_user_u1", // focused on Personal (home)
     });
 
     const ids = findAllByTestId(mounted.container, "sidebar-workspace-row").map((r) =>
       r.getAttribute("data-workspace-id"),
     );
-    expect(ids).toEqual(["ws_user_u1", "ws_acme", "ws_helix"]);
+    // Personal is home (shown in CurrentRoomNav); the rest are alphabetical.
+    expect(ids).toEqual(["ws_acme", "ws_helix"]);
+  });
+
+  test("excludes the focused room — it's promoted into the current-room section", async () => {
+    mounted = await mount({
+      workspaces: [
+        ws({ id: "ws_user_u1", name: "Personal", isPersonal: true }),
+        ws({ id: "ws_helix", name: "Helix" }),
+        ws({ id: "ws_acme", name: "Acme" }),
+      ],
+      activeId: "ws_helix", // focused on Helix
+    });
+
+    const ids = findAllByTestId(mounted.container, "sidebar-workspace-row").map((r) =>
+      r.getAttribute("data-workspace-id"),
+    );
+    // Helix promoted out, Personal is home → only Acme remains.
+    expect(ids).toEqual(["ws_acme"]);
   });
 
   test("renders the `+ add workspace` affordance", async () => {
@@ -205,257 +190,32 @@ describe("WorkspaceSection — render + ordering", () => {
 });
 
 // ---------------------------------------------------------------------------
-// (2) Active workspace marker
+// (2) Selection + navigation
 // ---------------------------------------------------------------------------
 
-describe("WorkspaceSection — active state (route-driven)", () => {
-  test("on /w/<slug>/, only that workspace row is active", async () => {
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    const personal = ws({ id: "ws_user_u1", name: "Personal", isPersonal: true });
-
-    // The persisted active workspace (tool-scoping) is personal, but the
-    // ROUTE is helix's overview. The highlight must follow the route.
-    mounted = await mount({
-      workspaces: [personal, helix],
-      activeId: "ws_user_u1",
-      initialPath: "/w/helix/",
-    });
-
-    expect(findRow(mounted.container, "ws_helix")?.getAttribute("data-is-active")).toBe("true");
-    expect(findRow(mounted.container, "ws_user_u1")?.getAttribute("data-is-active")).toBe("false");
-
-    // Exactly one active row at a time.
-    const allActive = findAllByTestId(mounted.container, "sidebar-workspace-row").filter(
-      (r) => r.getAttribute("data-is-active") === "true",
-    );
-    expect(allActive).toHaveLength(1);
-  });
-
-  test("on a global route (/), NO workspace row is active even with a persisted active workspace", async () => {
-    // Regression pin for the two-active-links bug: `activeWorkspace` is
-    // always set (it scopes tool dispatch), so a state-based highlight lit
-    // a workspace row while Home was simultaneously active. On global
-    // routes the workspace section must show zero active rows.
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    const personal = ws({ id: "ws_user_u1", name: "Personal", isPersonal: true });
-
-    mounted = await mount({
-      workspaces: [personal, helix],
-      activeId: "ws_helix",
-      initialPath: "/",
-    });
-
-    const allActive = findAllByTestId(mounted.container, "sidebar-workspace-row").filter(
-      (r) => r.getAttribute("data-is-active") === "true",
-    );
-    expect(allActive).toHaveLength(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// (3) Click topology — equality-guard pin
-// ---------------------------------------------------------------------------
-
-describe("WorkspaceSection — selection topology (equality guard)", () => {
-  test("cross-workspace click fires setActiveWorkspaceId once; re-click on active is a no-op (T009 equality guard)", async () => {
+describe("WorkspaceSection — selection + navigation", () => {
+  test("clicking a room fires setActiveWorkspaceId once and navigates to /w/<slug>/", async () => {
+    // A row here is always a non-focused room, so a click is always a
+    // cross-room switch — the setter fires exactly once (T009: the api/client
+    // equality guard never suppresses a real change).
     const personal = ws({ id: "ws_user_u1", name: "Personal", isPersonal: true });
     const helix = ws({ id: "ws_helix", name: "Helix" });
+    const acme = ws({ id: "ws_acme", name: "Acme" });
+    mounted = await mount({ workspaces: [personal, helix, acme], activeId: "ws_user_u1" });
 
-    mounted = await mount({ workspaces: [personal, helix], activeId: "ws_user_u1" });
-
-    // Baseline: mount-time fired setActiveWorkspaceId once (the initial
-    // active id). Reset so the test asserts only what happens on clicks.
+    // Baseline: mount fired the setter once (the initial active id). Reset so
+    // the test asserts only the click.
     setActiveSpy.mockClear();
 
-    // Click helix — cross-workspace click MUST fire the setter exactly once.
     const helixRow = findRow(mounted.container, "ws_helix");
     await act(async () => {
       helixRow?.click();
     });
+
     expect(setActiveSpy).toHaveBeenCalledTimes(1);
     expect(setActiveSpy.mock.calls[0]?.[0]).toBe("ws_helix");
     expect(mockedGetActiveWorkspaceId()).toBe("ws_helix");
-
-    // Click the SAME row again. The React-layer equality guard in
-    // WorkspaceSection.handleSelect catches this and never calls
-    // setActiveWorkspace, so the setter spy count stays at 1.
-    // Regression this pins: "every row click fires the setter."
-    await act(async () => {
-      helixRow?.click();
-    });
-    expect(setActiveSpy).toHaveBeenCalledTimes(1);
-
-    // Cross-workspace click again — back to personal — fires once more.
-    const personalRow = findRow(mounted.container, "ws_user_u1");
-    await act(async () => {
-      personalRow?.click();
-    });
-    expect(setActiveSpy).toHaveBeenCalledTimes(2);
-    expect(setActiveSpy.mock.calls[1]?.[0]).toBe("ws_user_u1");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// (4) Navigation contract
-// ---------------------------------------------------------------------------
-
-describe("WorkspaceSection — navigation", () => {
-  test("clicking a workspace row navigates to /w/<slug>/", async () => {
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    mounted = await mount({
-      workspaces: [ws({ id: "ws_user_u1", name: "Personal", isPersonal: true }), helix],
-      activeId: "ws_user_u1",
-    });
-
-    const helixRow = findRow(mounted.container, "ws_helix");
-    await act(async () => {
-      helixRow?.click();
-    });
     // toSlug strips the `ws_` prefix: "ws_helix" → "helix".
     expect(mounted.navigationTarget()).toBe("/w/helix/");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// (5) Inline app quick-list
-// ---------------------------------------------------------------------------
-
-function appPlacement(serverName: string, over: Partial<PlacementEntry> = {}): PlacementEntry {
-  return {
-    serverName,
-    slot: "sidebar.apps",
-    resourceUri: `ui://${serverName}/main`,
-    priority: 100,
-    label: serverName,
-    route: serverName,
-    ...over,
-  };
-}
-
-function appRows(container: HTMLElement): HTMLAnchorElement[] {
-  return findAllByTestId(container, "sidebar-workspace-app") as unknown as HTMLAnchorElement[];
-}
-
-describe("WorkspaceSection — inline app quick-list", () => {
-  test("renders the focused workspace's apps, capped at MAX_INLINE_APPS, with a View-all overflow link", async () => {
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    mounted = await mount({
-      workspaces: [ws({ id: "ws_user_u1", name: "Personal", isPersonal: true }), helix],
-      activeId: "ws_helix",
-      initialPath: "/w/helix/",
-      placements: [
-        appPlacement("collateral", { priority: 10 }),
-        appPlacement("salesforce", { priority: 20 }),
-        appPlacement("apollo", { priority: 30 }),
-        appPlacement("gong", { priority: 40 }),
-        appPlacement("knowledge", { priority: 50 }),
-      ],
-    });
-
-    // 5 apps installed, capped at 4 shown.
-    expect(appRows(mounted.container)).toHaveLength(4);
-    // Container reports the true (uncapped) count for the overflow copy.
-    const group = findAllByTestId(mounted.container, "sidebar-workspace-apps");
-    expect(group).toHaveLength(1);
-    expect(group[0]?.getAttribute("data-app-count")).toBe("5");
-
-    const viewAll = findAllByTestId(mounted.container, "sidebar-workspace-view-all");
-    expect(viewAll).toHaveLength(1);
-    expect(viewAll[0]?.textContent).toContain("View all 5 apps");
-    expect(viewAll[0]?.getAttribute("href")).toBe("/w/helix/");
-  });
-
-  test("no overflow link when apps fit within the cap", async () => {
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    mounted = await mount({
-      workspaces: [helix],
-      activeId: "ws_helix",
-      initialPath: "/w/helix/",
-      placements: [appPlacement("collateral"), appPlacement("salesforce")],
-    });
-
-    expect(appRows(mounted.container)).toHaveLength(2);
-    expect(findAllByTestId(mounted.container, "sidebar-workspace-view-all")).toHaveLength(0);
-  });
-
-  test("inline apps render only under the focused workspace", async () => {
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    const personal = ws({ id: "ws_user_u1", name: "Personal", isPersonal: true });
-    mounted = await mount({
-      workspaces: [personal, helix],
-      activeId: "ws_helix",
-      initialPath: "/w/helix/",
-      placements: [appPlacement("collateral")],
-    });
-
-    // Exactly one app group, and it sits under the focused (active) row.
-    expect(findAllByTestId(mounted.container, "sidebar-workspace-apps")).toHaveLength(1);
-  });
-
-  test("each app links into /w/<slug>/app/<route>", async () => {
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    mounted = await mount({
-      workspaces: [helix],
-      activeId: "ws_helix",
-      initialPath: "/w/helix/",
-      placements: [appPlacement("collateral", { route: "@nb/collateral", label: "Collateral" })],
-    });
-
-    const [row] = appRows(mounted.container);
-    expect(row?.getAttribute("data-app-route")).toBe("@nb/collateral");
-    expect(row?.getAttribute("href")?.startsWith("/w/helix/app/")).toBe(true);
-  });
-
-  test("the app matching the current route is marked active", async () => {
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    mounted = await mount({
-      workspaces: [helix],
-      activeId: "ws_helix",
-      initialPath: "/w/helix/app/salesforce",
-      placements: [
-        appPlacement("collateral", { priority: 10 }),
-        appPlacement("salesforce", { priority: 20 }),
-      ],
-    });
-
-    const active = appRows(mounted.container).filter(
-      (r) => r.getAttribute("data-is-active") === "true",
-    );
-    expect(active).toHaveLength(1);
-    expect(active[0]?.getAttribute("data-app-route")).toBe("salesforce");
-  });
-
-  test("active highlight is exact — a route that is a string prefix of the current one stays inactive", async () => {
-    // Regression pin: `crm` is a string prefix of `crm-archive`. A
-    // startsWith match would light BOTH rows when viewing crm-archive.
-    // App routes are leaf paths, so the match must be exact.
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    mounted = await mount({
-      workspaces: [helix],
-      activeId: "ws_helix",
-      initialPath: "/w/helix/app/crm-archive",
-      placements: [
-        appPlacement("crm", { priority: 10 }),
-        appPlacement("crm-archive", { priority: 20 }),
-      ],
-    });
-
-    const active = appRows(mounted.container).filter(
-      (r) => r.getAttribute("data-is-active") === "true",
-    );
-    expect(active).toHaveLength(1);
-    expect(active[0]?.getAttribute("data-app-route")).toBe("crm-archive");
-  });
-
-  test("renders nothing when the shell has no placements (null-shell path)", async () => {
-    const helix = ws({ id: "ws_helix", name: "Helix" });
-    mounted = await mount({
-      workspaces: [helix],
-      activeId: "ws_helix",
-      initialPath: "/w/helix/",
-      // no `placements` → no ShellProvider → useShellContext() is null
-    });
-
-    expect(findAllByTestId(mounted.container, "sidebar-workspace-apps")).toHaveLength(0);
   });
 });

--- a/web/src/components/ShellLayout.tsx
+++ b/web/src/components/ShellLayout.tsx
@@ -16,19 +16,10 @@ import { Logo } from "./Logo";
 import { MobileSidebarDrawer } from "./MobileSidebarDrawer";
 import { ReleaseUpdateBanner } from "./ReleaseUpdateBanner";
 import { SidebarToggle } from "./SidebarToggle";
+import { CurrentRoomNav } from "./shell/CurrentRoomNav";
 import { SidebarSearch } from "./shell/SidebarSearch";
 import { WorkspaceSection } from "./shell/WorkspaceSection";
 import { UserMenu } from "./UserMenu";
-
-/**
- * Priority threshold for core sidebar items. Items in the bare
- * "sidebar" slot with priority < 10 render as ungrouped core nav
- * (Home, Conversations, Automations, Files). Priority >= 10 items —
- * historically the "Apps" sub-slot group at the bottom of the sidebar —
- * are no longer rendered here; apps live on the workspace overview
- * page (`/w/<slug>/`) instead.
- */
-const UNGROUPED_PRIORITY_THRESHOLD = 10;
 
 interface ShellLayoutProps {
   forSlot: (slot: string) => PlacementEntry[];
@@ -47,14 +38,11 @@ interface ShellLayoutProps {
  * Sidebar zones (top → bottom):
  *   1. Identity (UserMenu)
  *   2. Search stub (⌘P)
- *   3. Core nav: Home, Conversations, Automations, Files (global,
- *      identity-bound, cross-workspace)
- *   4. WORKSPACES section — workspaces are a sibling category to the
- *      core nav, not a parent column. Click a workspace row =
- *      navigate to its overview at `/w/<slug>/`. No inline apps.
- *
- * The former bottom "APPS" group is gone — apps surface on each
- * workspace's overview page now.
+ *   3. Current-room section (`CurrentRoomNav`) — the room you're in is the
+ *      parent: its Conversations / Automations / Files / Connectors + its
+ *      apps nest under it. Home = Personal.
+ *   4. WORKSPACES section — the OTHER rooms. Click one to focus it; it
+ *      promotes into the current-room section above.
  */
 // Chat panel transition timings — kept in lockstep with `ChatChrome` so
 // the main content's marginRight slides in sync with the panel itself.
@@ -85,14 +73,6 @@ export const ShellLayout = memo(function ShellLayout({
   const mainMarginRight =
     chatIsSidebar && !isMobile ? chatPanel.panelWidth + CHAT_RESIZE_HANDLE_WIDTH : 0;
 
-  // Ungrouped core items: bare "sidebar" slot with priority < threshold.
-  // Grouped items (formerly the bottom "APPS" group, sourced from
-  // `sidebar.<group>` sub-slots) are no longer rendered in the sidebar —
-  // apps live on the workspace overview page (`/w/<slug>/`) now.
-  const ungrouped = forSlot("sidebar").filter(
-    (p) => p.slot === "sidebar" && p.priority < UNGROUPED_PRIORITY_THRESHOLD,
-  );
-
   // Sidebar bottom items: pinned to bottom, excluding settings (now in workspace dropdown)
   const sidebarBottom = forSlot("sidebar.bottom").filter((p) => p.route !== "settings");
 
@@ -117,31 +97,16 @@ export const ShellLayout = memo(function ShellLayout({
               session). Hidden when the sidebar is collapsed to icon-only. */}
           {!isCollapsed && <SidebarSearch />}
 
-          {/* Scrolling region. The nav is identity-level — the same Home /
-              Conversations / Automations / Files + workspaces list regardless
-              of which workspace is active — so it must NOT remount on a
-              workspace switch (no `key={wsSlug}`). Switching just re-renders the
-              active highlight + the workspace-routed hrefs in place; remounting
-              made the whole left nav visibly flash on every switch. The
-              fade-in runs once, on initial mount. */}
+          {/* Scrolling region. Must NOT remount on a workspace switch (no
+              `key={wsSlug}`): a switch reflows the current-room section + the
+              active highlight in place; remounting flashed the whole left nav.
+              The fade-in runs once, on initial mount. */}
           <div className="flex-1 overflow-y-auto py-1 sidebar-scroll sidebar-nav-fade">
-            {/* Core nav (Home, Conversations, Automations, Files) —
-                global, identity-bound. Siblings of workspaces. */}
-            {ungrouped.map((p) => (
-              <NavItem
-                key={p.resourceUri}
-                to={resolveRoute(p, wsSlug)}
-                icon={p.icon}
-                label={p.label ?? "Item"}
-                collapsed={isCollapsed}
-                end={p.route === "/"}
-              />
-            ))}
+            {/* The room you're in, as the parent of its contents. */}
+            <CurrentRoomNav collapsed={isCollapsed} />
 
-            {/* WORKSPACES section — sibling category to the core nav,
-                rendered with a labelled header (Linear / Notion
-                pattern) so the visual cue is "different kind of
-                thing," not "parent column." */}
+            {/* The OTHER rooms — click one to focus it (it promotes into the
+                current-room section above). */}
             <WorkspaceSection collapsed={isCollapsed} />
           </div>
 
@@ -212,18 +177,10 @@ export const ShellLayout = memo(function ShellLayout({
             <SidebarSearch />
 
             <div className="flex-1 overflow-y-auto py-1 sidebar-scroll">
-              {/* Core nav — siblings of workspaces, not parents. */}
-              {ungrouped.map((p) => (
-                <MobileNavItem
-                  key={p.resourceUri}
-                  to={resolveRoute(p, wsSlug)}
-                  icon={p.icon}
-                  label={p.label ?? "Item"}
-                  end={p.route === "/"}
-                />
-              ))}
+              {/* The room you're in, as the parent of its contents. */}
+              <CurrentRoomNav />
 
-              {/* WORKSPACES section */}
+              {/* The OTHER rooms. */}
               <WorkspaceSection />
             </div>
 
@@ -316,56 +273,6 @@ const SidebarEdgeToggle = memo(function SidebarEdgeToggle({
     >
       <Icon className="w-3.5 h-3.5" />
     </button>
-  );
-});
-
-const NavItem = memo(function NavItem({
-  to,
-  icon,
-  label,
-  collapsed,
-  end,
-}: {
-  to: string;
-  icon?: string;
-  label: string;
-  collapsed?: boolean;
-  end?: boolean;
-}) {
-  if (collapsed) {
-    return (
-      <NavLink
-        to={to}
-        end={end}
-        title={label}
-        className={({ isActive }) =>
-          `flex items-center justify-center p-2.5 mx-2 rounded-sm text-sm font-medium transition-colors ${
-            isActive
-              ? "bg-sidebar-foreground/10 text-sidebar-foreground"
-              : "text-sidebar-foreground hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground"
-          }`
-        }
-      >
-        {icon && <NavIcon name={icon} />}
-      </NavLink>
-    );
-  }
-
-  return (
-    <NavLink
-      to={to}
-      end={end}
-      className={({ isActive }) =>
-        `flex items-center gap-3 px-3 py-2.5 mx-2 rounded-sm text-sm font-medium transition-colors ${
-          isActive
-            ? "bg-sidebar-foreground/10 text-sidebar-foreground"
-            : "text-sidebar-foreground hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground"
-        }`
-      }
-    >
-      {icon && <NavIcon name={icon} />}
-      <span className="flex-1 truncate">{label}</span>
-    </NavLink>
   );
 });
 

--- a/web/src/components/shell/CurrentRoomNav.tsx
+++ b/web/src/components/shell/CurrentRoomNav.tsx
@@ -160,7 +160,9 @@ function RoomHeaderRow({
       type="button"
       onClick={onSelect}
       aria-label={collapsed ? label : undefined}
-      aria-current={focused ? "true" : undefined}
+      // The room you're in is a location indicator, not the active route — the
+      // nested NavLink carries aria-current="page" for the actual view.
+      aria-current={focused ? "location" : undefined}
       title={label}
       data-testid="sidebar-room-header"
       data-room-id={workspace.id}

--- a/web/src/components/shell/CurrentRoomNav.tsx
+++ b/web/src/components/shell/CurrentRoomNav.tsx
@@ -1,0 +1,255 @@
+// ---------------------------------------------------------------------------
+// CurrentRoomNav — the room you're in, as the parent of its contents.
+//
+// Room-centric IA: you are always *in* a room (Home = Personal), and the room
+// scopes everything beneath it. The focused room is promoted to this dedicated
+// section — its Conversations / Automations / Files / Connectors, then its own
+// apps (People, Tasks, …) — while the WORKSPACES list below holds the OTHER
+// rooms. When you're focused on a shared room, a compact Personal row sits
+// above it as the way home.
+//
+// This replaces the previous "Conversations / Automations / Files are global
+// top-level nav, workspaces are a sibling category" arrangement: those views
+// are room-scoped now (the runtime walls each session to one workspace), so
+// the UI nests them under the room rather than floating them above it.
+// ---------------------------------------------------------------------------
+
+import { ArrowRight } from "lucide-react";
+import { useMemo } from "react";
+import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
+import { useShellContext } from "../../context/ShellContext";
+import { useWorkspaceAppIcons } from "../../context/WorkspaceAppIconsContext";
+import { useWorkspaceContext, type WorkspaceInfo } from "../../context/WorkspaceContext";
+import { resolveIcon } from "../../lib/icons";
+import { identityAppRoute, isIdentityApp } from "../../lib/identity-apps";
+import { cn } from "../../lib/utils";
+import { MAX_INLINE_APPS, workspaceApps } from "../../lib/workspace-apps";
+import { getWorkspaceAvatar } from "../../lib/workspace-avatar";
+import { toSlug } from "../../lib/workspace-slug";
+import { ConnectorIcon } from "../connectors/ConnectorIcon";
+
+export function CurrentRoomNav({ collapsed = false }: { collapsed?: boolean }) {
+  const wsCtx = useWorkspaceContext();
+  const shell = useShellContext();
+  const { iconFor } = useWorkspaceAppIcons();
+  const navigate = useNavigate();
+
+  const focused = wsCtx.activeWorkspace;
+  const personal = useMemo(
+    () => wsCtx.workspaces.find((w) => w.isPersonal) ?? null,
+    [wsCtx.workspaces],
+  );
+
+  // Identity apps (Conversations / Automations / Files): the bare-"sidebar"
+  // placements that are identity-owned. Home is intentionally dropped — the
+  // Personal room IS home, so a separate Home item would be redundant.
+  const identityApps = useMemo(() => {
+    const placements = shell?.forSlot("sidebar") ?? [];
+    return placements
+      .filter((p) => p.slot === "sidebar" && isIdentityApp(p.serverName))
+      .sort((a, b) => a.priority - b.priority);
+  }, [shell]);
+
+  // The focused room's own apps (People, Tasks, …). Only once the shell's
+  // placements reflect THIS room — it lags a switch, so without the gate a
+  // switch would briefly paint the previous room's apps (mirrors the overview
+  // grid's readiness check).
+  const ready = shell != null && focused != null && shell.shellWorkspaceId === focused.id;
+  const apps = useMemo(
+    () => (ready && shell ? workspaceApps(shell.forSlot("sidebar")) : []),
+    [ready, shell],
+  );
+
+  if (wsCtx.loading || !focused) return null;
+
+  const isPersonalFocused = focused.isPersonal === true;
+  const slug = toSlug(focused.id);
+
+  // Cap the app quick-list; the overflow link routes to the room's overview
+  // grid (the full set) — same top-N contract as the previous inline list.
+  const shownApps = apps.slice(0, MAX_INLINE_APPS);
+  const hasAppOverflow = apps.length > shownApps.length;
+
+  return (
+    <div className="flex flex-col" data-testid="sidebar-current-room" data-room-id={focused.id}>
+      {/* The way home — shown only when focused on a shared room. */}
+      {!isPersonalFocused && personal && (
+        <RoomHeaderRow
+          workspace={personal}
+          label="Personal"
+          collapsed={collapsed}
+          focused={false}
+          onSelect={() => {
+            if (wsCtx.activeWorkspace?.id !== personal.id) wsCtx.setActiveWorkspace(personal);
+            navigate("/");
+          }}
+        />
+      )}
+
+      {/* The room you're in. */}
+      <RoomHeaderRow
+        workspace={focused}
+        label={isPersonalFocused ? "Personal" : focused.name}
+        collapsed={collapsed}
+        focused
+        onSelect={() => navigate(isPersonalFocused ? "/" : `/w/${slug}/`)}
+      />
+
+      {/* Its contents, nested under the room. Hidden in collapsed (icon-only)
+          mode — nested icons would float without their room-header context. */}
+      {!collapsed && (
+        <div
+          className="ml-4 mr-2 mb-1 mt-px flex flex-col border-l border-sidebar-foreground/10 pl-1"
+          data-testid="sidebar-current-room-contents"
+        >
+          {identityApps.map((p) => (
+            <NestedNavLink
+              key={p.resourceUri}
+              to={identityAppRoute(p.serverName)}
+              icon={p.icon}
+              label={p.label ?? p.serverName}
+              end
+            />
+          ))}
+          {/* Connectors — the room's installed tools. Routes to its settings
+              tab; sub-routes (browse, detail) keep it lit, so not `end`. */}
+          <NestedNavLink to={`/w/${slug}/settings/connectors`} icon="plug" label="Connectors" />
+          {shownApps.map((p) => (
+            <NestedAppLink
+              key={p.resourceUri}
+              to={`/w/${slug}/app/${p.route}`}
+              label={p.label ?? p.route ?? "App"}
+              serverName={p.serverName}
+              iconUrl={iconFor(p.serverName)}
+            />
+          ))}
+          {hasAppOverflow && (
+            <Link
+              to={`/w/${slug}/`}
+              data-testid="sidebar-room-view-all"
+              className="flex items-center gap-1.5 px-2 py-1 text-xs text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors"
+            >
+              <ArrowRight className="size-3 shrink-0" />
+              <span className="truncate">View all {apps.length} apps</span>
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The focused room (and the Personal way-home row) — avatar + name. `focused`
+// styles the room you're in more prominently than the muted home row.
+function RoomHeaderRow({
+  workspace,
+  label,
+  collapsed,
+  focused,
+  onSelect,
+}: {
+  workspace: WorkspaceInfo;
+  label: string;
+  collapsed: boolean;
+  focused: boolean;
+  onSelect: () => void;
+}) {
+  const avatar = getWorkspaceAvatar(workspace);
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-label={collapsed ? label : undefined}
+      aria-current={focused ? "true" : undefined}
+      title={label}
+      data-testid="sidebar-room-header"
+      data-room-id={workspace.id}
+      data-focused={focused ? "true" : "false"}
+      className={cn(
+        "flex items-center text-sm transition-colors text-left rounded-sm mx-2 my-px",
+        collapsed ? "justify-center p-1.5" : "gap-2 px-3 py-1.5",
+        focused
+          ? "font-medium text-sidebar-foreground"
+          : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-foreground/5",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="size-[18px] shrink-0 flex items-center justify-center rounded-sm text-white text-3xs font-semibold"
+        style={{ backgroundColor: avatar.color }}
+      >
+        {avatar.letter}
+      </span>
+      {!collapsed && <span className="flex-1 truncate">{label}</span>}
+    </button>
+  );
+}
+
+// A nested room view with a lucide icon — identity apps + Connectors.
+function NestedNavLink({
+  to,
+  icon,
+  label,
+  end,
+}: {
+  to: string;
+  icon?: string;
+  label: string;
+  end?: boolean;
+}) {
+  const Icon = resolveIcon(icon);
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      title={label}
+      className={({ isActive }) =>
+        cn(
+          "flex items-center gap-2 text-sm transition-colors rounded-sm px-2 py-1",
+          isActive
+            ? "bg-sidebar-foreground/10 text-sidebar-foreground"
+            : "text-sidebar-foreground/80 hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground",
+        )
+      }
+    >
+      <Icon className="size-[18px] shrink-0" />
+      <span className="flex-1 truncate">{label}</span>
+    </NavLink>
+  );
+}
+
+// A nested workspace app with a brand icon (letter-avatar fallback). Exact-match
+// active: app routes are leaf paths, so the URL maps to one placement (a
+// `startsWith` would mis-light `crm` when viewing a sibling `crm-archive`).
+function NestedAppLink({
+  to,
+  label,
+  serverName,
+  iconUrl,
+}: {
+  to: string;
+  label: string;
+  serverName: string;
+  iconUrl?: string;
+}) {
+  const location = useLocation();
+  const isActive = location.pathname === to;
+  return (
+    <Link
+      to={to}
+      title={label}
+      data-testid="sidebar-room-app"
+      data-app-route={serverName}
+      data-is-active={isActive ? "true" : "false"}
+      className={cn(
+        "flex items-center gap-2 text-sm transition-colors rounded-sm px-2 py-1",
+        isActive
+          ? "bg-sidebar-foreground/10 text-sidebar-foreground"
+          : "text-sidebar-foreground/80 hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground",
+      )}
+    >
+      <ConnectorIcon name={label} iconUrl={iconUrl} className="size-[18px] rounded-xs text-3xs" />
+      <span className="flex-1 truncate">{label}</span>
+    </Link>
+  );
+}

--- a/web/src/components/shell/WorkspaceSection.tsx
+++ b/web/src/components/shell/WorkspaceSection.tsx
@@ -1,51 +1,33 @@
 // ---------------------------------------------------------------------------
-// WorkspaceSection — labelled WORKSPACES list inside the main sidebar
+// WorkspaceSection — the labelled WORKSPACES list of the OTHER rooms.
 //
-// IA argument: Conversations / Automations / Files / Home are global
-// (identity-bound, cross-workspace). Workspaces are a sibling category,
-// not a parent column. A vertical sidebar with a labelled section
-// (Linear's "Workspaces" / Notion's "Teamspaces" / Things' "Areas"
-// pattern) signals "different kind of thing in this list" without
-// implying parent/child. Putting workspaces in a left rail — even
-// without inline apps — borrowed the Discord/Slack pattern where the
-// rail IS a parent column; that mismatch broke the metaphor here.
+// Room-centric IA: the room you're in is the parent of its contents (rendered
+// in `CurrentRoomNav` above). This list holds the rooms you're NOT in — click
+// one to focus it and it promotes into the current-room section above. Both
+// the focused room and the Personal room are filtered out here: the focused
+// room is shown above as the current room, and Personal is home (also shown
+// above, as the current room or the compact way-home row).
 //
-// Each workspace row: avatar (deterministic letter+color), workspace
-// name, role badge. One click target. Click = setActiveWorkspace +
-// navigate to `/w/<slug>/`.
+// Each row: avatar (deterministic letter+color) + workspace name; one click
+// target. Click = setActiveWorkspace + navigate to `/w/<slug>/`.
 //
-// Under the FOCUSED workspace (the one matching `activeWorkspace`, whose
-// placements the shell context holds) we render a quick-access list of
-// its top apps — see `WorkspaceInlineApps`. This is the Notion/Linear
-// "teamspace → pages" tree, still not the Discord rail (the section is a
-// sibling of the global nav, not a parent column). Capped at
-// `MAX_INLINE_APPS`; an overflow "View all N apps" link routes to the
-// workspace overview page (the full grid). No pinning / recency yet —
-// it's a priority-ordered top-N. Other rows stay collapsed (their
-// placements aren't loaded).
-//
-// The `+` affordance on the section heading routes to the existing
-// org-workspaces page (no new UX invented).
+// The `+` affordance on the section heading routes to the org-workspaces page.
 // ---------------------------------------------------------------------------
 
-import { ArrowRight, Plus } from "lucide-react";
-import { Fragment, useCallback, useMemo } from "react";
-import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
-import { useShellContext } from "../../context/ShellContext";
-import { useWorkspaceAppIcons } from "../../context/WorkspaceAppIconsContext";
+import { Plus } from "lucide-react";
+import { useCallback, useMemo } from "react";
+import { matchPath, useLocation, useNavigate } from "react-router-dom";
 import { useWorkspaceContext, type WorkspaceInfo } from "../../context/WorkspaceContext";
 import { cn } from "../../lib/utils";
-import { MAX_INLINE_APPS, workspaceApps } from "../../lib/workspace-apps";
 import { getWorkspaceAvatar } from "../../lib/workspace-avatar";
 import { orderWorkspacesForSidebar } from "../../lib/workspace-order";
 import { toSlug } from "../../lib/workspace-slug";
-import { ConnectorIcon } from "../connectors/ConnectorIcon";
 
 interface WorkspaceSectionProps {
   /**
    * Collapsed sidebar = icon-only mode. In that mode we render avatars
    * only (no labels, no header, no `+` affordance), matching the
-   * collapsed look of NavItem in the surrounding sidebar.
+   * collapsed look of the surrounding sidebar items.
    */
   collapsed?: boolean;
 }
@@ -54,7 +36,16 @@ export function WorkspaceSection({ collapsed = false }: WorkspaceSectionProps) {
   const wsCtx = useWorkspaceContext();
   const navigate = useNavigate();
   const location = useLocation();
-  const ordered = useMemo(() => orderWorkspacesForSidebar(wsCtx.workspaces), [wsCtx.workspaces]);
+  // The OTHER rooms: everything except Personal (home — shown in
+  // CurrentRoomNav) and the focused room (promoted into the current-room
+  // section above).
+  const ordered = useMemo(
+    () =>
+      orderWorkspacesForSidebar(wsCtx.workspaces).filter(
+        (w) => !w.isPersonal && w.id !== wsCtx.activeWorkspace?.id,
+      ),
+    [wsCtx.workspaces, wsCtx.activeWorkspace?.id],
+  );
 
   // The active marker follows the ROUTE, not the persisted active
   // workspace. `activeWorkspace` is always set (it scopes tool dispatch),
@@ -135,103 +126,14 @@ export function WorkspaceSection({ collapsed = false }: WorkspaceSectionProps) {
             </div>
           )
         : ordered.map((ws) => (
-            <Fragment key={ws.id}>
-              <WorkspaceItem
-                workspace={ws}
-                isActive={activeRouteSlug === toSlug(ws.id)}
-                onSelect={() => handleSelect(ws)}
-                collapsed={collapsed}
-              />
-              {/* Inline app quick-list under the focused workspace only.
-                  `activeWorkspace` is whose placements the shell context
-                  holds; rendering it under any other row would show the
-                  wrong workspace's apps. Hidden in collapsed (icon-only)
-                  mode — there's no room for labels. */}
-              {!collapsed && ws.id === wsCtx.activeWorkspace?.id && (
-                <WorkspaceInlineApps workspaceId={ws.id} />
-              )}
-            </Fragment>
-          ))}
-    </div>
-  );
-}
-
-// Quick-access list of the focused workspace's top apps, rendered under
-// its row. App set + ordering come from the shell placement registry
-// (same source as the overview grid, via `workspaceApps`); brand icons
-// come from `useWorkspaceAppIcons` with a letter-avatar fallback. The
-// workspace is already active here, so each app is a plain `<Link>` into
-// `/w/<slug>/app/<route>` (no setActiveWorkspace dance needed).
-function WorkspaceInlineApps({ workspaceId }: { workspaceId: string }) {
-  const shell = useShellContext();
-  const { iconFor } = useWorkspaceAppIcons();
-  const location = useLocation();
-  const slug = toSlug(workspaceId);
-
-  // Only show apps once the shell's placements reflect THIS workspace.
-  // The shell holds one workspace's placements at a time and lags a
-  // switch (see ShellContext.shellWorkspaceId), so without this gate a
-  // switch would briefly paint the previous workspace's apps under the
-  // newly-focused row. Mirrors the overview grid's readiness check.
-  const ready = shell != null && shell.shellWorkspaceId === workspaceId;
-  const apps = useMemo(
-    () => (ready && shell ? workspaceApps(shell.forSlot("sidebar")) : []),
-    [ready, shell],
-  );
-
-  if (apps.length === 0) return null;
-  const shown = apps.slice(0, MAX_INLINE_APPS);
-  const hasOverflow = apps.length > shown.length;
-
-  return (
-    <div
-      className="ml-4 mr-2 mb-1 mt-px flex flex-col border-l border-sidebar-foreground/10 pl-1"
-      data-testid="sidebar-workspace-apps"
-      data-app-count={apps.length}
-    >
-      {shown.map((p) => {
-        const label = p.label ?? p.route ?? "App";
-        const target = `/w/${slug}/app/${p.route}`;
-        // Exact match, not startsWith: app routes are leaf paths (App.tsx
-        // registers `app/<route>` with no splat), so the current URL maps to
-        // exactly one placement. startsWith would mis-light a `crm` row when
-        // viewing a sibling `crm-archive` (string prefix) or a `crm/board`
-        // sub-view.
-        const isActive = !!p.route && location.pathname === target;
-        return (
-          <Link
-            key={p.resourceUri}
-            to={target}
-            title={label}
-            data-testid="sidebar-workspace-app"
-            data-app-route={p.route ?? ""}
-            data-is-active={isActive ? "true" : "false"}
-            className={cn(
-              "flex items-center gap-2 text-sm transition-colors rounded-sm px-2 py-1",
-              isActive
-                ? "bg-sidebar-foreground/10 text-sidebar-foreground"
-                : "text-sidebar-foreground/80 hover:bg-sidebar-foreground/5 hover:text-sidebar-foreground",
-            )}
-          >
-            <ConnectorIcon
-              name={label}
-              iconUrl={iconFor(p.serverName)}
-              className="size-[18px] rounded-xs text-3xs"
+            <WorkspaceItem
+              key={ws.id}
+              workspace={ws}
+              isActive={activeRouteSlug === toSlug(ws.id)}
+              onSelect={() => handleSelect(ws)}
+              collapsed={collapsed}
             />
-            <span className="flex-1 truncate">{label}</span>
-          </Link>
-        );
-      })}
-      {hasOverflow && (
-        <Link
-          to={`/w/${slug}/`}
-          data-testid="sidebar-workspace-view-all"
-          className="flex items-center gap-1.5 px-2 py-1 text-xs text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors"
-        >
-          <ArrowRight className="size-3 shrink-0" />
-          <span className="truncate">View all {apps.length} apps</span>
-        </Link>
-      )}
+          ))}
     </div>
   );
 }


### PR DESCRIPTION
## What

Restructures the sidebar so the **room you're in is the parent of its contents** — the §5.1 room-centric IA. The sidebar previously listed Conversations / Automations / Files as global top-level nav with workspaces as a sibling category below; but the runtime walls each session to one workspace and those views are room-scoped now (see the conversation-list room-scoping that just landed), so the old nav contradicted the model.

```
Focused on Personal (home):        Focused on Helix:
┌────────────────────────┐         ┌────────────────────────┐
│ ▼ Personal             │         │ ⌂ Personal             │ ← way home
│    💬 Conversations     │         ├────────────────────────┤
│    ⏰ Automations       │         │ ▼ Helix                │ ← promoted
│    📁 Files             │         │    💬 Conversations     │
│    🔌 Connectors        │         │    ⏰ Automations       │
├────────────────────────┤         │    📁 Files             │
│ WORKSPACES          +  │         │    🔌 Connectors        │
│   M Helix              │         │    👥 People            │
│   A Acme               │         │    ✓ Tasks              │
└────────────────────────┘         ├────────────────────────┤
                                   │ WORKSPACES          +  │
                                   │   A Acme               │
                                   └────────────────────────┘
```

## Changes

- **New `CurrentRoomNav`** — the focused room is a section at the top: its Conversations / Automations / Files / Connectors + its apps (capped at `MAX_INLINE_APPS` with a View-all overflow) nest under it. **Home = Personal** (the standalone Home item is dropped). When focused on a **shared** room, a compact **Personal way-home row** sits above it (click → `/`).
- **`WorkspaceSection` is now the OTHER rooms** — Personal (home) and the focused room (promoted above) are filtered out; clicking a row focuses it (it promotes into the current-room section). The inline-apps-under-the-focused-row logic moved into `CurrentRoomNav`.
- **`ShellLayout`** drops the top-level identity-app `NavItem`s (subsumed by `CurrentRoomNav`) and the unused threshold/`NavItem` machinery.

## Decisions / scope

- **Routing unchanged for v1:** identity views keep their top-level routes (`/conversations`, …), scoped by the focused room. Re-homing them under `/w/:slug` is deferred to the storage-relocation track. Connectors → `/w/<slug>/settings/connectors`.
- This reverses the prior code's deliberate "Conversations/Automations/Files are global; workspaces are a sibling category, not a parent column" model — that comment is rewritten to the room-centric model throughout.
- Personal-connector support under the Personal room's Connectors is a later phase; the item routes to the personal workspace's connector settings.

## Verification

- `bun run verify` green: tsc, lint, codegen, cycles, **571/0 web tests**, bundles.
- New `current-room-nav.test.tsx` (focused-on-Personal vs focused-on-shared structure, identity/connectors/app routing, way-home click, app cap+overflow). `workspace-section.test.tsx` reworked to the OTHER-rooms contract.
- ⚠️ **No screenshots:** the Chrome DevTools MCP is disconnected this session, so I couldn't attach live captures. The component render-tests cover the structure/behavior; please eyeball with `bun run dev:worktree` (sidebar renders on every route). I'll attach screenshots once the MCP reconnects if useful.