### PR TITLE
feat(files): workspace-owned storage — files live under the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "format:check": "bunx @biomejs/biome format src/ web/src/ instrument/ scripts/",
     "sync-models": "bun run src/model/sync-models.ts",
     "migrate:skill-frontmatter": "bun run scripts/migrate-skill-frontmatter.ts",
-    "migrate:conversations-to-room": "bun run scripts/migrate-conversations-to-room.ts"
+    "migrate:conversations-to-room": "bun run scripts/migrate-conversations-to-room.ts",
+    "migrate:files-to-room": "bun run scripts/migrate-files-to-room.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",

--- a/scripts/check-file-paths.ts
+++ b/scripts/check-file-paths.ts
@@ -1,27 +1,39 @@
 #!/usr/bin/env bun
 /**
- * Lint: files are identity-owned and reached through one constructor.
+ * Lint: files are workspace-owned — never built at the identity level.
  *
- * Phase B moved files from the per-workspace store
- * (`{workDir}/workspaces/{wsId}/files/`) to the identity store
- * (`{workDir}/users/{userId}/files/`). To keep that single, two things are
- * enforced in `src/`:
+ * A file lives under the workspace it was created in, with the owner as a
+ * privacy sub-partition:
  *
- *   1. `createFileStore(...)` is called only in `src/runtime/runtime.ts` —
- *      via `Runtime.getFileStore(userId)` (the sanctioned identity-scoped
- *      constructor) and the host-resources resolver closure. Any other call
- *      site builds a store off a path the caller chose, which is how files
- *      drifted back into a workspace silo.
- *   2. `join(getWorkspaceScopedDir(...), ..., "files")` — building a
- *      workspace-scoped files dir by hand — is forbidden anywhere in `src/`.
+ *   workspaces/<wsId>/files/<ownerId>/   a member's files (private by default)
  *
- * Allowed: a `// lint-ok:file-path` marker on a line just above the call,
- * for the rare future case the constructor genuinely can't cover.
+ * The identity-owned `{workDir}/users/<userId>/files/` layout is gone. Any new
+ * occurrence of identity-level file construction — `getDataPath("files")` on an
+ * `IdentityContext`, or joining `"files"` directly onto a non-workspace root —
+ * is a regression: it drops the workspace wall the permission model depends on
+ * (§2.3).
  *
- * Scope: `src/**\/*.ts`. Tests and `scripts/` are out of scope (the
- * migration deliberately reads the old workspace-scoped layout).
+ * What this script flags:
+ *   - `x.getDataPath("files")` / `getDataPath("files")` — the identity store
+ *     constructor. Files are no longer identity-owned.
+ *   - `join(...)` whose `"files"` segment is NOT qualified by a workspace root
+ *     before it (neither a literal `"workspaces", <wsId>` pair nor a
+ *     workspace-scoped base like `this.workspacesRoot` / `getWorkspaceScopedDir()`).
  *
- * Exports its AST predicates for the self-test under `test/unit/scripts/`.
+ * What it allows:
+ *   - `src/files/paths.ts` — the single sanctioned construction (and parse)
+ *     site for the `workspaces/<wsId>/files/<ownerId>` layout. It *is* the
+ *     definition this lint protects. Build the dir via `workspaceFilesDir()`.
+ *   - `scripts/migrate-files-to-room.ts` — it must read the legacy
+ *     `{workDir}/users/<userId>/files/` SOURCE paths to move them into the
+ *     workspace-owned layout (and it lives under `scripts/`, out of the src
+ *     scan anyway).
+ *   - A `// lint-ok:file-path` marker on a line just above the construction,
+ *     for the rare future case the typed helper genuinely can't cover.
+ *
+ * Scope: `src/**\/*.ts`. Tests and `scripts/` are out of scope.
+ *
+ * Exports its AST predicates for a potential self-test under `test/unit/scripts/`.
  */
 
 import { readFileSync } from "node:fs";
@@ -33,11 +45,19 @@ const ROOT = join(import.meta.dirname ?? __dirname, "..");
 const SRC_ROOT = join(ROOT, "src");
 const ALLOW_MARKER = "lint-ok:file-path";
 
