### PR TITLE
Self-heal remote MCP sessions on the resource-read path

### DIFF
--- a/src/tools/health-monitor.ts
+++ b/src/tools/health-monitor.ts
@@ -1,5 +1,4 @@
 import type { EventSink } from "../engine/types.ts";
-import { log } from "../observability/log.ts";
 import type { McpSource } from "./mcp-source.ts";
 
 export type BundleState = "healthy" | "restarting" | "dead";
@@ -191,18 +190,15 @@ export class HealthMonitor {
     }
   }
 
-  /** Reconnect a remote source via transport-level stop+start. */
+  /**
+   * Reconnect a remote source. Routes through `restart()` (→ tryRestart) so a
+   * HealthMonitor tick shares the source's in-flight-restart guard with inline
+   * session recovery (readResource / callTool) — otherwise the two could fire
+   * concurrent stop()/start() cycles on the same source after a roll.
+   * `restart()` never throws: it returns false and emits `source.restart_failed`.
+   */
   private async reconnectRemote(source: McpSource): Promise<boolean> {
-    try {
-      await source.stop();
-      await source.start();
-      return true;
-    } catch (err) {
-      log.error("[health-monitor] reconnect failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return false;
-    }
+    return source.restart();
   }
 }
 

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -267,6 +267,12 @@ export class McpSource implements ToolSource {
   private transport: Transport | null = null;
   private cachedTools: Tool[] | null = null;
   private dead = false;
+  /** A restart in progress, shared so concurrent recoveries reuse one
+   *  stop()/start() cycle instead of stacking. Resource reads are NOT serialized
+   *  the way the engine serializes tool calls, so a remote roll can land several
+   *  session-loss reads here at once; without this each would fire its own
+   *  restart — a restart storm on a single source. */
+  private restartInFlight: Promise<boolean> | null = null;
   private startedAt: number | null = null;
   /** Optional `instructions` string returned by the MCP server during
    *  `initialize`. Captured after connect so callers (e.g. the system
@@ -1321,27 +1327,29 @@ export class McpSource implements ToolSource {
       return null;
     }
     try {
-      const result = await this.client.readResource({ uri });
-      if (!result.contents || result.contents.length === 0) return null;
-      const first = result.contents[0]!;
-      const meta = mergeResourceMeta(
-        (result as { _meta?: Record<string, unknown> })._meta,
-        (first as { _meta?: Record<string, unknown> })._meta,
-      );
-      if ("text" in first && typeof first.text === "string") {
-        return { text: first.text, mimeType: first.mimeType, meta };
-      }
-      if ("blob" in first && typeof first.blob === "string") {
-        const raw = atob(first.blob);
-        const bytes = new Uint8Array(raw.length);
-        for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
-        return { blob: bytes, mimeType: first.mimeType, meta };
-      }
-      return { text: JSON.stringify(first), meta };
+      return this.toResourceData(await this.client.readResource({ uri }));
     } catch (err) {
       // A genuine MCP miss is expected and stays a silent null — e.g. a skill://
       // or app://instructions probe against a server that has neither.
       if (isMcpResourceMiss(err)) return null;
+      // A stale session or a mid-roll gateway blip is recoverable, not a 404: the
+      // remote server rolled and forgot our Streamable-HTTP session, or isn't
+      // ready yet. Unlike a tools/call (whose `execute` catch already restarts +
+      // retries), a resource read would otherwise return null here —
+      // indistinguishable from a genuine miss — and strand the bundle's `ui://`
+      // placement until a manual runtime bounce (issue #571). Re-initialize the
+      // session and retry, riding the brief deploy window with bounded backoff.
+      if (isSessionLost(err) || isTransientTransport(err)) {
+        const recovered = await this.readResourceWithRecovery(uri);
+        if (recovered !== undefined) return recovered;
+        // Recovery exhausted within the inline window. Hand the source to
+        // HealthMonitor's longer exponential backoff: it only sweeps a NOT-alive
+        // source, and a stale session never closed the transport, so without
+        // this the source stays `isAlive()` and is never reconnected.
+        this.emitSourceCrashed(
+          `session recovery exhausted: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       // Anything else — a torn transport, a dropped connection, a timeout — is a
       // real failure, NOT a missing resource. The old bare `catch { return null }`
       // masked every such failure as a 404 with no log to say why, so a degraded
@@ -1359,6 +1367,56 @@ export class McpSource implements ToolSource {
       }
       return null;
     }
+  }
+
+  /**
+   * Project an MCP `resources/read` result into `ResourceData`, or null for an
+   * empty result. Preserves `_meta` from both the per-content entry and the
+   * result level (per-content wins on overlap — the ext-apps spec attaches ui
+   * metadata at the content level).
+   */
+  private toResourceData(result: Awaited<ReturnType<Client["readResource"]>>): ResourceData | null {
+    if (!result.contents || result.contents.length === 0) return null;
+    const first = result.contents[0]!;
+    const meta = mergeResourceMeta(
+      (result as { _meta?: Record<string, unknown> })._meta,
+      (first as { _meta?: Record<string, unknown> })._meta,
+    );
+    if ("text" in first && typeof first.text === "string") {
+      return { text: first.text, mimeType: first.mimeType, meta };
+    }
+    if ("blob" in first && typeof first.blob === "string") {
+      const raw = atob(first.blob);
+      const bytes = new Uint8Array(raw.length);
+      for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+      return { blob: bytes, mimeType: first.mimeType, meta };
+    }
+    return { text: JSON.stringify(first), meta };
+  }
+
+  /**
+   * Re-establish a lost remote session and retry a resource read across a remote
+   * server's restart window. Returns the read result (a `ResourceData`, or a
+   * genuine `null` miss) once the session recovers, or `undefined` if recovery is
+   * exhausted — the caller then escalates to HealthMonitor. Restart attempts are
+   * coalesced by `tryRestart`, so concurrent recovering reads share one cycle.
+   */
+  private async readResourceWithRecovery(uri: string): Promise<ResourceData | null | undefined> {
+    for (const delayMs of SESSION_RECOVERY_DELAYS_MS) {
+      if (delayMs > 0) await sleep(delayMs);
+      const restarted = await this.tryRestart();
+      if (!restarted || !this.client) continue; // server still rolling — back off
+      try {
+        return this.toResourceData(await this.client.readResource({ uri }));
+      } catch (retryErr) {
+        // Session's back but the resource is genuinely absent — a real null.
+        if (isMcpResourceMiss(retryErr)) return null;
+        // Still mid-roll (another stale-session or gateway error) — keep riding.
+        if (isSessionLost(retryErr) || isTransientTransport(retryErr)) continue;
+        return undefined; // a different, non-recoverable error — caller logs it
+      }
+    }
+    return undefined;
   }
 
   /** Expose the underlying MCP client (kept for tests and rare introspection). */
@@ -1971,6 +2029,19 @@ export class McpSource implements ToolSource {
   }
 
   private async tryRestart(): Promise<boolean> {
+    // Coalesce concurrent restarts behind one in-flight stop()/start() cycle —
+    // inline session recovery (readResource / callTool) and HealthMonitor can
+    // all reach here for the same source after a remote roll. See `restartInFlight`.
+    if (this.restartInFlight) return this.restartInFlight;
+    this.restartInFlight = this.doRestart();
+    try {
+      return await this.restartInFlight;
+    } finally {
+      this.restartInFlight = null;
+    }
+  }
+
+  private async doRestart(): Promise<boolean> {
     try {
       await this.stop();
       await this.start();
@@ -2016,6 +2087,59 @@ export function isMcpResourceMiss(err: unknown): boolean {
     typeof message === "string" &&
     /resource not found|unknown resource|no such resource/i.test(message)
   );
+}
+
+/**
+ * A *session* loss — the remote server forgot our Streamable-HTTP session (it
+ * rolled / restarted) — as opposed to a torn transport or an application error.
+ * Recoverable by a fresh `initialize`, so it warrants re-establish + retry.
+ *
+ * Wire shape (this is NOT a JSON-RPC code on `err.code`): the server answers a
+ * request carrying a stale `Mcp-Session-Id` with HTTP 404 and a JSON-RPC
+ * `-32001 "Session not found"` body. The SDK's StreamableHTTPClientTransport
+ * never parses that body — it throws a `StreamableHTTPError` whose `.code` is
+ * the HTTP status (404) and whose `.message` carries the `-32001` / "Session
+ * not found" text. So match status + message together; a code-only match on
+ * -32001 silently never fires on the canonical path. Defensively also accept a
+ * non-canonical server that returns the error inside an HTTP-200 JSON-RPC body
+ * (surfacing as `err.code === -32001`).
+ */
+export function isSessionLost(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === -32001) return true;
+  const message = (err as { message?: unknown }).message;
+  const msg = typeof message === "string" ? message : "";
+  return code === 404 && /session not found/i.test(msg);
+}
+
+/**
+ * A *transient* transport failure a remote MCP server emits mid-roll — a load
+ * balancer 502/503/504 while pods are not yet ready, or a `bad_gateway` body.
+ * Distinct from a stale session (server up, forgot us) and from a permanent
+ * error: back off and re-establish rather than surface it. Matches the HTTP
+ * status on `StreamableHTTPError.code` and the gateway-error message shapes.
+ */
+export function isTransientTransport(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === 502 || code === 503 || code === 504) return true;
+  const message = (err as { message?: unknown }).message;
+  const msg = typeof message === "string" ? message : "";
+  return /bad[ _]gateway|service unavailable|gateway time-?out/i.test(msg);
+}
+
+/**
+ * Delays (ms) before each remote-session re-establish attempt. The first is
+ * immediate — the common case is a stale session against an already-healthy
+ * server, recovered in one fresh `initialize`. The rest ride a rolling deploy's
+ * brief gateway window (~2.5s total); HealthMonitor's longer exponential backoff
+ * is the backstop for anything beyond it.
+ */
+const SESSION_RECOVERY_DELAYS_MS = [0, 500, 2000] as const;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /** Type guard: does this unknown value match Tool.execution's shape? */

