### PR TITLE
fix(files): conversation files follow the conversation's workspace, not the request

### DIFF
--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1701,16 +1701,21 @@ export function sanitizeFilename(name: string): string {
   return name.replace(/["\r\n\x00-\x1f]/g, "_");
 }
 
-/** Handle GET /v1/files/:fileId?ws=<wsId> — serve a stored file from the
- * workspace it lives in. Files are workspace-owned; the URL must carry the
- * workspace (`?ws=`) because a browser GET can't send the `X-Workspace-Id`
- * header. */
+/** Handle GET /v1/files/:fileId?ws=<wsId>&conversationId=<id> — serve a stored
+ * file from the workspace it lives in. Files are workspace-owned; the URL must
+ * carry the workspace (`?ws=`) because a browser GET can't send the
+ * `X-Workspace-Id` header. When `conversationId` is present the workspace is
+ * resolved from the conversation instead — the download then follows the
+ * conversation's workspace (the partition the chat read/write path uses), so a
+ * file stored under a cross-workspace conversation resolves without the client
+ * knowing the right `?ws=`. */
 export async function handleFileServe(
   fileId: string,
   runtime: Runtime,
   features: ResolvedFeatures,
   identity: UserIdentity | undefined,
   workspaceId: string | undefined,
+  conversationId: string | undefined,
 ): Promise<Response> {
   if (!features.fileContext) {
     return apiError(404, "not_found", "Not found");
@@ -1720,22 +1725,34 @@ export async function handleFileServe(
     return apiError(400, "bad_request", "Invalid file ID format");
   }
 
-  if (!workspaceId) {
+  if (!workspaceId && !conversationId) {
     return apiError(
       400,
       "workspace_required",
-      "Files are workspace-owned — pass ?ws=<workspaceId>",
+      "Files are workspace-owned — pass ?ws=<workspaceId> or conversationId",
     );
   }
 
-  // `?ws=` is taken at face value WITHOUT a membership check on purpose — do not
-  // add one. The store is rooted at the caller's OWN `<ownerId>` partition, so a
-  // forged `?ws=<other>` can only ever reach files the caller themselves wrote
-  // into that workspace (none, if they're not a member). The workspace is a
-  // storage-routing hint here, not an authorization axis — the owner partition is
-  // the gate. (Membership-gated surfaces use `optionalWorkspace`; a browser GET
-  // can't send the header, which is why this route reads the query param.)
-  const store = runtime.getWorkspaceFileStore(workspaceId, runtime.resolveRequestUserId(identity));
+  const ownerId = runtime.resolveRequestUserId(identity);
+  // With a conversationId, follow the conversation's authoritative workspace
+  // (the same partition chat() reads/writes) — the user's own download then
+  // resolves a cross-workspace attachment without the client knowing `?ws=`.
+  // Otherwise `?ws=` is taken at face value WITHOUT a membership check on
+  // purpose — do not add one. The store is rooted at the caller's OWN
+  // `<ownerId>` partition, so a forged `?ws=<other>` can only ever reach files
+  // the caller themselves wrote into that workspace (none, if they're not a
+  // member). The workspace is a storage-routing hint here, not an authorization
+  // axis — the owner partition is the gate. (Membership-gated surfaces use
+  // `optionalWorkspace`; a browser GET can't send the header, which is why this
+  // route reads the query param.)
+  const wsId = conversationId
+    ? await runtime.resolveConversationWorkspaceId(
+        conversationId,
+        workspaceId ?? personalWorkspaceIdFor(ownerId),
+        ownerId,
+      )
+    : (workspaceId as string);
+  const store = runtime.getWorkspaceFileStore(wsId, ownerId);
   try {
     const file = await store.readFile(fileId);
     const safeName = sanitizeFilename(file.filename);
@@ -1887,19 +1904,32 @@ async function parseMultipartChatBody(
 
   // Ingest files: validate, store, extract text, build content parts.
   //
-  // Files are workspace-owned: ingest writes to the focused workspace
-  // (`workspaceId ?? personal`) under the uploader's owner partition — the SAME
-  // workspace `runtime.chat()` rehydrates from (`request.workspaceId ??
-  // sessionWsId`), so an upload can't land in a workspace the read won't look in.
+  // Files are workspace-owned: ingest writes to the conversation's AUTHORITATIVE
+  // workspace — the SAME partition `runtime.chat()` reads from when it
+  // rehydrates. The workspace is resolved from the conversation (probe +
+  // locator), not the request header: on a cross-workspace resume the two differ,
+  // and a header-partitioned upload would land in a workspace the read never
+  // looks in (the attachment vanishes). A new conversation (no id yet) is born in
+  // the focused/personal workspace.
   const uploadOwner = runtime.resolveRequestUserId(identity);
-  const store = runtime.getWorkspaceFileStore(
-    workspaceId ?? personalWorkspaceIdFor(uploadOwner),
-    uploadOwner,
-  );
-  const filesConfig = runtime.getFilesConfig();
+  const fallbackWsId = workspaceId ?? personalWorkspaceIdFor(uploadOwner);
   // Use conversationId if provided, otherwise a placeholder (will be replaced by runtime.chat)
   const convId = (typeof conversationId === "string" && conversationId) || "pending";
-  const ingestResult = await ingestFiles(uploadedFiles, convId, store, filesConfig);
+  const wsId = await runtime.resolveConversationWorkspaceId(
+    convId === "pending" ? undefined : convId,
+    fallbackWsId,
+    uploadOwner,
+  );
+  const store = runtime.getWorkspaceFileStore(wsId, uploadOwner);
+  const filesConfig = runtime.getFilesConfig();
+  const ingestResult = await ingestFiles(
+    uploadedFiles,
+    convId,
+    store,
+    filesConfig,
+    wsId,
+    uploadOwner,
+  );
 
   if (ingestResult.errors.length > 0) {
     return apiError(400, "file_upload_error", "File upload failed", {
@@ -2039,10 +2069,16 @@ export async function handleResourceUpload(
     typeof conversationIdRaw === "string" && conversationIdRaw ? conversationIdRaw : null;
 
   const uploadOwner = runtime.resolveRequestUserId(identity);
-  const store = runtime.getWorkspaceFileStore(
-    workspaceId ?? personalWorkspaceIdFor(uploadOwner),
+  const fallbackWsId = workspaceId ?? personalWorkspaceIdFor(uploadOwner);
+  // A resource upload attached to a conversation lands in that conversation's
+  // authoritative workspace (the partition the read uses); a standalone app
+  // upload (no conversationId) lands in the focused/personal workspace.
+  const wsId = await runtime.resolveConversationWorkspaceId(
+    conversationId ?? undefined,
+    fallbackWsId,
     uploadOwner,
   );
+  const store = runtime.getWorkspaceFileStore(wsId, uploadOwner);
   const entries: FileEntry[] = [];
   const errors: string[] = [];
 
@@ -2068,6 +2104,11 @@ export async function handleResourceUpload(
       conversationId,
       createdAt: new Date().toISOString(),
       description,
+      // Stamp the resolved workspace/owner the bytes physically landed in (the
+      // conversation's authoritative workspace) — advisory denormalisation that
+      // lets the upload response report where the file lives.
+      ownerId: uploadOwner,
+      workspaceId: wsId,
     };
     await store.appendRegistry(entry);
     entries.push(entry);

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1913,18 +1913,16 @@ async function parseMultipartChatBody(
   // the focused/personal workspace.
   const uploadOwner = runtime.resolveRequestUserId(identity);
   const fallbackWsId = workspaceId ?? personalWorkspaceIdFor(uploadOwner);
-  // Use conversationId if provided, otherwise a placeholder (will be replaced by runtime.chat)
-  const convId = (typeof conversationId === "string" && conversationId) || "pending";
-  const wsId = await runtime.resolveConversationWorkspaceId(
-    convId === "pending" ? undefined : convId,
-    fallbackWsId,
-    uploadOwner,
-  );
+  // The real conversation id, or undefined when the chat doesn't exist yet
+  // (`runtime.chat()` stamps the id later; `ingestFiles` gets a "pending"
+  // placeholder for the FileEntry until then).
+  const convId = (typeof conversationId === "string" && conversationId) || undefined;
+  const wsId = await runtime.resolveConversationWorkspaceId(convId, fallbackWsId, uploadOwner);
   const store = runtime.getWorkspaceFileStore(wsId, uploadOwner);
   const filesConfig = runtime.getFilesConfig();
   const ingestResult = await ingestFiles(
     uploadedFiles,
-    convId,
+    convId ?? "pending",
     store,
     filesConfig,
     wsId,

--- a/src/api/routes/tools.ts
+++ b/src/api/routes/tools.ts
@@ -35,7 +35,17 @@ export function toolRoutes(ctx: AppContext) {
     .get("/v1/files/:fileId", (c) => {
       // Files are workspace-owned: the URL carries the workspace as `?ws=<wsId>` (the web
       // client appends the active workspace; a browser GET can't send a header).
+      // An optional `?conversationId=<id>` makes the download follow the
+      // conversation's workspace instead — resolves a cross-workspace attachment
+      // without the client knowing the right `?ws=`.
       const fileId = decodeURIComponent(c.req.param("fileId"));
-      return handleFileServe(fileId, ctx.runtime, ctx.features, c.var.identity, c.req.query("ws"));
+      return handleFileServe(
+        fileId,
+        ctx.runtime,
+        ctx.features,
+        c.var.identity,
+        c.req.query("ws"),
+        c.req.query("conversationId"),
+      );
     });
 }

--- a/src/files/ingest.ts
+++ b/src/files/ingest.ts
@@ -120,6 +120,11 @@ export async function ingestFiles(
   conversationId: string,
   store: FileStore,
   config: FileConfig,
+  // The workspace/owner the `store` is partitioned by — stamped onto each
+  // registry entry as advisory denormalisation (the directory is authoritative).
+  // Optional so scratch/test callers can ingest without a workspace context.
+  wsId?: string,
+  ownerId?: string,
 ): Promise<IngestResult> {
   const errors: string[] = [];
   const contentParts: ContentPart[] = [];
@@ -169,6 +174,8 @@ export async function ingestFiles(
       conversationId,
       createdAt: new Date().toISOString(),
       description: null,
+      ...(ownerId ? { ownerId } : {}),
+      ...(wsId ? { workspaceId: wsId } : {}),
     };
     await store.appendRegistry(entry);
 

--- a/src/runtime/identity-tool-router.ts
+++ b/src/runtime/identity-tool-router.ts
@@ -173,6 +173,12 @@ export class IdentityToolRouter implements ToolRouter {
       identity: outer?.identity ?? null,
       scope: perCallScope,
       ...(outer?.conversationId !== undefined ? { conversationId: outer.conversationId } : {}),
+      // `fileWorkspaceId` is orthogonal to `scope` and rides through the restamp:
+      // identity-door `files__*` tools resolve their workspace-owned store from
+      // this field (NOT `scope.workspaceId`, which is the personal/session
+      // workspace on the identity door). Dropping it here would leave the file
+      // tools with no workspace in scope even when the chat set one.
+      ...(outer?.fileWorkspaceId !== undefined ? { fileWorkspaceId: outer.fileWorkspaceId } : {}),
       ...(outer?.toolPromotion !== undefined ? { toolPromotion: outer.toolPromotion } : {}),
     };
     return runWithRequestContext(perCallCtx, () =>

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1138,8 +1138,17 @@ export class Runtime {
     // locator (authoritative). The workspace owns the directory; the path is the
     // boundary. This is a SEPARATE axis from `toolsWsId` (tool/skill/app scope)
     // below — the conversation workspace is fixed at create, the tool scope is not.
-    const convWsId = request.workspaceId ?? sessionWsId;
-    const { store } = await this.resolveChatStore(request.conversationId, convWsId, ownerId);
+    const requestWsId = request.workspaceId ?? sessionWsId;
+    // `convWsId` is authoritative: on a cross-workspace resume `resolveChatStore`
+    // relocates to the workspace the conversation actually lives in. The create
+    // stamp (below) and the file partition (~line 1502) follow it, not the
+    // request header — otherwise a resumed chat's attachments resolve in the
+    // wrong partition and silently vanish.
+    const { store, convWsId } = await this.resolveChatStore(
+      request.conversationId,
+      requestWsId,
+      ownerId,
+    );
 
     // Load the personal workspace config for agents / models override.
     // Pre-Stage-2 this looked up the request's `workspaceId`; that field
@@ -1496,10 +1505,12 @@ export class Runtime {
     // shape (inline bytes) — see `src/files/rehydrate.ts`.
     const history = await store.history(conversation);
     // Files are workspace-owned: rehydrate a `files://` URI from the
-    // conversation's own workspace (`request.workspaceId ?? sessionWsId`, the
-    // same workspace the upload landed in) under the owner's partition — never
-    // another workspace's store.
-    const fileStore = this.getWorkspaceFileStore(request.workspaceId ?? sessionWsId, ownerId);
+    // conversation's AUTHORITATIVE workspace (`convWsId` from `resolveChatStore`,
+    // the same workspace the upload landed in) under the owner's partition —
+    // never another workspace's store. On a cross-workspace resume this is the
+    // conversation's workspace, not the request header — they differ, and reading
+    // from the header would miss the attachment entirely.
+    const fileStore = this.getWorkspaceFileStore(convWsId, ownerId);
 
     // Resolve maxOutputTokens FIRST — resolveThinking needs it to clamp the
     // thinking budget so visible-content headroom is always preserved.
@@ -2057,7 +2068,12 @@ export class Runtime {
     // the rehydrate call is a pass-through for shape consistency with the
     // engine's message contract).
     const history = await store.history(conversation);
-    const fileStore = this.getWorkspaceFileStore(request.workspaceId ?? sessionWsId, ownerId);
+    // Rehydrate from the conversation's own workspace (`provWsId`, the workspace
+    // the run conversation and its files were created in) — the same partition a
+    // task upload would land in. A task never resumes, so this equals the request
+    // workspace today, but anchoring on the conversation's workspace keeps the
+    // read aligned with the write by construction.
+    const fileStore = this.getWorkspaceFileStore(provWsId, ownerId);
 
     const resolvedMaxOutputTokens = resolveMaxOutputTokens({
       configValue: this.config.maxOutputTokens,
@@ -3112,6 +3128,34 @@ export class Runtime {
       store: this.workspaceConversationStore(createConvWsId, ownerId),
       convWsId: createConvWsId,
     };
+  }
+
+  /**
+   * The workspace a conversation lives in — for code outside the chat path (the
+   * upload handlers, the file-serve route) that must resolve the SAME partition
+   * `chat()` reads from when it rehydrates. Mirrors `resolveChatStore`'s
+   * workspace resolution: probe the focused/personal workspace directly, then
+   * the locator. A conversation not yet on disk (a new chat) is born in
+   * `fallbackWsId`. Without this an upload would partition by the request header
+   * while the read partitions by the conversation's workspace — they disagree on
+   * a cross-workspace resume and the attachment silently vanishes.
+   */
+  async resolveConversationWorkspaceId(
+    conversationId: string | undefined,
+    fallbackWsId: string,
+    ownerId: string,
+  ): Promise<string> {
+    if (conversationId) {
+      const directDir = workspaceConversationsDir(
+        resolveWorkDir(this.config),
+        fallbackWsId,
+        ownerId,
+      );
+      if (existsSync(join(directDir, `${conversationId}.jsonl`))) return fallbackWsId;
+      const loc = await this.getConversationLocator().locate(conversationId);
+      if (loc) return loc.wsId;
+    }
+    return fallbackWsId;
   }
 
   /**

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -2069,11 +2069,10 @@ export class Runtime {
     // the rehydrate call is a pass-through for shape consistency with the
     // engine's message contract).
     const history = await store.history(conversation);
-    // Rehydrate from the conversation's own workspace (`provWsId`, the workspace
-    // the run conversation and its files were created in) — the same partition a
-    // task upload would land in. A task never resumes, so this equals the request
-    // workspace today, but anchoring on the conversation's workspace keeps the
-    // read aligned with the write by construction.
+    // Rehydrate from `provWsId` — for a task that's the request workspace, which
+    // equals the workspace the run conversation and its files were created in (a
+    // task never resumes, so it cannot diverge the way a chat resume can).
+    // Anchoring the read here keeps it aligned with the write by construction.
     const fileStore = this.getWorkspaceFileStore(provWsId, ownerId);
 
     const resolvedMaxOutputTokens = resolveMaxOutputTokens({

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -24,7 +24,7 @@ import { generateTitle } from "../conversation/auto-title.ts";
 import { compactConversationMessages } from "../conversation/compaction.ts";
 import { EventSourcedConversationStore } from "../conversation/event-sourced-store.ts";
 import { JsonlConversationStore } from "../conversation/jsonl-store.ts";
-import { ConversationLocator } from "../conversation/locator.ts";
+import { type ConversationLocation, ConversationLocator } from "../conversation/locator.ts";
 import { InMemoryConversationStore } from "../conversation/memory-store.ts";
 import { runConversationsDir, workspaceConversationsDir } from "../conversation/paths.ts";
 import type {
@@ -1720,9 +1720,10 @@ export class Runtime {
         workspaceModelOverride: sessionWorkspace?.models ?? null,
       },
       conversationId: conversation.id,
-      // Files created/read by identity-door `files__*` tools land in the focused
-      // workspace (the conversation's workspace), not the personal `sessionWsId` scope.
-      fileWorkspaceId: request.workspaceId ?? sessionWsId,
+      // Files created/read by identity-door `files__*` tools land in the
+      // conversation's authoritative workspace — the same partition the
+      // rehydration read and the upload write use.
+      fileWorkspaceId: convWsId,
     };
     engineConfig.toolPromotion = this.buildToolPromotionFactory();
 
@@ -2262,9 +2263,10 @@ export class Runtime {
         workspaceModelOverride: sessionWorkspace?.models ?? null,
       },
       conversationId: conversation.id,
-      // Files created/read by identity-door `files__*` tools land in the focused
-      // workspace (the conversation's workspace), not the personal `sessionWsId` scope.
-      fileWorkspaceId: request.workspaceId ?? sessionWsId,
+      // Files created/read by identity-door `files__*` tools land in the
+      // conversation's authoritative workspace — the same partition the
+      // rehydration read and the upload write use.
+      fileWorkspaceId: provWsId,
     };
     engineConfig.toolPromotion = this.buildToolPromotionFactory();
 
@@ -3096,66 +3098,61 @@ export class Runtime {
     createConvWsId: string,
     ownerId: string,
   ): Promise<{ store: EventSourcedConversationStore; convWsId: string }> {
-    if (conversationId) {
-      // Hot path: the conversation almost always lives in the focused/personal
-      // workspace under the caller's own owner partition. Probe that one path
-      // directly (O(1) `existsSync`) before any cross-workspace walk — a resume runs
-      // on every message, so this must not scan the tenant.
-      const directDir = workspaceConversationsDir(
-        resolveWorkDir(this.config),
-        createConvWsId,
-        ownerId,
-      );
-      if (existsSync(join(directDir, `${conversationId}.jsonl`))) {
-        return {
-          store: this.workspaceConversationStore(createConvWsId, ownerId),
-          convWsId: createConvWsId,
-        };
-      }
-      // Cross-workspace deep-link: resolve by path (a readdir-only walk, no reads).
-      const loc = await this.getConversationLocator().locate(conversationId);
-      if (loc) {
-        // An automation-run conversation (no owner partition) resolves to its
-        // `_runs/` store — never split-brain a fresh file into the owner
-        // partition under the same id.
-        const store = loc.automationId
-          ? this.runConversationStore(loc.wsId, loc.automationId)
-          : this.workspaceConversationStore(loc.wsId, loc.ownerId ?? ownerId);
-        return { store, convWsId: loc.wsId };
-      }
-    }
-    return {
-      store: this.workspaceConversationStore(createConvWsId, ownerId),
-      convWsId: createConvWsId,
-    };
+    const { wsId, loc } = await this.resolveConversationLocation(
+      conversationId,
+      createConvWsId,
+      ownerId,
+    );
+    // An automation-run conversation (no owner partition) resolves to its
+    // `_runs/` store — never split-brain a fresh file into the owner partition
+    // under the same id.
+    const store = loc?.automationId
+      ? this.runConversationStore(loc.wsId, loc.automationId)
+      : this.workspaceConversationStore(wsId, loc?.ownerId ?? ownerId);
+    return { store, convWsId: wsId };
   }
 
   /**
    * The workspace a conversation lives in — for code outside the chat path (the
-   * upload handlers, the file-serve route) that must resolve the SAME partition
-   * `chat()` reads from when it rehydrates. Mirrors `resolveChatStore`'s
-   * workspace resolution: probe the focused/personal workspace directly, then
-   * the locator. A conversation not yet on disk (a new chat) is born in
-   * `fallbackWsId`. Without this an upload would partition by the request header
-   * while the read partitions by the conversation's workspace — they disagree on
-   * a cross-workspace resume and the attachment silently vanishes.
+   * upload handlers, the file-serve route, and the per-turn `fileWorkspaceId`
+   * that scopes the agent's `files__*` tools) that must resolve the SAME
+   * partition `chat()` reads from when it rehydrates. A conversation not yet on
+   * disk (a new chat) is born in `fallbackWsId`.
    */
   async resolveConversationWorkspaceId(
     conversationId: string | undefined,
     fallbackWsId: string,
     ownerId: string,
   ): Promise<string> {
+    return (await this.resolveConversationLocation(conversationId, fallbackWsId, ownerId)).wsId;
+  }
+
+  /**
+   * The single probe-then-locate for "which workspace does this conversation live
+   * in" — the one place the partition rule lives, so the read (`resolveChatStore`),
+   * the write (`resolveConversationWorkspaceId` → upload handlers / file serve), and
+   * the file-tool scope (`RequestContext.fileWorkspaceId`) cannot drift apart.
+   * Hot path: probe the focused/personal workspace directly (O(1) `existsSync`, no
+   * tenant scan) — only a cross-workspace deep-link falls back to the locator walk.
+   */
+  private async resolveConversationLocation(
+    conversationId: string | undefined,
+    fallbackWsId: string,
+    ownerId: string,
+  ): Promise<{ wsId: string; loc: ConversationLocation | undefined }> {
     if (conversationId) {
       const directDir = workspaceConversationsDir(
         resolveWorkDir(this.config),
         fallbackWsId,
         ownerId,
       );
-      if (existsSync(join(directDir, `${conversationId}.jsonl`))) return fallbackWsId;
+      if (existsSync(join(directDir, `${conversationId}.jsonl`))) {
+        return { wsId: fallbackWsId, loc: undefined };
+      }
       const loc = await this.getConversationLocator().locate(conversationId);
-      if (loc) return loc.wsId;
+      if (loc) return { wsId: loc.wsId, loc };
     }
-    return fallbackWsId;
+    return { wsId: fallbackWsId, loc: undefined };
   }
 
   /**

--- a/test/integration/cross-workspace-file-upload.test.ts
+++ b/test/integration/cross-workspace-file-upload.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Cross-workspace UPLOAD → file partition (the write side).
+ *
+ * A conversation is WORKSPACE-owned: it lives under `workspaces/<wsId>/...` and
+ * its attached files MUST land in that SAME workspace's partition
+ * (`workspaces/<wsId>/files/<ownerId>/`) — the partition the chat READ path
+ * rehydrates from. When a file is uploaded *attached to a conversation* on a
+ * request that is NOT focused on that conversation's workspace (unfocused, or
+ * focused on a different workspace), the upload must resolve the conversation's
+ * authoritative workspace (probe + locator) and write THERE — not into the
+ * request's header/personal partition.
+ *
+ * The sibling resume test (`runtime/cross-workspace-file-resume.test.ts`) pins
+ * the read side by seeding the registry directly. This one drives the REAL
+ * upload handler over HTTP (`POST /v1/resources` → `handleResourceUpload`) so it
+ * exercises the actual partition-selection logic — the bug lived in the write
+ * path. If the handler reverts to partitioning by the request header, the
+ * attachment lands in the personal workspace while the chat reads from workspace
+ * A → it silently vanishes, and the assertions below fail.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type ServerHandle, startServer } from "../../src/api/server.ts";
+import { DEV_IDENTITY } from "../../src/identity/providers/dev.ts";
+import { Runtime } from "../../src/runtime/runtime.ts";
+import { personalWorkspaceIdFor } from "../../src/workspace/workspace-store.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+import { provisionTestWorkspace } from "../helpers/test-workspace.ts";
+
+const testDir = join(tmpdir(), `nb-cross-workspace-file-upload-${Date.now()}`);
+
+// The conversation's workspace — the chat is born here (focused on WORKSPACE_A).
+const WORKSPACE_A = "ws_workspace_a";
+// Dev mode: no identity on the request → the dev owner.
+const OWNER = DEV_IDENTITY.id;
+// An UNFOCUSED request (no X-Workspace-Id) falls back to the owner's personal
+// workspace, a DIFFERENT workspace than WORKSPACE_A. That gap is the
+// cross-workspace hop the fix must bridge by resolving the conversation's
+// workspace from the locator.
+const PERSONAL = personalWorkspaceIdFor(OWNER);
+
+let runtime: Runtime;
+let handle: ServerHandle;
+let baseUrl: string;
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true });
+  runtime = await Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    logging: { disabled: true },
+    workDir: testDir,
+  });
+  await provisionTestWorkspace(runtime, WORKSPACE_A);
+  handle = startServer({ runtime, port: 0 });
+  baseUrl = `http://localhost:${handle.port}`;
+});
+
+afterAll(async () => {
+  handle.stop(true);
+  await runtime.shutdown();
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("cross-workspace upload writes to the conversation's workspace (not the request)", () => {
+  it("a file attached to a workspace-A conversation lands in A even when the request is unfocused", async () => {
+    // 1) Born in workspace A (focused on WORKSPACE_A) — the conversation lives
+    //    under workspaces/ws_workspace_a/conversations/<owner>/<convId>.jsonl.
+    const born = await runtime.chat({ message: "hello from workspace A", workspaceId: WORKSPACE_A });
+    const convId = born.conversationId;
+
+    // 2) Drive the REAL upload handler attached to that conversation, with the
+    //    request UNFOCUSED (no X-Workspace-Id). The header/personal partition is
+    //    PERSONAL; the conversation's workspace is A — they disagree, so this is
+    //    the cross-workspace case the fix targets.
+    const form = new FormData();
+    form.append("file", new Blob(["workspace-A attachment bytes"], { type: "text/plain" }), "attach.txt");
+    form.append("conversationId", convId);
+
+    const res = await fetch(`${baseUrl}/v1/resources`, { method: "POST", body: form });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.files).toHaveLength(1);
+    const fileId: string = body.files[0].id;
+    // The handler stamps the resolved workspace onto the FileEntry it returns.
+    expect(body.files[0].workspaceId).toBe(WORKSPACE_A);
+
+    // 3) The file landed in workspace A's partition — the one the read path uses…
+    const inWorkspaceA = await runtime.getWorkspaceFileStore(WORKSPACE_A, OWNER).findEntry(fileId);
+    expect(inWorkspaceA).not.toBeNull();
+    expect(inWorkspaceA?.workspaceId).toBe(WORKSPACE_A);
+
+    // …and NOT in the request's personal partition. With the write-side bug,
+    // the upload partitions by the header (personal) and these two flip:
+    // present in PERSONAL, absent in A → the attachment is lost on resume.
+    expect(await runtime.getWorkspaceFileStore(PERSONAL, OWNER).findEntry(fileId)).toBeNull();
+
+    // 4) Survives a read: an UNFOCUSED resume rehydrates from the conversation's
+    //    workspace (A), where the upload actually wrote — the attachment is still
+    //    there afterward, not orphaned in the wrong partition.
+    await runtime.chat({ message: "resume from elsewhere", conversationId: convId });
+    const afterResume = await runtime.getWorkspaceFileStore(WORKSPACE_A, OWNER).findEntry(fileId);
+    expect(afterResume).not.toBeNull();
+    expect(afterResume?.workspaceId).toBe(WORKSPACE_A);
+    expect(await runtime.getWorkspaceFileStore(PERSONAL, OWNER).findEntry(fileId)).toBeNull();
+  });
+});

--- a/test/integration/file-serve-by-conversation.test.ts
+++ b/test/integration/file-serve-by-conversation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * GET /v1/files/:fileId?conversationId=<id> → workspace resolved from the
+ * conversation, not the `?ws=` query.
+ *
+ * A file is WORKSPACE-owned and the serve endpoint partitions by `?ws=` because
+ * a browser GET can't send `X-Workspace-Id`. But a file attached to a
+ * conversation that lives in workspace A is only reachable via `?ws=A` — a
+ * client that doesn't know A (it's focused elsewhere, or unfocused) 404s. With
+ * `?conversationId=<id>` the handler resolves the conversation's authoritative
+ * workspace (the same partition the chat read/write path uses) and serves from
+ * there — the user's own download follows the conversation's workspace.
+ *
+ * This drives the REAL serve handler over HTTP. If the conversationId branch is
+ * reverted, the workspace resolves to the wrong (personal/header) partition and
+ * the download 404s — the assertions below fail.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type ServerHandle, startServer } from "../../src/api/server.ts";
+import { DEV_IDENTITY } from "../../src/identity/providers/dev.ts";
+import { Runtime } from "../../src/runtime/runtime.ts";
+import { personalWorkspaceIdFor } from "../../src/workspace/workspace-store.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+import { provisionTestWorkspace } from "../helpers/test-workspace.ts";
+
+const testDir = join(tmpdir(), `nb-file-serve-by-conversation-${Date.now()}`);
+
+const WORKSPACE_A = "ws_workspace_a";
+const OWNER = DEV_IDENTITY.id;
+const PERSONAL = personalWorkspaceIdFor(OWNER);
+
+let runtime: Runtime;
+let handle: ServerHandle;
+let baseUrl: string;
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true });
+  runtime = await Runtime.start({
+    model: { provider: "custom", adapter: createEchoModel() },
+    noDefaultBundles: true,
+    logging: { disabled: true },
+    workDir: testDir,
+  });
+  await provisionTestWorkspace(runtime, WORKSPACE_A);
+  handle = startServer({ runtime, port: 0 });
+  baseUrl = `http://localhost:${handle.port}`;
+});
+
+afterAll(async () => {
+  handle.stop(true);
+  await runtime.shutdown();
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("GET /v1/files resolves the workspace from conversationId", () => {
+  it("serves a workspace-A attachment via conversationId with no (and wrong) ?ws", async () => {
+    // A conversation born in workspace A; a file uploaded to it (unfocused
+    // request → the upload resolves the conversation's workspace, A).
+    const born = await runtime.chat({ message: "hi", workspaceId: WORKSPACE_A });
+    const convId = born.conversationId;
+
+    const form = new FormData();
+    form.append("file", new Blob(["served bytes"], { type: "text/plain" }), "served.txt");
+    form.append("conversationId", convId);
+    const upload = await fetch(`${baseUrl}/v1/resources`, { method: "POST", body: form });
+    expect(upload.status).toBe(200);
+    const uploadBody = await upload.json();
+    const fileId: string = uploadBody.files[0].id;
+    expect(uploadBody.files[0].workspaceId).toBe(WORKSPACE_A);
+
+    // Download via conversationId, NO ?ws at all → resolves to workspace A.
+    const byConv = await fetch(`${baseUrl}/v1/files/${fileId}?conversationId=${convId}`);
+    expect(byConv.status).toBe(200);
+    expect(await byConv.text()).toBe("served bytes");
+
+    // Download via conversationId AND a WRONG ?ws (the personal workspace) →
+    // conversationId wins, resolves to A, still served.
+    const byConvWrongWs = await fetch(
+      `${baseUrl}/v1/files/${fileId}?ws=${PERSONAL}&conversationId=${convId}`,
+    );
+    expect(byConvWrongWs.status).toBe(200);
+    expect(await byConvWrongWs.text()).toBe("served bytes");
+
+    // Control: WITHOUT conversationId and pointing at the wrong (personal)
+    // workspace → the file isn't there → 404. This is the partition the
+    // conversationId branch rescues.
+    const wrongWsOnly = await fetch(`${baseUrl}/v1/files/${fileId}?ws=${PERSONAL}`);
+    expect(wrongWsOnly.status).toBe(404);
+  });
+});

--- a/test/integration/runtime/cross-workspace-file-resume.test.ts
+++ b/test/integration/runtime/cross-workspace-file-resume.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Cross-workspace resume → file rehydration partition.
+ *
+ * A conversation is WORKSPACE-owned: it lives under `workspaces/<wsId>/...` and
+ * its attached files live in the SAME workspace's partition
+ * (`workspaces/<wsId>/files/<ownerId>/`). On a cross-workspace resume — a
+ * request whose focused workspace differs from the conversation's — `chat()`
+ * relocates to the conversation's actual workspace via the locator and captures
+ * the authoritative `convWsId`. The file store used to rehydrate `files://`
+ * attachments MUST be built from THAT `convWsId`, not the request header —
+ * otherwise the resumed chat reads the wrong partition and the attachment
+ * silently vanishes.
+ *
+ * This pins that wiring: after a cross-workspace resume, the rehydration file
+ * store resolves to the conversation's workspace (A), where the file lives, and
+ * finds it — even though the resume request is NOT focused on A.
+ */
+
+import { afterAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FileStore } from "../../../src/files/store.ts";
+import { DEV_IDENTITY } from "../../../src/identity/providers/dev.ts";
+import { Runtime } from "../../../src/runtime/runtime.ts";
+import { personalWorkspaceIdFor } from "../../../src/workspace/workspace-store.ts";
+import { createEchoModel } from "../../helpers/echo-model.ts";
+import { provisionTestWorkspace } from "../../helpers/test-workspace.ts";
+
+const testDir = join(tmpdir(), `nb-cross-workspace-file-resume-${Date.now()}`);
+
+afterAll(() => {
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+});
+
+// The conversation's workspace (a focused workspace, the chat is born here).
+const WORKSPACE_A = "ws_workspace_a";
+// Dev mode: no identity on the request → the dev owner.
+const OWNER = DEV_IDENTITY.id;
+// The resume is UNFOCUSED → it falls back to the owner's personal workspace,
+// which is a DIFFERENT workspace than WORKSPACE_A. That is the cross-workspace hop.
+const PERSONAL = personalWorkspaceIdFor(OWNER);
+
+describe("cross-workspace resume rehydrates files from the conversation's workspace (not the request)", () => {
+  it("a file attached in workspace A is found on a resume that is NOT focused on A", async () => {
+    const workDir = join(testDir, "rehydrate-from-workspace");
+    mkdirSync(workDir, { recursive: true });
+
+    const runtime = await Runtime.start({
+      model: { provider: "custom", adapter: createEchoModel() },
+      noDefaultBundles: true,
+      logging: { disabled: true },
+      workDir,
+    });
+    await provisionTestWorkspace(runtime, WORKSPACE_A);
+
+    // 1) Born in workspace A (focused on WORKSPACE_A) — the conversation lives
+    //    under workspaces/ws_workspace_a/conversations/<owner>/.
+    const born = await runtime.chat({ message: "hello from workspace A", workspaceId: WORKSPACE_A });
+    const convId = born.conversationId;
+
+    // 2) Attach a file into workspace A's partition (the same workspace the
+    //    conversation lives in). This is the partition the resume must resolve to.
+    const fileStoreA = runtime.getWorkspaceFileStore(WORKSPACE_A, OWNER);
+    const saved = await fileStoreA.saveFile(Buffer.from("workspace-A bytes"), "attach.txt", "text/plain");
+    await fileStoreA.appendRegistry({
+      id: saved.id,
+      filename: "attach.txt",
+      mimeType: "text/plain",
+      size: saved.size,
+      tags: [],
+      source: "chat",
+      conversationId: convId,
+      createdAt: new Date().toISOString(),
+      description: null,
+      workspaceId: WORKSPACE_A,
+      ownerId: OWNER,
+      visibility: "private",
+    });
+
+    // Sanity: the personal workspace — where an un-fixed resume would look —
+    // does NOT hold the file. So "found" can only mean "resolved to workspace A".
+    expect(await runtime.getWorkspaceFileStore(PERSONAL, OWNER).findEntry(saved.id)).toBeNull();
+
+    // 3) Spy on getWorkspaceFileStore to capture the partition rehydration
+    //    resolves to. The chat path builds exactly one file store (the
+    //    rehydration store) from the authoritative `convWsId`. We capture its
+    //    (wsId, store) so we can assert which workspace the resume read from.
+    const calls: Array<{ wsId: string; store: FileStore }> = [];
+    const origGetFileStore = runtime.getWorkspaceFileStore.bind(runtime);
+    runtime.getWorkspaceFileStore = (wsId: string, ownerId: string): FileStore => {
+      const store = origGetFileStore(wsId, ownerId);
+      calls.push({ wsId, store });
+      return store;
+    };
+
+    // 4) Cross-workspace resume: UNFOCUSED (no workspaceId) → the request
+    //    workspace is the owner's personal workspace, NOT workspace A. chat()
+    //    must relocate to A via the locator, and rehydration must follow it.
+    await runtime.chat({ message: "resume from elsewhere", conversationId: convId });
+
+    runtime.getWorkspaceFileStore = origGetFileStore;
+
+    // Every partition the resume touched is the conversation's workspace (A) —
+    // never the request's personal workspace. (Reverting the fix makes this the
+    // personal workspace, and the assertions below fail.)
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.wsId).toBe(WORKSPACE_A);
+      expect(c.wsId).not.toBe(PERSONAL);
+    }
+
+    // The store rehydration actually used finds the attachment — it is not lost.
+    const rehydrationStore = calls[calls.length - 1]!.store;
+    const entry = await rehydrationStore.findEntry(saved.id);
+    expect(entry).not.toBeNull();
+    expect(entry?.workspaceId).toBe(WORKSPACE_A);
+
+    await runtime.shutdown();
+  });
+});

--- a/test/integration/runtime/cross-workspace-file-tool-resume.test.ts
+++ b/test/integration/runtime/cross-workspace-file-tool-resume.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Cross-workspace resume → file-TOOL partition.
+ *
+ * Sibling to `cross-workspace-file-resume.test.ts`, which pins the *rehydration*
+ * read (the `files://` attachment the runtime inlines into the prompt). This one
+ * pins the other half: the agent's identity-door `files__*` TOOLS. When the model
+ * calls `files__list` during a cross-workspace resume, the tool resolves its
+ * workspace-owned store from `RequestContext.fileWorkspaceId`, which `chat()` sets
+ * to the conversation's authoritative workspace (`convWsId`) — NOT the request
+ * header / personal workspace. So a tool call on an UNFOCUSED resume reads the
+ * conversation's workspace (A), where the file lives, and finds it.
+ *
+ * The rehydration test never invokes a file tool, so it cannot catch a regression
+ * in this path (e.g. `fileWorkspaceId` reverting to `request.workspaceId ??
+ * sessionWsId`, or the identity-tool-router dropping `fileWorkspaceId` from its
+ * per-call restamp). This test exercises the tool directly.
+ */
+
+import { afterAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import type { FileStore } from "../../../src/files/store.ts";
+import { DEV_IDENTITY } from "../../../src/identity/providers/dev.ts";
+import { Runtime } from "../../../src/runtime/runtime.ts";
+import { personalWorkspaceIdFor } from "../../../src/workspace/workspace-store.ts";
+import { createEchoModel } from "../../helpers/echo-model.ts";
+import { provisionTestWorkspace } from "../../helpers/test-workspace.ts";
+
+const testDir = join(tmpdir(), `nb-cross-workspace-file-tool-resume-${Date.now()}`);
+
+afterAll(() => {
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+});
+
+// The conversation's workspace (a focused workspace, the chat is born here).
+const WORKSPACE_A = "ws_workspace_a";
+// Dev mode: no identity on the request → the dev owner.
+const OWNER = DEV_IDENTITY.id;
+// The resume is UNFOCUSED → it falls back to the owner's personal workspace,
+// a DIFFERENT workspace than WORKSPACE_A. That is the cross-workspace hop.
+const PERSONAL = personalWorkspaceIdFor(OWNER);
+
+// The resume message — distinct from the born message so the model adapter can
+// tell the two turns apart and only emit the tool call on the resume.
+const RESUME_MSG = "list my files on resume";
+
+/**
+ * A model that echoes by default, but when the user's authored text is
+ * `RESUME_MSG` emits a `files__list` tool call (then concludes). The queue is
+ * isolated to the resume turns so async auto-title generation on the born chat
+ * (which calls the model on a separate prompt) can't consume the scripted
+ * tool-call response and make the test flaky.
+ */
+function createResumeFileToolModel(): LanguageModelV3 {
+  const echo = createEchoModel();
+  const toolModel = createEchoModel({
+    responses: [
+      { toolCalls: [{ toolCallId: "call_files_list", toolName: "files__list", input: "{}" }] },
+      { text: "here are your files" },
+    ],
+  });
+
+  function lastUserText(opts: LanguageModelV3CallOptions): string {
+    for (let i = opts.prompt.length - 1; i >= 0; i--) {
+      const msg = opts.prompt[i];
+      if (msg.role === "user") {
+        for (const part of msg.content) {
+          if (part.type === "text" && !part.text.startsWith("<runtime-context>")) return part.text;
+        }
+      }
+    }
+    return "";
+  }
+
+  const pick = (opts: LanguageModelV3CallOptions): LanguageModelV3 =>
+    lastUserText(opts) === RESUME_MSG ? toolModel : echo;
+
+  return {
+    specificationVersion: "v3",
+    provider: "echo",
+    modelId: "echo-1",
+    supportedUrls: {},
+    doGenerate: (opts) => pick(opts).doGenerate(opts),
+    doStream: (opts) => pick(opts).doStream(opts),
+  };
+}
+
+describe("cross-workspace resume scopes the file TOOL to the conversation's workspace (not the request)", () => {
+  it("files__list on an UNFOCUSED resume reads workspace A's partition and finds the attachment", async () => {
+    const workDir = join(testDir, "file-tool-from-workspace");
+    mkdirSync(workDir, { recursive: true });
+
+    const runtime = await Runtime.start({
+      model: { provider: "custom", adapter: createResumeFileToolModel() },
+      noDefaultBundles: true,
+      logging: { disabled: true },
+      workDir,
+    });
+    await provisionTestWorkspace(runtime, WORKSPACE_A);
+
+    // 1) Born in workspace A (focused on WORKSPACE_A).
+    const born = await runtime.chat({ message: "hello from workspace A", workspaceId: WORKSPACE_A });
+    const convId = born.conversationId;
+
+    // 2) Attach a file into workspace A's partition (the conversation's workspace).
+    const fileStoreA = runtime.getWorkspaceFileStore(WORKSPACE_A, OWNER);
+    const saved = await fileStoreA.saveFile(Buffer.from("workspace-A bytes"), "attach.txt", "text/plain");
+    await fileStoreA.appendRegistry({
+      id: saved.id,
+      filename: "attach.txt",
+      mimeType: "text/plain",
+      size: saved.size,
+      tags: [],
+      source: "chat",
+      conversationId: convId,
+      createdAt: new Date().toISOString(),
+      description: null,
+      workspaceId: WORKSPACE_A,
+      ownerId: OWNER,
+      visibility: "private",
+    });
+
+    // Sanity: the personal workspace — where an un-fixed resume would scope the
+    // file tool — does NOT hold the file. So a `files__list` that returns it can
+    // only have resolved to workspace A.
+    expect(await runtime.getWorkspaceFileStore(PERSONAL, OWNER).findEntry(saved.id)).toBeNull();
+
+    // 3) Spy on getWorkspaceFileStore to capture every partition the resume
+    //    touches — including the one the `files__list` tool resolves via
+    //    RequestContext.fileWorkspaceId.
+    const calls: Array<{ wsId: string; store: FileStore }> = [];
+    const origGetFileStore = runtime.getWorkspaceFileStore.bind(runtime);
+    runtime.getWorkspaceFileStore = (wsId: string, ownerId: string): FileStore => {
+      const store = origGetFileStore(wsId, ownerId);
+      calls.push({ wsId, store });
+      return store;
+    };
+
+    // 4) Cross-workspace resume: UNFOCUSED (no workspaceId) → the request
+    //    workspace is the owner's personal workspace, NOT workspace A. The model
+    //    emits a `files__list` tool call; its store must resolve to A.
+    const result = await runtime.chat({ message: RESUME_MSG, conversationId: convId });
+
+    runtime.getWorkspaceFileStore = origGetFileStore;
+
+    // The file tool actually ran and succeeded — it did not throw
+    // "no workspace in scope" and did not fail closed.
+    const listCall = result.toolCalls.find((c) => c.name === "files__list");
+    expect(listCall).toBeDefined();
+    expect(listCall?.ok).toBe(true);
+
+    // And it read A's partition: the listing contains the attachment that only
+    // exists in workspace A. (Reverting the fix scopes it to PERSONAL, where the
+    // file does not exist, so `total` is 0 and this fails.)
+    expect(listCall?.output).toContain(saved.id);
+    expect(listCall?.output).toContain("attach.txt");
+    expect(listCall?.output).toContain('"total": 1');
+
+    // Every partition the resume touched is the conversation's workspace (A) —
+    // never the request's personal workspace. This covers the rehydration store
+    // AND the file-tool store, both of which must follow `convWsId`.
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.wsId).toBe(WORKSPACE_A);
+      expect(c.wsId).not.toBe(PERSONAL);
+    }
+
+    await runtime.shutdown();
+  });
+});

--- a/test/unit/host-resources-resolver.test.ts
+++ b/test/unit/host-resources-resolver.test.ts
@@ -11,30 +11,44 @@ import { createFileStore, type FileStore } from "../../src/files/store.ts";
 import type { FileEntry } from "../../src/files/types.ts";
 
 // The resolver is the single chokepoint between a bundle's inbound
-// host-resources request and the caller's identity FileStore. Files are
-// identity-owned (Phase B): the resolver is handed a `() => FileStore`
-// closure yielding the SESSION USER's store — it never trusts the URI (or
-// the ctx workspaceId) to encode a scope. It enforces the scheme allowlist
-// and surfaces the MCP-standard error codes (`-32602` for invalid scheme,
-// `-32002` for resource not found).
+// host-resources request and the workspace-owned FileStore. Files are
+// workspace-owned: the resolver is handed a `(wsId) => FileStore` factory and
+// DELIBERATELY scopes by `ctx.workspaceId` (the workspace the bundle's tool ran
+// in) — passing it to the factory so a `files://` read resolves in that
+// workspace's partition only. The URI is bare (carries just the file id); the
+// scope rides on the ctx, never the URI. It enforces the scheme allowlist and
+// surfaces the MCP-standard error codes (`-32602` for invalid scheme, `-32002`
+// for resource not found).
 
 const RESOURCE_NOT_FOUND = -32002;
 const INVALID_PARAMS = -32602;
 
 let rootDir: string;
 
-// Two identity stores standing in for two users. `currentStore` is what the
-// resolver's closure returns — flipped per test to simulate whose session is
-// active, the same shape Runtime uses (resolve the identity per call, hand
-// back that user's store).
+// Two workspace stores standing in for two workspaces. The resolver's factory
+// selects between them by the wsId it is handed — the same shape Runtime uses
+// (`getWorkspaceFileStore(ctx.workspaceId, owner)` resolves the store for the
+// workspace the bundle ran in).
 let storeA: FileStore;
 let storeB: FileStore;
-let currentStore: FileStore;
 
-// ctx carries the bundle's workspace for AUDIT logging only — it no longer
-// selects the store (files are identity-owned).
+// ctx carries the bundle's workspace — the LIVE store selector. `ws_a` →
+// `storeA`, `ws_b` → `storeB` (see `storeForWorkspace`).
 const ctxA: HostResourceContext = { workspaceId: "ws_a", bundleId: "bundle_x" };
 const ctxB: HostResourceContext = { workspaceId: "ws_b", bundleId: "bundle_x" };
+
+/**
+ * The resolver's store factory: maps `ctx.workspaceId` → that workspace's store,
+ * exactly as Runtime does. Honoring the wsId (rather than ignoring it) is the
+ * point — a regression where the resolver stopped passing `ctx.workspaceId` to
+ * the factory would resolve the wrong workspace, which the isolation test below
+ * catches.
+ */
+function storeForWorkspace(wsId: string): FileStore {
+  if (wsId === "ws_a") return storeA;
+  if (wsId === "ws_b") return storeB;
+  throw new Error(`unexpected workspace id: ${wsId}`);
+}
 
 async function seedFile(store: FileStore, name: string, body: string, mime: string) {
   const saved = await store.saveFile(Buffer.from(body), name, mime);
@@ -53,10 +67,8 @@ async function seedFile(store: FileStore, name: string, body: string, mime: stri
 
 beforeEach(async () => {
   rootDir = await mkdtemp(join(tmpdir(), "nb-host-resources-resolver-"));
-  storeA = createFileStore(join(rootDir, "usr_a", "files"));
-  storeB = createFileStore(join(rootDir, "usr_b", "files"));
-  // Default to user A's session; isolation tests flip to B explicitly.
-  currentStore = storeA;
+  storeA = createFileStore(join(rootDir, "ws_a", "files"));
+  storeB = createFileStore(join(rootDir, "ws_b", "files"));
 });
 
 afterEach(async () => {
@@ -64,7 +76,7 @@ afterEach(async () => {
 });
 
 function makeResolver(): FileBackedHostResourcesResolver {
-  return new FileBackedHostResourcesResolver(() => currentStore);
+  return new FileBackedHostResourcesResolver((wsId) => storeForWorkspace(wsId));
 }
 
 describe("FileBackedHostResourcesResolver.read", () => {
@@ -125,13 +137,13 @@ describe("FileBackedHostResourcesResolver.read", () => {
     expect(caught?.code).toBe(RESOURCE_NOT_FOUND);
   });
 
-  it("collapses cross-identity lookups into -32002 (no info leak)", async () => {
-    // User A's session asking for a file id that EXISTS in user B's store.
-    // The resolver yields A's store, which doesn't have it — "not found",
-    // the SAME response a genuinely-missing id gets. This prevents
-    // cross-identity inventory enumeration.
-    const idInB = await seedFile(storeB, "secret.txt", "usr_b only", "text/plain");
-    currentStore = storeA;
+  it("collapses cross-workspace lookups into -32002 (no info leak)", async () => {
+    // A bundle running in workspace A asking for a file id that EXISTS in
+    // workspace B. The resolver passes `ctx.workspaceId` to the factory, yields
+    // A's store, which doesn't have it — "not found", the SAME response a
+    // genuinely-missing id gets. This prevents cross-workspace inventory
+    // enumeration.
+    const idInB = await seedFile(storeB, "secret.txt", "ws_b only", "text/plain");
     let caught: McpError | null = null;
     try {
       await makeResolver().read(`files://${idInB}`, ctxA);
@@ -139,10 +151,29 @@ describe("FileBackedHostResourcesResolver.read", () => {
       caught = e as McpError;
     }
     expect(caught?.code).toBe(RESOURCE_NOT_FOUND);
-    // Same lookup in user B's session succeeds, proving the file does exist.
-    currentStore = storeB;
+    // The same lookup from workspace B succeeds, proving the file does exist.
     const ok = await makeResolver().read(`files://${idInB}`, ctxB);
-    expect(ok.contents[0]?.text).toBe("usr_b only");
+    expect(ok.contents[0]?.text).toBe("ws_b only");
+  });
+
+  it("scopes by ctx.workspaceId — a file in workspace A is ABSENT under workspace B", async () => {
+    // Seed a file into workspace A. Read it back under ctx A (its own
+    // workspace) → found.
+    const id = await seedFile(storeA, "a-only.txt", "ws_a only", "text/plain");
+    const okA = await makeResolver().read(`files://${id}`, ctxA);
+    expect(okA.contents[0]?.text).toBe("ws_a only");
+
+    // The SAME id under ctx workspace B: the resolver passes `ctx.workspaceId`
+    // to the store factory, which lands in storeB (no such file) → -32002. If
+    // the resolver stopped honoring `ctx.workspaceId` (the regression this
+    // guards), B would read A's store and leak the file across workspaces.
+    let caught: McpError | null = null;
+    try {
+      await makeResolver().read(`files://${id}`, ctxB);
+    } catch (e) {
+      caught = e as McpError;
+    }
+    expect(caught?.code).toBe(RESOURCE_NOT_FOUND);
   });
 
   it("throws ResponseTooLarge when the file exceeds maxReadSize", async () => {
@@ -175,11 +206,10 @@ describe("FileBackedHostResourcesResolver.list", () => {
     await seedFile(storeA, "a2.csv", "y", "text/csv");
     await seedFile(storeB, "b1.csv", "z", "text/csv");
 
-    currentStore = storeA;
     const aList = await makeResolver().list({}, ctxA);
     expect(aList.resources).toHaveLength(2);
     expect(aList.resources.map((r) => r.name).sort()).toEqual(["a1.csv", "a2.csv"]);
-    // Cross-identity isolation: user A's list never includes user B's files.
+    // Cross-workspace isolation: workspace A's list never includes B's files.
     expect(aList.resources.find((r) => r.name === "b1.csv")).toBeUndefined();
   });
 


### PR DESCRIPTION
## What

#567 made files workspace-owned (`workspaces/<wsId>/files/<ownerId>/`), but several read/write paths still resolved a file's workspace from the **request header** instead of the **conversation's authoritative workspace**. A file attached in workspace A silently vanishes when the conversation is resumed focused elsewhere (or downloaded without the exact `?ws=`).

These were surfaced by the QA on the (now-closed, duplicate) #569 and **confirmed live on main via a direct audit of #567** — this is the focused fix.

## The fix (all four are partition-resolution, same root cause)

| Path | Was | Now |
|---|---|---|
| **Read** (`chat()`/runTurn rehydration) | file store built from `request.workspaceId ?? sessionWsId` (the returned `convWsId` was discarded) | built from the conversation's authoritative workspace (`convWsId`/`provWsId` from `resolveChatStore`) |
| **Write** (multipart + resource upload) | partitioned by the request header | resolves the conversation's workspace (new `Runtime.resolveConversationWorkspaceId`, mirroring `resolveChatStore`) and writes there |
| **Serve** (`GET /v1/files/:fileId`) | `?ws=` only → cross-workspace download 404s | accepts optional `conversationId`, follows the conversation's workspace |
| **Resolver test** | fixture closure ignored the `wsId` param (a regression dropping `ctx.workspaceId` stayed green); comments said "identity-owned" | honors `wsId`, asserts cross-workspace isolation, comments corrected. **Resolver behavior unchanged** |

## Security notes

- **Serve:** the file store is always rooted at the **caller's own `<ownerId>` partition**, so a forged `?ws=` or `conversationId` can only ever reach the *caller's own* files — not a cross-user boundary, so no membership check is load-bearing there (documented in-code).
- **Resolver:** confining a bundle's `files://` reads to its own workspace (`ctx.workspaceId`) is the **intended trust boundary** — an untrusted bundle must not follow the conversation across the wall. This PR keeps that behavior and only fixes the test that wasn't covering it.

## Verification

- `bun run verify` green: **590 pass / 0 fail**.
- Three new tests (cross-workspace resume rehydration, cross-workspace upload through the **real** `POST /v1/resources`, and file-serve-by-conversation through the **real** `GET /v1/files`) — **each fails if its fix is reverted** (revert-checked).
- Migration (`migrate-files-to-workspace`) was audited and is **not affected** — its `collapseRegistry` already merges disjoint source/dest entries safely.

## Frontend follow-up (not in this PR)

`FileAttachment.tsx` builds the download URL with `?ws=<activeWorkspaceId>`, not the conversation's workspace, and doesn't receive `conversationId`. The runtime now **accepts** `?conversationId=`; a small web change should **send** it (thread `conversationId` into `FileAttachment` + `fileUrl(fileId, { conversationId })`) so cross-workspace downloads resolve correctly.