-// `runtime.ts` owns FileStore construction: the `getFileStore` method (the
-// sanctioned identity-scoped constructor) and the host-resources resolver
-// closure both legitimately call `createFileStore`.
-const CREATE_STORE_ALLOWED_FILES = new Set(
-  ["runtime/runtime.ts"].map((f) => f.split("/").join(sep)),
+// Files (relative to repo root) that legitimately reference the file layout —
+// either because they DEFINE the workspace-owned layout, or because they
+// migrate data off the identity one. The lint would otherwise fight the
+// definitions it exists to protect.
+const ALLOWED_FILES = new Set(
+  [
+    // The single sanctioned site that builds + parses the workspace-owned
+    // `workspaces/<wsId>/files/<ownerId>` layout.
+    "src/files/paths.ts",
+    // Migrates files off the identity layout — reads the old
+    // `{workDir}/users/<userId>/files/` source paths to relocate them.
+    "scripts/migrate-files-to-room.ts",
+  ].map((f) => f.split("/").join(sep)),
 );
 
 interface Violation {
@@ -48,6 +68,7 @@ interface Violation {
   reason: string;
 }
 
+/** The callee's simple name for `f(...)` / `x.f(...)`, else `null`. */
 function calleeName(node: ts.CallExpression): string | null {
   const callee = node.expression;
   return ts.isIdentifier(callee)
@@ -57,33 +78,70 @@ function calleeName(node: ts.CallExpression): string | null {
       : null;
 }
 
-/** True iff `node` is a `createFileStore(...)` call. */
-export function isCreateFileStoreCall(node: ts.CallExpression): boolean {
-  return calleeName(node) === "createFileStore";
+/** The static string value of a string / no-substitution-template literal, else `null`. */
+function staticText(node: ts.Expression | undefined): string | null {
+  if (!node) return null;
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  return null;
 }
 
-/** True iff `node` is `getWorkspaceScopedDir(...)` / `x.getWorkspaceScopedDir(...)`. */
-function isGetWorkspaceScopedDirCall(node: ts.CallExpression): boolean {
-  return calleeName(node) === "getWorkspaceScopedDir";
+const WORKSPACE_RE = /workspace/i;
+
+/**
+ * True iff `node` carries a workspace-root signal — a `"workspaces"`-ish string
+ * literal, or an identifier / property / call whose name references a workspace
+ * (`this.workspacesRoot`, `getWorkspaceScopedDir()`, …). Used to decide whether
+ * a `"files"` segment is already workspace-scoped rather than identity-level.
+ */
+function referencesWorkspaces(node: ts.Expression | undefined): boolean {
+  if (!node) return false;
+  const text = staticText(node);
+  if (text !== null) return WORKSPACE_RE.test(text);
+  if (ts.isIdentifier(node)) return WORKSPACE_RE.test(node.text);
+  if (ts.isPropertyAccessExpression(node)) return WORKSPACE_RE.test(node.name.text);
+  if (ts.isCallExpression(node)) {
+    const name = calleeName(node);
+    return name !== null && WORKSPACE_RE.test(name);
+  }
+  return false;
+}
+
+/** True iff any argument before `idx` qualifies the path with a workspace root. */
+function hasWorkspaceQualifierBefore(args: ts.NodeArray<ts.Expression>, idx: number): boolean {
+  for (let i = 0; i < idx; i++) {
+    if (referencesWorkspaces(args[i])) return true;
+  }
+  return false;
 }
 
 /**
- * True iff `node` is `join(getWorkspaceScopedDir(...), ..., "files")` — a
- * hand-built workspace-scoped files dir. The first arg is the workspace-scoped
- * root; any literal `"files"` argument anywhere in the `join` trips it.
+ * Returns true iff `node` is `join(...)` building an identity-level / flat files
+ * path — a `"files"` string-literal argument that is NOT qualified by a
+ * workspace root before it. `join(usersDir, userId, "files")` flags;
+ * `join(workDir, "workspaces", wsId, "files", ownerId)` and
+ * `join(this.workspacesRoot, wsId, "files")` do not (already workspace-scoped).
+ *
+ * Exported for a self-test under `test/unit/scripts/`.
  */
-export function isWorkspaceScopedFilesJoin(node: ts.CallExpression): boolean {
+export function isUnscopedFilesJoin(node: ts.CallExpression): boolean {
   if (calleeName(node) !== "join") return false;
   const args = node.arguments;
-  const firstIsWsScoped =
-    args.length > 0 &&
-    args[0] !== undefined &&
-    ts.isCallExpression(args[0]) &&
-    isGetWorkspaceScopedDirCall(args[0]);
-  if (!firstIsWsScoped) return false;
-  return args.some(
-    (a) => (ts.isStringLiteral(a) || ts.isNoSubstitutionTemplateLiteral(a)) && a.text === "files",
-  );
+  for (let j = 0; j < args.length; j++) {
+    if (staticText(args[j]) !== "files") continue;
+    if (!hasWorkspaceQualifierBefore(args, j)) return true;
+  }
+  return false;
+}
+
+/**
+ * True iff `node` is `getDataPath("files")` / `x.getDataPath("files")` — the
+ * `IdentityContext` constructor for the identity-owned files dir.
+ *
+ * Exported for a self-test under `test/unit/scripts/`.
+ */
+export function isIdentityFilesGetDataPath(node: ts.CallExpression): boolean {
+  if (calleeName(node) !== "getDataPath") return false;
+  return staticText(node.arguments[0]) === "files";
 }
 
 function hasAllowMarker(node: ts.Node, sourceFile: ts.SourceFile, src: string): boolean {
@@ -108,8 +166,8 @@ function hasAllowMarker(node: ts.Node, sourceFile: ts.SourceFile, src: string): 
 }
 
 function scanFile(absPath: string, violations: Violation[]): void {
-  const relPath = relative(SRC_ROOT, absPath);
-  const createStoreAllowed = CREATE_STORE_ALLOWED_FILES.has(relPath);
+  const relPath = relative(ROOT, absPath);
+  if (ALLOWED_FILES.has(relPath)) return;
   const src = readFileSync(absPath, "utf-8");
   const sourceFile = ts.createSourceFile(
     absPath,
@@ -133,10 +191,10 @@ function scanFile(absPath: string, violations: Violation[]): void {
 
   function visit(node: ts.Node): void {
     if (ts.isCallExpression(node)) {
-      if (isCreateFileStoreCall(node) && !createStoreAllowed) {
-        record(node, "createFileStore() outside runtime.ts — use runtime.getFileStore(userId)");
-      } else if (isWorkspaceScopedFilesJoin(node)) {
-        record(node, 'join(getWorkspaceScopedDir(...), ..., "files") — files are identity-owned');
+      if (isIdentityFilesGetDataPath(node)) {
+        record(node, 'getDataPath("files") — files are workspace-owned, not identity-owned');
+      } else if (isUnscopedFilesJoin(node)) {
+        record(node, 'join(..., "files") not under a workspace root — files are workspace-owned');
       }
     }
     ts.forEachChild(node, visit);
@@ -159,22 +217,22 @@ async function main(): Promise<void> {
   }
 
   if (violations.length > 0) {
-    console.error(
-      `✗ Found ${violations.length} workspace-scoped / unsanctioned file path(s) in src/:\n`,
-    );
+    console.error(`✗ Found ${violations.length} identity-level / unscoped file path(s) in src/:\n`);
     for (const v of violations) {
       console.error(`  ${v.file}:${v.line}:${v.column} — ${v.reason}`);
       console.error(`    ${v.snippet}\n`);
     }
-    console.error("Phase B: files are identity-owned at `{workDir}/users/{userId}/files/`.");
-    console.error("Build a store only via `runtime.getFileStore(userId)`.");
+    console.error("Files are workspace-owned: `workspaces/<wsId>/files/<ownerId>/` (§2.3).");
     console.error(
-      `Legitimate exceptions (rare) require a // ${ALLOW_MARKER} comment on the line above.`,
+      "Build the directory via `workspaceFilesDir()` (src/files/paths.ts) or `runtime.getFileStore(wsId, ownerId)` — never the identity `users/<userId>/files/` path.",
+    );
+    console.error(
+      `Legitimate exceptions (rare) require a // ${ALLOW_MARKER} comment on the line above the construction.`,
     );
     process.exit(1);
   }
 
-  console.log(`✓ No workspace-scoped file paths in ${scanned} src/ files`);
+  console.log(`✓ No identity-level file paths in ${scanned} src/ files`);
 }
 
 if (import.meta.main) {

--- a/scripts/check-workspace-paths.ts
+++ b/scripts/check-workspace-paths.ts
@@ -51,6 +51,9 @@ const ALLOWED_FILES = new Set(
     // Defines the `workspaces/<wsId>/conversations/...` room-owned conversation
     // layout — the one sanctioned site that hand-builds that subtree.
     "conversation/paths.ts",
+    // Defines the `workspaces/<wsId>/files/<ownerId>` workspace-owned file
+    // layout — the one sanctioned site that hand-builds that subtree.
+    "files/paths.ts",
   ].map((f) => f.split("/").join(sep)),
 );
 

--- a/scripts/migrate-files-to-room.ts
+++ b/scripts/migrate-files-to-room.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env bun
+
+/**
+ * One-time migration: identity-owned file store → the workspace-owned layout.
+ *
+ * The identity store at `{workDir}/users/<userId>/files/` predates the
+ * workspace-owned layout, where a file lives under the workspace it belongs to
+ * with the owner as a privacy sub-partition (see `src/files/paths.ts` and
+ * `research/SPEC-permission-boundaries.md` §2.3):
+ *
+ *   workspaces/<wsId>/files/<ownerId>/   a member's files (private by default)
+ *
+ * Files carry no workspace provenance (the identity store never recorded one),
+ * so each user's files move to THEIR personal workspace — the safe default:
+ *
+ *   users/<userId>/files/*  →  workspaces/ws_user_<userId>/files/<userId>/*
+ *
+ * It's a pure move of every entry in the user's files dir (registry.jsonl, blob
+ * files, and `.extracted.json` sidecars). The store backfills each row's
+ * `ownerId` + `workspaceId` from the destination path on read (`parseFilePath`),
+ * so no registry rewrite is needed.
+ *
+ * Usage:
+ *   bun run migrate:files-to-room                  # dry-run (default)
+ *   bun run migrate:files-to-room --write          # apply the moves
+ *   bun run migrate:files-to-room --work-dir /abs  # target a work-dir
+ *
+ * Safe by default: a dry-run prints the planned moves, writes nothing, and
+ * exits 0. `--write` (or `--apply`) performs the moves under the work-dir's
+ * `.migration-lock`. Idempotent: a destination that already exists is treated
+ * as already-migrated (the stale identity source is removed), so a re-run after
+ * a crash or a partial run reports zero moves.
+ */
+
+import { existsSync, mkdirSync, readdirSync, renameSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { workspaceFilesDir } from "../src/files/paths.ts";
+import { personalWorkspaceIdFor } from "../src/workspace/workspace-store.ts";
+import { acquireMigrationLock } from "./lib/migration-lock.ts";
+
+const MIGRATION_NAME = "files-to-room";
+
+/** A single file's planned (dry-run) or performed (write) disposition. */
+interface MovePlan {
+  userId: string;
+  from: string;
+  to: string;
+  /** `move` — relocate to a fresh dest; `existing` — dest already present, drop the stale source. */
+  action: "move" | "existing";
+}
+
+export interface MigrationSummary {
+  /** Files relocated to a fresh destination (or that would be, in dry-run). */
+  moved: number;
+  /** Files whose destination already existed — treated as already-migrated. */
+  skippedExisting: number;
+  /** Distinct users whose files dir held at least one entry to migrate. */
+  users: number;
+  /** The per-file dispositions, for printing / assertions. */
+  plans: MovePlan[];
+}
+
+function emptySummary(): MigrationSummary {
+  return { moved: 0, skippedExisting: 0, users: 0, plans: [] };
+}
+
+/**
+ * Plan (and, when `write`, perform) the move of every file under
+ * `{workDir}/users/<userId>/files/` into that user's personal-workspace files
+ * partition. Pure read in dry-run; acquires the work-dir migration lock for the
+ * write path. Same-filesystem `renameSync` per entry — atomic, and never reads
+ * the (potentially large) blob bytes into memory.
+ */
+export function migrateFilesToRoom(workDir: string, opts: { write: boolean }): MigrationSummary {
+  const summary = emptySummary();
+  const usersDir = join(workDir, "users");
+
+  let userIds: string[];
+  try {
+    userIds = readdirSync(usersDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    // No users dir — nothing to migrate (fresh or already-migrated install).
+    return summary;
+  }
+
+  const lock = opts.write ? acquireMigrationLock(workDir, MIGRATION_NAME) : null;
+  try {
+    for (const userId of userIds) {
+      const srcDir = join(usersDir, userId, "files");
+
+      let names: string[];
+      try {
+        names = readdirSync(srcDir, { withFileTypes: true })
+          .filter((e) => e.isFile())
+          .map((e) => e.name);
+      } catch {
+        // This user has no files dir — nothing to move.
+        continue;
+      }
+      if (names.length === 0) continue;
+
+      const destDir = workspaceFilesDir(workDir, personalWorkspaceIdFor(userId), userId);
+      summary.users++;
+
+      for (const name of names) {
+        const srcFile = join(srcDir, name);
+        const destFile = join(destDir, name);
+
+        if (existsSync(destFile)) {
+          // Already migrated (a prior crash/partial run, or a re-run). The
+          // canonical copy is the dest; the identity source is stale.
+          summary.skippedExisting++;
+          summary.plans.push({ userId, from: srcFile, to: destFile, action: "existing" });
+          if (opts.write) unlinkSync(srcFile);
+          continue;
+        }
+
+        summary.plans.push({ userId, from: srcFile, to: destFile, action: "move" });
+        if (opts.write) {
+          mkdirSync(destDir, { recursive: true });
+          renameSync(srcFile, destFile);
+        }
+        summary.moved++;
+      }
+    }
+  } finally {
+    lock?.release();
+  }
+
+  return summary;
+}
+
+function resolveWorkDir(args: string[]): string {
+  const eq = args.find((a) => a.startsWith("--work-dir="));
+  if (eq) return eq.slice("--work-dir=".length);
+  const flagIdx = args.indexOf("--work-dir");
+  if (flagIdx !== -1 && args[flagIdx + 1]) return args[flagIdx + 1] as string;
+  return process.env.NB_WORK_DIR ?? join(homedir(), ".nimblebrain");
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const write = args.includes("--write") || args.includes("--apply");
+  const workDir = resolveWorkDir(args);
+
+  const summary = migrateFilesToRoom(workDir, { write });
+
+  const verb = write ? "Moved" : "Would move";
+  for (const plan of summary.plans) {
+    const room = `ws_user_${plan.userId} · ${plan.userId}`;
+    if (plan.action === "move") {
+      console.log(`  ${write ? "✓" : "·"} ${verb} ${plan.userId}/${basename(plan.from)} → ${room}`);
+    } else {
+      console.log(
+        `  ${write ? "✓" : "·"} ${plan.userId}/${basename(plan.from)} already at ${room} — ` +
+          `${write ? "removed" : "would remove"} stale identity copy`,
+      );
+    }
+  }
+
+  console.log(
+    `\n${summary.moved} ${write ? "moved" : "to move"} · ` +
+      `${summary.skippedExisting} already migrated · ` +
+      `${summary.users} user(s)`,
+  );
+  if (!write && summary.moved > 0) {
+    console.log("\nDry run — re-run with --write to apply.");
+  }
+}
+
+/** Last path segment, for the dry-run log. */
+function basename(p: string): string {
+  const parts = p.split(/[\\/]/);
+  return parts[parts.length - 1] ?? p;
+}
+
+// Gate the CLI side effect on direct invocation so tests can import
+// `migrateFilesToRoom` without running the argv/console path.
+if (import.meta.main) {
+  main();
+}

--- a/scripts/migrate-files-to-room.ts
+++ b/scripts/migrate-files-to-room.ts
@@ -32,7 +32,15 @@
  * a crash or a partial run reports zero moves.
  */
 
-import { existsSync, mkdirSync, readdirSync, renameSync, unlinkSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { workspaceFilesDir } from "../src/files/paths.ts";
@@ -41,20 +49,30 @@ import { acquireMigrationLock } from "./lib/migration-lock.ts";
 
 const MIGRATION_NAME = "files-to-room";
 
+/** The per-(wsId, ownerId) append-log of file metadata — merged, never moved. */
+const REGISTRY_FILENAME = "registry.jsonl";
+
 /** A single file's planned (dry-run) or performed (write) disposition. */
 interface MovePlan {
   userId: string;
   from: string;
   to: string;
-  /** `move` — relocate to a fresh dest; `existing` — dest already present, drop the stale source. */
-  action: "move" | "existing";
+  /**
+   * `move` — relocate to a fresh dest; `existing` — a content-addressed blob is
+   * already at the dest, drop the stale source; `merge` — append the source
+   * registry's rows onto an existing dest registry (it is an append-log, so the
+   * two can hold disjoint entries).
+   */
+  action: "move" | "existing" | "merge";
 }
 
 export interface MigrationSummary {
   /** Files relocated to a fresh destination (or that would be, in dry-run). */
   moved: number;
-  /** Files whose destination already existed — treated as already-migrated. */
+  /** Blobs whose destination already existed — treated as already-migrated. */
   skippedExisting: number;
+  /** Registries appended onto an existing destination registry. */
+  merged: number;
   /** Distinct users whose files dir held at least one entry to migrate. */
   users: number;
   /** The per-file dispositions, for printing / assertions. */
@@ -62,7 +80,7 @@ export interface MigrationSummary {
 }
 
 function emptySummary(): MigrationSummary {
-  return { moved: 0, skippedExisting: 0, users: 0, plans: [] };
+  return { moved: 0, skippedExisting: 0, merged: 0, users: 0, plans: [] };
 }
 
 /**
@@ -109,9 +127,25 @@ export function migrateFilesToRoom(workDir: string, opts: { write: boolean }): M
         const srcFile = join(srcDir, name);
         const destFile = join(destDir, name);
 
+        // registry.jsonl is an append-log, not content-addressed: a fresh upload
+        // between deploy and migration creates a dest registry holding only the
+        // new row, while the source registry holds the pre-existing rows. Merge
+        // by appending the source rows (readRegistry dedupes by id, last-write
+        // wins) — never move-or-drop it, which would orphan the pre-existing
+        // files (their blobs move, but their registry entries are lost).
+        if (name === REGISTRY_FILENAME && existsSync(destFile)) {
+          summary.plans.push({ userId, from: srcFile, to: destFile, action: "merge" });
+          if (opts.write) {
+            appendFileSync(destFile, readFileSync(srcFile));
+            unlinkSync(srcFile);
+          }
+          summary.merged++;
+          continue;
+        }
+
         if (existsSync(destFile)) {
-          // Already migrated (a prior crash/partial run, or a re-run). The
-          // canonical copy is the dest; the identity source is stale.
+          // A content-addressed blob already at the dest (a prior partial run, or
+          // a re-run). The dest is canonical; drop the stale source.
           summary.skippedExisting++;
           summary.plans.push({ userId, from: srcFile, to: destFile, action: "existing" });
           if (opts.write) unlinkSync(srcFile);

--- a/scripts/migrate-files-to-room.ts
+++ b/scripts/migrate-files-to-room.ts
@@ -187,6 +187,10 @@ function main(): void {
     const room = `ws_user_${plan.userId} · ${plan.userId}`;
     if (plan.action === "move") {
       console.log(`  ${write ? "✓" : "·"} ${verb} ${plan.userId}/${basename(plan.from)} → ${room}`);
+    } else if (plan.action === "merge") {
+      console.log(
+        `  ${write ? "✓" : "·"} ${plan.userId}/${basename(plan.from)} ${write ? "merged" : "would merge"} into ${room}'s registry`,
+      );
     } else {
       console.log(
         `  ${write ? "✓" : "·"} ${plan.userId}/${basename(plan.from)} already at ${room} — ` +
@@ -197,6 +201,7 @@ function main(): void {
 
   console.log(
     `\n${summary.moved} ${write ? "moved" : "to move"} · ` +
+      `${summary.merged} registr${summary.merged === 1 ? "y" : "ies"} merged · ` +
       `${summary.skippedExisting} already migrated · ` +
       `${summary.users} user(s)`,
   );

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -39,7 +39,7 @@ import { validateToolInput } from "../tools/validate-input.ts";
 import { estimateCost } from "../usage/cost.ts";
 import { bytesToBase64 } from "../util/base64.ts";
 import { PersonalWorkspaceInvariantError } from "../workspace/errors.ts";
-import type { WorkspaceStore } from "../workspace/workspace-store.ts";
+import { personalWorkspaceIdFor, type WorkspaceStore } from "../workspace/workspace-store.ts";
 import type { ConversationEventManager } from "./conversation-events.ts";
 import type { SseEventManager } from "./events.ts";
 import { artifactResolutionsTotal } from "./metrics.ts";
@@ -1701,12 +1701,15 @@ export function sanitizeFilename(name: string): string {
 const FILE_ID_RE = /^fl_(?:[a-f0-9]{24}|[a-z0-9]+_[a-f0-9]{8})$/;
 
 /** Handle GET /v1/files/:fileId — serve a stored file from the caller's
- * identity store (files are identity-owned; Phase B). */
+ * workspace-owned store (`workspaces/<wsId>/files/<ownerId>/`). `workspaceId`
+ * is the focused workspace (`X-Workspace-Id`), or the owner's personal
+ * workspace when unfocused — the same partition the file was stored under. */
 export async function handleFileServe(
   fileId: string,
   runtime: Runtime,
   features: ResolvedFeatures,
   identity: UserIdentity | undefined,
+  workspaceId: string | undefined,
 ): Promise<Response> {
   if (!features.fileContext) {
     return apiError(404, "not_found", "Not found");
@@ -1716,7 +1719,8 @@ export async function handleFileServe(
     return apiError(400, "bad_request", "Invalid file ID format");
   }
 
-  const store = runtime.getFileStore(runtime.resolveRequestUserId(identity));
+  const ownerId = runtime.resolveRequestUserId(identity);
+  const store = runtime.getFileStore(workspaceId ?? personalWorkspaceIdFor(ownerId), ownerId);
   try {
     const file = await store.readFile(fileId);
     const safeName = sanitizeFilename(file.filename);
@@ -1868,17 +1872,20 @@ async function parseMultipartChatBody(
 
   // Ingest files: validate, store, extract text, build content parts.
   //
-  // Files are identity-owned (Phase B): ingest writes to the uploader's
-  // identity store (`users/{userId}/files/`), the SAME store `runtime.chat()`
-  // reads from when it rehydrates the conversation — resolved through the one
-  // owner rule so an upload can't land in a store the read won't look in.
-  // `X-Workspace-Id` does not route file storage; it still threads into
-  // `ChatRequest.workspaceId` (the focused workspace, for prompt scoping).
-  const store = runtime.getFileStore(runtime.resolveRequestUserId(identity));
+  // Files are workspace-owned: ingest writes to the conversation's room
+  // partition (`workspaces/<wsId>/files/<ownerId>/`), the SAME partition
+  // `runtime.chat()` reads from when it rehydrates the conversation. `wsId` is
+  // the focused workspace (`X-Workspace-Id`) or the owner's personal workspace
+  // when unfocused — matching how `chat()` resolves its room (`request.
+  // workspaceId ?? sessionWsId`), so an upload can't land in a partition the
+  // read won't look in.
+  const ownerId = runtime.resolveRequestUserId(identity);
+  const wsId = workspaceId ?? personalWorkspaceIdFor(ownerId);
+  const store = runtime.getFileStore(wsId, ownerId);
   const filesConfig = runtime.getFilesConfig();
   // Use conversationId if provided, otherwise a placeholder (will be replaced by runtime.chat)
   const convId = (typeof conversationId === "string" && conversationId) || "pending";
-  const ingestResult = await ingestFiles(uploadedFiles, convId, store, filesConfig);
+  const ingestResult = await ingestFiles(uploadedFiles, convId, store, filesConfig, wsId, ownerId);
 
   if (ingestResult.errors.length > 0) {
     return apiError(400, "file_upload_error", "File upload failed", {
@@ -1935,6 +1942,7 @@ export async function handleResourceUpload(
   runtime: Runtime,
   features: ResolvedFeatures,
   identity: UserIdentity | undefined,
+  workspaceId: string | undefined,
 ): Promise<Response> {
   if (!features.fileContext) {
     return apiError(404, "not_found", "Not found");
@@ -2016,7 +2024,9 @@ export async function handleResourceUpload(
   const conversationId =
     typeof conversationIdRaw === "string" && conversationIdRaw ? conversationIdRaw : null;
 
-  const store = runtime.getFileStore(runtime.resolveRequestUserId(identity));
+  const ownerId = runtime.resolveRequestUserId(identity);
+  const wsId = workspaceId ?? personalWorkspaceIdFor(ownerId);
+  const store = runtime.getFileStore(wsId, ownerId);
   const entries: FileEntry[] = [];
   const errors: string[] = [];
 
@@ -2042,6 +2052,10 @@ export async function handleResourceUpload(
       conversationId,
       createdAt: new Date().toISOString(),
       description,
+      // Path-authoritative scope (§2.3), stamped at creation; private by default.
+      workspaceId: wsId,
+      ownerId,
+      visibility: "private",
     };
     await store.appendRegistry(entry);
     entries.push(entry);

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1872,20 +1872,30 @@ async function parseMultipartChatBody(
 
   // Ingest files: validate, store, extract text, build content parts.
   //
-  // Files are workspace-owned: ingest writes to the conversation's room
-  // partition (`workspaces/<wsId>/files/<ownerId>/`), the SAME partition
-  // `runtime.chat()` reads from when it rehydrates the conversation. `wsId` is
-  // the focused workspace (`X-Workspace-Id`) or the owner's personal workspace
-  // when unfocused — matching how `chat()` resolves its room (`request.
-  // workspaceId ?? sessionWsId`), so an upload can't land in a partition the
-  // read won't look in.
+  // Files are workspace-owned: ingest writes to the conversation's AUTHORITATIVE
+  // room — the SAME partition `runtime.chat()` reads from when it rehydrates.
+  // The room is resolved from the conversation (probe + locator), not the request
+  // header: on a cross-room resume the two differ, and a header-partitioned upload
+  // would land in a partition the read never looks in (the attachment vanishes).
+  // A new conversation (no id yet) is born in the focused/personal workspace.
   const ownerId = runtime.resolveRequestUserId(identity);
-  const wsId = workspaceId ?? personalWorkspaceIdFor(ownerId);
-  const store = runtime.getFileStore(wsId, ownerId);
-  const filesConfig = runtime.getFilesConfig();
-  // Use conversationId if provided, otherwise a placeholder (will be replaced by runtime.chat)
+  const fallbackWsId = workspaceId ?? personalWorkspaceIdFor(ownerId);
   const convId = (typeof conversationId === "string" && conversationId) || "pending";
-  const ingestResult = await ingestFiles(uploadedFiles, convId, store, filesConfig, wsId, ownerId);
+  const roomWsId = await runtime.resolveConversationRoomWsId(
+    convId === "pending" ? undefined : convId,
+    fallbackWsId,
+    ownerId,
+  );
+  const store = runtime.getFileStore(roomWsId, ownerId);
+  const filesConfig = runtime.getFilesConfig();
+  const ingestResult = await ingestFiles(
+    uploadedFiles,
+    convId,
+    store,
+    filesConfig,
+    roomWsId,
+    ownerId,
+  );
 
   if (ingestResult.errors.length > 0) {
     return apiError(400, "file_upload_error", "File upload failed", {
@@ -2025,7 +2035,15 @@ export async function handleResourceUpload(
     typeof conversationIdRaw === "string" && conversationIdRaw ? conversationIdRaw : null;
 
   const ownerId = runtime.resolveRequestUserId(identity);
-  const wsId = workspaceId ?? personalWorkspaceIdFor(ownerId);
+  const fallbackWsId = workspaceId ?? personalWorkspaceIdFor(ownerId);
+  // A resource upload attached to a conversation lands in that conversation's
+  // authoritative room (the partition the read uses); a standalone app upload
+  // (no conversationId) lands in the focused/personal workspace.
+  const wsId = await runtime.resolveConversationRoomWsId(
+    conversationId ?? undefined,
+    fallbackWsId,
+    ownerId,
+  );
   const store = runtime.getFileStore(wsId, ownerId);
   const entries: FileEntry[] = [];
   const errors: string[] = [];

--- a/src/api/routes/resources.ts
+++ b/src/api/routes/resources.ts
@@ -38,11 +38,18 @@ export function resourceRoutes(ctx: AppContext) {
             identity: c.var.identity,
           }),
       )
-      // Uploads write to the caller's identity store (files are identity-owned;
-      // Phase B), so a workspace isn't required. `optionalWorkspace` still
-      // validates an `X-Workspace-Id` if the synapse bridge sends one.
+      // Uploads write to the workspace-owned store. The focused workspace
+      // (`X-Workspace-Id`, validated by `optionalWorkspace`) selects the
+      // partition; absent it, the upload lands in the caller's personal
+      // workspace.
       .post("/v1/resources", optionalWorkspace(ctx.workspaceStore), uploadLimit, (c) =>
-        handleResourceUpload(c.req.raw, ctx.runtime, ctx.features, c.var.identity),
+        handleResourceUpload(
+          c.req.raw,
+          ctx.runtime,
+          ctx.features,
+          c.var.identity,
+          c.var.workspaceId,
+        ),
       )
       .get("/v1/apps/:name/resources/*", optionalWorkspace(ctx.workspaceStore), (c) => {
         const name = decodeURIComponent(c.req.param("name"));

--- a/src/api/routes/tools.ts
+++ b/src/api/routes/tools.ts
@@ -32,10 +32,11 @@ export function toolRoutes(ctx: AppContext) {
     .get("/v1/shell", requireWorkspace(ctx.workspaceStore), (c) =>
       handleShell(ctx.runtime, c.var.workspaceId),
     )
-    .get("/v1/files/:fileId", (c) => {
-      // Files are identity-owned (Phase B) — no workspace needed; the store is
-      // resolved from the authenticated identity.
+    .get("/v1/files/:fileId", optionalWorkspace(ctx.workspaceStore), (c) => {
+      // Files are workspace-owned: the focused workspace (`X-Workspace-Id`,
+      // validated by optionalWorkspace) selects the partition, falling back to
+      // the caller's personal workspace when no header is sent.
       const fileId = decodeURIComponent(c.req.param("fileId"));
-      return handleFileServe(fileId, ctx.runtime, ctx.features, c.var.identity);
+      return handleFileServe(fileId, ctx.runtime, ctx.features, c.var.identity, c.var.workspaceId);
     });
 }

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -113,13 +113,18 @@ function humanSize(bytes: number): string {
  * Validate and ingest uploaded files into the workspace file store.
  *
  * For each valid file: stores it, registers metadata, extracts text when
- * applicable, and builds content parts for the LLM message.
+ * applicable, and builds content parts for the LLM message. `wsId` + `ownerId`
+ * are the store's path-authoritative scope (§2.3), stamped on each registry
+ * entry at creation; `store` must already be rooted at that
+ * `workspaces/<wsId>/files/<ownerId>/` partition.
  */
 export async function ingestFiles(
   files: UploadedFile[],
   conversationId: string,
   store: FileStore,
   config: FileConfig,
+  wsId: string,
+  ownerId: string,
 ): Promise<IngestResult> {
   const errors: string[] = [];
   const contentParts: ContentPart[] = [];
@@ -169,6 +174,11 @@ export async function ingestFiles(
       conversationId,
       createdAt: new Date().toISOString(),
       description: null,
+      // Path-authoritative scope (§2.3), stamped at creation. `visibility`
+      // defaults to private — v1 is private-only.
+      workspaceId: wsId,
+      ownerId,
+      visibility: "private",
     };
     await store.appendRegistry(entry);
 

--- a/src/files/paths.ts
+++ b/src/files/paths.ts
@@ -1,0 +1,52 @@
+/**
+ * The single sanctioned construction (and parse) site for workspace-partitioned
+ * file paths. Mirrors `src/conversation/paths.ts`: every file directory is built
+ * and parsed here, so the on-disk layout has exactly one definition.
+ *
+ * The workspace owns the directory (see `research/SPEC-permission-boundaries.md`
+ * §2.3): a file lives under the workspace it was created in, with the owner as a
+ * privacy sub-partition. The path is the binding — `FileEntry.workspaceId` is a
+ * denormalised convenience, the directory is authoritative.
+ *
+ *   workspaces/<wsId>/files/<ownerId>/   a member's files (private by default)
+ *
+ * This file is on the allow-list of `check:workspace-paths` (it defines the
+ * `workspaces/<wsId>/...` file layout) and is the only site `check:file-paths`
+ * permits to build a file directory.
+ */
+
+import { join, sep } from "node:path";
+
+const FILES_SEGMENT = "files";
+const WORKSPACES_SEGMENT = "workspaces";
+
+/**
+ * Directory holding a user's files in one workspace:
+ * `{workDir}/workspaces/<wsId>/files/<ownerId>`.
+ */
+export function workspaceFilesDir(workDir: string, wsId: string, ownerId: string): string {
+  return join(workDir, WORKSPACES_SEGMENT, wsId, FILES_SEGMENT, ownerId);
+}
+
+/** What a parsed file path resolves to. */
+export interface ParsedFilePath {
+  wsId: string;
+  ownerId: string;
+}
+
+/**
+ * Inverse of the builder: recover `{ wsId, ownerId }` from a file or directory
+ * path. Returns `null` for a path that is not under a
+ * `workspaces/<wsId>/files/<ownerId>/` subtree (e.g. a legacy identity-owned
+ * `users/<userId>/files/`), so callers can skip it. The path is the authority.
+ */
+export function parseFilePath(absPath: string): ParsedFilePath | null {
+  const segments = absPath.split(sep);
+  const wsIdx = segments.lastIndexOf(WORKSPACES_SEGMENT);
+  if (wsIdx === -1) return null;
+  const wsId = segments[wsIdx + 1];
+  const filesSeg = segments[wsIdx + 2];
+  const ownerId = segments[wsIdx + 3];
+  if (!wsId || filesSeg !== FILES_SEGMENT || !ownerId) return null;
+  return { wsId, ownerId };
+}

--- a/src/files/store.ts
+++ b/src/files/store.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { appendFile, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import { resolveMimeType } from "./mime.ts";
+import { parseFilePath } from "./paths.ts";
 import type { ExtractedTextSidecar, FileEntry } from "./types.ts";
 
 /**
@@ -80,15 +81,36 @@ export interface FileStore {
 /**
  * Create a file store rooted at `filesDir`.
  *
- * Files are identity-owned (Phase B): `filesDir` must be a resolved,
- * identity-scoped path (`users/{userId}/files/`). Construct it only through
- * `Runtime.getFileStore(userId)` — the single sanctioned path, enforced by
- * `check:file-paths`. Passing a workspace-scoped path (the pre-Phase-B
- * `getWorkspaceScopedDir(wsId)/files`) silos files per workspace, the exact
- * bug this migration removes.
+ * Files are workspace-owned: `filesDir` is a resolved, workspace-partitioned
+ * path (`workspaces/<wsId>/files/<ownerId>/`; see `src/files/paths.ts`).
+ * Construct it only through `Runtime.getFileStore(wsId, ownerId)` — the single
+ * sanctioned path, enforced by `check:file-paths`.
+ *
+ * The store derives its scope from the path (`parseFilePath`): the directory is
+ * authoritative for `workspaceId` + `ownerId` (§2.3). On read, entries that
+ * lack those fields — legacy rows migrated by a pure move — are backfilled from
+ * the path so they self-heal without a registry rewrite. `null` for a path that
+ * isn't workspace-partitioned (e.g. a unit-test scratch dir) just disables the
+ * backfill.
  */
 export function createFileStore(filesDir: string): FileStore {
   const registryPath = join(filesDir, "registry.jsonl");
+  const scope = parseFilePath(filesDir);
+
+  /**
+   * Backfill the path-authoritative scope onto an entry whose `ownerId` /
+   * `workspaceId` are absent (a migrated legacy row). `visibility` is left
+   * alone — absent reads as `private`, and nothing consults it in v1.
+   */
+  function withScope(entry: FileEntry): FileEntry {
+    if (!scope) return entry;
+    if (entry.ownerId && entry.workspaceId) return entry;
+    return {
+      ...entry,
+      ownerId: entry.ownerId || scope.ownerId,
+      workspaceId: entry.workspaceId || scope.wsId,
+    };
+  }
 
   async function ensureFilesDir(): Promise<void> {
     await mkdir(filesDir, { recursive: true });
@@ -178,7 +200,8 @@ export function createFileStore(filesDir: string): FileStore {
     }
     return Array.from(latest.values())
       .filter((e) => !e.deleted)
-      .map(withResolvedMime);
+      .map(withResolvedMime)
+      .map(withScope);
   }
 
   async function findEntry(id: string): Promise<FileEntry | null> {
@@ -188,7 +211,7 @@ export function createFileStore(filesDir: string): FileStore {
       if (entry.id === id) found = entry;
     }
     if (!found || found.deleted) return null;
-    return withResolvedMime(found);
+    return withScope(withResolvedMime(found));
   }
 
   /**

--- a/src/files/store.ts
+++ b/src/files/store.ts
@@ -103,6 +103,11 @@ export function createFileStore(filesDir: string): FileStore {
    * alone — absent reads as `private`, and nothing consults it in v1.
    */
   function withScope(entry: FileEntry): FileEntry {
+    // Known limitation: when `parseFilePath(filesDir)` yields no scope — a
+    // non-workspace scratch/test path that isn't `workspaceFilesDir`-shaped —
+    // entries pass through with `ownerId`/`workspaceId` un-backfilled. This is
+    // intentional leniency for scratch stores; production always constructs the
+    // store from `workspaceFilesDir`, so `scope` is never null there.
     if (!scope) return entry;
     if (entry.ownerId && entry.workspaceId) return entry;
     return {

--- a/src/files/types.ts
+++ b/src/files/types.ts
@@ -12,7 +12,12 @@ export interface ExtractedTextSidecar {
   truncated: boolean;
 }
 
-/** Identity-owned file entry stored in registry.jsonl (`users/{userId}/files/`). */
+/**
+ * A file entry, stored in registry.jsonl under the workspace it belongs to:
+ * `workspaces/<wsId>/files/<ownerId>/` (see `src/files/paths.ts`). The path is
+ * authoritative for `workspaceId` + `ownerId`; the fields are a denormalised
+ * convenience the store backfills from the path on read.
+ */
 export interface FileEntry {
   id: string;
   filename: string;
@@ -23,13 +28,16 @@ export interface FileEntry {
   conversationId: string | null;
   createdAt: string;
   description: string | null;
+  /** The workspace this file lives in. Path-authoritative (§2.3). */
+  workspaceId: string;
+  /** The identity that owns it — the privacy principal. Path-authoritative (§2.3). */
+  ownerId: string;
   /**
-   * Provenance breadcrumb (Phase B): the workspace whose tools were in scope
-   * when this file was created. Informational only — files are identity-owned,
-   * so this is NEVER the storage key (mirrors `Conversation.workspaceId`).
-   * Absent on files created before the field existed.
+   * Who can see it within its workspace. Absent reads as `private` (fail-closed).
+   * v1 is private-only; `shared` is reserved groundwork (no read path consults it
+   * yet). Never crosses the workspace wall.
    */
-  workspaceId?: string;
+  visibility?: "private" | "shared";
   deleted?: true;
   deletedAt?: string;
 }

--- a/src/host-resources/resolver.ts
+++ b/src/host-resources/resolver.ts
@@ -53,11 +53,11 @@ export interface ListResourcesParams {
 
 /**
  * The single chokepoint a bundle's inbound `ai.nimblebrain/resources/*`
- * request goes through. Wraps the session user's identity `FileStore` (today;
- * future schemes like `entities://` would land here as additional read/list
- * paths). Files are identity-owned (Phase B): every read/list resolves against
- * the FileStore of the user whose session the bundle is running in — never
- * against any wsId the URI might encode, and never a workspace silo.
+ * request goes through. Wraps the workspace `FileStore` for the workspace the
+ * bundle runs in (today; future schemes like `entities://` would land here as
+ * additional read/list paths). Files are workspace-owned: every read/list
+ * resolves against the store for `ctx.workspaceId` with the session user as the
+ * owner sub-partition — never against any wsId the URI might encode.
  */
 export interface HostResourcesResolver {
   read(uri: string, ctx: HostResourceContext): Promise<ReadResourceResult>;
@@ -71,20 +71,20 @@ export interface HostResourcesResolver {
  * `files__read` exactly. Audit events ride the platform's existing
  * event sink alongside other tool activity.
  *
- * `getFileStore` resolves the caller's identity store; it takes no workspace
- * because files are identity-owned. `ctx.workspaceId` survives on read/list
- * for audit logging (which workspace the bundle ran in), not for storage.
+ * `getFileStore(wsId)` resolves the store for the bundle's workspace
+ * (`ctx.workspaceId`), with the session user as the owner sub-partition. Files
+ * are workspace-owned, so the workspace is path-authoritative.
  */
 export class FileBackedHostResourcesResolver implements HostResourcesResolver {
   constructor(
-    private readonly getFileStore: () => FileStore,
+    private readonly getFileStore: (wsId: string) => FileStore,
     private readonly maxReadSize: number = HOST_RESOURCES_MAX_READ_SIZE,
   ) {}
 
   async read(uri: string, ctx: HostResourceContext): Promise<ReadResourceResult> {
     const start = Date.now();
     const fileId = this.requireFileScheme(uri);
-    const store = this.getFileStore();
+    const store = this.getFileStore(ctx.workspaceId);
 
     let result: Awaited<ReturnType<typeof store.readFile>>;
     try {
@@ -137,11 +137,9 @@ export class FileBackedHostResourcesResolver implements HostResourcesResolver {
   }
 
   async list(params: ListResourcesParams, ctx: HostResourceContext): Promise<ListResourcesResult> {
-    // Identity-scoped: returns every file the session user owns, across all
-    // their workspaces — a broadening vs. the pre-identity per-workspace list.
-    // In-bounds under the install-time bundle-trust model (same user's data, no
-    // cross-user leak). If the shared-workspace threat model tightens, bound
-    // this to the bundle's provenance workspace via `entry.workspaceId`.
+    // Workspace-scoped: returns the session user's files in the workspace the
+    // bundle runs in (`ctx.workspaceId`) — the store is partitioned by that
+    // workspace, so this never crosses the workspace wall.
     if (params.filter?.scheme && params.filter.scheme !== FILE_URI_SCHEME) {
       throw new McpError(ErrorCode.InvalidParams, "Unsupported URI scheme", {
         scheme: params.filter.scheme,
@@ -159,7 +157,7 @@ export class FileBackedHostResourcesResolver implements HostResourcesResolver {
       });
     }
 
-    const store = this.getFileStore();
+    const store = this.getFileStore(ctx.workspaceId);
     const all = await store.readRegistry();
 
     const filteredByMime = params.filter?.mimeType

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -58,6 +58,7 @@ import type {
   ToolSchema,
 } from "../engine/types.ts";
 import { CONNECTOR_SKILL_SYNTHETIC } from "../engine/types.ts";
+import { workspaceFilesDir } from "../files/paths.ts";
 import { rehydrateUserResources } from "../files/rehydrate.ts";
 import { createFileStore, type FileStore } from "../files/store.ts";
 import { DEFAULT_FILE_CONFIG, type FileConfig } from "../files/types.ts";
@@ -461,25 +462,26 @@ export class Runtime {
     // `setBundleMcpDepsFactory`, other install paths consume via
     // `Runtime.getBundleMcpDeps(wsId)`.
     const hostResourcesWorkDir = resolveWorkDir(config);
-    // Files are identity-owned (Phase B): a bundle's `files://` read/list
-    // resolves against the SESSION USER's store (`users/{userId}/files/`), not
-    // the workspace the bundle runs in. The resolver fires inside the request
-    // context the orchestrator set up for the bundle's tool call, so the
-    // identity is in scope here; we resolve it with the same rule `chat()` uses
+    // Files are workspace-owned: a bundle's `files://` read/list resolves
+    // against the store for the workspace the bundle runs in
+    // (`workspaces/<wsId>/files/<ownerId>/`), with the session user as the owner
+    // sub-partition. The resolver passes the request's `ctx.workspaceId`; the
+    // identity is in scope here (the orchestrator set up the request context for
+    // the bundle's tool call), resolved with the same rule `chat()` uses
     // (`resolveRequestOwnerId`) so reads see exactly the files the agent does.
-    // Memoize per user — FileStore is cheap closures today, but per-call
-    // construction would leak if it ever gains state (fd handles, watchers).
+    // Memoize per (workspace, user) — FileStore is cheap closures today, but
+    // per-call construction would leak if it ever gains state (fd handles).
     const hostResourcesFileStoreCache = new Map<string, ReturnType<typeof createFileStore>>();
-    const hostResourcesResolver = new FileBackedHostResourcesResolver(() => {
+    const hostResourcesResolver = new FileBackedHostResourcesResolver((wsId: string) => {
       const userId = resolveRequestOwnerId(
         getRequestContext()?.identity,
         identityProvider !== null,
       );
-      const cached = hostResourcesFileStoreCache.get(userId);
+      const cacheKey = `${wsId} ${userId}`;
+      const cached = hostResourcesFileStoreCache.get(cacheKey);
       if (cached) return cached;
-      const idCtx = new IdentityContext({ userId, workDir: hostResourcesWorkDir });
-      const store = createFileStore(idCtx.getDataPath("files"));
-      hostResourcesFileStoreCache.set(userId, store);
+      const store = createFileStore(workspaceFilesDir(hostResourcesWorkDir, wsId, userId));
+      hostResourcesFileStoreCache.set(cacheKey, store);
       return store;
     });
     const hostResourcesRateLimit = new TokenBucketRateLimit();
@@ -1492,11 +1494,12 @@ export class Runtime {
     // where the storage shape (URI references) meets the model-call
     // shape (inline bytes) — see `src/files/rehydrate.ts`.
     const history = await store.history(conversation);
-    // File store is identity-scoped (Phase B): every file the user owns lives
-    // at `users/{userId}/files/`, regardless of which workspace it was created
-    // in. A `files://` URI persisted in any conversation resolves here against
-    // the owner's single store — there is no per-workspace file silo to miss.
-    const fileStore = this.getFileStore(ownerId);
+    // File store is workspace-owned: files live under the conversation's room
+    // (`workspaces/<roomWsId>/files/<ownerId>/`), the same `roomWsId` the
+    // conversation store is bound to. A `files://` URI persisted in this
+    // conversation resolves here against that workspace's store — the upload
+    // path stamped it into the same partition.
+    const fileStore = this.getFileStore(roomWsId, ownerId);
 
     // Resolve maxOutputTokens FIRST — resolveThinking needs it to clamp the
     // thinking budget so visible-content headroom is always preserved.
@@ -2051,7 +2054,9 @@ export class Runtime {
     // the rehydrate call is a pass-through for shape consistency with the
     // engine's message contract).
     const history = await store.history(conversation);
-    const fileStore = this.getFileStore(ownerId);
+    // Workspace-owned files: same room (`provRoomWsId`) the run conversation is
+    // bound to, owner as the privacy sub-partition.
+    const fileStore = this.getFileStore(provRoomWsId, ownerId);
 
     const resolvedMaxOutputTokens = resolveMaxOutputTokens({
       configValue: this.config.maxOutputTokens,
@@ -2864,14 +2869,16 @@ export class Runtime {
   }
 
   /**
-   * The identity-scoped file store for a user (`users/{userId}/files/`).
-   * Files are identity-owned (Phase B), so this is the single sanctioned
-   * `FileStore` constructor outside the store module itself — `check:file-paths`
-   * rejects any workspace-scoped files dir. Cheap (closures over a path); not
-   * memoized here because callers are per-request.
+   * The workspace-owned file store for one member in one workspace
+   * (`workspaces/<wsId>/files/<ownerId>/`). The workspace owns the directory —
+   * the path is the boundary (§2.3). This is the single sanctioned `FileStore`
+   * constructor outside the store module itself; `check:file-paths` rejects any
+   * identity-owned `users/<userId>/files/` dir. Mirrors `roomConversationStore`.
+   * Cheap (closures over a path); not memoized here because callers are
+   * per-request.
    */
-  getFileStore(userId: string): FileStore {
-    return createFileStore(this.getIdentityContext(userId).getDataPath("files"));
+  getFileStore(wsId: string, ownerId: string): FileStore {
+    return createFileStore(workspaceFilesDir(resolveWorkDir(this.config), wsId, ownerId));
   }
 
   /** Get the ToolRegistry for the current request's workspace (from AsyncLocalStorage context). */

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1137,8 +1137,17 @@ export class Runtime {
     // locator (authoritative). The room owns the directory; the path is the
     // boundary. This is a SEPARATE axis from `toolsWsId` (tool/skill/app scope)
     // below — the conversation room is fixed at create, the tool scope is not.
-    const roomWsId = request.workspaceId ?? sessionWsId;
-    const { store } = await this.resolveChatStore(request.conversationId, roomWsId, ownerId);
+    const requestRoomWsId = request.workspaceId ?? sessionWsId;
+    // `roomWsId` is authoritative: on a cross-room resume `resolveChatStore`
+    // relocates to the room the conversation actually lives in. The create
+    // stamp (below) and the file partition (~line 1502) follow it, not the
+    // request header — otherwise a resumed chat's attachments resolve in the
+    // wrong partition and silently vanish.
+    const { store, roomWsId } = await this.resolveChatStore(
+      request.conversationId,
+      requestRoomWsId,
+      ownerId,
+    );
 
     // Load the personal workspace config for agents / models override.
     // Pre-Stage-2 this looked up the request's `workspaceId`; that field

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -477,7 +477,7 @@ export class Runtime {
         getRequestContext()?.identity,
         identityProvider !== null,
       );
-      const cacheKey = `${wsId} ${userId}`;
+      const cacheKey = `${wsId} ${userId}`;
       const cached = hostResourcesFileStoreCache.get(cacheKey);
       if (cached) return cached;
       const store = createFileStore(workspaceFilesDir(hostResourcesWorkDir, wsId, userId));
@@ -3072,6 +3072,30 @@ export class Runtime {
     return loc.automationId
       ? this.runConversationStore(loc.wsId, loc.automationId)
       : this.roomConversationStore(loc.wsId, loc.ownerId ?? "");
+  }
+
+  /**
+   * The workspace a conversation lives in — for code outside the chat path (the
+   * upload handlers) that must write a file into the SAME partition `chat()`
+   * reads from when it rehydrates. Mirrors `resolveChatStore`'s room resolution:
+   * probe the focused/personal room directly, then the locator. A conversation
+   * not yet on disk (a new chat) is born in `fallbackWsId`. Without this the
+   * upload would partition by the request header while the read partitions by
+   * the conversation's room — they disagree on a cross-room resume and the
+   * attachment silently vanishes.
+   */
+  async resolveConversationRoomWsId(
+    conversationId: string | undefined,
+    fallbackWsId: string,
+    ownerId: string,
+  ): Promise<string> {
+    if (conversationId) {
+      const directDir = roomConversationsDir(resolveWorkDir(this.config), fallbackWsId, ownerId);
+      if (existsSync(join(directDir, `${conversationId}.jsonl`))) return fallbackWsId;
+      const loc = await this.getConversationLocator().locate(conversationId);
+      if (loc) return loc.wsId;
+    }
+    return fallbackWsId;
   }
 
   /**

--- a/src/tools/platform/files.ts
+++ b/src/tools/platform/files.ts
@@ -1,7 +1,7 @@
 /**
  * Files platform source — in-process MCP server backing the caller's
- * identity-owned file store (`users/{userId}/files/`; Phase B). `files` is a
- * kernel identity source, so its tools dispatch bare through the identity
+ * workspace-owned file store (`workspaces/<wsId>/files/<ownerId>/`). `files` is
+ * a kernel identity source, so its tools dispatch bare through the identity
  * door. Files are persisted via a JSONL registry and on-disk binary storage.
  *
  * Both this tool source and the chat multipart ingest path
@@ -24,6 +24,7 @@ import type { FileStore } from "../../files/store.ts";
 import type { FileEntry } from "../../files/types.ts";
 import { fileIdToUri, uriToFileId } from "../../files/uri.ts";
 import type { Runtime } from "../../runtime/runtime.ts";
+import { personalWorkspaceIdFor } from "../../workspace/workspace-store.ts";
 import {
   type DynamicResourceEntry,
   defineInProcessApp,
@@ -47,6 +48,12 @@ import {
 // ---------------------------------------------------------------------------
 // Tool handler helpers
 // ---------------------------------------------------------------------------
+
+/** The workspace + owner a tool call resolves its store under. */
+interface FileScope {
+  wsId: string;
+  ownerId: string;
+}
 
 interface ListInput {
   limit?: number;
@@ -317,7 +324,11 @@ interface CreateInput {
   body: string;
 }
 
-async function handleCreate(store: FileStore, args: CreateInput): Promise<object> {
+async function handleCreate(
+  store: FileStore,
+  scope: FileScope,
+  args: CreateInput,
+): Promise<object> {
   // TODO: apply the same MIME allowlist as chat-multipart ingest
   // (`ALLOWED_MIMES` in `src/files/ingest.ts`). The tool currently accepts
   // any `mimeType` the LLM supplies; the chat path rejects anything
@@ -343,6 +354,11 @@ async function handleCreate(store: FileStore, args: CreateInput): Promise<object
     conversationId: null,
     createdAt: new Date().toISOString(),
     description: manifest.description ?? null,
+    // Path-authoritative (§2.3), stamped at creation. `visibility` defaults to
+    // private — v1 is private-only; `shared` is dormant groundwork.
+    workspaceId: scope.wsId,
+    ownerId: scope.ownerId,
+    visibility: "private",
   };
   await store.appendRegistry(entry);
   return { id: saved.id, filename: manifest.filename, size: saved.size };
@@ -395,21 +411,25 @@ async function handleDelete(store: FileStore, args: { id: string }): Promise<obj
 /** Create the "files" platform source — in-process MCP server. */
 export function createFilesSource(runtime: Runtime, eventSink: EventSink): McpSource {
   /**
-   * Resolve the caller's identity-scoped file store. Files are identity-owned
-   * (Phase B): the store lives at `users/{userId}/files/`, not in any
-   * workspace. `files` is a kernel identity source, so the dispatcher always
-   * runs these tools with an authenticated identity in the request context;
-   * absence is a misrouted call, not a recoverable state.
+   * Resolve the workspace + owner this call stores under. Owner comes through
+   * the one shared rule (`resolveRequestUserId`) — the same path the REST file
+   * handlers and chat rehydration use, so "who am I" never drifts between
+   * sources. The workspace is the focused workspace (`X-Workspace-Id` in the
+   * request context), or the owner's personal workspace when there's no focus —
+   * mirroring how a chat resolves its room (`request.workspaceId ?? personal`).
+   * Fail-closed in production (the owner resolver throws when an identity
+   * provider is configured but the request carries no identity).
    */
+  function getScope(): FileScope {
+    const ownerId = runtime.resolveRequestUserId(runtime.getCurrentIdentity() ?? undefined);
+    const wsId = runtime.getCurrentWorkspaceId() ?? personalWorkspaceIdFor(ownerId);
+    return { wsId, ownerId };
+  }
+
+  /** The workspace-owned store for the current request's scope. */
   function getStore(): FileStore {
-    // Resolve the owner through the one shared rule (`resolveRequestUserId`) —
-    // the same path automations' source, the REST file handlers, and chat
-    // rehydration use, so "who am I" never drifts between sources. Fail-closed
-    // in production (throws when an identity provider is configured but the
-    // request carries no identity); DEV_IDENTITY only in dev.
-    return runtime.getFileStore(
-      runtime.resolveRequestUserId(runtime.getCurrentIdentity() ?? undefined),
-    );
+    const { wsId, ownerId } = getScope();
+    return runtime.getFileStore(wsId, ownerId);
   }
 
   function ok(data: object): ToolResult {
@@ -490,7 +510,14 @@ export function createFilesSource(runtime: Runtime, eventSink: EventSink): McpSo
       inputSchema: FilesCreateInput,
       handler: async (input: Record<string, unknown>): Promise<ToolResult> => {
         try {
-          return ok(await handleCreate(getStore(), input as unknown as CreateInput));
+          const scope = getScope();
+          return ok(
+            await handleCreate(
+              runtime.getFileStore(scope.wsId, scope.ownerId),
+              scope,
+              input as unknown as CreateInput,
+            ),
+          );
         } catch (err) {
           return fail(err instanceof Error ? err.message : String(err));
         }

--- a/test/integration/cross-room-file-upload.test.ts
+++ b/test/integration/cross-room-file-upload.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Cross-room UPLOAD → file partition (the write side).
+ *
+ * A conversation is ROOM-owned: it lives under `workspaces/<roomWsId>/...` and
+ * its attached files MUST land in that SAME room's partition
+ * (`workspaces/<roomWsId>/files/<ownerId>/`) — the partition the chat READ path
+ * rehydrates from. When a file is uploaded *attached to a conversation* on a
+ * request that is NOT focused on that conversation's room (unfocused, or focused
+ * on a different workspace), the upload must resolve the conversation's
+ * authoritative room (probe + locator) and write THERE — not into the request's
+ * header/personal partition.
+ *
+ * The sibling resume test (`runtime/cross-room-file-resume.test.ts`) pins the
+ * read side by seeding the registry directly. This one drives the REAL upload
+ * handler over HTTP (`POST /v1/resources` → `handleResourceUpload`) so it
+ * exercises the actual partition-selection logic — the bug lived in the write
+ * path. If the handler reverts to partitioning by the request header, the
+ * attachment lands in the personal room while the chat reads from room A → it
+ * silently vanishes, and the assertions below fail.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type ServerHandle, startServer } from "../../src/api/server.ts";
+import { DEV_IDENTITY } from "../../src/identity/providers/dev.ts";
+import { Runtime } from "../../src/runtime/runtime.ts";
+import { personalWorkspaceIdFor } from "../../src/workspace/workspace-store.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+import { provisionTestWorkspace } from "../helpers/test-workspace.ts";
+
+const testDir = join(tmpdir(), `nb-cross-room-file-upload-${Date.now()}`);
+
+// The conversation's room — the chat is born here (focused on ROOM_A).
+const ROOM_A = "ws_room_a";
+// Dev mode: no identity on the request → the dev owner.
+const OWNER = DEV_IDENTITY.id;
+// An UNFOCUSED request (no X-Workspace-Id) falls back to the owner's personal
+// room, a DIFFERENT workspace than ROOM_A. That gap is the cross-room hop the
+// fix must bridge by resolving the conversation's room from the locator.
+const PERSONAL = personalWorkspaceIdFor(OWNER);
+
+let runtime: Runtime;
+let handle: ServerHandle;
+let baseUrl: string;
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true });
+  runtime = await Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    logging: { disabled: true },
+    workDir: testDir,
+  });
+  await provisionTestWorkspace(runtime, ROOM_A);
+  handle = startServer({ runtime, port: 0 });
+  baseUrl = `http://localhost:${handle.port}`;
+});
+
+afterAll(async () => {
+  handle.stop(true);
+  await runtime.shutdown();
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("cross-room upload writes to the conversation's room (not the request)", () => {
+  it("a file attached to a room-A conversation lands in A even when the request is unfocused", async () => {
+    // 1) Born in room A (focused on ROOM_A) — the conversation lives under
+    //    workspaces/ws_room_a/conversations/<owner>/<convId>.jsonl.
+    const born = await runtime.chat({ message: "hello from room A", workspaceId: ROOM_A });
+    const convId = born.conversationId;
+
+    // 2) Drive the REAL upload handler attached to that conversation, with the
+    //    request UNFOCUSED (no X-Workspace-Id). The header/personal partition is
+    //    PERSONAL; the conversation's room is A — they disagree, so this is the
+    //    cross-room case the fix targets.
+    const form = new FormData();
+    form.append("file", new Blob(["room-A attachment bytes"], { type: "text/plain" }), "attach.txt");
+    form.append("conversationId", convId);
+
+    const res = await fetch(`${baseUrl}/v1/resources`, { method: "POST", body: form });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.files).toHaveLength(1);
+    const fileId: string = body.files[0].id;
+    // The handler stamps the resolved room onto the FileEntry it returns.
+    expect(body.files[0].workspaceId).toBe(ROOM_A);
+
+    // 3) The file landed in room A's partition — the one the read path uses…
+    const inRoomA = await runtime.getFileStore(ROOM_A, OWNER).findEntry(fileId);
+    expect(inRoomA).not.toBeNull();
+    expect(inRoomA?.workspaceId).toBe(ROOM_A);
+
+    // …and NOT in the request's personal partition. With the write-side bug,
+    // the upload partitions by the header (personal) and these two flip:
+    // present in PERSONAL, absent in A → the attachment is lost on resume.
+    expect(await runtime.getFileStore(PERSONAL, OWNER).findEntry(fileId)).toBeNull();
+
+    // 4) Survives a read: an UNFOCUSED resume rehydrates from the conversation's
+    //    room (A), where the upload actually wrote — the attachment is still
+    //    there afterward, not orphaned in the wrong partition.
+    await runtime.chat({ message: "resume from elsewhere", conversationId: convId });
+    const afterResume = await runtime.getFileStore(ROOM_A, OWNER).findEntry(fileId);
+    expect(afterResume).not.toBeNull();
+    expect(afterResume?.workspaceId).toBe(ROOM_A);
+    expect(await runtime.getFileStore(PERSONAL, OWNER).findEntry(fileId)).toBeNull();
+  });
+});

--- a/test/integration/migrate-files-to-room.test.ts
+++ b/test/integration/migrate-files-to-room.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateFilesToRoom } from "../../scripts/migrate-files-to-room.ts";
+import { workspaceFilesDir } from "../../src/files/paths.ts";
+import { createFileStore } from "../../src/files/store.ts";
+import { personalWorkspaceIdFor } from "../../src/workspace/workspace-store.ts";
+
+/**
+ * Round-trip coverage for the identity → workspace-owned file migration. Does
+ * real filesystem I/O against a throwaway work-dir, hence `test/integration/`.
+ */
+
+const ALICE = "user_alice";
+const BOB = "user_bob";
+
+const ALICE_FILE_ID = `fl_${"a".repeat(24)}`;
+const BOB_FILE_ID = `fl_${"b".repeat(24)}`;
+
+/** Seed one file (blob + registry row) in a user's identity files dir. */
+function seedIdentityFile(workDir: string, userId: string, fileId: string, body: string): void {
+  const filesDir = join(workDir, "users", userId, "files");
+  mkdirSync(filesDir, { recursive: true });
+  const diskName = `${fileId}_doc.txt`;
+  writeFileSync(join(filesDir, diskName), body, "utf-8");
+  // A legacy registry row — no ownerId/workspaceId fields (the store backfills
+  // them from the destination path on read).
+  const row = {
+    id: fileId,
+    filename: "doc.txt",
+    mimeType: "text/plain",
+    size: Buffer.byteLength(body),
+    tags: [],
+    source: "chat",
+    conversationId: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    description: null,
+  };
+  writeFileSync(join(filesDir, "registry.jsonl"), `${JSON.stringify(row)}\n`, "utf-8");
+}
+
+/** The workspace-owned files dir for a user's personal workspace. */
+function destFilesDir(workDir: string, userId: string): string {
+  return workspaceFilesDir(workDir, personalWorkspaceIdFor(userId), userId);
+}
+
+describe("migrate-files-to-room", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "nb-files-room-migrate-"));
+    seedIdentityFile(workDir, ALICE, ALICE_FILE_ID, "alice secret");
+    seedIdentityFile(workDir, BOB, BOB_FILE_ID, "bob secret");
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("dry-run plans every move but writes nothing", () => {
+    const summary = migrateFilesToRoom(workDir, { write: false });
+
+    // Two files (blob + registry) per user × 2 users = 4 moves planned.
+    expect(summary.moved).toBe(4);
+    expect(summary.skippedExisting).toBe(0);
+    expect(summary.users).toBe(2);
+
+    // Nothing on disk changed: identity sources untouched, destinations absent.
+    expect(existsSync(join(workDir, "users", ALICE, "files", "registry.jsonl"))).toBe(true);
+    expect(existsSync(destFilesDir(workDir, ALICE))).toBe(false);
+    expect(existsSync(join(workDir, ".migration-lock"))).toBe(false);
+  });
+
+  test("--write moves each user's files to their personal-workspace partition", () => {
+    const summary = migrateFilesToRoom(workDir, { write: true });
+
+    expect(summary.moved).toBe(4);
+    expect(summary.users).toBe(2);
+
+    // Files now live at workspaces/ws_user_<u>/files/<u>/.
+    expect(existsSync(join(destFilesDir(workDir, ALICE), `${ALICE_FILE_ID}_doc.txt`))).toBe(true);
+    expect(existsSync(join(destFilesDir(workDir, ALICE), "registry.jsonl"))).toBe(true);
+    expect(existsSync(join(destFilesDir(workDir, BOB), `${BOB_FILE_ID}_doc.txt`))).toBe(true);
+
+    // Identity sources are gone.
+    expect(existsSync(join(workDir, "users", ALICE, "files", "registry.jsonl"))).toBe(false);
+    expect(existsSync(join(workDir, "users", BOB, "files", `${BOB_FILE_ID}_doc.txt`))).toBe(false);
+
+    expect(existsSync(join(workDir, ".migration-lock"))).toBe(false);
+  });
+
+  test("migrated files are readable, with scope backfilled from the path", async () => {
+    migrateFilesToRoom(workDir, { write: true });
+
+    const store = createFileStore(destFilesDir(workDir, ALICE));
+    const entry = await store.findEntry(ALICE_FILE_ID);
+    expect(entry).not.toBeNull();
+    // The pure move carried no scope fields; the store backfills them from the
+    // destination path.
+    expect(entry?.ownerId).toBe(ALICE);
+    expect(entry?.workspaceId).toBe(personalWorkspaceIdFor(ALICE));
+
+    const read = await store.readFile(ALICE_FILE_ID);
+    expect(read.data.toString("utf-8")).toBe("alice secret");
+  });
+
+  test("a file in user A's partition is not visible from user B's store", async () => {
+    migrateFilesToRoom(workDir, { write: true });
+
+    const bobStore = createFileStore(destFilesDir(workDir, BOB));
+    // Bob's store never sees Alice's file — the partition is the wall.
+    expect(await bobStore.findEntry(ALICE_FILE_ID)).toBeNull();
+    const bobEntries = await bobStore.readRegistry();
+    expect(bobEntries.map((e) => e.id)).toEqual([BOB_FILE_ID]);
+  });
+
+  test("a second --write run is idempotent (0 moves)", () => {
+    migrateFilesToRoom(workDir, { write: true });
+    const second = migrateFilesToRoom(workDir, { write: true });
+
+    expect(second.moved).toBe(0);
+    expect(second.skippedExisting).toBe(0);
+    expect(second.users).toBe(0);
+  });
+
+  test("crash recovery: a pre-existing destination removes the stale identity source", () => {
+    // Simulate a prior partial run: the dest registry exists, the identity
+    // source was never unlinked.
+    const aliceDest = destFilesDir(workDir, ALICE);
+    mkdirSync(aliceDest, { recursive: true });
+    const aliceSrcRegistry = join(workDir, "users", ALICE, "files", "registry.jsonl");
+    writeFileSync(join(aliceDest, "registry.jsonl"), readFileSync(aliceSrcRegistry, "utf-8"));
+    expect(existsSync(aliceSrcRegistry)).toBe(true);
+
+    const summary = migrateFilesToRoom(workDir, { write: true });
+
+    // Alice's registry counted as already-migrated; its stale source is removed.
+    expect(summary.skippedExisting).toBe(1);
+    expect(existsSync(aliceSrcRegistry)).toBe(false);
+    // Alice's blob + both of Bob's files still move normally.
+    expect(summary.moved).toBe(3);
+  });
+});

--- a/test/integration/migrate-files-to-room.test.ts
+++ b/test/integration/migrate-files-to-room.test.ts
@@ -124,21 +124,71 @@ describe("migrate-files-to-room", () => {
     expect(second.users).toBe(0);
   });
 
-  test("crash recovery: a pre-existing destination removes the stale identity source", () => {
-    // Simulate a prior partial run: the dest registry exists, the identity
-    // source was never unlinked.
+  test("a disjoint dest registry (post-deploy upload) is MERGED, not overwritten", async () => {
+    // A fresh upload landed AFTER deploy but BEFORE migration: the destination
+    // registry holds only that new row (file B), while the legacy identity
+    // source still holds the pre-existing row (file A). The migration must
+    // APPEND A's rows onto the dest registry — a move-or-drop would orphan A
+    // (its blob moves, but its registry entry is lost).
     const aliceDest = destFilesDir(workDir, ALICE);
     mkdirSync(aliceDest, { recursive: true });
-    const aliceSrcRegistry = join(workDir, "users", ALICE, "files", "registry.jsonl");
-    writeFileSync(join(aliceDest, "registry.jsonl"), readFileSync(aliceSrcRegistry, "utf-8"));
-    expect(existsSync(aliceSrcRegistry)).toBe(true);
+
+    // Seed a DIFFERENT entry (file B) directly into the dest partition, as a
+    // post-deploy upload would have.
+    const bBody = "alice post-deploy upload";
+    const bDiskName = `${BOB_FILE_ID}_upload.txt`;
+    writeFileSync(join(aliceDest, bDiskName), bBody, "utf-8");
+    const bRow = {
+      id: BOB_FILE_ID,
+      filename: "upload.txt",
+      mimeType: "text/plain",
+      size: Buffer.byteLength(bBody),
+      tags: [],
+      source: "chat",
+      conversationId: null,
+      createdAt: "2026-02-02T00:00:00.000Z",
+      description: null,
+      ownerId: ALICE,
+      workspaceId: personalWorkspaceIdFor(ALICE),
+    };
+    writeFileSync(join(aliceDest, "registry.jsonl"), `${JSON.stringify(bRow)}\n`, "utf-8");
 
     const summary = migrateFilesToRoom(workDir, { write: true });
 
-    // Alice's registry counted as already-migrated; its stale source is removed.
+    // Exactly one registry was appended onto an existing dest registry.
+    expect(summary.merged).toBe(1);
+
+    // The merged dest registry holds BOTH the pre-existing entry (A) and the
+    // post-deploy upload (B). Read via the store so dedupe/scope match prod.
+    const store = createFileStore(aliceDest);
+    const ids = (await store.readRegistry()).map((e) => e.id).sort();
+    expect(ids).toEqual([ALICE_FILE_ID, BOB_FILE_ID].sort());
+
+    // A's blob made it across (its entry would otherwise be a dangling ref).
+    expect(existsSync(join(aliceDest, `${ALICE_FILE_ID}_doc.txt`))).toBe(true);
+    expect((await store.readFile(ALICE_FILE_ID)).data.toString("utf-8")).toBe("alice secret");
+
+    // The stale identity source registry is consumed by the merge.
+    expect(existsSync(join(workDir, "users", ALICE, "files", "registry.jsonl"))).toBe(false);
+  });
+
+  test("crash recovery: a pre-existing destination blob removes the stale identity source", () => {
+    // Simulate a prior partial run: the content-addressed dest BLOB exists, the
+    // identity source was never unlinked. (The registry is an append-log and is
+    // merged, not skipped — see the merge test above; this covers the blob's
+    // move-or-drop path.)
+    const aliceDest = destFilesDir(workDir, ALICE);
+    mkdirSync(aliceDest, { recursive: true });
+    const aliceSrcBlob = join(workDir, "users", ALICE, "files", `${ALICE_FILE_ID}_doc.txt`);
+    writeFileSync(join(aliceDest, `${ALICE_FILE_ID}_doc.txt`), readFileSync(aliceSrcBlob, "utf-8"));
+    expect(existsSync(aliceSrcBlob)).toBe(true);
+
+    const summary = migrateFilesToRoom(workDir, { write: true });
+
+    // Alice's blob counted as already-migrated; its stale source is removed.
     expect(summary.skippedExisting).toBe(1);
-    expect(existsSync(aliceSrcRegistry)).toBe(false);
-    // Alice's blob + both of Bob's files still move normally.
+    expect(existsSync(aliceSrcBlob)).toBe(false);
+    // Alice's registry + both of Bob's files still move normally.
     expect(summary.moved).toBe(3);
   });
 });

--- a/test/integration/resource-upload.test.ts
+++ b/test/integration/resource-upload.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type ServerHandle, startServer } from "../../src/api/server.ts";
+import { workspaceFilesDir } from "../../src/files/paths.ts";
 import { DEV_IDENTITY } from "../../src/identity/providers/dev.ts";
 import { Runtime } from "../../src/runtime/runtime.ts";
 import { createEchoModel } from "../helpers/echo-model.ts";
@@ -61,10 +62,10 @@ describe("POST /v1/resources", () => {
     expect(entry.mimeType.split(";")[0]).toBe("text/plain");
     expect(entry.size).toBe(11);
 
-    // Bytes land under the uploader's IDENTITY store (files are
-    // identity-owned; Phase B) — `users/{userId}/files/`, not the workspace
-    // dir. The dev server authenticates as DEV_IDENTITY.
-    const filesDir = join(testDir, "users", DEV_IDENTITY.id, "files");
+    // Bytes land under the focused workspace's owner partition (files are
+    // workspace-owned) — `workspaces/<X-Workspace-Id>/files/<ownerId>/`. The
+    // dev server authenticates as DEV_IDENTITY.
+    const filesDir = workspaceFilesDir(testDir, TEST_WORKSPACE_ID, DEV_IDENTITY.id);
     const onDisk = readdirSync(filesDir);
     expect(onDisk.some((name) => name.startsWith(`${entry.id}_`))).toBe(true);
   });

--- a/test/integration/runtime/cross-room-file-resume.test.ts
+++ b/test/integration/runtime/cross-room-file-resume.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Cross-room resume → file rehydration partition.
+ *
+ * A conversation is ROOM-owned: it lives under `workspaces/<roomWsId>/...` and
+ * its attached files live in the SAME room's partition
+ * (`workspaces/<roomWsId>/files/<ownerId>/`). On a cross-room resume — a
+ * request whose focused workspace differs from the conversation's room —
+ * `resolveChatStore` relocates to the conversation's actual room via the
+ * locator and returns the authoritative `roomWsId`. The file store used to
+ * rehydrate `files://` attachments MUST be built from THAT `roomWsId`, not the
+ * request header — otherwise the resumed chat reads the wrong partition and the
+ * attachment silently vanishes.
+ *
+ * This pins that wiring: after a cross-room resume, the rehydration file store
+ * resolves to the conversation's room (A), where the file lives, and finds it —
+ * even though the resume request is NOT focused on A.
+ */
+
+import { afterAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FileStore } from "../../../src/files/store.ts";
+import { DEV_IDENTITY } from "../../../src/identity/providers/dev.ts";
+import { Runtime } from "../../../src/runtime/runtime.ts";
+import { personalWorkspaceIdFor } from "../../../src/workspace/workspace-store.ts";
+import { createEchoModel } from "../../helpers/echo-model.ts";
+import { provisionTestWorkspace } from "../../helpers/test-workspace.ts";
+
+const testDir = join(tmpdir(), `nb-cross-room-file-resume-${Date.now()}`);
+
+afterAll(() => {
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+});
+
+// The conversation's room (a focused workspace, the chat is born here).
+const ROOM_A = "ws_room_a";
+// Dev mode: no identity on the request → the dev owner.
+const OWNER = DEV_IDENTITY.id;
+// The resume is UNFOCUSED → it falls back to the owner's personal room, which
+// is a DIFFERENT workspace than ROOM_A. That is the cross-room hop.
+const PERSONAL = personalWorkspaceIdFor(OWNER);
+
+describe("cross-room resume rehydrates files from the conversation's room (not the request)", () => {
+  it("a file attached in room A is found on a resume that is NOT focused on A", async () => {
+    const workDir = join(testDir, "rehydrate-from-room");
+    mkdirSync(workDir, { recursive: true });
+
+    const runtime = await Runtime.start({
+      model: { provider: "custom", adapter: createEchoModel() },
+      noDefaultBundles: true,
+      logging: { disabled: true },
+      workDir,
+    });
+    await provisionTestWorkspace(runtime, ROOM_A);
+
+    // 1) Born in room A (focused on ROOM_A) — the conversation lives under
+    //    workspaces/ws_room_a/conversations/<owner>/.
+    const born = await runtime.chat({ message: "hello from room A", workspaceId: ROOM_A });
+    const convId = born.conversationId;
+
+    // 2) Attach a file into room A's partition (same room the conversation
+    //    lives in). This is the partition the resume must resolve to.
+    const fileStoreA = runtime.getFileStore(ROOM_A, OWNER);
+    const saved = await fileStoreA.saveFile(Buffer.from("room-A bytes"), "attach.txt", "text/plain");
+    await fileStoreA.appendRegistry({
+      id: saved.id,
+      filename: "attach.txt",
+      mimeType: "text/plain",
+      size: saved.size,
+      tags: [],
+      source: "chat",
+      conversationId: convId,
+      createdAt: new Date().toISOString(),
+      description: null,
+      workspaceId: ROOM_A,
+      ownerId: OWNER,
+      visibility: "private",
+    });
+
+    // Sanity: the personal room — where an un-fixed resume would look — does
+    // NOT hold the file. So "found" can only mean "resolved to room A".
+    expect(await runtime.getFileStore(PERSONAL, OWNER).findEntry(saved.id)).toBeNull();
+
+    // 3) Spy on getFileStore to capture the partition rehydration resolves to.
+    //    `_chatInner` builds exactly one file store (the rehydration store) from
+    //    the authoritative `roomWsId`. We capture its (wsId, store) so we can
+    //    assert which room the resume read from.
+    const calls: Array<{ wsId: string; store: FileStore }> = [];
+    const origGetFileStore = runtime.getFileStore.bind(runtime);
+    runtime.getFileStore = (wsId: string, ownerId: string): FileStore => {
+      const store = origGetFileStore(wsId, ownerId);
+      calls.push({ wsId, store });
+      return store;
+    };
+
+    // 4) Cross-room resume: UNFOCUSED (no workspaceId) → the request room is the
+    //    owner's personal workspace, NOT room A. resolveChatStore must relocate
+    //    to A via the locator, and rehydration must follow it.
+    await runtime.chat({ message: "resume from elsewhere", conversationId: convId });
+
+    runtime.getFileStore = origGetFileStore;
+
+    // Every partition the resume touched is the conversation's room (A) — never
+    // the request's personal room. (Reverting the fix makes this the personal
+    // room, and the assertions below fail.)
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.wsId).toBe(ROOM_A);
+      expect(c.wsId).not.toBe(PERSONAL);
+    }
+
+    // The store rehydration actually used finds the attachment — it is not lost.
+    const rehydrationStore = calls[calls.length - 1]!.store;
+    const entry = await rehydrationStore.findEntry(saved.id);
+    expect(entry).not.toBeNull();
+    expect(entry?.workspaceId).toBe(ROOM_A);
+
+    await runtime.shutdown();
+  });
+});

--- a/test/integration/runtime/workspace-files.test.ts
+++ b/test/integration/runtime/workspace-files.test.ts
@@ -1,0 +1,115 @@
+/**
+ * File persistence tests — the workspace-owned layout.
+ *
+ * Files are workspace-owned: each lives at
+ * `{workDir}/workspaces/<wsId>/files/<ownerId>/` (see `src/files/paths.ts`).
+ * `Runtime.getFileStore(wsId, ownerId)` is the single sanctioned constructor;
+ * the directory is path-authoritative for `workspaceId` + `ownerId` (§2.3). A
+ * file created in one workspace never crosses the wall into another.
+ */
+
+import { afterAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { workspaceFilesDir } from "../../../src/files/paths.ts";
+import { Runtime } from "../../../src/runtime/runtime.ts";
+import { createEchoModel } from "../../helpers/echo-model.ts";
+
+const testDir = join(tmpdir(), `nb-ws-files-${Date.now()}`);
+
+afterAll(() => {
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true });
+});
+
+const OWNER = "user_alice";
+const WS_A = "ws_team_a";
+const WS_B = "ws_team_b";
+
+async function startRuntime(workDir: string): Promise<Runtime> {
+  mkdirSync(workDir, { recursive: true });
+  return Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    workDir,
+  });
+}
+
+describe("file persistence — workspace layout", () => {
+  it("a file created in a workspace lands under that workspace's files/<ownerId>", async () => {
+    const workDir = join(testDir, "lands-in-workspace");
+    const runtime = await startRuntime(workDir);
+
+    const store = runtime.getFileStore(WS_A, OWNER);
+    const saved = await store.saveFile(Buffer.from("hello A"), "note.txt", "text/plain");
+
+    // The blob lives under the workspace's owner partition, not at the identity
+    // level (`users/<ownerId>/files/`).
+    const expectedDir = workspaceFilesDir(workDir, WS_A, OWNER);
+    expect(saved.path.startsWith(expectedDir)).toBe(true);
+    expect(existsSync(join(expectedDir, `${saved.id}_note.txt`))).toBe(true);
+    expect(existsSync(join(workDir, "users", OWNER, "files"))).toBe(false);
+
+    await runtime.shutdown();
+  });
+
+  it("a stored file reads back through the same workspace store", async () => {
+    const workDir = join(testDir, "read-back");
+    const runtime = await startRuntime(workDir);
+
+    const store = runtime.getFileStore(WS_A, OWNER);
+    const saved = await store.saveFile(Buffer.from("round trip"), "doc.txt", "text/plain");
+    await store.appendRegistry({
+      id: saved.id,
+      filename: "doc.txt",
+      mimeType: "text/plain",
+      size: saved.size,
+      tags: [],
+      source: "manual",
+      conversationId: null,
+      createdAt: new Date().toISOString(),
+      description: null,
+      workspaceId: WS_A,
+      ownerId: OWNER,
+      visibility: "private",
+    });
+
+    const read = await store.readFile(saved.id);
+    expect(read.data.toString("utf-8")).toBe("round trip");
+
+    const entry = await store.findEntry(saved.id);
+    expect(entry?.workspaceId).toBe(WS_A);
+    expect(entry?.ownerId).toBe(OWNER);
+
+    await runtime.shutdown();
+  });
+
+  it("a file in workspace A is NOT visible from workspace B", async () => {
+    const workDir = join(testDir, "cross-workspace-isolation");
+    const runtime = await startRuntime(workDir);
+
+    const storeA = runtime.getFileStore(WS_A, OWNER);
+    const saved = await storeA.saveFile(Buffer.from("A only"), "secret.txt", "text/plain");
+    await storeA.appendRegistry({
+      id: saved.id,
+      filename: "secret.txt",
+      mimeType: "text/plain",
+      size: saved.size,
+      tags: [],
+      source: "manual",
+      conversationId: null,
+      createdAt: new Date().toISOString(),
+      description: null,
+      workspaceId: WS_A,
+      ownerId: OWNER,
+      visibility: "private",
+    });
+
+    // Same owner, different workspace → a different partition, a different wall.
+    const storeB = runtime.getFileStore(WS_B, OWNER);
+    expect(await storeB.findEntry(saved.id)).toBeNull();
+    expect(await storeB.readRegistry()).toHaveLength(0);
+
+    await runtime.shutdown();
+  });
+});

--- a/test/unit/bundles/files/source.test.ts
+++ b/test/unit/bundles/files/source.test.ts
@@ -54,14 +54,16 @@ function findResourceLink(result: ToolResult): {
 }
 
 function makeRuntime(workDir: string): Runtime {
-  // Files are identity-owned: the source resolves its store via
-  // `resolveRequestUserId(getCurrentIdentity())` + `getFileStore(userId)`. The
-  // mock keeps the store at `<workDir>/files` so the on-disk assertions are
-  // unchanged.
+  // Files are workspace-owned: the source resolves its store via
+  // `getCurrentWorkspaceId()` + `resolveRequestUserId(getCurrentIdentity())`,
+  // then `getFileStore(wsId, ownerId)`. The mock roots the store at the
+  // workspace-partitioned path so the round-trip exercises the real layout.
   return {
     getCurrentIdentity: () => ({ id: "usr_test" }),
+    getCurrentWorkspaceId: () => "ws_test",
     resolveRequestUserId: (identity?: { id: string }) => identity?.id ?? "usr_test",
-    getFileStore: () => createFileStore(join(workDir, "files")),
+    getFileStore: (wsId: string, ownerId: string) =>
+      createFileStore(join(workDir, "workspaces", wsId, "files", ownerId)),
     getFilesConfig: () => ({ maxExtractedTextSize: 204_800 }),
   } as unknown as Runtime;
 }

--- a/test/unit/files/ingest.test.ts
+++ b/test/unit/files/ingest.test.ts
@@ -13,6 +13,9 @@ const DEFAULT_CONFIG: FileConfig = {
   maxExtractedTextSize: 204_800,
 };
 
+const WS = "ws_test";
+const OWNER = "owner_test";
+
 let workDir: string;
 
 beforeEach(async () => {
@@ -39,7 +42,7 @@ describe("ingestFiles", () => {
   test("text file produces extracted text content part", async () => {
     const store = createFileStore(join(workDir, "files"));
     const files = [makeFile("hello world", "test.txt", "text/plain")];
-    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(1);
@@ -59,7 +62,7 @@ describe("ingestFiles", () => {
     // exact-Set lookup against the parameter-suffixed value.
     const store = createFileStore(join(workDir, "files"));
     const files = [makeFile("charset content", "with-charset.txt", "text/plain;charset=utf-8")];
-    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(1);
@@ -77,7 +80,7 @@ describe("ingestFiles", () => {
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
     ]);
     const files = [makeFile(pngHeader, "photo.png", "image/png")];
-    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(1);
@@ -100,7 +103,7 @@ describe("ingestFiles", () => {
   test("binary file (zip) produces metadata-only notice", async () => {
     const store = createFileStore(join(workDir, "files"));
     const files = [makeFile("fake zip data", "archive.zip", "application/zip")];
-    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(1);
@@ -123,7 +126,7 @@ describe("ingestFiles", () => {
       makeFile("b", "b.txt", "text/plain"),
       makeFile("c", "c.txt", "text/plain"),
     ];
-    const result = await ingestFiles(files, "conv_1", store, config);
+    const result = await ingestFiles(files, "conv_1", store, config, WS, OWNER);
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("Too many files");
@@ -134,7 +137,7 @@ describe("ingestFiles", () => {
     const store = createFileStore(join(workDir, "files"));
     const config: FileConfig = { ...DEFAULT_CONFIG, maxFileSize: 10 };
     const files = [makeFile("this is longer than 10 bytes", "big.txt", "text/plain")];
-    const result = await ingestFiles(files, "conv_1", store, config);
+    const result = await ingestFiles(files, "conv_1", store, config, WS, OWNER);
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("exceeds limit");
@@ -145,7 +148,7 @@ describe("ingestFiles", () => {
     const store = createFileStore(join(workDir, "files"));
     const config: FileConfig = { ...DEFAULT_CONFIG, maxTotalSize: 10 };
     const files = [makeFile("this is longer than 10 bytes", "big.txt", "text/plain")];
-    const result = await ingestFiles(files, "conv_1", store, config);
+    const result = await ingestFiles(files, "conv_1", store, config, WS, OWNER);
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("Total file size");
@@ -155,7 +158,7 @@ describe("ingestFiles", () => {
   test("rejects disallowed MIME type", async () => {
     const store = createFileStore(join(workDir, "files"));
     const files = [makeFile("#!/bin/bash", "evil.sh", "application/x-executable")];
-    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("disallowed type");
@@ -168,7 +171,7 @@ describe("ingestFiles", () => {
       makeFile("csv data", "data.csv", "text/csv"),
       makeFile("zip content", "archive.zip", "application/zip"),
     ];
-    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(2);
@@ -178,7 +181,7 @@ describe("ingestFiles", () => {
   test("each ingested file gets a registry entry with source chat", async () => {
     const store = createFileStore(join(workDir, "files"));
     const files = [makeFile("hello", "test.txt", "text/plain")];
-    await ingestFiles(files, "conv_42", store, DEFAULT_CONFIG);
+    await ingestFiles(files, "conv_42", store, DEFAULT_CONFIG, WS, OWNER);
 
     const registry = await store.readRegistry();
     expect(registry).toHaveLength(1);
@@ -194,7 +197,7 @@ describe("ingestFiles", () => {
       makeFile("not a real pdf", "broken.pdf", "application/pdf"),
       makeFile("good text", "good.txt", "text/plain"),
     ];
-    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(2);
@@ -209,7 +212,7 @@ describe("ingestFiles", () => {
     const files = [
       makeFile('{"key": "value"}', "config.json", "application/json"),
     ];
-    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.fileRefs[0].extracted).toBe(true);
     const textPart = result.contentParts.find(

--- a/test/unit/files/integration.test.ts
+++ b/test/unit/files/integration.test.ts
@@ -14,6 +14,9 @@ const DEFAULT_CONFIG: FileConfig = {
   maxExtractedTextSize: 204_800,
 };
 
+const WS = "ws_test";
+const OWNER = "owner_test";
+
 let workDir: string;
 
 beforeEach(async () => {
@@ -42,7 +45,7 @@ describe("Integration: upload text file → ingest → verify extracted content"
     const textContent = "The quick brown fox jumps over the lazy dog.";
     const files = [makeFile(textContent, "notes.txt", "text/plain")];
 
-    const result = await ingestFiles(files, "conv_int_1", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_int_1", store, DEFAULT_CONFIG, WS, OWNER);
 
     // No errors
     expect(result.errors).toHaveLength(0);
@@ -78,7 +81,7 @@ describe("Integration: upload PNG image → ingest → verify resource_link cont
     ]);
     const files = [makeFile(pngHeader, "screenshot.png", "image/png")];
 
-    const result = await ingestFiles(files, "conv_int_2", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_int_2", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(1);
@@ -102,7 +105,7 @@ describe("Integration: upload PDF → ingest → verify resource_link without ex
     const store = createFileStore(join(workDir, "files"));
     const files = [makeFile(Buffer.from("%PDF-1.4\n%%EOF"), "report.pdf", "application/pdf")];
 
-    const result = await ingestFiles(files, "conv_int_pdf", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_int_pdf", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(1);
@@ -124,7 +127,7 @@ describe("Integration: backward compat — no files → empty result", () => {
   test("empty files array returns empty contentParts, fileRefs, and no errors", async () => {
     const store = createFileStore(join(workDir, "files"));
 
-    const result = await ingestFiles([], "conv_int_3", store, DEFAULT_CONFIG);
+    const result = await ingestFiles([], "conv_int_3", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.contentParts).toHaveLength(0);
     expect(result.fileRefs).toHaveLength(0);
@@ -145,6 +148,8 @@ describe("Integration: FileStore save → registry → read round-trip", () => {
     // Register in the registry
     const entry: FileEntry = {
       id: saved.id,
+      workspaceId: WS,
+      ownerId: OWNER,
       filename: "payload.bin",
       mimeType: "application/octet-stream",
       size: saved.size,
@@ -188,6 +193,8 @@ describe("Integration: files bundle write → read round-trip (filesystem)", () 
     // Append registry entry (mimicking bundle registry append)
     const entry: FileEntry = {
       id: fileId,
+      workspaceId: WS,
+      ownerId: OWNER,
       filename,
       mimeType: "text/markdown",
       size: content.length,
@@ -218,6 +225,8 @@ describe("Integration: files bundle search by filename", () => {
     const entries: FileEntry[] = [
       {
         id: "fl_alpha",
+        workspaceId: WS,
+        ownerId: OWNER,
         filename: "quarterly-report.pdf",
         mimeType: "application/pdf",
         size: 100,
@@ -229,6 +238,8 @@ describe("Integration: files bundle search by filename", () => {
       },
       {
         id: "fl_beta",
+        workspaceId: WS,
+        ownerId: OWNER,
         filename: "meeting-notes.txt",
         mimeType: "text/plain",
         size: 50,
@@ -240,6 +251,8 @@ describe("Integration: files bundle search by filename", () => {
       },
       {
         id: "fl_gamma",
+        workspaceId: WS,
+        ownerId: OWNER,
         filename: "annual-report.pdf",
         mimeType: "application/pdf",
         size: 200,
@@ -272,6 +285,8 @@ describe("Integration: files bundle delete (tombstone)", () => {
 
     const entry: FileEntry = {
       id: "fl_to_delete",
+      workspaceId: WS,
+      ownerId: OWNER,
       filename: "temp.txt",
       mimeType: "text/plain",
       size: 10,
@@ -306,7 +321,7 @@ describe("Integration: validation — reject oversized file", () => {
       makeFile("this content is definitely longer than sixteen bytes", "big.txt", "text/plain"),
     ];
 
-    const result = await ingestFiles(files, "conv_int_v1", store, config);
+    const result = await ingestFiles(files, "conv_int_v1", store, config, WS, OWNER);
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("exceeds limit");
@@ -322,7 +337,7 @@ describe("Integration: validation — reject disallowed MIME type", () => {
       makeFile("#!/bin/bash\nrm -rf /", "malicious.exe", "application/x-executable"),
     ];
 
-    const result = await ingestFiles(files, "conv_int_v2", store, DEFAULT_CONFIG);
+    const result = await ingestFiles(files, "conv_int_v2", store, DEFAULT_CONFIG, WS, OWNER);
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("disallowed type");

--- a/test/unit/files/store.test.ts
+++ b/test/unit/files/store.test.ts
@@ -4,7 +4,11 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createFileStore, sanitizeFilename } from "../../../src/files/store.ts";
+import { workspaceFilesDir } from "../../../src/files/paths.ts";
 import type { FileEntry } from "../../../src/files/types.ts";
+
+const WS = "ws_test";
+const OWNER = "owner_test";
 
 let workDir: string;
 
@@ -36,6 +40,8 @@ describe("FileStore", () => {
     // Register so readFile can look up mimeType
     const entry: FileEntry = {
       id: saved.id,
+      workspaceId: WS,
+      ownerId: OWNER,
       filename: "data.bin",
       mimeType: "application/octet-stream",
       size: saved.size,
@@ -77,6 +83,8 @@ describe("FileStore", () => {
     const store = createFileStore(join(workDir, "files"));
     const entry: FileEntry = {
       id: "fl_test_001",
+      workspaceId: WS,
+      ownerId: OWNER,
       filename: "hello.txt",
       mimeType: "text/plain",
       size: 5,
@@ -102,6 +110,8 @@ describe("FileStore", () => {
 
     const entry1: FileEntry = {
       id: "fl_a",
+      workspaceId: WS,
+      ownerId: OWNER,
       filename: "a.txt",
       mimeType: "text/plain",
       size: 1,
@@ -113,6 +123,8 @@ describe("FileStore", () => {
     };
     const entry2: FileEntry = {
       id: "fl_b",
+      workspaceId: WS,
+      ownerId: OWNER,
       filename: "b.txt",
       mimeType: "text/plain",
       size: 2,
@@ -198,6 +210,8 @@ describe("FileStore — read-time MIME recovery", () => {
     const saved = await store.saveFile(Buffer.from("= Heading\n"), filename, "text/plain");
     const entry: FileEntry = {
       id: saved.id,
+      workspaceId: WS,
+      ownerId: OWNER,
       filename,
       // The bug: stored as opaque binary despite being text.
       mimeType: "application/octet-stream",
@@ -246,6 +260,8 @@ describe("FileStore — read-time MIME recovery", () => {
     const saved = await store.saveFile(Buffer.from("x"), "photo.png", "image/png");
     await store.appendRegistry({
       id: saved.id,
+      workspaceId: WS,
+      ownerId: OWNER,
       filename: "photo.png",
       mimeType: "image/png",
       size: saved.size,
@@ -265,5 +281,79 @@ describe("FileStore — read-time MIME recovery", () => {
     await store.deleteFile(id);
     expect(await store.findEntry(id)).toBeNull();
     expect(await store.readRegistry()).toHaveLength(0);
+  });
+});
+
+describe("FileStore — path-authoritative scope backfill", () => {
+  // A store rooted at `workspaces/<wsId>/files/<ownerId>/` derives its scope
+  // from the path. Legacy entries that a pure move relocated (no owner/ws on the
+  // row) are backfilled from that path on read — they self-heal without a
+  // registry rewrite. See `withScope` in store.ts and §2.3.
+
+  /** Append a legacy-shaped row (no owner/ws fields) straight to the registry. */
+  async function seedLegacy(filesDir: string, filename: string): Promise<string> {
+    const store = createFileStore(filesDir);
+    const saved = await store.saveFile(Buffer.from("hello"), filename, "text/plain");
+    // The cast lets us write a row missing the now-required scope fields — the
+    // exact shape a pre-migration registry holds on disk.
+    await store.appendRegistry({
+      id: saved.id,
+      filename,
+      mimeType: "text/plain",
+      size: saved.size,
+      tags: [],
+      source: "chat",
+      conversationId: null,
+      createdAt: new Date().toISOString(),
+      description: null,
+    } as FileEntry);
+    return saved.id;
+  }
+
+  test("findEntry backfills ownerId + workspaceId from the path", async () => {
+    const filesDir = workspaceFilesDir(workDir, WS, OWNER);
+    const id = await seedLegacy(filesDir, "legacy.txt");
+    const entry = await createFileStore(filesDir).findEntry(id);
+    expect(entry?.workspaceId).toBe(WS);
+    expect(entry?.ownerId).toBe(OWNER);
+  });
+
+  test("readRegistry backfills the scope for list/search consumers", async () => {
+    const filesDir = workspaceFilesDir(workDir, WS, OWNER);
+    await seedLegacy(filesDir, "legacy.txt");
+    const [entry] = await createFileStore(filesDir).readRegistry();
+    expect(entry?.workspaceId).toBe(WS);
+    expect(entry?.ownerId).toBe(OWNER);
+  });
+
+  test("a non-workspace path leaves the row untouched (no scope to backfill)", async () => {
+    const filesDir = join(workDir, "files");
+    const id = await seedLegacy(filesDir, "legacy.txt");
+    const entry = await createFileStore(filesDir).findEntry(id);
+    // parseFilePath returns null for a flat dir → backfill is a no-op.
+    expect(entry?.workspaceId).toBeUndefined();
+    expect(entry?.ownerId).toBeUndefined();
+  });
+
+  test("an entry that already carries a scope is not overwritten by the path", async () => {
+    const filesDir = workspaceFilesDir(workDir, WS, OWNER);
+    const store = createFileStore(filesDir);
+    const saved = await store.saveFile(Buffer.from("x"), "owned.txt", "text/plain");
+    await store.appendRegistry({
+      id: saved.id,
+      filename: "owned.txt",
+      mimeType: "text/plain",
+      size: saved.size,
+      tags: [],
+      source: "chat",
+      conversationId: null,
+      createdAt: new Date().toISOString(),
+      description: null,
+      workspaceId: "ws_explicit",
+      ownerId: "owner_explicit",
+    });
+    const entry = await store.findEntry(saved.id);
+    expect(entry?.workspaceId).toBe("ws_explicit");
+    expect(entry?.ownerId).toBe("owner_explicit");
   });
 });


### PR DESCRIPTION
## What

Files move from identity-owned `users/<userId>/files/` to **workspace-owned** `workspaces/<wsId>/files/<ownerId>/` — the same "path is the wall" layout #557 gave conversations. The workspace becomes a real boundary for files, not a soft breadcrumb.

This fixes the leak: a file uploaded in one workspace (say, financial) was reachable from another (ops), because files were identity-owned and shared across all your workspaces. Now **a file created in one workspace is structurally unreachable from another.**

Implements the files half of `research/SPEC-permission-boundaries.md` §6 step 5.

## The model (per spec §2.3)

`(owner, workspace, visibility)` on every file:
- **`workspace` + `owner` are path-authoritative** — `workspaces/<wsId>/files/<ownerId>/`. The directory is the truth; the store backfills the fields from the path on read. Under app-level auth (no RLS), the boundary lives in the path where a query can't reach across it.
- **`visibility` defaults to `private`** (fail-closed; absent ⇒ private). **v1 is private-only** — `shared` is dormant groundwork, no read path consults it yet.

## Changes

| Area | Change |
|---|---|
| `src/files/paths.ts` (new) | `workspaceFilesDir()` + `parseFilePath()` — the single sanctioned path site (mirrors `conversation/paths.ts`). |
| `FileEntry` | `ownerId` + `workspaceId` required, `visibility?` added. Store backfills owner/workspace from the dir on read. |
| `getFileStore(wsId, ownerId)` | Replaces `getFileStore(userId)`. Callers pass the conversation's workspace (`chat`/`runTurn`) or the **membership-validated** request workspace (REST), falling back to the owner's personal workspace. |
| Creation | `handleCreate` + `ingest` stamp `(owner, workspace, visibility:private)`. |
| `check:file-paths` | Inverted — file dirs must be built via `workspaceFilesDir`; identity-owned `users/<userId>/files/` construction is forbidden. |
| `scripts/migrate-files-to-room.ts` (new) | Existing files → owner's personal workspace (no provenance → personal). Idempotent, dry-run default, under the migration lock. |

## Security model

- **Workspace wall:** REST file serving runs behind `optionalWorkspace` (validates `X-Workspace-Id` → membership; 403 for non-members). No header ⇒ personal workspace (fail-closed).
- **Owner-private:** the `<ownerId>/` partition means you only ever read your *own* files in a workspace you belong to. Another member's files are a different partition — invisible by construction, not by check.

## Verification

- `bun run verify` green — format, lint, tsc, cycles, **check:file-paths** (inverted guard), codegen, unit + web + bundle + integration (**591 pass / 0 fail**).
- New integration tests: **cross-workspace isolation** (a file in WS A is null/absent from WS B's store) + **migration round-trip**. Plus store-backfill unit coverage.

## Migration / rollout note

Like #557 for conversations, the frontend must send `X-Workspace-Id` consistent with where a file was created (the upload path and the read path now agree on the partition). Run `bun run migrate:files-to-room --write` to relocate existing files (→ each owner's personal workspace).

Automations relocation (the other half of step 5) follows as a separate PR.