### PR TITLE
Phase 1: MCP failure taxonomy + recovery policy as pure data

### DIFF
--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -2090,43 +2090,142 @@ export function isMcpResourceMiss(err: unknown): boolean {
 }
 
 /**
- * A *session* loss — the remote server forgot our Streamable-HTTP session (it
- * rolled / restarted) — as opposed to a torn transport or an application error.
- * Recoverable by a fresh `initialize`, so it warrants re-establish + retry.
+ * The **connection-level** failure classes — properties of the source's
+ * connection, independent of which op (`tools/call`, `resources/read`, …) threw.
+ * This is the only thing classifiable from a throw regardless of op. The
+ * application-outcome question ("server answered, but with a miss / an error?")
+ * is op-DEPENDENT — the same wire code (`-32601`, `-32602`) is a resource miss on
+ * `resources/read` but a method/param error on `tools/call` — so it lives in a
+ * separate, op-scoped classifier (`isMcpResourceMiss` for reads), NOT here. See
+ * `research/SPEC-mcp-source-recovery.md` §3.1.
  *
- * Wire shape (this is NOT a JSON-RPC code on `err.code`): the server answers a
- * request carrying a stale `Mcp-Session-Id` with HTTP 404 and a JSON-RPC
- * `-32001 "Session not found"` body. The SDK's StreamableHTTPClientTransport
- * never parses that body — it throws a `StreamableHTTPError` whose `.code` is
- * the HTTP status (404) and whose `.message` carries the `-32001` / "Session
- * not found" text. So match status + message together; a code-only match on
- * -32001 silently never fires on the canonical path. Defensively also accept a
- * non-canonical server that returns the error inside an HTTP-200 JSON-RPC body
- * (surfacing as `err.code === -32001`).
+ * `source-absent` (a registry-lookup miss before any call) and `credential-lost`
+ * (a `ConnectionRevalidator` probe verdict) are deliberately absent: they are not
+ * thrown errors, so they cannot be classified from one. They reach recovery as
+ * detector *signals*, and `policyFor` accepts them as kinds — but they are never
+ * outputs of `classifyConnectionFailure`.
  */