--- a/test/integration/remote-session-recovery.test.ts
+++ b/test/integration/remote-session-recovery.test.ts
@@ -1,0 +1,135 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import {
+	ListResourcesRequestSchema,
+	ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { McpSource } from "../../src/tools/mcp-source.ts";
+
+/**
+ * End-to-end recovery half of issue #571: when a remote MCP server rolls and
+ * forgets our Streamable-HTTP session, a subsequent `ui://` read must
+ * re-initialize the session and retry — returning the resource — rather than
+ * surfacing the "Session not found" error as a null that strands the bundle's
+ * sidebar UI until a manual runtime bounce.
+ *
+ * Unlike the unit test (which hand-builds the error shape), this drives the real
+ * MCP SDK client transport against a real Streamable-HTTP server, so it proves
+ * `isSessionLost` matches the actual `StreamableHTTPError` the SDK throws on the
+ * canonical 404 + "-32001 Session not found" wire shape.
+ */
+
+const UI_HTML = "<html><body>main</body></html>";
+
+interface MockRollingServer {
+	url: string;
+	/** Drop all live sessions — the next request on an old session id 404s,
+	 *  exactly as a rolling deploy's fresh pod does. */
+	roll: () => void;
+	close: () => void;
+}
+
+function createMcpServer(): Server {
+	const server = new Server(
+		{ name: "rolling-remote", version: "0.1.0" },
+		{ capabilities: { resources: {} } },
+	);
+	server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+		resources: [{ uri: "ui://main", name: "main", mimeType: "text/html" }],
+	}));
+	server.setRequestHandler(ReadResourceRequestSchema, async (req) => ({
+		contents: [{ uri: req.params.uri, mimeType: "text/html", text: UI_HTML }],
+	}));
+	return server;
+}
+
+function startRollingServer(): MockRollingServer {
+	let counter = 0;
+	const transports = new Map<string, WebStandardStreamableHTTPServerTransport>();
+
+	const httpServer = Bun.serve({
+		port: 0,
+		async fetch(req: Request) {
+			const url = new URL(req.url);
+			if (url.pathname !== "/mcp") return new Response("Not found", { status: 404 });
+
+			const sid = req.headers.get("mcp-session-id");
+
+			// Known session — route to its transport.
+			if (sid) {
+				const existing = transports.get(sid);
+				if (existing) return existing.handleRequest(req);
+				// Stale session (server rolled). The canonical wire shape: HTTP 404
+				// with a JSON-RPC `-32001 "Session not found"` body. The SDK client
+				// surfaces this as `StreamableHTTPError(404, "...Session not found...")`.
+				return new Response(
+					JSON.stringify({
+						jsonrpc: "2.0",
+						error: { code: -32001, message: "Session not found" },
+						id: null,
+					}),
+					{ status: 404, headers: { "content-type": "application/json" } },
+				);
+			}
+
+			// No session id → a fresh `initialize`. Mint a session + transport.
+			const transport = new WebStandardStreamableHTTPServerTransport({
+				sessionIdGenerator: () => `sess-${++counter}`,
+				onsessioninitialized: (id) => transports.set(id, transport),
+			});
+			await createMcpServer().connect(transport);
+			return transport.handleRequest(req);
+		},
+	});
+
+	return {
+		url: `http://localhost:${httpServer.port}/mcp`,
+		roll() {
+			for (const t of transports.values()) t.close().catch(() => {});
+			transports.clear();
+		},
+		close() {
+			httpServer.stop(true);
+			for (const t of transports.values()) t.close().catch(() => {});
+			transports.clear();
+		},
+	};
+}
+
+describe("McpSource — remote session recovery (issue #571)", () => {
+	let server: MockRollingServer;
+	let source: McpSource;
+
+	beforeEach(() => {
+		server = startRollingServer();
+	});
+
+	afterEach(async () => {
+		await source?.stop();
+		server?.close();
+	});
+
+	it("recovers a ui:// read after the server drops the session — no manual bounce", async () => {
+		source = new McpSource(
+			"rolling-remote",
+			{ type: "remote", url: new URL(server.url), allowInsecure: true },
+			new NoopEventSink(),
+		);
+		await source.start();
+
+		// Baseline: the read works while the session is live.
+		const before = await source.readResource("ui://main", { logFailures: true });
+		expect(before?.text).toBe(UI_HTML);
+
+		// The server rolls: every live session id is now stale.
+		server.roll();
+
+		// Without recovery this returns null ("Resource not found" in the UI). With
+		// the fix, readResource detects the lost session, re-initializes, retries,
+		// and returns the resource on the same call.
+		const after = await source.readResource("ui://main", { logFailures: true });
+		expect(after?.text).toBe(UI_HTML);
+	}, 20_000);
+});

