### PR TITLE
Phase 2: one recovery path for MCP outbound ops (withRecovery)

### DIFF
--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -2160,11 +2160,11 @@ export type ConnectionFailure =
  * shapes, with `unknown` as the residue.
  *
  * - **session-lost** — the server forgot our Streamable-HTTP session (it rolled).
- *   Wire shape (NOT a JSON-RPC code on `err.code`): a request on a stale
- *   `Mcp-Session-Id` gets HTTP 404 + a `-32001 "Session not found"` body, which the
- *   SDK throws as a `StreamableHTTPError` whose `.code` is the status (404) and
- *   whose `.message` carries the `-32001`/text. Match status + message together; a
- *   code-only match on -32001 silently never fires on the canonical path.
+ *   Matched on the "session not found" MESSAGE (plus the `-32001` code), NOT the
+ *   HTTP status: the fleet servers' Python SDK returns it as HTTP 404 with a
+ *   `{"code":-32600,"message":"Session not found"}` body (so the client's
+ *   `StreamableHTTPError.code` is 404 and the `-32600` is body text), but remote
+ *   bundles are untrusted/heterogeneous — the message is the reliable signal.
  * - **transient** — a mid-roll gateway blip (502/503/504, `bad_gateway`). Back off.
  * - **auth-lost** — a rejected credential. Detectable only as `UnauthorizedError`;
  *   note its recovery *policy* is config-dependent — a static-auth remote can't
