### PR TITLE
web(files): send conversationId on file download so cross-workspace attachments resolve

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { fileUrl, setActiveWorkspaceId } from "./client";
+
+describe("fileUrl", () => {
+  afterEach(() => {
+    setActiveWorkspaceId(null);
+  });
+
+  test("includes both ws and conversationId when given", () => {
+    const url = fileUrl("f1", "ws1", "conv1");
+    const query = new URLSearchParams(url.split("?")[1]);
+    expect(url).toContain("/v1/files/f1");
+    expect(query.get("ws")).toBe("ws1");
+    expect(query.get("conversationId")).toBe("conv1");
+  });
+
+  test("omits conversationId when not given", () => {
+    const url = fileUrl("f1", "ws1");
+    const query = new URLSearchParams(url.split("?")[1]);
+    expect(query.get("ws")).toBe("ws1");
+    expect(query.has("conversationId")).toBe(false);
+  });
+
+  test("falls back to the active workspace when workspaceId is omitted", () => {
+    setActiveWorkspaceId("active-ws");
+    const url = fileUrl("f1", undefined, "conv1");
+    const query = new URLSearchParams(url.split("?")[1]);
+    expect(query.get("ws")).toBe("active-ws");
+    expect(query.get("conversationId")).toBe("conv1");
+  });
+
+  test("emits no query string when there is no workspace or conversation", () => {
+    expect(fileUrl("f1")).toBe("/v1/files/f1");
+  });
+
+  test("encodes the file id", () => {
+    expect(fileUrl("a/b c")).toContain("/v1/files/a%2Fb%20c");
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -116,10 +116,20 @@ export function getActiveWorkspaceId(): string | null {
  * `workspace_required`). Defaults to the active workspace; pass `workspaceId`
  * to target a specific workspace.
  */
-export function fileUrl(fileId: string, workspaceId?: string | null): string {
+export function fileUrl(
+  fileId: string,
+  workspaceId?: string | null,
+  conversationId?: string | null,
+): string {
   const ws = workspaceId ?? activeWorkspaceId;
-  const query = ws ? `?ws=${encodeURIComponent(ws)}` : "";
-  return `${API_BASE}/v1/files/${encodeURIComponent(fileId)}${query}`;
+  const params = new URLSearchParams();
+  if (ws) params.set("ws", ws);
+  // The conversation id lets the server resolve the file's authoritative
+  // workspace even when the focused workspace differs (a cross-workspace
+  // resume); `ws` is the fallback when there's no conversation.
+  if (conversationId) params.set("conversationId", conversationId);
+  const query = params.toString();
+  return `${API_BASE}/v1/files/${encodeURIComponent(fileId)}${query ? `?${query}` : ""}`;
 }
 
 /** Register a callback invoked on 401 responses. */

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -215,6 +215,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(function ChatP
 
       <MessageList
         messages={messages}
+        conversationId={conversationId ?? undefined}
         isStreaming={isStreaming}
         streamingState={streamingState}
         preparingTool={preparingTool}

--- a/web/src/components/FileAttachment.tsx
+++ b/web/src/components/FileAttachment.tsx
@@ -12,6 +12,12 @@ export interface FileAttachmentData {
 
 interface Props {
   file: FileAttachmentData;
+  /**
+   * The conversation this attachment belongs to. Sent to the file endpoint so a
+   * cross-workspace attachment resolves to the conversation's workspace, not the
+   * focused one (which can differ on a resume).
+   */
+  conversationId?: string;
 }
 
 function formatFileSize(bytes: number): string {
@@ -27,7 +33,7 @@ function getTypeIcon(mimeType: string) {
   return FileIcon;
 }
 
-export function FileAttachment({ file }: Props) {
+export function FileAttachment({ file, conversationId }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [imgError, setImgError] = useState(false);
   const isImage = file.mimeType.startsWith("image/");
@@ -44,7 +50,7 @@ export function FileAttachment({ file }: Props) {
           className="block cursor-pointer"
         >
           <img
-            src={fileUrl(file.id)}
+            src={fileUrl(file.id, undefined, conversationId)}
             alt={file.filename}
             loading="lazy"
             onError={() => setImgError(true)}

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -139,6 +139,9 @@ function shouldShowSpeaker(
 
 interface MessageListProps {
   messages: ChatMessage[];
+  /** The conversation being shown — threaded to attachments so cross-workspace
+   *  file downloads resolve to the conversation's workspace. */
+  conversationId?: string;
   isStreaming: boolean;
   streamingState: StreamingState;
   /** Set while the model is emitting a tool-call block (pre-execution). */
@@ -249,6 +252,7 @@ function useSmartScroll(messages: ChatMessage[]) {
 
 export function MessageList({
   messages,
+  conversationId,
   isStreaming,
   streamingState,
   preparingTool,
@@ -355,7 +359,11 @@ export function MessageList({
                     {msg.files && msg.files.length > 0 && (
                       <div className="flex flex-wrap gap-2 mb-2">
                         {msg.files.map((file) => (
-                          <FileAttachment key={file.id} file={file} />
+                          <FileAttachment
+                            key={file.id}
+                            file={file}
+                            conversationId={conversationId}
+                          />
                         ))}
                       </div>
                     )}
@@ -391,7 +399,11 @@ export function MessageList({
                     {msg.files && msg.files.length > 0 && (
                       <div className="flex flex-wrap gap-2">
                         {msg.files.map((file) => (
-                          <FileAttachment key={file.id} file={file} />
+                          <FileAttachment
+                            key={file.id}
+                            file={file}
+                            conversationId={conversationId}
+                          />
                         ))}
                       </div>
                     )}


### PR DESCRIPTION
## What

The frontend completion of #574. That PR made the runtime resolve a file's workspace from an optional `?conversationId=` on `GET /v1/files/:fileId` (so a download follows the conversation's workspace, not the focused one). But the web client only ever sent `?ws=<activeWorkspaceId>` — so an image attachment in a conversation you've resumed while focused on a *different* workspace would 404.

This threads the conversation id through to the file URL:
- `fileUrl(fileId, workspaceId?, conversationId?)` adds a `conversationId` param (via `URLSearchParams`).
- `FileAttachment` takes an optional `conversationId` prop and passes it to `fileUrl` for the image thumbnail src.
- `MessageList` passes `conversationId` to each `FileAttachment`.
- `ChatPanel` supplies it from `useChatContext()`.

The server prefers `conversationId` (resolves the conversation's authoritative workspace) and falls back to `?ws=` when absent — so nothing regresses for files viewed in their own workspace.

## Verification

- `web` tsc clean, `bun run build` clean, `bun run test:web` green (575 pass).
- No behavior change when no conversation is in scope (e.g. the Files app) — `?ws=` is still sent.

Closes the only open follow-up from the files-workspace-storage work.

---

_QA polish addressed: added `fileUrl` unit coverage (ws/conversationId branches, active-workspace fallback, id encoding) — web suite now 580 pass._