--- a/test/unit/health-monitor-remote.test.ts
+++ b/test/unit/health-monitor-remote.test.ts
@@ -34,8 +34,17 @@ function makeMockRemoteSource(
       return startedAt !== null ? Date.now() - startedAt : null;
     },
     async restart() {
-      // Should NOT be called for remote sources
-      throw new Error("restart() should not be called for remote sources");
+      // HealthMonitor reconnects remote sources through restart() (→ tryRestart)
+      // so the tick shares the source's in-flight-restart guard with inline
+      // session recovery. restart() drives the same stop()+start() cycle and
+      // returns a boolean — it never throws.
+      await mock.stop();
+      try {
+        await mock.start();
+        return true;
+      } catch {
+        return false;
+      }
     },
     async stop() {
       mock.stopCalls++;
@@ -115,7 +124,7 @@ function eventData(collector: { events: EngineEvent[] }): Record<string, unknown
 }
 
 describe("HealthMonitor — remote sources", () => {
-  it("detects crashed remote source and reconnects via stop+start", async () => {
+  it("detects crashed remote source and reconnects via restart() (stop+start)", async () => {
     const source = makeMockRemoteSource("remote-bundle");
     const sink = makeEventCollector();
     const monitor = new HealthMonitor([source], sink, { checkIntervalMs: 60_000, baseDelayMs: 1 });
@@ -136,7 +145,7 @@ describe("HealthMonitor — remote sources", () => {
       expect(data.remote).toBe(true);
     }
 
-    // Should have used stop+start, not restart()
+    // restart() drove one stop()+start() reconnect cycle.
     expect(source.stopCalls).toBe(1);
     expect(source.startCalls).toBe(1);
 
@@ -300,7 +309,7 @@ describe("HealthMonitor — remote sources", () => {
       expect(ev.remote).toBeUndefined();
     }
 
-    // Remote used stop+start, stdio used restart()
+    // Remote reconnect drove one stop()+start() via restart(); stdio used restart().
     expect(remote.stopCalls).toBe(1);
     expect(remote.startCalls).toBe(1);
     expect(stdio.restartCalls).toBe(1);

--- a/test/unit/mcp-source-resource-errors.test.ts
+++ b/test/unit/mcp-source-resource-errors.test.ts
@@ -1,7 +1,12 @@
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it, spyOn } from "bun:test";
 import { NoopEventSink } from "../../src/adapters/noop-events.ts";
-import { isMcpResourceMiss, McpSource } from "../../src/tools/mcp-source.ts";
+import {
+  isMcpResourceMiss,
+  isSessionLost,
+  isTransientTransport,
+  McpSource,
+} from "../../src/tools/mcp-source.ts";
 
 /**
  * `readResource` must distinguish a genuine "resource not here" from a transport
@@ -127,5 +132,154 @@ describe("McpSource.readResource — log scoping (no probe spam)", () => {
     const transport = makeSourceWithThrowingClient(new Error("Connection closed"));
     expect(await miss.readResource("ui://x")).toBeNull();
     expect(await transport.readResource("ui://x", { logFailures: true })).toBeNull();
+  });
+});
+
+/**
+ * Classifiers that gate remote-session self-heal (issue #571). The canonical
+ * wire shape for a forgotten Streamable-HTTP session is HTTP 404 with the
+ * `-32001 "Session not found"` text inside the SDK's StreamableHTTPError
+ * message — NOT a JSON-RPC `-32600` (as the issue first guessed) and NOT a
+ * numeric `-32001` on `err.code`. A code-only matcher silently never fires on
+ * that path, so these lock the real shape down.
+ */
+describe("isSessionLost — forgotten remote session", () => {
+  it("matches the canonical 404 + 'Session not found' StreamableHTTPError shape", () => {
+    expect(
+      isSessionLost({
+        code: 404,
+        message:
+          'Streamable HTTP error: Error POSTing to endpoint: {"code":-32001,"message":"Session not found"}',
+      }),
+    ).toBe(true);
+  });
+
+  it("matches a -32001 code from a non-canonical HTTP-200 JSON-RPC body", () => {
+    expect(isSessionLost(new McpError(-32001, "Session not found"))).toBe(true);
+  });
+
+  it("does NOT match a generic 404 (e.g. wrong URL) with no session text", () => {
+    expect(isSessionLost({ code: 404, message: "Not Found" })).toBe(false);
+  });
+
+  it("does NOT match a resource miss or a plain transport error", () => {
+    expect(isSessionLost(new McpError(-32002, "Resource not found"))).toBe(false);
+    expect(isSessionLost(new Error("Connection closed"))).toBe(false);
+  });
+
+  it("is null/non-object safe", () => {
+    expect(isSessionLost(null)).toBe(false);
+    expect(isSessionLost(undefined)).toBe(false);
+    expect(isSessionLost("nope")).toBe(false);
+  });
+});
+
+describe("isTransientTransport — mid-roll gateway blip", () => {
+  it("matches gateway HTTP statuses on err.code", () => {
+    for (const code of [502, 503, 504]) {
+      expect(isTransientTransport({ code, message: "x" })).toBe(true);
+    }
+  });
+
+  it("matches gateway-error message shapes", () => {
+    expect(isTransientTransport({ message: '{"error":"bad_gateway"}' })).toBe(true);
+    expect(isTransientTransport(new Error("Service Unavailable"))).toBe(true);
+    expect(isTransientTransport(new Error("Gateway Timeout"))).toBe(true);
+  });
+
+  it("does NOT match a stale session or a plain transport error", () => {
+    expect(isTransientTransport({ code: 404, message: "Session not found" })).toBe(false);
+    expect(isTransientTransport(new Error("Connection closed"))).toBe(false);
+  });
+
+  it("is null/non-object safe", () => {
+    expect(isTransientTransport(null)).toBe(false);
+    expect(isTransientTransport("nope")).toBe(false);
+  });
+});
+
+/**
+ * The recovery half of issue #571: a remote bundle's `ui://` read must
+ * re-initialize the session and retry after the server rolls, rather than
+ * returning a null that strands the sidebar until a manual runtime bounce.
+ * `tryRestart` is mocked so these stay unit-level (no real network / Bun.serve);
+ * the faithful end-to-end roll is exercised in integration.
+ */
+describe("McpSource.readResource — remote session self-heal (issue #571)", () => {
+  const sessionLost = {
+    code: 404,
+    message: 'Error POSTing to endpoint: {"code":-32001,"message":"Session not found"}',
+  };
+
+  function makeSource(readResource: () => Promise<unknown>): McpSource {
+    const source = new McpSource(
+      "stub",
+      { type: "remote", url: new URL("http://localhost:0/mcp") },
+      new NoopEventSink(),
+    );
+    (source as unknown as { client: { readResource: () => Promise<unknown> } }).client = {
+      readResource,
+    };
+    return source;
+  }
+
+  it("re-initializes the session and retries on 'Session not found', returning content", async () => {
+    let calls = 0;
+    const source = makeSource(async () => {
+      calls++;
+      if (calls === 1) throw sessionLost;
+      return { contents: [{ uri: "ui://stub/main", text: "<html>ok</html>" }] };
+    });
+    const restart = spyOn(
+      source as unknown as { tryRestart: () => Promise<boolean> },
+      "tryRestart",
+    ).mockResolvedValue(true);
+    try {
+      const result = await source.readResource("ui://stub/main", { logFailures: true });
+      expect(restart).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ text: "<html>ok</html>", mimeType: undefined, meta: undefined });
+    } finally {
+      restart.mockRestore();
+    }
+  });
+
+  it("does NOT restart on a genuine resource miss", async () => {
+    const source = makeSource(async () => {
+      throw new McpError(-32002, "Resource not found");
+    });
+    const restart = spyOn(
+      source as unknown as { tryRestart: () => Promise<boolean> },
+      "tryRestart",
+    ).mockResolvedValue(true);
+    try {
+      expect(await source.readResource("ui://stub/main", { logFailures: true })).toBeNull();
+      expect(restart).not.toHaveBeenCalled();
+    } finally {
+      restart.mockRestore();
+    }
+  });
+
+  it("exhausts retries, returns null, and marks the source dead for HealthMonitor", async () => {
+    const source = makeSource(async () => {
+      throw sessionLost;
+    });
+    const restart = spyOn(
+      source as unknown as { tryRestart: () => Promise<boolean> },
+      "tryRestart",
+    ).mockResolvedValue(false);
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await source.readResource("ui://stub/main", { logFailures: true })).toBeNull();
+      // One re-establish attempt per backoff slot.
+      expect(restart).toHaveBeenCalledTimes(3);
+      // Escalated to HealthMonitor: emitSourceCrashed flipped `dead`, so a stale
+      // session that never closed the transport is now sweepable.
+      expect(
+        (source as unknown as { _isDeadForTesting: () => boolean })._isDeadForTesting(),
+      ).toBe(true);
+    } finally {
+      spy.mockRestore();
+      restart.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Problem

When a remote MCP bundle's server restarts (a rolling deploy of a fleet MCP server), the runtime's cached Streamable-HTTP session goes stale. The `tools/call` path already self-heals — its `execute` catch restarts the transport and retries — but **`resources/read` had no equivalent**: it caught the error, saw it wasn't an `isMcpResourceMiss`, logged `[mcp] readResource failed`, and returned `null`. That null is indistinguishable from a genuine 404, so the bundle's `ui://<bundle>/main` placement shows *"Resource not found"* until the runtime is manually bounced.

It strands **every** installed remote bundle's UI at once, and HealthMonitor never rescues it: a stale *session* never closes the transport, so `isAlive()` stays `true` and the source is never swept.

## Root cause

`readResource` is the one MCP-call path with zero session-loss recovery, and session-death-without-transport-close is invisible to the liveness-based HealthMonitor. Fix lives in the runtime (`src/tools/mcp-source.ts`).

## Fix

- **`readResource` re-initializes + retries on a lost session / mid-roll gateway blip**, riding the brief deploy window with bounded backoff. On exhaustion it marks the source crashed so HealthMonitor's longer exponential backoff takes over as the backstop.
- **Correct error classifiers.** The wire shape is **HTTP 404** → `StreamableHTTPError` with `.code === 404` and `"Session not found"` (a `-32001` body) in the message — *not* the `-32600` the issue first guessed. A code-only matcher would silently never fire on the canonical path. `isTransientTransport` covers `bad_gateway`/502/503/504.
- **Concurrent-restart dedup.** Resource reads aren't serialized like tool calls, so a roll can land several session-loss reads at once; `tryRestart` now coalesces them behind one in-flight stop()/start() cycle. HealthMonitor's remote reconnect routes through `restart()` to share that guard.

## Tests

- Unit: classifier shapes; `readResource` recover-and-retry; no-restart on a genuine `-32002` miss; exhaustion → `dead` escalation.
- Integration: drives the **real** SDK client against a session-dropping Streamable-HTTP server and asserts the `ui://` read recovers with no manual bounce (this also proves the classifier matches the real `StreamableHTTPError`).

`bun run verify:static` + full unit suite (3839 pass) + remote/resource integration tests green.

## Issues

Closes #571.

Substantially addresses #533 (the resource-read self-heal + the single-flight restart guard it explicitly called for). One sub-mode from #533 remains and is **not** covered here: an *absent* source dropped from the registry being re-registered on the resource path (`readAppResource` → `tryRecoverSource`). This PR handles the present-but-dead-session shape, which is #571's actual failure. Leaving #533 open for that remainder.