-export function isSessionLost(err: unknown): boolean {
-  if (err === null || typeof err !== "object") return false;
+export type ConnectionFailure =
+  | "session-lost"
+  | "transient"
+  | "transport-dead"
+  | "auth-lost"
+  | "none";
+
+/**
+ * Classify a thrown error into a connection-failure class. Order is load-bearing
+ * for behavior-preservation: `session-lost` and `transient` use the exact prior
+ * predicate logic and are tested first, so the `isSessionLost` / `isTransientTransport`
+ * wrappers below stay byte-identical to their pre-extraction behavior.
+ *
+ * - **session-lost** — the server forgot our Streamable-HTTP session (it rolled).
+ *   Wire shape (NOT a JSON-RPC code on `err.code`): a request on a stale
+ *   `Mcp-Session-Id` gets HTTP 404 + a `-32001 "Session not found"` body, which the
+ *   SDK throws as a `StreamableHTTPError` whose `.code` is the status (404) and
+ *   whose `.message` carries the `-32001`/text. Match status + message together; a
+ *   code-only match on -32001 silently never fires on the canonical path.
+ * - **transient** — a mid-roll gateway blip (502/503/504, `bad_gateway`). Back off.
+ * - **auth-lost** — a rejected credential. Detectable only as `UnauthorizedError`;
+ *   note its *policy* is config-dependent (a static-auth remote can't reauth), so
+ *   `policyFor` takes `hasReauthableProvider`.
+ * - **transport-dead** — the connection is torn (closed / refused / timed out).
+ * - **none** — not a connection failure; ask the op-scoped outcome classifier.
+ */
+export function classifyConnectionFailure(err: unknown): ConnectionFailure {
+  if (err === null || typeof err !== "object") return "none";
   const code = (err as { code?: unknown }).code;
-  if (code === -32001) return true;
   const message = (err as { message?: unknown }).message;
   const msg = typeof message === "string" ? message : "";
-  return code === 404 && /session not found/i.test(msg);
+
+  // session-lost — exact prior `isSessionLost` logic, checked first.
+  if (code === -32001 || (code === 404 && /session not found/i.test(msg))) {
+    return "session-lost";
+  }
+  // transient — exact prior `isTransientTransport` logic, checked second.
+  if (
+    code === 502 ||
+    code === 503 ||
+    code === 504 ||
+    /bad[ _]gateway|service unavailable|gateway time-?out/i.test(msg)
+  ) {
+    return "transient";
+  }
+  if (err instanceof UnauthorizedError) return "auth-lost";
+  if (
+    code === -32000 ||
+    /connection closed|fetch failed|socket hang ?up|terminated|network error|econnre(set|fused)|timed? ?out/i.test(
+      msg,
+    )
+  ) {
+    return "transport-dead";
+  }
+  return "none";
+}
+
+/** @see classifyConnectionFailure — the canonical detector; this is a named view of it. */
+export function isSessionLost(err: unknown): boolean {
+  return classifyConnectionFailure(err) === "session-lost";
+}
+
+/** @see classifyConnectionFailure — the canonical detector; this is a named view of it. */
+export function isTransientTransport(err: unknown): boolean {
+  return classifyConnectionFailure(err) === "transient";
 }
 
 /**
- * A *transient* transport failure a remote MCP server emits mid-roll — a load
- * balancer 502/503/504 while pods are not yet ready, or a `bad_gateway` body.
- * Distinct from a stale session (server up, forgot us) and from a permanent
- * error: back off and re-establish rather than surface it. Matches the HTTP
- * status on `StreamableHTTPError.code` and the gateway-error message shapes.
+ * The recovery action a failure class maps to. Flat union = pure data: the
+ * execution wrapper (Phase 2) interprets it; this table just decides.
+ *
+ * - `surface` — return the error / null to the caller
+ * - `retry` — back off, retry the same op (no re-establish)
+ * - `reinit-retry` — re-run the MCP `initialize`, then retry
+ * - `restart-retry` — `stop()` + `start()`, then retry
+ * - `reauth` — flip to `reauth_required`, surface a Reconnect; do NOT loop
+ * - `re-register` — re-add the source to the registry, then retry
+ * - `re-register-only` — re-add the source, then surface (non-idempotent op)
  */
-export function isTransientTransport(err: unknown): boolean {
-  if (err === null || typeof err !== "object") return false;
-  const code = (err as { code?: unknown }).code;
-  if (code === 502 || code === 503 || code === 504) return true;
-  const message = (err as { message?: unknown }).message;
-  const msg = typeof message === "string" ? message : "";
-  return /bad[ _]gateway|service unavailable|gateway time-?out/i.test(msg);
+export type RecoveryAction =
+  | "surface"
+  | "retry"
+  | "reinit-retry"
+  | "restart-retry"
+  | "reauth"
+  | "re-register"
+  | "re-register-only";
+
+/** Kinds the policy table decides over: connection failures + the two detector
+ *  signals that are not thrown errors. `"none"` never reaches policy. */
+export type RecoveryKind = Exclude<ConnectionFailure, "none"> | "source-absent" | "credential-lost";
+
+/**
+ * Pure policy: `(kind, context) → action`. `idempotent` is false for
+ * task-augmented `tools/call` (retrying would duplicate server-side state — the
+ * invariant at `execute`'s task branch), so non-idempotent failures surface
+ * rather than retry. `hasReauthableProvider` is a property of the *source*, not
+ * the error: a 401 on an OAuth remote is recoverable by reauth, the same 401 on a
+ * static-auth remote is not (it falls through to a transport restart). See
+ * `research/SPEC-mcp-source-recovery.md` §3.2. No caller yet — Phase 2 wires the
+ * `withRecovery` wrapper through this; Phase 1 establishes and tests the contract.
+ */
+export function policyFor(
+  kind: RecoveryKind,
+  ctx: { idempotent: boolean; hasReauthableProvider: boolean },
+): RecoveryAction {
+  switch (kind) {
+    case "session-lost":
+      return ctx.idempotent ? "reinit-retry" : "surface";
+    case "transient":
+      return ctx.idempotent ? "retry" : "surface";
+    case "transport-dead":
+      return ctx.idempotent ? "restart-retry" : "surface";
+    case "auth-lost":
+      if (ctx.hasReauthableProvider) return "reauth";
+      return ctx.idempotent ? "restart-retry" : "surface";
+    case "credential-lost":
+      return "reauth";
+    case "source-absent":
+      return ctx.idempotent ? "re-register" : "re-register-only";
+  }
 }
 
 /**

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -2102,7 +2102,7 @@ export function isMcpResourceMiss(err: unknown): boolean {
  * `source-absent` (a registry-lookup miss before any call) and `credential-lost`
  * (a `ConnectionRevalidator` probe verdict) are deliberately absent: they are not
  * thrown errors, so they cannot be classified from one. They reach recovery as
- * detector *signals*, and `policyFor` accepts them as kinds — but they are never
+ * detector *signals* (handled by the recovery policy in Phase 2), never as
  * outputs of `classifyConnectionFailure`.
  */
 export type ConnectionFailure =
@@ -2126,8 +2126,8 @@ export type ConnectionFailure =
  *   code-only match on -32001 silently never fires on the canonical path.
  * - **transient** — a mid-roll gateway blip (502/503/504, `bad_gateway`). Back off.
  * - **auth-lost** — a rejected credential. Detectable only as `UnauthorizedError`;
- *   note its *policy* is config-dependent (a static-auth remote can't reauth), so
- *   `policyFor` takes `hasReauthableProvider`.
+ *   note its recovery *policy* is config-dependent — a static-auth remote can't
+ *   reauth — but that decision is Phase 2's (see the SPEC §3.2), not this function's.
  * - **transport-dead** — the connection is torn (closed / refused / timed out).
  * - **none** — not a connection failure; ask the op-scoped outcome classifier.
  */
@@ -2170,62 +2170,6 @@ export function isSessionLost(err: unknown): boolean {
 /** @see classifyConnectionFailure — the canonical detector; this is a named view of it. */
 export function isTransientTransport(err: unknown): boolean {
   return classifyConnectionFailure(err) === "transient";
-}
-
-/**
- * The recovery action a failure class maps to. Flat union = pure data: the
- * execution wrapper (Phase 2) interprets it; this table just decides.
- *
- * - `surface` — return the error / null to the caller
- * - `retry` — back off, retry the same op (no re-establish)
- * - `reinit-retry` — re-run the MCP `initialize`, then retry
- * - `restart-retry` — `stop()` + `start()`, then retry
- * - `reauth` — flip to `reauth_required`, surface a Reconnect; do NOT loop
- * - `re-register` — re-add the source to the registry, then retry
- * - `re-register-only` — re-add the source, then surface (non-idempotent op)
- */
-export type RecoveryAction =
-  | "surface"
-  | "retry"
-  | "reinit-retry"
-  | "restart-retry"
-  | "reauth"
-  | "re-register"
-  | "re-register-only";
-
-/** Kinds the policy table decides over: connection failures + the two detector
- *  signals that are not thrown errors. `"none"` never reaches policy. */
-export type RecoveryKind = Exclude<ConnectionFailure, "none"> | "source-absent" | "credential-lost";
-
-/**
- * Pure policy: `(kind, context) → action`. `idempotent` is false for
- * task-augmented `tools/call` (retrying would duplicate server-side state — the
- * invariant at `execute`'s task branch), so non-idempotent failures surface
- * rather than retry. `hasReauthableProvider` is a property of the *source*, not
- * the error: a 401 on an OAuth remote is recoverable by reauth, the same 401 on a
- * static-auth remote is not (it falls through to a transport restart). See
- * `research/SPEC-mcp-source-recovery.md` §3.2. No caller yet — Phase 2 wires the
- * `withRecovery` wrapper through this; Phase 1 establishes and tests the contract.
- */
-export function policyFor(
-  kind: RecoveryKind,
-  ctx: { idempotent: boolean; hasReauthableProvider: boolean },
-): RecoveryAction {
-  switch (kind) {
-    case "session-lost":
-      return ctx.idempotent ? "reinit-retry" : "surface";
-    case "transient":
-      return ctx.idempotent ? "retry" : "surface";
-    case "transport-dead":
-      return ctx.idempotent ? "restart-retry" : "surface";
-    case "auth-lost":
-      if (ctx.hasReauthableProvider) return "reauth";
-      return ctx.idempotent ? "restart-retry" : "surface";
-    case "credential-lost":
-      return "reauth";
-    case "source-absent":
-      return ctx.idempotent ? "re-register" : "re-register-only";
-  }
 }
 
 /**

--- a/test/unit/mcp-failure-taxonomy.test.ts
+++ b/test/unit/mcp-failure-taxonomy.test.ts
@@ -6,14 +6,11 @@ import {
   type ConnectionFailure,
   isSessionLost,
   isTransientTransport,
-  policyFor,
-  type RecoveryAction,
-  type RecoveryKind,
 } from "../../src/tools/mcp-source.ts";
 
 /**
  * Phase 1 of the recovery redesign (research/SPEC-mcp-source-recovery.md): the
- * failure taxonomy + policy as pure, tested data. Two invariants:
+ * connection-failure taxonomy as pure, tested data. Two invariants:
  *  1. classifyConnectionFailure is OP-INDEPENDENT — it returns only
  *     connection-level classes; application outcomes (resource-miss vs app-error)
  *     are op-scoped and stay in isMcpResourceMiss. So the resource-"miss" wire
@@ -21,6 +18,9 @@ import {
  *  2. isSessionLost / isTransientTransport are now thin views of the classifier
  *     and MUST stay byte-identical to their pre-extraction behavior (the
  *     readResource contract in mcp-source-resource-errors.test.ts depends on it).
+ *
+ * The recovery *policy* (what to do with each class) lands in Phase 2 with the
+ * `withRecovery` wrapper that consumes it — abstractions ship with their caller.
  */
 describe("classifyConnectionFailure — op-independent connection classes", () => {
   const sessionLost404 = {
@@ -89,55 +89,6 @@ describe("isSessionLost / isTransientTransport — thin views, behavior preserve
     expect(isTransientTransport({ code: 404, message: "Session not found" })).toBe(false);
     expect(isTransientTransport(new Error("Connection closed"))).toBe(false);
     expect(isTransientTransport(null)).toBe(false);
-  });
-});
-
-describe("policyFor — pure recovery policy table", () => {
-  const idem = { idempotent: true, hasReauthableProvider: false };
-  const task = { idempotent: false, hasReauthableProvider: false };
-
-  it("idempotent connection failures recover; non-idempotent (task) surface", () => {
-    expect(policyFor("session-lost", idem)).toBe("reinit-retry");
-    expect(policyFor("session-lost", task)).toBe("surface");
-    expect(policyFor("transient", idem)).toBe("retry");
-    expect(policyFor("transient", task)).toBe("surface");
-    expect(policyFor("transport-dead", idem)).toBe("restart-retry");
-    expect(policyFor("transport-dead", task)).toBe("surface");
-  });
-
-  it("auth-lost is config-dependent: reauth only when a reauthable provider exists", () => {
-    expect(policyFor("auth-lost", { idempotent: true, hasReauthableProvider: true })).toBe("reauth");
-    expect(policyFor("auth-lost", { idempotent: false, hasReauthableProvider: true })).toBe("reauth");
-    // static-auth remote (no provider): can't reauth — falls to transport handling
-    expect(policyFor("auth-lost", { idempotent: true, hasReauthableProvider: false })).toBe(
-      "restart-retry",
-    );
-    expect(policyFor("auth-lost", { idempotent: false, hasReauthableProvider: false })).toBe(
-      "surface",
-    );
-  });
-
-  it("detector-signal kinds: credential-lost reauths, source-absent re-registers", () => {
-    expect(policyFor("credential-lost", idem)).toBe("reauth");
-    expect(policyFor("credential-lost", task)).toBe("reauth");
-    expect(policyFor("source-absent", idem)).toBe("re-register");
-    expect(policyFor("source-absent", task)).toBe("re-register-only");
-  });
-
-  it("is total over every RecoveryKind (no kind returns undefined)", () => {
-    const kinds: RecoveryKind[] = [
-      "session-lost",
-      "transient",
-      "transport-dead",
-      "auth-lost",
-      "source-absent",
-      "credential-lost",
-    ];
-    const actions: RecoveryAction[] = kinds.flatMap((k) => [
-      policyFor(k, { idempotent: true, hasReauthableProvider: true }),
-      policyFor(k, { idempotent: false, hasReauthableProvider: false }),
-    ]);
-    expect(actions.every((a) => typeof a === "string")).toBe(true);
   });
 });
 

--- a/test/unit/mcp-failure-taxonomy.test.ts
+++ b/test/unit/mcp-failure-taxonomy.test.ts
@@ -1,0 +1,146 @@
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "bun:test";
+import {
+  classifyConnectionFailure,
+  type ConnectionFailure,
+  isSessionLost,
+  isTransientTransport,
+  policyFor,
+  type RecoveryAction,
+  type RecoveryKind,
+} from "../../src/tools/mcp-source.ts";
+
+/**
+ * Phase 1 of the recovery redesign (research/SPEC-mcp-source-recovery.md): the
+ * failure taxonomy + policy as pure, tested data. Two invariants:
+ *  1. classifyConnectionFailure is OP-INDEPENDENT — it returns only
+ *     connection-level classes; application outcomes (resource-miss vs app-error)
+ *     are op-scoped and stay in isMcpResourceMiss. So the resource-"miss" wire
+ *     codes (-32002/-32601/-32602) classify as "none" here.
+ *  2. isSessionLost / isTransientTransport are now thin views of the classifier
+ *     and MUST stay byte-identical to their pre-extraction behavior (the
+ *     readResource contract in mcp-source-resource-errors.test.ts depends on it).
+ */
+describe("classifyConnectionFailure — op-independent connection classes", () => {
+  const sessionLost404 = {
+    code: 404,
+    message: 'Error POSTing to endpoint: {"code":-32001,"message":"Session not found"}',
+  };
+
+  it("classifies session loss (canonical 404 + a non-canonical -32001)", () => {
+    expect(classifyConnectionFailure(sessionLost404)).toBe("session-lost");
+    expect(classifyConnectionFailure(new McpError(-32001, "Session not found"))).toBe(
+      "session-lost",
+    );
+  });
+
+  it("classifies transient gateway failures (status + message shapes)", () => {
+    for (const code of [502, 503, 504]) {
+      expect(classifyConnectionFailure({ code, message: "x" })).toBe("transient");
+    }
+    expect(classifyConnectionFailure({ message: '{"error":"bad_gateway"}' })).toBe("transient");
+    expect(classifyConnectionFailure(new Error("Service Unavailable"))).toBe("transient");
+    expect(classifyConnectionFailure(new Error("Gateway Timeout"))).toBe("transient");
+  });
+
+  it("classifies auth loss only from UnauthorizedError", () => {
+    expect(classifyConnectionFailure(new UnauthorizedError("nope"))).toBe("auth-lost");
+  });
+
+  it("classifies a torn transport", () => {
+    expect(classifyConnectionFailure(new McpError(-32000, "Connection closed"))).toBe(
+      "transport-dead",
+    );
+    expect(classifyConnectionFailure(new Error("fetch failed"))).toBe("transport-dead");
+    expect(classifyConnectionFailure(new Error("socket hang up"))).toBe("transport-dead");
+    expect(classifyConnectionFailure(new Error("read ECONNRESET"))).toBe("transport-dead");
+    expect(classifyConnectionFailure(new Error("Request timed out"))).toBe("transport-dead");
+  });
+
+  it("returns 'none' for application outcomes — those are op-scoped, not connection failures", () => {
+    // resource-"miss" wire codes are NOT connection failures (isMcpResourceMiss owns them, per op).
+    expect(classifyConnectionFailure(new McpError(-32002, "Resource not found"))).toBe("none");
+    expect(classifyConnectionFailure(new McpError(-32601, "Method not found"))).toBe("none");
+    expect(classifyConnectionFailure(new McpError(-32602, "Invalid params"))).toBe("none");
+    expect(classifyConnectionFailure(new Error("the tool said no"))).toBe("none");
+  });
+
+  it("is null/non-object safe", () => {
+    expect(classifyConnectionFailure(null)).toBe("none");
+    expect(classifyConnectionFailure(undefined)).toBe("none");
+    expect(classifyConnectionFailure("nope")).toBe("none");
+  });
+});
+
+describe("isSessionLost / isTransientTransport — thin views, behavior preserved", () => {
+  it("isSessionLost is exactly the session-lost class", () => {
+    expect(isSessionLost({ code: 404, message: "Session not found" })).toBe(true);
+    expect(isSessionLost(new McpError(-32001, "Session not found"))).toBe(true);
+    expect(isSessionLost({ code: 404, message: "Not Found" })).toBe(false);
+    expect(isSessionLost(new McpError(-32002, "Resource not found"))).toBe(false);
+    expect(isSessionLost(new Error("Connection closed"))).toBe(false);
+    expect(isSessionLost(null)).toBe(false);
+  });
+
+  it("isTransientTransport is exactly the transient class", () => {
+    for (const code of [502, 503, 504]) expect(isTransientTransport({ code, message: "x" })).toBe(true);
+    expect(isTransientTransport({ message: '{"error":"bad_gateway"}' })).toBe(true);
+    expect(isTransientTransport({ code: 404, message: "Session not found" })).toBe(false);
+    expect(isTransientTransport(new Error("Connection closed"))).toBe(false);
+    expect(isTransientTransport(null)).toBe(false);
+  });
+});
+
+describe("policyFor — pure recovery policy table", () => {
+  const idem = { idempotent: true, hasReauthableProvider: false };
+  const task = { idempotent: false, hasReauthableProvider: false };
+
+  it("idempotent connection failures recover; non-idempotent (task) surface", () => {
+    expect(policyFor("session-lost", idem)).toBe("reinit-retry");
+    expect(policyFor("session-lost", task)).toBe("surface");
+    expect(policyFor("transient", idem)).toBe("retry");
+    expect(policyFor("transient", task)).toBe("surface");
+    expect(policyFor("transport-dead", idem)).toBe("restart-retry");
+    expect(policyFor("transport-dead", task)).toBe("surface");
+  });
+
+  it("auth-lost is config-dependent: reauth only when a reauthable provider exists", () => {
+    expect(policyFor("auth-lost", { idempotent: true, hasReauthableProvider: true })).toBe("reauth");
+    expect(policyFor("auth-lost", { idempotent: false, hasReauthableProvider: true })).toBe("reauth");
+    // static-auth remote (no provider): can't reauth — falls to transport handling
+    expect(policyFor("auth-lost", { idempotent: true, hasReauthableProvider: false })).toBe(
+      "restart-retry",
+    );
+    expect(policyFor("auth-lost", { idempotent: false, hasReauthableProvider: false })).toBe(
+      "surface",
+    );
+  });
+
+  it("detector-signal kinds: credential-lost reauths, source-absent re-registers", () => {
+    expect(policyFor("credential-lost", idem)).toBe("reauth");
+    expect(policyFor("credential-lost", task)).toBe("reauth");
+    expect(policyFor("source-absent", idem)).toBe("re-register");
+    expect(policyFor("source-absent", task)).toBe("re-register-only");
+  });
+
+  it("is total over every RecoveryKind (no kind returns undefined)", () => {
+    const kinds: RecoveryKind[] = [
+      "session-lost",
+      "transient",
+      "transport-dead",
+      "auth-lost",
+      "source-absent",
+      "credential-lost",
+    ];
+    const actions: RecoveryAction[] = kinds.flatMap((k) => [
+      policyFor(k, { idempotent: true, hasReauthableProvider: true }),
+      policyFor(k, { idempotent: false, hasReauthableProvider: false }),
+    ]);
+    expect(actions.every((a) => typeof a === "string")).toBe(true);
+  });
+});
+
+// Type-level guard: ConnectionFailure is exported and usable.
+const _exhaustive: ConnectionFailure = "none";
+void _exhaustive;


### PR DESCRIPTION
First of the staged source-recovery redesign (design doc: `research/SPEC-mcp-source-recovery.md`). #572 (merged) was Phase 0 — the resource-path self-heal. This phase extracts the **connection-failure taxonomy** as pure, exhaustively-tested data — the single ordered source of truth the live predicates now share, and the foundation Phase 2's `withRecovery` wrapper builds on.

## What

- **`classifyConnectionFailure(err)`** — the op-**independent** connection classes: `session-lost | transient | transport-dead | auth-lost | none`.
- **`isSessionLost` / `isTransientTransport`** re-expressed as thin views over the classifier — **byte-identical** behavior (the `readResource` contract from #572 depends on it; its tests are unchanged and green).

## First-principles corrections baked in (from an adversarial review of the spec)

1. **Classification is op-dependent and must split.** The same wire code means different things per op — `-32601`/`-32602` is a *resource miss* on `resources/read` but a *method/param error* on `tools/call`. So connection-health (op-independent, here) is split from application-outcome (op-scoped, stays in `isMcpResourceMiss`). The resource-miss codes classify as `"none"` here, by design.
2. **Detector signals are not error classes.** `source-absent` (a registry-lookup miss) and `credential-lost` (a probe verdict) are not thrown errors, so they are never classifier outputs.

## Scope (trimmed per QA on this PR — thanks)

The recovery **policy** (`policyFor` + the action/kind types) was dropped from this PR and **deferred to Phase 2**, where the `withRecovery` wrapper consumes it. A policy table with no caller is the likeliest thing to reshape on first contact with a real consumer — so it ships with that consumer. What remains earns its place now: the classifier consolidates two live predicates into one ordered source of truth.

No call site is rewired — zero behavior change. `withRecovery` + `app-error→surface` on `tools/call` is Phase 2.

## Tests

`test/unit/mcp-failure-taxonomy.test.ts`: every connection class + the behavior-preservation of both views. Full unit suite green; `verify:static` green.

Refs #533 (closed when the Phase 3 supervisor absorbs the absent-source sub-mode).