@@ -2187,11 +2187,20 @@ export function classifyConnectionFailure(err: unknown): ConnectionFailure {
   const message = (err as { message?: unknown }).message;
   const msg = typeof message === "string" ? message : "";
 
-  // session-lost — exact prior `isSessionLost` logic, checked first. NOTE the SDK
-  // also uses -32001 for RequestTimeout; a timeout is recover-eligible too, so the
-  // overlap is benign — but the tool path caps replays at one (see recover) so a
-  // server that processed-then-timed-out isn't re-sent repeatedly.
-  if (code === -32001 || (code === 404 && /session not found/i.test(msg))) {
+  // session-lost — checked first (most specific). Match the "session not found"
+  // MESSAGE regardless of the HTTP status / JSON-RPC code, because the signal is
+  // the server's text, not the envelope: the fleet servers' Python MCP SDK returns
+  // it as HTTP 404 with a `{"code":-32600,"message":"Session not found"}` body
+  // (so the SDK client's StreamableHTTPError has `code === 404`), but a remote
+  // bundle is untrusted and heterogeneous — another server (or the same one in
+  // HTTP-200 + JSON-RPC-error mode) could surface it as `McpError(-32600)` or a
+  // non-404 status. Gating on the status would silently strand those. Matching the
+  // message also takes precedence over the `-32600 → none` branch below, so a
+  // session loss carrying the -32600 code still recovers instead of surfacing.
+  // (`-32001` is the canonical session-expired code; the SDK also reuses it for
+  // RequestTimeout — both are recover-eligible, and the tool path caps replays at
+  // one, so a processed-then-timed-out call isn't re-sent repeatedly.)
+  if (code === -32001 || /session not found/i.test(msg)) {
     return "session-lost";
   }
   // transient — exact prior `isTransientTransport` logic, checked second.

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -1308,15 +1308,16 @@ export class McpSource implements ToolSource {
       miss?: (err: unknown) => T;
     },
   ): Promise<T> {
-    // The server answered "not here" — an application outcome, not a connection
-    // failure. Never recover from it (it's op-scoped; only reads pass `miss`).
-    if (shape.miss && isMcpResourceMiss(firstErr)) return shape.miss(firstErr);
-
     const hasReauthableProvider = this.mode.type === "remote" && this.mode.authProvider != null;
     const delays = this.recoveryDelaysMs ?? shape.delays;
     let err = firstErr;
 
     for (let attempt = 0; attempt <= delays.length; attempt++) {
+      // The server answered "not here" — an application outcome, not a connection
+      // failure. Checked each iteration (only reads pass `miss`): a genuine miss
+      // discovered AFTER a successful re-establish stays a silent null, matching
+      // the pre-unification behavior, instead of logging a spurious read failure.
+      if (shape.miss && isMcpResourceMiss(err)) return shape.miss(err);
       const classified = classifyConnectionFailure(err);
       // An `unknown` throw is recoverable only where the caller opts in (tool path);
       // elsewhere it's surfaced like a protocol error.
@@ -2153,10 +2154,10 @@ export type ConnectionFailure =
   | "none";
 
 /**
- * Classify a thrown error into a connection-failure class. Order is load-bearing
- * for behavior-preservation: `session-lost` and `transient` use the exact prior
- * predicate logic and are tested first, so the `isSessionLost` / `isTransientTransport`
- * wrappers below stay byte-identical to their pre-extraction behavior.
+ * Classify a thrown error into a connection-failure class. Order matters:
+ * `session-lost` and `transient` are checked first (most specific), then
+ * `auth-lost`, then the standard protocol codes, then recognized torn-transport
+ * shapes, with `unknown` as the residue.
  *
  * - **session-lost** — the server forgot our Streamable-HTTP session (it rolled).
  *   Wire shape (NOT a JSON-RPC code on `err.code`): a request on a stale
@@ -2226,16 +2227,6 @@ export function classifyConnectionFailure(err: unknown): ConnectionFailure {
   }
   // Couldn't positively classify it — let the caller decide (recover vs surface).
   return "unknown";
-}
-
-/** @see classifyConnectionFailure — the canonical detector; this is a named view of it. */
-export function isSessionLost(err: unknown): boolean {
-  return classifyConnectionFailure(err) === "session-lost";
-}
-
-/** @see classifyConnectionFailure — the canonical detector; this is a named view of it. */
-export function isTransientTransport(err: unknown): boolean {
-  return classifyConnectionFailure(err) === "transient";
 }
 
 /**

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -2203,7 +2203,7 @@ export function classifyConnectionFailure(err: unknown): ConnectionFailure {
   if (code === -32001 || /session not found/i.test(msg)) {
     return "session-lost";
   }
-  // transient — exact prior `isTransientTransport` logic, checked second.
+  // transient — a mid-roll gateway blip (502/503/504, `bad_gateway`). Back off.
   if (
     code === 502 ||
     code === 503 ||

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -273,6 +273,10 @@ export class McpSource implements ToolSource {
    *  session-loss reads here at once; without this each would fire its own
    *  restart — a restart storm on a single source. */
   private restartInFlight: Promise<boolean> | null = null;
+  /** Backoff schedule for `recover`'s re-establish loop. Defaults to
+   *  `SESSION_RECOVERY_DELAYS_MS`; overridable so tests exercise the policy
+   *  branches without real sleeps. */
+  private recoveryDelaysMs?: readonly number[];
   private startedAt: number | null = null;
   /** Optional `instructions` string returned by the MCP server during
    *  `initialize`. Captured after connect so callers (e.g. the system
@@ -1217,88 +1221,144 @@ export class McpSource implements ToolSource {
         };
       }
 
-      // Authorization loss is not a crash. A remote tool call that throws
-      // UnauthorizedError means the persisted refresh token was rejected
-      // (expired / revoked / conditional-access pulled) — restarting the
-      // transport can't fix a dead credential, and routing it through the
-      // crash/restart path below wrongly escalates the connection toward
-      // `dead`. Flip the connection to `reauth_required` via the provider
-      // (which holds the (wsId, serverName) owner context) so the UI shows
-      // "Reconnect" and a `connection.state_changed` event fires, then surface
-      // a clear, structured reauth error instead of a generic crash. This
-      // wires the documented `running → reauth_required` transition
-      // (see connection.ts) that nothing else triggered.
+      // One recovery path for every outbound op. `recover` classifies the throw,
+      // consults `policyFor`, and effects the action (surface / reauth / restart
+      // + retry with bounded backoff). Two op-specific facts come from here:
       //
-      // Gated on `authProvider`: only an OAuth-provider remote can be
-      // "reconnected" by the user — a 401 there means the refresh token died
-      // and re-running OAuth fixes it. A static-auth remote (e.g. a Composio
-      // bundle's `x-api-key` header) that 401s is a bad OPERATOR credential,
-      // not user-reconnectable: there's no flow to re-run, and `notifyAuthLost`
-      // would no-op anyway (no provider). Fall through to the normal error
-      // path rather than show a misleading "Reconnect".
-      if (
-        err instanceof UnauthorizedError &&
-        this.mode.type === "remote" &&
-        this.mode.authProvider
-      ) {
-        this.mode.authProvider.notifyAuthLost();
-        return {
-          content: textContent(
-            `${this.name} needs to be reconnected — its authorization has expired. Open the connector and click Reconnect.`,
-          ),
-          isError: true,
-          structuredContent: {
-            error: "auth_required",
-            reason: "reauth_required",
-            source: this.name,
-          },
-        };
-      }
-
-      // De-duped via the `dead` guard inside emitSourceCrashed: if the
-      // transport's `onclose` already fired (subprocess died before our
-      // catch ran), this is a no-op and the onclose-side payload — which
-      // includes stderrTail — wins. If we get here first, the thrown
-      // error is the more informative payload.
-      this.emitSourceCrashed(String(err));
-
-      // Crash-retry is ONLY safe for inline calls. A task-augmented call has
-      // spawned server-side state (the task, an entity, possibly external
-      // side effects); retrying would create a duplicate and orphan the
-      // original. Surface the error and let the agent decide whether to
-      // initiate a new run.
-      if (isTaskAugmented) {
-        return {
-          content: textContent(
-            `Task failed and cannot be auto-retried: ${err instanceof Error ? err.message : String(err)}`,
-          ),
-          isError: true,
-        };
-      }
-
-      const restarted = await this.tryRestart();
-      if (restarted) {
-        try {
-          // Use scrubbed args on retry too — the original `input` still
-          // carries any no-op sentinels the upstream API will reject.
-          // Without this, a crash-restart retry bypasses the scrubber on
-          // exactly the code path that's most likely to hit
-          // deterministic-rejection bugs.
-          return await this.callToolInline(toolName, dispatchArgs, signal);
-        } catch (retryErr) {
-          return {
+      //  - `idempotent: !isTaskAugmented` — a task-augmented call has spawned
+      //    server-side state (the task, an entity, side effects); retrying would
+      //    duplicate it. So `policyFor` surfaces every failure for tasks rather
+      //    than retrying. Inline calls are re-issued with the SCRUBBED args
+      //    (`dispatchArgs`), same as the direct call — the original `input` may
+      //    carry no-op sentinels an upstream API rejects.
+      //  - `reauth` — a remote with an OAuth provider flips to `reauth_required`
+      //    and shows a structured "Reconnect"; a static-auth remote (no provider)
+      //    has nothing to re-run, so `policyFor` surfaces it as a normal error.
+      const failMsg = (e: unknown) => (e instanceof Error ? e.message : String(e));
+      return this.recover<ToolResult>(
+        err,
+        () => this.callToolInline(toolName, dispatchArgs, signal),
+        {
+          idempotent: !isTaskAugmented,
+          // A throw on a tools/call is almost always the transport; recover even
+          // unrecognized shapes (old robustness), but only ONCE — see
+          // TOOL_CALL_RECOVERY_DELAYS — so a mutating call isn't replayed N times.
+          recoverUnknown: true,
+          delays: TOOL_CALL_RECOVERY_DELAYS,
+          surface: (e) => ({
             content: textContent(
-              `Retry failed after restart: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+              isTaskAugmented
+                ? `Task failed and cannot be auto-retried: ${failMsg(e)}`
+                : `${this.name} call failed: ${failMsg(e)}`,
             ),
             isError: true,
-          };
-        }
-      }
-      return {
-        content: textContent(`Server crashed and could not restart: ${this.name}`),
-        isError: true,
-      };
+          }),
+          reauth: () => ({
+            content: textContent(
+              `${this.name} needs to be reconnected — its authorization has expired. Open the connector and click Reconnect.`,
+            ),
+            isError: true,
+            structuredContent: {
+              error: "auth_required",
+              reason: "reauth_required",
+              source: this.name,
+            },
+          }),
+        },
+      );
     }
+  }
+
+  /**
+   * Shared recovery for a failed outbound op — the single place recovery
+   * semantics live (both `execute` and `readResource` route their catch here).
+   * Classifies the throw via `classifyConnectionFailure` (op-INDEPENDENT),
+   * consults `policyFor`, and effects the action:
+   *
+   *  - **surface** — give up; return the caller's terminal representation.
+   *  - **reauth** — flip the connection to `reauth_required` (`notifyAuthLost`),
+   *    then surface the caller's reauth representation.
+   *  - **recover** — re-establish (`tryRestart`, single-flight) and retry the op,
+   *    riding a remote roll with bounded backoff; on exhaustion, mark the source
+   *    crashed so HealthMonitor's longer backoff takes over, then surface.
+   *
+   * Op-scoped outcomes (a genuine resource miss) short-circuit via `shape.miss`
+   * before any recovery — those are application answers, not connection failures.
+   * The op-specific terminal shapes (a `ToolResult` vs a `ResourceData | null`)
+   * come from `shape`. See research/SPEC-mcp-source-recovery.md §3.3.
+   */
+  private async recover<T>(
+    firstErr: unknown,
+    op: () => Promise<T>,
+    shape: {
+      idempotent: boolean;
+      /** How to treat an `unknown` (unclassifiable) throw. Tool calls set this so
+       *  an unrecognized transport error still recovers (old "restart on any
+       *  throw" robustness); reads leave it false so a malformed result / 429 /
+       *  server code surfaces instead of restart-storming the whole source. */
+      recoverUnknown: boolean;
+      /** Per-call-site backoff schedule. Tool calls pass a single immediate
+       *  attempt (`TOOL_CALL_RECOVERY_DELAYS`) to preserve the historical
+       *  one-retry budget — a non-idempotent mutating call must NOT be replayed
+       *  several times. Reads pass the wider roll-window schedule. The test seam
+       *  `recoveryDelaysMs` overrides both. */
+      delays: readonly number[];
+      surface: (err: unknown) => T;
+      reauth: (err: unknown) => T;
+      miss?: (err: unknown) => T;
+    },
+  ): Promise<T> {
+    // The server answered "not here" — an application outcome, not a connection
+    // failure. Never recover from it (it's op-scoped; only reads pass `miss`).
+    if (shape.miss && isMcpResourceMiss(firstErr)) return shape.miss(firstErr);
+
+    const hasReauthableProvider = this.mode.type === "remote" && this.mode.authProvider != null;
+    const delays = this.recoveryDelaysMs ?? shape.delays;
+    let err = firstErr;
+
+    for (let attempt = 0; attempt <= delays.length; attempt++) {
+      const classified = classifyConnectionFailure(err);
+      // An `unknown` throw is recoverable only where the caller opts in (tool path);
+      // elsewhere it's surfaced like a protocol error.
+      const kind =
+        classified === "unknown" ? (shape.recoverUnknown ? "transport-dead" : "none") : classified;
+      if (kind === "none") return shape.surface(err); // app/protocol/unknown — don't restart
+      const action = policyFor(kind, { idempotent: shape.idempotent, hasReauthableProvider });
+      if (action === "reauth") {
+        if (this.mode.type === "remote" && this.mode.authProvider) {
+          this.mode.authProvider.notifyAuthLost();
+        }
+        return shape.reauth(err);
+      }
+      if (action === "surface") {
+        // Giving up on a genuine connection failure we won't retry (a
+        // non-idempotent op — e.g. a task-augmented call whose transport broke).
+        // Mark the source crashed so HealthMonitor heals it for later calls; the
+        // transport is actually broken even though we don't retry this call.
+        // `auth-lost` is a credential problem, not a transport crash — excluded,
+        // so a static-auth 401 surfaces without thrashing restarts.
+        if (kind !== "auth-lost") this.emitSourceCrashed(String(err));
+        return shape.surface(err);
+      }
+      // action === "recover": re-establish + retry, riding the roll window.
+      if (attempt === delays.length) break; // out of attempts
+      const delayMs = delays[attempt] ?? 0;
+      if (delayMs > 0) await sleep(delayMs);
+      if (!(await this.tryRestart())) continue; // server still rolling — back off
+      try {
+        return await op();
+      } catch (retryErr) {
+        err = retryErr; // re-classify on the next iteration
+      }
+    }
+
+    // Recovery exhausted. A stale session never closed the transport, so the
+    // source still reports `isAlive()` — mark it crashed so HealthMonitor's
+    // longer exponential backoff sweeps it (it only acts on a not-alive source).
+    this.emitSourceCrashed(
+      `recovery exhausted: ${firstErr instanceof Error ? firstErr.message : String(firstErr)}`,
+    );
+    return shape.surface(err);
   }
 
   /**
@@ -1326,38 +1386,13 @@ export class McpSource implements ToolSource {
       }
       return null;
     }
-    try {
-      return this.toResourceData(await this.client.readResource({ uri }));
-    } catch (err) {
-      // A genuine MCP miss is expected and stays a silent null — e.g. a skill://
-      // or app://instructions probe against a server that has neither.
-      if (isMcpResourceMiss(err)) return null;
-      // A stale session or a mid-roll gateway blip is recoverable, not a 404: the
-      // remote server rolled and forgot our Streamable-HTTP session, or isn't
-      // ready yet. Unlike a tools/call (whose `execute` catch already restarts +
-      // retries), a resource read would otherwise return null here —
-      // indistinguishable from a genuine miss — and strand the bundle's `ui://`
-      // placement until a manual runtime bounce (issue #571). Re-initialize the
-      // session and retry, riding the brief deploy window with bounded backoff.
-      if (isSessionLost(err) || isTransientTransport(err)) {
-        const recovered = await this.readResourceWithRecovery(uri);
-        if (recovered !== undefined) return recovered;
-        // Recovery exhausted within the inline window. Hand the source to
-        // HealthMonitor's longer exponential backoff: it only sweeps a NOT-alive
-        // source, and a stale session never closed the transport, so without
-        // this the source stays `isAlive()` and is never reconnected.
-        this.emitSourceCrashed(
-          `session recovery exhausted: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-      // Anything else — a torn transport, a dropped connection, a timeout — is a
-      // real failure, NOT a missing resource. The old bare `catch { return null }`
-      // masked every such failure as a 404 with no log to say why, so a degraded
-      // source was undiagnosable. Log it ONLY for app-surface reads (the resource
-      // proxy passes `logFailures`), where a failure is anomalous. Discovery
-      // probes stay silent, so a bundle that simply lacks a probed resource never
-      // spams — whatever non-standard error shape it returns. The null (404) is
-      // preserved either way; this only makes the anomalous case visible.
+    // A real failure (a torn transport, a dropped connection, an exhausted
+    // recovery) is NOT a missing resource — log it ONLY on the app-surface path
+    // (the resource proxy passes `logFailures`), where a failure is anomalous.
+    // Discovery probes stay silent so a bundle that simply lacks a probed
+    // resource never spams. The null (404) is preserved either way; this only
+    // makes the anomalous case visible.
+    const logAndNull = (err: unknown): null => {
       if (opts?.logFailures) {
         log.warn("[mcp] readResource failed", {
           uri,
@@ -1366,6 +1401,35 @@ export class McpSource implements ToolSource {
         });
       }
       return null;
+    };
+    try {
+      return this.toResourceData(await this.client.readResource({ uri }));
+    } catch (err) {
+      // Route every failure through the shared recovery. A genuine MCP miss
+      // (`shape.miss`) stays a silent null — e.g. a skill:// or app://instructions
+      // probe against a server that has neither. A stale session / mid-roll
+      // gateway blip / torn transport re-initializes and retries (issue #571);
+      // an auth loss flips the connection to `reauth_required`. Reads are
+      // idempotent, so they retry across the deploy window.
+      return this.recover<ResourceData | null>(
+        err,
+        async () => {
+          if (!this.client) throw err; // restart produced no client — keep recovering
+          return this.toResourceData(await this.client.readResource({ uri }));
+        },
+        {
+          idempotent: true,
+          // Reads are conservative on unclassifiable errors: a malformed result
+          // (ZodError), a 429, or a server-defined code must NOT restart-storm the
+          // whole source — surface it as a null. Recognized transport failures and
+          // session loss still recover across the deploy window.
+          recoverUnknown: false,
+          delays: SESSION_RECOVERY_DELAYS_MS,
+          miss: () => null,
+          surface: logAndNull,
+          reauth: logAndNull,
+        },
+      );
     }
   }
 
@@ -1392,31 +1456,6 @@ export class McpSource implements ToolSource {
       return { blob: bytes, mimeType: first.mimeType, meta };
     }
     return { text: JSON.stringify(first), meta };
-  }
-
-  /**
-   * Re-establish a lost remote session and retry a resource read across a remote
-   * server's restart window. Returns the read result (a `ResourceData`, or a
-   * genuine `null` miss) once the session recovers, or `undefined` if recovery is
-   * exhausted — the caller then escalates to HealthMonitor. Restart attempts are
-   * coalesced by `tryRestart`, so concurrent recovering reads share one cycle.
-   */
-  private async readResourceWithRecovery(uri: string): Promise<ResourceData | null | undefined> {
-    for (const delayMs of SESSION_RECOVERY_DELAYS_MS) {
-      if (delayMs > 0) await sleep(delayMs);
-      const restarted = await this.tryRestart();
-      if (!restarted || !this.client) continue; // server still rolling — back off
-      try {
-        return this.toResourceData(await this.client.readResource({ uri }));
-      } catch (retryErr) {
-        // Session's back but the resource is genuinely absent — a real null.
-        if (isMcpResourceMiss(retryErr)) return null;
-        // Still mid-roll (another stale-session or gateway error) — keep riding.
-        if (isSessionLost(retryErr) || isTransientTransport(retryErr)) continue;
-        return undefined; // a different, non-recoverable error — caller logs it
-      }
-    }
-    return undefined;
   }
 
   /** Expose the underlying MCP client (kept for tests and rare introspection). */
@@ -2110,6 +2149,7 @@ export type ConnectionFailure =
   | "transient"
   | "transport-dead"
   | "auth-lost"
+  | "unknown"
   | "none";
 
 /**
@@ -2128,8 +2168,17 @@ export type ConnectionFailure =
  * - **auth-lost** — a rejected credential. Detectable only as `UnauthorizedError`;
  *   note its recovery *policy* is config-dependent — a static-auth remote can't
  *   reauth — but that decision is Phase 2's (see the SPEC §3.2), not this function's.
- * - **transport-dead** — the connection is torn (closed / refused / timed out).
- * - **none** — not a connection failure; ask the op-scoped outcome classifier.
+ * - **transport-dead** — a RECOGNIZED torn-transport shape (closed / refused /
+ *   reset / timed out / fetch error / broken pipe).
+ * - **none** — the server answered with a standard JSON-RPC *protocol* error
+ *   (parse/invalid-request/method/params/internal, or resource-not-found), or a
+ *   non-object throw. A restart won't change the answer; surface it. App-level
+ *   tool failures don't reach here at all — they come back as `isError` *results*.
+ * - **unknown** — a throw we can't positively classify. The caller decides: the
+ *   tool path treats it as recoverable (old "restart on any throw" robustness,
+ *   now capped); the read path surfaces it (a malformed result / 429 / server
+ *   code must NOT restart-storm the whole source). This split is why `unknown` is
+ *   distinct from `transport-dead` — see `recover`'s `recoverUnknown`.
  */
 export function classifyConnectionFailure(err: unknown): ConnectionFailure {
   if (err === null || typeof err !== "object") return "none";
@@ -2137,7 +2186,10 @@ export function classifyConnectionFailure(err: unknown): ConnectionFailure {
   const message = (err as { message?: unknown }).message;
   const msg = typeof message === "string" ? message : "";
 
-  // session-lost — exact prior `isSessionLost` logic, checked first.
+  // session-lost — exact prior `isSessionLost` logic, checked first. NOTE the SDK
+  // also uses -32001 for RequestTimeout; a timeout is recover-eligible too, so the
+  // overlap is benign — but the tool path caps replays at one (see recover) so a
+  // server that processed-then-timed-out isn't re-sent repeatedly.
   if (code === -32001 || (code === 404 && /session not found/i.test(msg))) {
     return "session-lost";
   }
@@ -2151,15 +2203,29 @@ export function classifyConnectionFailure(err: unknown): ConnectionFailure {
     return "transient";
   }
   if (err instanceof UnauthorizedError) return "auth-lost";
+  // Standard JSON-RPC protocol errors the server *answered* with — the transport
+  // is fine, restarting won't help.
+  if (
+    code === -32700 || // parse error
+    code === -32600 || // invalid request
+    code === -32601 || // method not found
+    code === -32602 || // invalid params
+    code === -32603 || // internal error
+    code === -32002 // resource not found (op-scoped; isMcpResourceMiss owns it per op)
+  ) {
+    return "none";
+  }
+  // Recognized torn-transport shapes. (-32000 is the SDK's connection-closed code.)
   if (
     code === -32000 ||
-    /connection closed|fetch failed|socket hang ?up|terminated|network error|econnre(set|fused)|timed? ?out/i.test(
+    /connection closed|fetch failed|socket hang ?up|terminated|network error|econnre(set|fused)|timed? ?out|epipe|broken pipe/i.test(
       msg,
     )
   ) {
     return "transport-dead";
   }
-  return "none";
+  // Couldn't positively classify it — let the caller decide (recover vs surface).
+  return "unknown";
 }
 
 /** @see classifyConnectionFailure — the canonical detector; this is a named view of it. */
@@ -2173,6 +2239,39 @@ export function isTransientTransport(err: unknown): boolean {
 }
 
 /**
+ * What `McpSource.recover` does with a connection failure. A deliberately small
+ * vocabulary — only what the recovery effector actually distinguishes:
+ *
+ *  - `recover` — re-establish (a fresh `initialize` via stop()+start()) and retry.
+ *  - `reauth` — flip to `reauth_required` and surface a Reconnect; never loop
+ *    (a dead credential won't heal by restarting).
+ *  - `surface` — return the error to the caller; recovery can't help.
+ *
+ * (The richer vocabulary in the SPEC — separate reinit/restart actions,
+ * re-register, credential-lost — lands with its consumers in later phases; at
+ * this layer reinit and restart are the same stop()+start(), so they're one.)
+ */
+export type RecoveryAction = "recover" | "reauth" | "surface";
+
+/**
+ * Pure policy: `(connection-failure, context) → action`. The single decision
+ * point for recovery. `idempotent` is false for task-augmented `tools/call`
+ * (retrying would duplicate spawned server-side state), so every failure on a
+ * non-idempotent op surfaces rather than retries. `hasReauthableProvider` is a
+ * property of the *source*, not the error: a 401 on an OAuth remote is fixable by
+ * reauth; the same 401 on a static-auth remote is an operator-credential problem
+ * with nothing to re-run, so it surfaces. See SPEC §3.2.
+ */
+export function policyFor(
+  kind: Exclude<ConnectionFailure, "none" | "unknown">,
+  ctx: { idempotent: boolean; hasReauthableProvider: boolean },
+): RecoveryAction {
+  if (kind === "auth-lost") return ctx.hasReauthableProvider ? "reauth" : "surface";
+  // session-lost / transient / transport-dead: re-establishable iff the op is safe to repeat.
+  return ctx.idempotent ? "recover" : "surface";
+}
+
+/**
  * Delays (ms) before each remote-session re-establish attempt. The first is
  * immediate — the common case is a stale session against an already-healthy
  * server, recovered in one fresh `initialize`. The rest ride a rolling deploy's
@@ -2180,6 +2279,16 @@ export function isTransientTransport(err: unknown): boolean {
  * is the backstop for anything beyond it.
  */
 const SESSION_RECOVERY_DELAYS_MS = [0, 500, 2000] as const;
+
+/**
+ * Backoff for a tool-call (`execute`) recovery: a SINGLE immediate re-establish +
+ * retry. A `tools/call` can be a mutation (and `idempotent: !isTaskAugmented`
+ * only means "didn't spawn a server-side task", not "safe to replay"), so it
+ * keeps the historical one-retry budget — never the multi-attempt window reads
+ * use — to bound duplicate-side-effect exposure when a call times out or the
+ * transport drops after the server may already have processed it.
+ */
+const TOOL_CALL_RECOVERY_DELAYS = [0] as const;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/integration/remote-session-recovery.test.ts
+++ b/test/integration/remote-session-recovery.test.ts
@@ -17,8 +17,8 @@ import { McpSource } from "../../src/tools/mcp-source.ts";
  *
  * Unlike the unit test (which hand-builds the error shape), this drives the real
  * MCP SDK client transport against a real Streamable-HTTP server, so it proves
- * `isSessionLost` matches the actual `StreamableHTTPError` the SDK throws on the
- * canonical 404 + "-32001 Session not found" wire shape.
+ * `classifyConnectionFailure` matches the actual `StreamableHTTPError` the SDK
+ * throws on the canonical 404 + "-32001 Session not found" wire shape.
  */
 
 const UI_HTML = "<html><body>main</body></html>";

--- a/test/integration/remote-session-recovery.test.ts
+++ b/test/integration/remote-session-recovery.test.ts
@@ -61,14 +61,16 @@ function startRollingServer(): MockRollingServer {
 			if (sid) {
 				const existing = transports.get(sid);
 				if (existing) return existing.handleRequest(req);
-				// Stale session (server rolled). The canonical wire shape: HTTP 404
-				// with a JSON-RPC `-32001 "Session not found"` body. The SDK client
-				// surfaces this as `StreamableHTTPError(404, "...Session not found...")`.
+				// Stale session (server rolled). This is the REAL wire shape the fleet
+				// servers' Python MCP SDK emits (streamable_http_manager.py): HTTP 404
+				// with a `{"code":-32600,"message":"Session not found"}` body and the
+				// `id:"server-error"` sentinel. The SDK client surfaces it as
+				// `StreamableHTTPError(404, "...Session not found...")`.
 				return new Response(
 					JSON.stringify({
 						jsonrpc: "2.0",
-						error: { code: -32001, message: "Session not found" },
-						id: null,
+						id: "server-error",
+						error: { code: -32600, message: "Session not found" },
 					}),
 					{ status: 404, headers: { "content-type": "application/json" } },
 				);

--- a/test/unit/mcp-failure-taxonomy.test.ts
+++ b/test/unit/mcp-failure-taxonomy.test.ts
@@ -4,23 +4,15 @@ import { describe, expect, it } from "bun:test";
 import {
   classifyConnectionFailure,
   type ConnectionFailure,
-  isSessionLost,
-  isTransientTransport,
 } from "../../src/tools/mcp-source.ts";
 
 /**
- * Phase 1 of the recovery redesign (research/SPEC-mcp-source-recovery.md): the
- * connection-failure taxonomy as pure, tested data. Two invariants:
- *  1. classifyConnectionFailure is OP-INDEPENDENT — it returns only
- *     connection-level classes; application outcomes (resource-miss vs app-error)
- *     are op-scoped and stay in isMcpResourceMiss. So the resource-"miss" wire
- *     codes (-32002/-32601/-32602) classify as "none" here.
- *  2. isSessionLost / isTransientTransport are now thin views of the classifier
- *     and MUST stay byte-identical to their pre-extraction behavior (the
- *     readResource contract in mcp-source-resource-errors.test.ts depends on it).
- *
- * The recovery *policy* (what to do with each class) lands in Phase 2 with the
- * `withRecovery` wrapper that consumes it — abstractions ship with their caller.
+ * The connection-failure taxonomy (research/SPEC-mcp-source-recovery.md) as pure,
+ * tested data. `classifyConnectionFailure` is OP-INDEPENDENT — it returns only
+ * connection-level classes; application outcomes (resource-miss vs app-error) are
+ * op-scoped and stay in `isMcpResourceMiss`, so the resource-"miss" wire codes
+ * (-32002/-32601/-32602) classify as "none" here. The recovery *policy* (what to
+ * do with each class) is `policyFor`, consumed by `McpSource.recover`.
  */
 describe("classifyConnectionFailure — op-independent connection classes", () => {
   const sessionLost404 = {
@@ -90,25 +82,6 @@ describe("classifyConnectionFailure — op-independent connection classes", () =
     expect(classifyConnectionFailure(null)).toBe("none");
     expect(classifyConnectionFailure(undefined)).toBe("none");
     expect(classifyConnectionFailure("nope")).toBe("none");
-  });
-});
-
-describe("isSessionLost / isTransientTransport — thin views, behavior preserved", () => {
-  it("isSessionLost is exactly the session-lost class", () => {
-    expect(isSessionLost({ code: 404, message: "Session not found" })).toBe(true);
-    expect(isSessionLost(new McpError(-32001, "Session not found"))).toBe(true);
-    expect(isSessionLost({ code: 404, message: "Not Found" })).toBe(false);
-    expect(isSessionLost(new McpError(-32002, "Resource not found"))).toBe(false);
-    expect(isSessionLost(new Error("Connection closed"))).toBe(false);
-    expect(isSessionLost(null)).toBe(false);
-  });
-
-  it("isTransientTransport is exactly the transient class", () => {
-    for (const code of [502, 503, 504]) expect(isTransientTransport({ code, message: "x" })).toBe(true);
-    expect(isTransientTransport({ message: '{"error":"bad_gateway"}' })).toBe(true);
-    expect(isTransientTransport({ code: 404, message: "Session not found" })).toBe(false);
-    expect(isTransientTransport(new Error("Connection closed"))).toBe(false);
-    expect(isTransientTransport(null)).toBe(false);
   });
 });
 

--- a/test/unit/mcp-failure-taxonomy.test.ts
+++ b/test/unit/mcp-failure-taxonomy.test.ts
@@ -27,6 +27,28 @@ describe("classifyConnectionFailure — op-independent connection classes", () =
     );
   });
 
+  it("classifies the REAL production session-loss shape, status-independent", () => {
+    // Ground truth (mcp/server/streamable_http_manager.py): the fleet servers'
+    // Python SDK returns an unknown session as HTTP 404 with a -32600 body. The
+    // client wraps it as StreamableHTTPError(code=404, message="...session not
+    // found..."). The -32600 is body text, NOT err.code.
+    const realProd = {
+      code: 404,
+      message:
+        'Streamable HTTP error: Error POSTing to endpoint: {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}',
+    };
+    expect(classifyConnectionFailure(realProd)).toBe("session-lost");
+    // Same loss carried as an in-body JSON-RPC error (HTTP 200) → McpError(-32600).
+    // The message match must win over the `-32600 → none` branch, or we'd strand it.
+    expect(classifyConnectionFailure(new McpError(-32600, "Session not found"))).toBe(
+      "session-lost",
+    );
+    // A non-spec remote returning the loss under a different status still recovers.
+    expect(classifyConnectionFailure({ code: 400, message: "Session not found" })).toBe(
+      "session-lost",
+    );
+  });
+
   it("classifies transient gateway failures (status + message shapes)", () => {
     for (const code of [502, 503, 504]) {
       expect(classifyConnectionFailure({ code, message: "x" })).toBe("transient");

--- a/test/unit/mcp-failure-taxonomy.test.ts
+++ b/test/unit/mcp-failure-taxonomy.test.ts
@@ -58,12 +58,32 @@ describe("classifyConnectionFailure — op-independent connection classes", () =
     expect(classifyConnectionFailure(new Error("Request timed out"))).toBe("transport-dead");
   });
 
-  it("returns 'none' for application outcomes — those are op-scoped, not connection failures", () => {
-    // resource-"miss" wire codes are NOT connection failures (isMcpResourceMiss owns them, per op).
-    expect(classifyConnectionFailure(new McpError(-32002, "Resource not found"))).toBe("none");
+  it("returns 'none' for standard JSON-RPC protocol errors the server answered with", () => {
+    // The transport is fine; restarting won't change the answer. (resource-miss
+    // codes are also op-scoped — isMcpResourceMiss owns them per op.)
+    expect(classifyConnectionFailure(new McpError(-32700, "Parse error"))).toBe("none");
+    expect(classifyConnectionFailure(new McpError(-32600, "Invalid request"))).toBe("none");
     expect(classifyConnectionFailure(new McpError(-32601, "Method not found"))).toBe("none");
     expect(classifyConnectionFailure(new McpError(-32602, "Invalid params"))).toBe("none");
-    expect(classifyConnectionFailure(new Error("the tool said no"))).toBe("none");
+    expect(classifyConnectionFailure(new McpError(-32603, "Internal error"))).toBe("none");
+    expect(classifyConnectionFailure(new McpError(-32002, "Resource not found"))).toBe("none");
+  });
+
+  it("classifies recognized torn-transport shapes as transport-dead", () => {
+    expect(classifyConnectionFailure(new McpError(-32000, "Connection closed"))).toBe(
+      "transport-dead",
+    );
+    expect(classifyConnectionFailure(new Error("write EPIPE"))).toBe("transport-dead");
+    expect(classifyConnectionFailure(new Error("read ECONNRESET"))).toBe("transport-dead");
+  });
+
+  it("classifies an unclassifiable throw as 'unknown' (caller decides recover vs surface)", () => {
+    // Not a standard protocol error, not a recognized transport shape — e.g. a
+    // 429, a server-defined code, or a malformed-result parse error. The tool
+    // path recovers these; reads surface them. See recover()'s recoverUnknown.
+    expect(classifyConnectionFailure({ code: 429, message: "Too Many Requests" })).toBe("unknown");
+    expect(classifyConnectionFailure(new McpError(-32050, "custom server error"))).toBe("unknown");
+    expect(classifyConnectionFailure(new Error("Unexpected token < in JSON"))).toBe("unknown");
   });
 
   it("is null/non-object safe", () => {

--- a/test/unit/mcp-source-recovery.test.ts
+++ b/test/unit/mcp-source-recovery.test.ts
@@ -1,0 +1,205 @@
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import type { EngineEvent, EventSink } from "../../src/engine/types.ts";
+import { McpSource, type McpTransportMode, policyFor } from "../../src/tools/mcp-source.ts";
+import type { WorkspaceOAuthProvider } from "../../src/tools/workspace-oauth-provider.ts";
+
+/**
+ * Phase 2 of the recovery redesign (research/SPEC-mcp-source-recovery.md): the
+ * single `recover` path that both `execute` (tools/call) and `readResource` route
+ * their catch through, driven by `classifyConnectionFailure` + `policyFor`. These
+ * lock the intentional behavior CONVERGENCES that the unification introduces:
+ *   - app/protocol errors on tools/call surface WITHOUT a futile restart
+ *   - readResource now handles auth-loss (flips reauth_required) and recovers a
+ *     torn transport — previously a silent null
+ *   - the task-augmented no-retry invariant survives (policy-level)
+ */
+
+function remoteSource(opts: {
+  callTool?: () => Promise<unknown>;
+  readResource?: () => Promise<unknown>;
+  notifyAuthLost?: () => void;
+  delays?: readonly number[];
+  sink?: EventSink;
+}): McpSource {
+  const authProvider =
+    opts.notifyAuthLost === undefined
+      ? undefined
+      : ({ notifyAuthLost: opts.notifyAuthLost } as unknown as WorkspaceOAuthProvider);
+  const mode: McpTransportMode = {
+    type: "remote",
+    url: new URL("https://svc.example.com/mcp"),
+    ...(authProvider ? { authProvider } : {}),
+  };
+  const source = new McpSource("svc", mode, opts.sink ?? new NoopEventSink());
+  const internal = source as unknown as {
+    client: { callTool?: unknown; readResource?: unknown; close: () => Promise<void> };
+    dead: boolean;
+    start: () => Promise<void>;
+    recoveryDelaysMs: readonly number[];
+  };
+  internal.client = {
+    callTool: opts.callTool,
+    readResource: opts.readResource,
+    close: () => Promise.resolve(),
+  };
+  internal.dead = false;
+  internal.start = () => Promise.resolve(); // neutralize real network on tryRestart
+  // Only override the per-call-site budget when a test asks — otherwise exercise
+  // the real production schedule (tool calls = one immediate retry).
+  if (opts.delays !== undefined) internal.recoveryDelaysMs = opts.delays;
+  return source;
+}
+
+function spyRestart(source: McpSource, result: boolean) {
+  return spyOn(
+    source as unknown as { tryRestart: () => Promise<boolean> },
+    "tryRestart",
+  ).mockResolvedValue(result);
+}
+
+describe("policyFor — recovery policy", () => {
+  const reauthable = { idempotent: true, hasReauthableProvider: true };
+  const idem = { idempotent: true, hasReauthableProvider: false };
+  const task = { idempotent: false, hasReauthableProvider: false };
+
+  it("re-establishes idempotent connection failures", () => {
+    for (const k of ["session-lost", "transient", "transport-dead"] as const) {
+      expect(policyFor(k, idem)).toBe("recover");
+    }
+  });
+
+  it("surfaces every failure on a non-idempotent (task) op — the no-retry invariant", () => {
+    for (const k of ["session-lost", "transient", "transport-dead"] as const) {
+      expect(policyFor(k, task)).toBe("surface");
+    }
+  });
+
+  it("auth-lost reauths only with a reauthable provider, else surfaces", () => {
+    expect(policyFor("auth-lost", reauthable)).toBe("reauth");
+    expect(policyFor("auth-lost", { idempotent: false, hasReauthableProvider: true })).toBe("reauth");
+    expect(policyFor("auth-lost", idem)).toBe("surface");
+    expect(policyFor("auth-lost", task)).toBe("surface");
+  });
+});
+
+describe("execute (tools/call) — unified recovery", () => {
+  it("surfaces an app/protocol error WITHOUT restarting (no futile crash-restart)", async () => {
+    const source = remoteSource({
+      callTool: () => Promise.reject(new McpError(-32601, "Method not found")),
+    });
+    const restart = spyRestart(source, true);
+    try {
+      const result = await source.execute("do_thing", {});
+      expect(result.isError).toBe(true);
+      expect(restart).not.toHaveBeenCalled(); // -32601 is "none" → surface, never restart
+    } finally {
+      restart.mockRestore();
+    }
+  });
+
+  it("recovers a torn transport: re-establish + retry returns the result", async () => {
+    let calls = 0;
+    const source = remoteSource({
+      callTool: () => {
+        calls++;
+        if (calls === 1) return Promise.reject(new Error("Connection closed"));
+        return Promise.resolve({ content: [{ type: "text", text: "ok" }], isError: false });
+      },
+    });
+    const restart = spyRestart(source, true);
+    try {
+      const result = await source.execute("do_thing", {});
+      expect(result.isError).toBe(false);
+      expect(result.content.map((c) => ("text" in c ? c.text : "")).join("")).toBe("ok");
+      expect(restart).toHaveBeenCalledTimes(1);
+    } finally {
+      restart.mockRestore();
+    }
+  });
+
+  it("retries a persistently-failing inline call at most ONCE (no replay tripling)", async () => {
+    // A mutating tool that keeps failing must not be replayed N times — the
+    // historical budget is one retry. No `delays` override → production
+    // TOOL_CALL_RECOVERY_DELAYS ([0]) applies.
+    let calls = 0;
+    const source = remoteSource({
+      callTool: () => {
+        calls++;
+        return Promise.reject(new Error("Connection closed"));
+      },
+    });
+    const restart = spyRestart(source, true);
+    try {
+      const result = await source.execute("send_email", {});
+      expect(result.isError).toBe(true);
+      expect(calls).toBe(2); // 1 initial + exactly 1 retry
+      expect(restart).toHaveBeenCalledTimes(1);
+    } finally {
+      restart.mockRestore();
+    }
+  });
+});
+
+describe("readResource — unified recovery (new behaviors)", () => {
+  it("flips reauth_required on auth loss (was a silent null before)", async () => {
+    const notifyAuthLost = mock(() => {});
+    const source = remoteSource({
+      readResource: () => Promise.reject(new UnauthorizedError("token rejected")),
+      notifyAuthLost,
+    });
+    const restart = spyRestart(source, true);
+    try {
+      expect(await source.readResource("ui://svc/main", { logFailures: true })).toBeNull();
+      expect(notifyAuthLost).toHaveBeenCalledTimes(1);
+      expect(restart).not.toHaveBeenCalled(); // reauth, not restart
+    } finally {
+      restart.mockRestore();
+    }
+  });
+
+  it("recovers a torn transport on a ui:// read (was a silent null before)", async () => {
+    let calls = 0;
+    const source = remoteSource({
+      readResource: () => {
+        calls++;
+        if (calls === 1) return Promise.reject(new Error("fetch failed"));
+        return Promise.resolve({ contents: [{ uri: "ui://svc/main", text: "<html>ok</html>" }] });
+      },
+    });
+    const restart = spyRestart(source, true);
+    try {
+      const result = await source.readResource("ui://svc/main", { logFailures: true });
+      expect(result?.text).toBe("<html>ok</html>");
+      expect(restart).toHaveBeenCalledTimes(1);
+    } finally {
+      restart.mockRestore();
+    }
+  });
+
+  it("does NOT restart or crash the source on an unclassifiable read error (no restart-storm)", async () => {
+    // A malformed result / 429 / server-defined code is `unknown`; a read must
+    // surface it as null — never tear down + re-init or mark the whole source
+    // crashed (which would make HealthMonitor restart it on a per-read error).
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    for (const err of [{ code: 429, message: "Too Many Requests" }, new Error("Unexpected token < in JSON")]) {
+      const events: EngineEvent[] = [];
+      const sink: EventSink = { emit: (e) => events.push(e) };
+      const source = remoteSource({ readResource: () => Promise.reject(err), sink });
+      const restart = spyRestart(source, true);
+      try {
+        expect(await source.readResource("ui://svc/main", { logFailures: true })).toBeNull();
+        expect(restart).not.toHaveBeenCalled();
+        const crashed = events.filter(
+          (e) => (e.data as { event?: string }).event === "source.crashed",
+        );
+        expect(crashed).toHaveLength(0);
+      } finally {
+        restart.mockRestore();
+      }
+    }
+    spy.mockRestore();
+  });
+});

--- a/test/unit/mcp-source-recovery.test.ts
+++ b/test/unit/mcp-source-recovery.test.ts
@@ -179,6 +179,34 @@ describe("readResource — unified recovery (new behaviors)", () => {
     }
   });
 
+  it("a genuine miss discovered AFTER recovery stays a silent null (no spurious log)", async () => {
+    // session lost → restart succeeds → the retry finds the resource genuinely
+    // absent (-32002). That's a clean miss, not a failure: null, no warn log —
+    // parity with the pre-unification readResourceWithRecovery.
+    let calls = 0;
+    const sessionLost = {
+      code: 404,
+      message: 'Error POSTing to endpoint: {"code":-32001,"message":"Session not found"}',
+    };
+    const source = remoteSource({
+      readResource: () => {
+        calls++;
+        if (calls === 1) return Promise.reject(sessionLost);
+        return Promise.reject(new McpError(-32002, "Resource not found"));
+      },
+    });
+    const restart = spyRestart(source, true);
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await source.readResource("ui://svc/main", { logFailures: true })).toBeNull();
+      expect(restart).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls.some((c) => String(c[0]).includes("readResource failed"))).toBe(false);
+    } finally {
+      spy.mockRestore();
+      restart.mockRestore();
+    }
+  });
+
   it("does NOT restart or crash the source on an unclassifiable read error (no restart-storm)", async () => {
     // A malformed result / 429 / server-defined code is `unknown`; a read must
     // surface it as null — never tear down + re-init or mark the whole source

--- a/test/unit/mcp-source-resource-errors.test.ts
+++ b/test/unit/mcp-source-resource-errors.test.ts
@@ -55,6 +55,10 @@ describe("McpSource.readResource — log scoping (no probe spam)", () => {
         throw err;
       },
     };
+    // A torn transport now routes through recovery; with no backoff slots it
+    // exhausts immediately (no real stop()/start(), no sleeps) and surfaces —
+    // exactly the terminal (logged null / silent null) these tests assert.
+    (source as unknown as { recoveryDelaysMs: readonly number[] }).recoveryDelaysMs = [];
     return source;
   }
 

--- a/test/unit/mcp-source-resource-errors.test.ts
+++ b/test/unit/mcp-source-resource-errors.test.ts
@@ -1,12 +1,7 @@
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it, spyOn } from "bun:test";
 import { NoopEventSink } from "../../src/adapters/noop-events.ts";
-import {
-  isMcpResourceMiss,
-  isSessionLost,
-  isTransientTransport,
-  McpSource,
-} from "../../src/tools/mcp-source.ts";
+import { isMcpResourceMiss, McpSource } from "../../src/tools/mcp-source.ts";
 
 /**
  * `readResource` must distinguish a genuine "resource not here" from a transport
@@ -136,69 +131,6 @@ describe("McpSource.readResource — log scoping (no probe spam)", () => {
     const transport = makeSourceWithThrowingClient(new Error("Connection closed"));
     expect(await miss.readResource("ui://x")).toBeNull();
     expect(await transport.readResource("ui://x", { logFailures: true })).toBeNull();
-  });
-});
-
-/**
- * Classifiers that gate remote-session self-heal (issue #571). The canonical
- * wire shape for a forgotten Streamable-HTTP session is HTTP 404 with the
- * `-32001 "Session not found"` text inside the SDK's StreamableHTTPError
- * message — NOT a JSON-RPC `-32600` (as the issue first guessed) and NOT a
- * numeric `-32001` on `err.code`. A code-only matcher silently never fires on
- * that path, so these lock the real shape down.
- */
-describe("isSessionLost — forgotten remote session", () => {
-  it("matches the canonical 404 + 'Session not found' StreamableHTTPError shape", () => {
-    expect(
-      isSessionLost({
-        code: 404,
-        message:
-          'Streamable HTTP error: Error POSTing to endpoint: {"code":-32001,"message":"Session not found"}',
-      }),
-    ).toBe(true);
-  });
-
-  it("matches a -32001 code from a non-canonical HTTP-200 JSON-RPC body", () => {
-    expect(isSessionLost(new McpError(-32001, "Session not found"))).toBe(true);
-  });
-
-  it("does NOT match a generic 404 (e.g. wrong URL) with no session text", () => {
-    expect(isSessionLost({ code: 404, message: "Not Found" })).toBe(false);
-  });
-
-  it("does NOT match a resource miss or a plain transport error", () => {
-    expect(isSessionLost(new McpError(-32002, "Resource not found"))).toBe(false);
-    expect(isSessionLost(new Error("Connection closed"))).toBe(false);
-  });
-
-  it("is null/non-object safe", () => {
-    expect(isSessionLost(null)).toBe(false);
-    expect(isSessionLost(undefined)).toBe(false);
-    expect(isSessionLost("nope")).toBe(false);
-  });
-});
-
-describe("isTransientTransport — mid-roll gateway blip", () => {
-  it("matches gateway HTTP statuses on err.code", () => {
-    for (const code of [502, 503, 504]) {
-      expect(isTransientTransport({ code, message: "x" })).toBe(true);
-    }
-  });
-
-  it("matches gateway-error message shapes", () => {
-    expect(isTransientTransport({ message: '{"error":"bad_gateway"}' })).toBe(true);
-    expect(isTransientTransport(new Error("Service Unavailable"))).toBe(true);
-    expect(isTransientTransport(new Error("Gateway Timeout"))).toBe(true);
-  });
-
-  it("does NOT match a stale session or a plain transport error", () => {
-    expect(isTransientTransport({ code: 404, message: "Session not found" })).toBe(false);
-    expect(isTransientTransport(new Error("Connection closed"))).toBe(false);
-  });
-
-  it("is null/non-object safe", () => {
-    expect(isTransientTransport(null)).toBe(false);
-    expect(isTransientTransport("nope")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Third in the staged source-recovery redesign (design doc: `research/SPEC-mcp-source-recovery.md`). #572 fixed the resource-read self-heal (Phase 0); #573 extracted the classifier (Phase 1). **This collapses the two ad-hoc recovery blocks into one path.**

## What

`McpSource.execute` (tools/call) and `readResource` had separate, divergent recovery logic. Both now route their `catch` through a single private `recover` that: classifies the throw (`classifyConnectionFailure`) → consults `policyFor` → effects **surface / reauth / re-establish+retry** (single-flight `tryRestart`, bounded backoff). `readResourceWithRecovery` is deleted. `policyFor` lands here, with its consumer (deferred from #573 per that PR's review).

## Intentional behavior changes (each has a test)

| Path | Before | After |
|---|---|---|
| `readResource` on auth loss | silent `null` | flips `reauth_required` (`notifyAuthLost`), returns `null` |
| `readResource` on a torn transport | silent `null` | re-establishes + retries across the deploy window |
| `tools/call` on a standard JSON-RPC protocol error (`-32601`/`-32602`/…) | restart + retry | **surface, no restart** (it won't help) |

## Two regressions caught by adversarial review and fixed before this PR

1. **Retry budget.** A first cut gave tool calls the multi-attempt read budget — tripling replay exposure for a non-idempotent mutating call. Fixed: tool calls keep the **historical one-retry budget** (`TOOL_CALL_RECOVERY_DELAYS = [0]`); reads keep the roll-window schedule. (`idempotent: !isTaskAugmented` only gates task-no-retry; the *budget* is what bounds replays.)
2. **Read restart-storm.** The catch-all defaulted unrecognized throws to `transport-dead`, so a malformed result / 429 / server-defined code on a read would tear down + re-init the whole source repeatedly. Fixed with an explicit **`unknown`** class: the tool path recovers `unknown` (old robustness, capped at one), but reads **surface it as `null`** with no restart and no `source.crashed`.

## Invariants preserved (verified)

- **Task-augmented no-retry** — `idempotent: false` ⇒ every connection failure surfaces; `op` is never re-invoked; a genuine transport break still emits exactly one `source.crashed` for HealthMonitor.
- **OAuth** — reauth (provider present) calls `notifyAuthLost` once + returns the structured `reauth_required`; static-auth 401 surfaces with no thrash; `start()`'s OAuth retry is untouched.

## Tests

New `test/unit/mcp-source-recovery.test.ts` (policy table; app-error-surfaces-without-restart; torn-transport recover; **one-retry cap**; read auth-loss reauth; **unknown read surfaces with no restart/crash**). Taxonomy + resource-error + auth-loss + tasks suites updated/green. Full unit suite **3858 pass**; `verify:static` green; the #571 e2e self-heal still passes through the unified path.

Refs #533 (the absent-source-from-registry sub-mode lands with the Phase 3 supervisor).