### PR TITLE
docs: correct accuracy drift across docs against current runtime

### DIFF
--- a/docs/src/content/docs/apps/custom-instructions.mdx
+++ b/docs/src/content/docs/apps/custom-instructions.mdx
@@ -75,7 +75,7 @@ That's it. Once installed in a workspace, anything saved via `set_custom_instruc
 
 ## Settings panel (optional but recommended)
 
-If you want a UI surface where the user edits their instructions (versus only the agent setting them via tool call), declare a top-level `settings` object in your manifest. This is a sibling of `placements`, not a placement slot:
+If you want a UI surface where the user edits their instructions (versus only the agent setting them via tool call), declare a `"settings"` placement in your manifest — a settings section is a placement slot, not a separate object:
 
 ```json title="manifest.json"
 {
@@ -84,12 +84,14 @@ If you want a UI surface where the user edits their instructions (versus only th
       "host_version": "1.0",
       "name": "My App",
       "icon": "list-checks",
-      "settings": {
-        "id": "my-app",
-        "label": "My App",
-        "icon": "list-checks",
-        "resourceUri": "ui://my-app/settings"
-      }
+      "placements": [
+        {
+          "slot": "settings",
+          "resourceUri": "ui://my-app/settings",
+          "label": "My App",
+          "icon": "list-checks"
+        }
+      ]
     }
   }
 }
@@ -97,7 +99,7 @@ If you want a UI surface where the user edits their instructions (versus only th
 
 Then publish the panel HTML at `ui://my-app/settings` and call your tools via the iframe bridge. NimbleBrain shows the panel under **Settings → This Workspace → Apps → My App**.
 
-See the [Manifest reference](/apps/manifest/#settings-object) for the `settings` object shape and the [MCP App Bridge](/apps/bridge/) page for iframe → tool call wiring.
+See the [Manifest reference](/apps/manifest/#settings-sections) for the `"settings"` placement shape and the [MCP App Bridge](/apps/bridge/) page for iframe → tool call wiring.
 
 ## Why this convention
 
@@ -109,5 +111,5 @@ See the [Manifest reference](/apps/manifest/#settings-object) for the `settings`
 ## Related
 
 - [Workspace and org-level overlays](/guide/settings/) — managed by the host, not by your bundle. Set via the `instructions__write_instructions` system tool or the workspace/org settings UI.
-- [Manifest reference](/apps/manifest/) — full `_meta["ai.nimblebrain/host"]` schema, including the top-level `settings` object.
+- [Manifest reference](/apps/manifest/) — full `_meta["ai.nimblebrain/host"]` schema, including the `"settings"` placement slot.
 - [Placements & Navigation](/apps/placements/) — sidebar and main slots for your app's views.

--- a/docs/src/content/docs/apps/host-capabilities.mdx
+++ b/docs/src/content/docs/apps/host-capabilities.mdx
@@ -15,7 +15,7 @@ Most apps don't. You need host capabilities only when your bundle wants to use a
 
 ## Declaring capabilities
 
-Capability declarations live in a `host_capabilities` block inside `_meta["ai.nimblebrain/host"]`. Declaring the block **requires `host_version: "1.1"`** — the schema rejects the block under `1.0`.
+Capability declarations live in a `host_capabilities` block inside `_meta["ai.nimblebrain/host"]`. `host_capabilities` is the `1.1` contract addition, so declare `host_version: "1.1"` alongside the block.
 
 ```json title="manifest.json"
 {

--- a/docs/src/content/docs/apps/manifest.mdx
+++ b/docs/src/content/docs/apps/manifest.mdx
@@ -5,7 +5,7 @@ description: Complete reference for the _meta["ai.nimblebrain/host"] manifest ex
 
 import { Aside } from '@astrojs/starlight/components';
 
-NimbleBrain reads host metadata from the `_meta["ai.nimblebrain/host"]` key in your MCPB `manifest.json`. This is where you declare your app's name, icon, category, sidebar placements, briefing facets, and settings section.
+NimbleBrain reads host metadata from the `_meta["ai.nimblebrain/host"]` key in your MCPB `manifest.json`. This is where you declare your app's name, icon, placements (sidebar items, main views, and settings sections), and briefing facets.
 
 ## Full manifest structure
 
@@ -32,27 +32,23 @@ NimbleBrain reads host metadata from the `_meta["ai.nimblebrain/host"]` key in y
       "host_version": "1.0",
       "name": "My App",
       "icon": "database",
-      "category": "custom",
-      "primaryView": {
-        "resourceUri": "ui://dashboard"
-      },
       "placements": [
         {
-          "slot": "sidebar",
-          "resourceUri": "ui://nav",
+          "slot": "main",
+          "resourceUri": "ui://dashboard",
           "priority": 50,
           "label": "My App",
           "icon": "database",
           "route": "my-app",
-          "size": "compact"
+          "size": "full"
+        },
+        {
+          "slot": "settings",
+          "resourceUri": "ui://settings",
+          "label": "My App",
+          "icon": "settings"
         }
-      ],
-      "settings": {
-        "id": "my-app",
-        "label": "My App",
-        "icon": "settings",
-        "resourceUri": "ui://settings"
-      }
+      ]
     }
   }
 }
@@ -86,36 +82,28 @@ These fields are defined by the [MCPB specification](https://github.com/modelcon
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `host_version` | `string` | Yes | Schema version: `"1.0"` or `"1.1"`. `1.1` adds the `host_capabilities` block (declaring it requires `host_version: "1.1"`, enforced by the schema). |
-| `name` | `string` | Yes | Display name shown in the sidebar and app list. |
-| `icon` | `string` | Yes | [Lucide icon](https://lucide.dev/icons) name in kebab-case (e.g., `"database"`, `"message-square"`, `"hand"`). |
-| `category` | `string` | No | App category: `"sales"`, `"marketing"`, `"operations"`, `"research"`, `"finance"`, `"hr"`, `"engineering"`, `"support"`, or `"custom"`. |
-| `primaryView` | `object` | No | The main view loaded when a user navigates to your app. |
-| `primaryView.resourceUri` | `string` | Yes (if `primaryView` set) | `ui://` URI for the main view (e.g., `"ui://dashboard"`). |
-| `placements` | `PlacementDeclaration[]` | No | Explicit shell layout placement declarations. See [Placements](/apps/placements). |
-| `settings` | `object` | No | Settings section contributed by this bundle. See [settings object](#settings-object) below. |
+| `host_version` | `string` | Yes | Host extension contract version: `"1.0"` or `"1.1"`. `1.1` is the version that adds the `host_capabilities` block — set it when you declare that block. |
+| `name` | `string` | Recommended | Display name shown in the sidebar and app list. Without a `name` the host surfaces no UI for the bundle, so it's required in practice for any app with a presence in the shell. |
+| `icon` | `string` | No | [Lucide icon](https://lucide.dev/icons) name in kebab-case (e.g., `"database"`, `"message-square"`, `"hand"`). Defaults to `""`. |
+| `category` | `string` | No | Reserved, free-form string. Not currently consumed by the host — declare it only as forward-looking metadata. |
+| `placements` | `PlacementDeclaration[]` | No | Shell layout placement declarations — sidebar items, main views, and settings sections. See [Placements](/apps/placements). |
 | `briefing` | `object` | No | Daily briefing contribution. See [briefing](#briefing-object) below. |
-| `host_capabilities` | `object` | No | NimbleBrain host capabilities this bundle requires or prefers. Requires `host_version: "1.1"`. See [Host Capabilities](/apps/host-capabilities). |
+| `host_capabilities` | `object` | No | NimbleBrain host capabilities this bundle requires or prefers. Declare `host_version: "1.1"` alongside it. See [Host Capabilities](/apps/host-capabilities). |
 
-### `settings` object
+### Settings sections
 
-`settings` is a **top-level field** on `_meta["ai.nimblebrain/host"]` — a sibling of `placements`, not a placement slot. Declaring it contributes a tab to the settings UI under **Settings → This Workspace → Apps → &lt;your app&gt;**.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `settings.id` | `string` | Yes | Unique section ID across all bundles. |
-| `settings.label` | `string` | Yes | Tab label in the settings UI. |
-| `settings.icon` | `string` | Yes | Lucide icon name for the settings tab. |
-| `settings.resourceUri` | `string` | Yes | `ui://` URI that renders the settings section HTML. |
+A settings section is a placement with `slot: "settings"`, not a separate top-level object. Add an entry to `placements` and the host renders it as a tab under **Settings → This Workspace → Apps → &lt;your app&gt;**, served from the placement's `resourceUri`:
 
 ```json
-"settings": {
-  "id": "my-app",
+{
+  "slot": "settings",
+  "resourceUri": "ui://settings",
   "label": "My App",
-  "icon": "settings",
-  "resourceUri": "ui://settings"
+  "icon": "settings"
 }
 ```
+
+The `resourceUri` points at the `ui://` page that renders the settings HTML; `label` and `icon` set the tab's appearance. See [Placements](/apps/placements) for the full `PlacementDeclaration` shape.
 
 ### `briefing` object
 
@@ -187,7 +175,7 @@ Each entry in the `placements` array:
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `slot` | `string` | Yes | — | Shell slot to fill: `"sidebar"`, `"sidebar.apps"`, `"sidebar.bottom"`, or `"main"`. See [Placements](/apps/placements). |
+| `slot` | `string` | Yes | — | Shell slot to fill: `"sidebar"`, `"sidebar.apps"`, `"sidebar.bottom"`, `"main"`, or `"settings"`. See [Placements](/apps/placements). |
 | `resourceUri` | `string` | Yes | — | `ui://` URI served by this MCP server. |
 | `priority` | `number` | No | `100` | Sort order within the slot. Lower values appear first. |
 | `label` | `string` | No | — | Human-readable label for sidebar items and tabs. |
@@ -195,7 +183,7 @@ Each entry in the `placements` array:
 | `route` | `string` | No | — | Route path for `"main"` slot placements. Registers as `/app/<route>`. |
 | `size` | `"compact" \| "full" \| "auto"` | No | — | Size hint for the slot renderer. |
 
-## How `primaryView` and `placements` interact
+## Registering your main view
 
 `placements` is what the shell renders and routes from. To give your app a navigable main view, declare a `"main"` slot placement with a `route`:
 
@@ -212,6 +200,8 @@ Each entry in the `placements` array:
 ```
 
 The virtual `primary` resource path resolves to the **first declared placement's** `resourceUri`, so the shell can load your main view without knowing its URI ahead of time. See [UI Resources](/apps/ui-resources) for how `primary` resolves.
+
+The schema also accepts a `primaryView` object for back-compat, but the host does not consume it — placements are the source of truth for what is registered and routed. Declare a `"main"` placement, not `primaryView`.
 
 <Aside type="tip">
 Declare at least one `"main"` placement with a `route` so users can navigate to your app. Add `"sidebar.*"` or `"sidebar.bottom"` placements when you need sidebar widgets or pinned items.
@@ -247,9 +237,14 @@ The smallest manifest that registers a UI view:
       "host_version": "1.0",
       "name": "Hello",
       "icon": "hand",
-      "primaryView": {
-        "resourceUri": "ui://index"
-      }
+      "placements": [
+        {
+          "slot": "main",
+          "resourceUri": "ui://index",
+          "route": "hello",
+          "label": "Hello"
+        }
+      ]
     }
   }
 }

--- a/docs/src/content/docs/apps/overview.mdx
+++ b/docs/src/content/docs/apps/overview.mdx
@@ -89,15 +89,21 @@ Add `_meta["ai.nimblebrain/host"]` to give your app a presence in the shell:
       "host_version": "1.0",
       "name": "Weather",
       "icon": "cloud-sun",
-      "primaryView": {
-        "resourceUri": "ui://dashboard"
-      }
+      "placements": [
+        {
+          "slot": "main",
+          "resourceUri": "ui://dashboard",
+          "route": "weather",
+          "label": "Weather",
+          "icon": "cloud-sun"
+        }
+      ]
     }
   }
 }
 ```
 
-This registers a main view at `/app/@myorg/weather` and adds a sidebar entry. The `ui://dashboard` resource is an HTML page served by your MCP server and rendered in an iframe.
+This registers a main view at `/app/weather` and adds a sidebar entry under the "Apps" group. Registration and sidebar placement come from the `placements` array — the `ui://dashboard` resource is an HTML page served by your MCP server and rendered in an iframe.
 
 <Aside type="tip">
 You don't need UI to build a useful app. Many powerful apps are tools-only — the agent calls them directly during conversations.

--- a/docs/src/content/docs/apps/placements.mdx
+++ b/docs/src/content/docs/apps/placements.mdx
@@ -17,6 +17,7 @@ The shell layout has the following slots:
 | `sidebar.apps` | Left sidebar, "Apps" group | Items grouped under the "Apps" heading. |
 | `sidebar.bottom` | Left sidebar, bottom zone | Pinned items below the scrollable area (e.g., settings). |
 | `main` | Central content area | Full-page views rendered in iframes. Requires a `route`. |
+| `settings` | Settings → Apps | A per-app settings section, rendered as a tab under **Settings → This Workspace → Apps**. |
 
 A `"sidebar.<group>"` slot renders under a named group heading derived from the group name (e.g., `"sidebar.apps"` → "Apps").
 

--- a/docs/src/content/docs/apps/ui-resources.mdx
+++ b/docs/src/content/docs/apps/ui-resources.mdx
@@ -13,7 +13,7 @@ When your manifest declares a resource URI like `ui://dashboard`, NimbleBrain re
 
 The flow:
 
-1. User navigates to your app (e.g., `/app/@myorg/my-app`).
+1. User navigates to your app (e.g., `/app/my-app`).
 2. The web client requests `GET /v1/apps/my-app/resources/primary`.
 3. The platform resolves `"primary"` to your first placement's `resourceUri`.
 4. The platform calls `resources/read` on your MCP server for that URI.

--- a/docs/src/content/docs/apps/ui-resources.mdx
+++ b/docs/src/content/docs/apps/ui-resources.mdx
@@ -15,14 +15,14 @@ The flow:
 
 1. User navigates to your app (e.g., `/app/@myorg/my-app`).
 2. The web client requests `GET /v1/apps/my-app/resources/primary`.
-3. The platform resolves `"primary"` to your `primaryView.resourceUri`.
+3. The platform resolves `"primary"` to your first placement's `resourceUri`.
 4. The platform calls `resources/read` on your MCP server for that URI.
 5. The HTML response is returned to the web client and loaded into an iframe.
 6. The [MCP App Bridge](/apps/bridge) initializes via `postMessage`.
 
-## The `primaryView`
+## The main view
 
-The `primaryView` is the main HTML page for your app. Declare it in your manifest:
+The main view is the primary HTML page for your app. Declare it as a `"main"` placement in your manifest — placements are what the host registers and routes from:
 
 ```json
 {
@@ -31,15 +31,20 @@ The `primaryView` is the main HTML page for your app. Declare it in your manifes
       "host_version": "1.0",
       "name": "My App",
       "icon": "database",
-      "primaryView": {
-        "resourceUri": "ui://dashboard"
-      }
+      "placements": [
+        {
+          "slot": "main",
+          "resourceUri": "ui://dashboard",
+          "route": "my-app",
+          "label": "My App"
+        }
+      ]
     }
   }
 }
 ```
 
-Your MCP server must register a resource handler for `ui://dashboard` that returns an HTML string.
+The virtual `primary` path derives from the **first declared placement's** `resourceUri`, so the shell can load this view without knowing its URI. Your MCP server must register a resource handler for `ui://dashboard` that returns an HTML string.
 
 ### Python (FastMCP)
 

--- a/docs/src/content/docs/cli/overview.mdx
+++ b/docs/src/content/docs/cli/overview.mdx
@@ -44,9 +44,10 @@ NimbleBrain loads its configuration from a `nimblebrain.json` file. The CLI reso
 
 | Priority | Source | Path |
 |----------|--------|------|
-| 1 | `--config` flag | Exactly the path you specify |
-| 2 | `NB_WORK_DIR` env var | `<NB_WORK_DIR>/nimblebrain.json` |
-| 3 | Default work directory | `~/.nimblebrain/nimblebrain.json` |
+| 1 | `--config` / `-c` flag | Exactly the path you specify |
+| 2 | Project-local directory | `./.nimblebrain/nimblebrain.json` (used only when it exists) |
+| 3 | Default work directory | `<NB_WORK_DIR>/nimblebrain.json`, where `NB_WORK_DIR` defaults to `~/.nimblebrain` |
+| 4 | Current directory | `./nimblebrain.json` |
 
 Both `bun run start` and `bun run dev` default to the same global work directory at `~/.nimblebrain`. `bun run dev` starts the server (`bun run src/cli/index.ts serve`) under the hood, so it inherits that default unless you override it with `--config` or `NB_WORK_DIR`.
 
@@ -55,9 +56,7 @@ If no config file exists at the resolved path, NimbleBrain auto-creates one with
 ```json title="nimblebrain.json"
 {
   "$schema": "https://schemas.nimblebrain.ai/v1/nimblebrain-config.schema.json",
-  "version": "1",
-  "bundles": [],
-  "skills": []
+  "version": "1"
 }
 ```
 

--- a/docs/src/content/docs/concepts.mdx
+++ b/docs/src/content/docs/concepts.mdx
@@ -131,17 +131,15 @@ NimbleBrain does not install any MCP bundles by default. Platform capabilities (
 ```json
 {
   "name": "@nimblebraininc/postgres",
-  "env": { "DATABASE_URL": "postgres://localhost/mydb" },
-  "protected": true
+  "env": { "DATABASE_URL": "postgres://localhost/mydb" }
 }
 ```
 
 | Field | Description |
 |-------|-------------|
 | `env` | Environment variables passed to the bundle process |
-| `protected` | Prevents uninstall through the management tools |
 | `trustScore` | MTF trust score (0–100) from the mpak registry |
-| `ui` | UI metadata: name, icon, and optional `primaryView` resource URI |
+| `ui` | UI metadata: name, icon, and placement declarations |
 
 ## Skills
 
@@ -262,12 +260,15 @@ The child agent's iteration budget is capped at `min(child.maxIterations, parent
 
 Conversations persist across messages so the agent remembers context.
 
-### Storage backends
+### Storage
 
-| Backend | Default for | Location |
-|---------|------------|----------|
-| **JSONL** | CLI, HTTP server | `~/.nimblebrain/conversations/` |
-| **In-memory** | Programmatic/SDK use | — |
+Conversations are workspace-owned. Every turn is written to a per-conversation JSONL file under the workspace it ran in:
+
+```
+~/.nimblebrain/workspaces/<wsId>/conversations/<ownerId>/<convId>.jsonl
+```
+
+The owner (`ownerId`) is the authorization principal — only they can read or resume the conversation — while the workspace (`wsId`) is where it is stored. Persistence does not depend on any top-level `store` setting; programmatic/SDK embedding can supply an in-memory `ConversationStore` instead.
 
 ### JSONL format
 

--- a/docs/src/content/docs/concepts/mcp-apps.mdx
+++ b/docs/src/content/docs/concepts/mcp-apps.mdx
@@ -98,9 +98,9 @@ Any MCPB bundle can become an MCP App by:
       "host_version": "1.0",
       "name": "Dashboard",
       "icon": "bar-chart-3",
-      "primaryView": {
-        "resourceUri": "ui://main"
-      }
+      "placements": [
+        { "slot": "main", "resourceUri": "ui://main" }
+      ]
     }
   }
 }

--- a/docs/src/content/docs/config/bundles.mdx
+++ b/docs/src/content/docs/config/bundles.mdx
@@ -77,7 +77,7 @@ These fields apply to all bundle types.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `env` | `object` | `{}` | Environment variables passed to the bundle process. Each key-value pair is a string. |
-| `protected` | `boolean` | `false` | When `true`, the bundle cannot be uninstalled through the connectors / apps management tools or the API. |
+| `allowedEnv` | `string[]` | `[]` | Names of host environment variables to pass through to the bundle process, on top of the safe default allowlist. `NB_API_KEY` and `NB_INTERNAL_TOKEN` are always denied. |
 | `trustScore` | `number \| null` | `null` | MTF trust score (0--100) recorded at install time. Set automatically by the install flow. |
 | `ui` | `object \| null` | `null` | UI metadata from the bundle manifest. Set automatically at install time. |
 
@@ -93,8 +93,7 @@ Use `env` to inject secrets or configuration into a bundle process:
       "env": {
         "DATABASE_URL": "postgres://localhost:5432/mydb",
         "PG_MAX_CONNECTIONS": "10"
-      },
-      "protected": true
+      }
     }
   ]
 }
@@ -113,9 +112,9 @@ The `ui` field is populated automatically when you install a bundle that declare
   "ui": {
     "name": "Tasks",
     "icon": "clipboard",
-    "primaryView": {
-      "resourceUri": "ui://tasks/index.html"
-    }
+    "placements": [
+      { "slot": "main", "resourceUri": "ui://tasks/index.html" }
+    ]
   }
 }
 ```
@@ -124,7 +123,7 @@ The `ui` field is populated automatically when you install a bundle that declare
 |-------|------|-------------|
 | `ui.name` | `string` | Human-readable app name shown in the sidebar. |
 | `ui.icon` | `string` | Emoji or icon identifier. |
-| `ui.primaryView.resourceUri` | `string` | `ui://` resource URI for the app's full-page view. |
+| `ui.placements` | `array` | Placement declarations (each a `slot` plus a `ui://` resource URI) that register the app's views. |
 
 ## Remote transport configuration
 
@@ -222,8 +221,7 @@ A `workspace.json` `bundles` array with all three bundle types:
   "bundles": [
     {
       "name": "@nimblebraininc/postgres",
-      "env": { "DATABASE_URL": "postgres://localhost:5432/mydb" },
-      "protected": true
+      "env": { "DATABASE_URL": "postgres://localhost:5432/mydb" }
     },
     {
       "path": "./my-local-server"

--- a/docs/src/content/docs/config/environment.mdx
+++ b/docs/src/content/docs/config/environment.mdx
@@ -163,7 +163,7 @@ Sets the working directory where NimbleBrain stores runtime state.
 export NB_WORK_DIR=/data/nimblebrain
 ```
 
-The working directory contains `conversations/` (JSONL conversation files), `logs/`, `workspaces/<wsId>/`, `users/<userId>/`, `registries.json`, and `cache/`.
+The working directory contains `workspaces/<wsId>/` (which holds each workspace's conversations, files, and automations), `users/<userId>/`, `logs/`, `registries.json`, and `cache/`.
 
 `NB_WORK_DIR` sets the `workDir` runtime value (where state lives) and is forwarded to bundle subprocesses. It does **not** select which `nimblebrain.json` is loaded — config-file discovery is driven by `--config`, a project-local `.nimblebrain/`, and the command's default workdir. See [config resolution](/config/nimblebrain-json/#config-resolution).
 

--- a/docs/src/content/docs/config/logging.mdx
+++ b/docs/src/content/docs/config/logging.mdx
@@ -5,7 +5,7 @@ description: Structured JSONL logging configuration and log format reference.
 
 import { Aside } from '@astrojs/starlight/components';
 
-NimbleBrain writes structured logs as JSONL (one JSON object per line) to daily rolling log files. These logs capture LLM latency, tool execution times, cache token usage, per-tool statistics, and estimated costs.
+NimbleBrain writes a structured workspace event log as JSONL (one JSON object per line) to daily rolling log files. These logs capture workspace-level events — bundle lifecycle, skill and file changes, data and config mutations, tool-surface changes, and audit signals.
 
 ## Configuration
 
@@ -41,25 +41,25 @@ Structured logging is enabled by default. To disable it:
 
 ## Log file naming
 
-Log files follow a daily rolling pattern:
+Log files follow a daily rolling pattern under a `workspace/` subdirectory of `dir`:
 
 ```
-{dir}/nimblebrain-YYYY-MM-DD.jsonl
+{dir}/workspace/YYYY-MM-DD.jsonl
 ```
 
 A new file is created automatically each day. Examples:
 
 ```
-~/.nimblebrain/logs/nimblebrain-2026-03-25.jsonl
-~/.nimblebrain/logs/nimblebrain-2026-03-26.jsonl
+~/.nimblebrain/logs/workspace/2026-03-25.jsonl
+~/.nimblebrain/logs/workspace/2026-03-26.jsonl
 ```
 
 ## Log entry format
 
-Every log line is a JSON object with at minimum a timestamp and event type:
+Every log line is a JSON object: a timestamp, the event type, and the event's own data fields spread alongside them.
 
 ```json
-{"ts":"2026-03-25T14:30:00.123Z","event":"run.start","runId":"abc123","model":"anthropic:claude-sonnet-4-6"}
+{"ts":"2026-03-25T14:30:00.123Z","event":"bundle.installed","serverName":"postgres","bundleName":"@nimblebraininc/postgres","version":"1.2.0"}
 ```
 
 ### Common fields
@@ -67,107 +67,89 @@ Every log line is a JSON object with at minimum a timestamp and event type:
 | Field | Type | Description |
 |-------|------|-------------|
 | `ts` | `string` | ISO 8601 timestamp of when the event was recorded. |
-| `event` | `string` | Event type (e.g., `run.start`, `tool.done`, `run.done`). |
-| `sid` | `string` | Conversation ID, present when the log sink has a conversation context. |
-| `runId` | `string` | Unique identifier for the agent run. Correlates all events in a single request. |
+| `event` | `string` | Event type (e.g., `bundle.installed`, `data.changed`, `audit.permission_denied`). |
+
+Remaining fields vary by event type — they are the event's payload, written inline.
 
 ### Event types
 
-The following events are logged. `text.delta` events are excluded to avoid log noise.
+Only workspace-level events are written to this log; conversation streaming events (`text.delta`, `tool.start`, and the like) are not.
 
-**`run.start`** — An agent run begins.
-
-```json
-{"ts":"2026-03-25T14:30:00.123Z","event":"run.start","runId":"abc123","model":"anthropic:claude-sonnet-4-6","sid":"conv-456"}
-```
-
-**`iteration.done`** — One LLM call + tool execution cycle completes.
+**Bundle lifecycle** — `bundle.installed`, `bundle.uninstalled`, `bundle.upgraded`, `bundle.crashed`, `bundle.recovered`, `bundle.dead`. Track connectors entering, leaving, and changing health in the workspace.
 
 ```json
-{"ts":"2026-03-25T14:30:01.456Z","event":"iteration.done","runId":"abc123","llmMs":823,"cacheCreationTokens":1200,"cacheReadTokens":4500}
+{"ts":"2026-03-25T14:30:00.123Z","event":"bundle.installed","wsId":"ws_product","serverName":"postgres","bundleName":"@nimblebraininc/postgres","version":"1.2.0","trustScore":92}
 ```
 
-**`tool.done`** — A tool call finishes.
+**`data.changed`** — A tool mutated workspace data. Carries the `server` and `tool` that wrote, and `source: "agent"` when emitted from the agent's tool dispatch.
 
 ```json
-{"ts":"2026-03-25T14:30:01.200Z","event":"tool.done","runId":"abc123","name":"postgres__query","ms":45,"ok":true}
+{"ts":"2026-03-25T14:30:01.200Z","event":"data.changed","source":"agent","server":"tasks","tool":"create_task"}
 ```
 
-**`run.done`** — The agent run completes. This is the summary record with accumulated metrics.
+**`config.changed`** — Workspace configuration was modified.
+
+**`skill.created`, `skill.updated`, `skill.deleted`** — A workspace skill or context file changed. Carry the skill's `id` (filesystem path), `name`, and `scope`.
 
 ```json
-{
-  "ts": "2026-03-25T14:30:02.789Z",
-  "event": "run.done",
-  "runId": "abc123",
-  "sid": "conv-456",
-  "inputTokens": 12500,
-  "outputTokens": 1830,
-  "cacheCreationTokens": 1200,
-  "cacheReadTokens": 4500,
-  "llmMs": 1650,
-  "toolMs": 320,
-  "toolCalls": 3,
-  "toolErrors": 0,
-  "costUsd": 0.004215,
-  "toolStats": {
-    "postgres__query": { "count": 2, "totalMs": 250 },
-    "filesystem__read_file": { "count": 1, "totalMs": 70 }
-  }
-}
+{"ts":"2026-03-25T14:30:02.000Z","event":"skill.created","id":"/skills/triage/SKILL.md","name":"triage","scope":"workspace","type":"skill"}
 ```
 
-**`run.error`** — The agent run failed with an error.
+**`file.created`, `file.deleted`** — A workspace file was added or removed. `file.created` carries `id`, `filename`, `mimeType`, and `size`.
 
 ```json
-{"ts":"2026-03-25T14:30:03.000Z","event":"run.error","runId":"abc123","error":"Token budget exceeded"}
+{"ts":"2026-03-25T14:30:03.000Z","event":"file.created","id":"file_abc","filename":"report.pdf","mimeType":"application/pdf","size":20184}
 ```
 
-### run.done summary fields
+**`tool.promoted`, `tool.released`** — A tool entered or left the active tool set. Carry the `runId` and `toolName`; `tool.released` adds `reason: "evicted"` when the engine reclaimed a slot under the active-tool cap.
 
-The `run.done` event accumulates metrics across all iterations in the run:
+```json
+{"ts":"2026-03-25T14:30:04.000Z","event":"tool.promoted","runId":"abc123","toolName":"postgres__query"}
+```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `inputTokens` | `number` | Total input tokens consumed. |
-| `outputTokens` | `number` | Total output tokens generated. |
-| `cacheCreationTokens` | `number` | Tokens written to prompt cache during this run. |
-| `cacheReadTokens` | `number` | Tokens read from prompt cache (cache hits). |
-| `llmMs` | `number` | Total milliseconds spent in LLM calls. |
-| `toolMs` | `number` | Total milliseconds spent executing tools. |
-| `toolCalls` | `number` | Total number of tool calls made. |
-| `toolErrors` | `number` | Number of tool calls that returned errors. |
-| `costUsd` | `number` | Estimated cost in USD, based on the model's token pricing. |
-| `toolStats` | `object` | Per-tool breakdown: `{ "toolName": { "count": N, "totalMs": N } }`. Only present when at least one tool was called. |
+**`bridge.tool.done`** — A bridged tool call completed.
+
+**`http.error`** — An HTTP-level error surfaced in the workspace.
+
+**`audit.auth_failure`** — Authentication failed for a request. Carries `ip`, `method`, and `path`.
+
+```json
+{"ts":"2026-03-25T14:30:05.000Z","event":"audit.auth_failure","ip":"203.0.113.7","method":"POST","path":"/api/chat"}
+```
+
+**`audit.permission_denied`** — A user declined a tool's confirmation prompt. Carries the `tool`, the unprefixed `action`, and the `target` (or `null`).
+
+```json
+{"ts":"2026-03-25T14:30:06.000Z","event":"audit.permission_denied","tool":"tasks__delete","action":"delete","target":"task-42"}
+```
 
 ## Querying logs
 
 Log files are plain JSONL, so you can use standard command-line tools:
 
 ```bash
-# Total cost for today
-cat ~/.nimblebrain/logs/nimblebrain-2026-03-25.jsonl \
-  | jq -s '[.[] | select(.event == "run.done") | .costUsd] | add'
+# Bundles installed today
+cat ~/.nimblebrain/logs/workspace/2026-03-25.jsonl \
+  | jq 'select(.event == "bundle.installed") | {bundleName, version}'
 
-# Slowest tool calls
-cat ~/.nimblebrain/logs/nimblebrain-2026-03-25.jsonl \
-  | jq 'select(.event == "tool.done") | {name, ms}' \
-  | jq -s 'sort_by(-.ms) | .[0:5]'
+# Audit events only
+cat ~/.nimblebrain/logs/workspace/2026-03-25.jsonl \
+  | jq 'select(.event | startswith("audit."))'
 
-# Errors only
-cat ~/.nimblebrain/logs/nimblebrain-2026-03-25.jsonl \
-  | jq 'select(.event == "run.error")'
+# Count events by type
+cat ~/.nimblebrain/logs/workspace/2026-03-25.jsonl \
+  | jq -s 'group_by(.event) | map({event: .[0].event, count: length})'
 ```
 
 <Aside type="tip">
-  For programmatic cost tracking, query the agent's `usage__report` tool instead of parsing the JSONL logs directly.
+  This log captures workspace events, not per-run token usage or cost. For run-level token counts and estimated cost, query the agent's `usage__report` tool instead.
 </Aside>
 
 ## Log rotation
 
-NimbleBrain does not delete old log files. Each day creates a new file, so you can manage retention with standard tools:
+A new file is created each day. Set `retentionDays` to have NimbleBrain delete log files older than that threshold on startup. Without it, files accumulate and you can manage retention with standard tools:
 
 ```bash
-# Delete logs older than 30 days
-find ~/.nimblebrain/logs -name "nimblebrain-*.jsonl" -mtime +30 -delete
+# Delete workspace logs older than 30 days
+find ~/.nimblebrain/logs/workspace -name "*.jsonl" -mtime +30 -delete
 ```

--- a/docs/src/content/docs/config/nimblebrain-json.mdx
+++ b/docs/src/content/docs/config/nimblebrain-json.mdx
@@ -55,7 +55,6 @@ A sibling `nimblebrain.overrides.json` next to the resolved config file is **dee
   "maxHistoryMessages": 40,
   "maxToolResultSize":  1000000,
 
-  "store":   { "type": "jsonl", "dir": "~/.nimblebrain/conversations" },
   "logging": { "dir": "~/.nimblebrain/logs", "disabled": false, "level": "normal", "retentionDays": 30 },
   "http":    { "port": 27247, "host": "127.0.0.1" },
 
@@ -161,10 +160,21 @@ Each provider key is optional. If a provider's `apiKey` is omitted, the SDK fall
 
 ## store
 
-Choose where conversations are persisted. **The CLI (`bun run start`) defaults to `jsonl`** — conversations persist across restarts at `{workDir}/conversations/`. In-memory is the fallback only for programmatic embedding where no `store` is given.
+Conversations are **workspace-owned and persisted automatically** — you do not configure where they live. Every turn is written to a per-conversation JSONL file at `{workDir}/workspaces/<wsId>/conversations/<ownerId>/<convId>.jsonl` in the **event-sourced** format (one append-only event log per conversation), which is what enables crash-resilient run replay and history [compaction](/config/features/). Legacy message-format JSONL files are still read. This persistence does not depend on the `store` setting below.
+
+The optional top-level `store` field selects the `ConversationStore` the runtime holds for **programmatic / SDK embedding**. It defaults to in-memory, and the platform CLI does not write conversation history through it (workspace stores handle that). Set it only when embedding the runtime as a library.
 
 <Tabs>
-  <TabItem label="JSONL (default for the CLI)">
+  <TabItem label="In-memory (default)">
+    ```json
+    {
+      "store": { "type": "memory" }
+    }
+    ```
+
+    The default. The platform's workspace-owned conversation persistence is unaffected; this only governs the embedded `ConversationStore` handle.
+  </TabItem>
+  <TabItem label="JSONL">
     ```json
     {
       "store": {
@@ -174,23 +184,14 @@ Choose where conversations are persisted. **The CLI (`bun run start`) defaults t
     }
     ```
 
-    File-backed conversations in `{workDir}/conversations/`. New conversations are written in the **event-sourced** JSONL format (one append-only event log per conversation), which is what enables crash-resilient run replay and history [compaction](/config/features/). Legacy message-format JSONL files are still read.
-  </TabItem>
-  <TabItem label="In-memory">
-    ```json
-    {
-      "store": { "type": "memory" }
-    }
-    ```
-
-    Conversations are lost when the process exits. Only the fallback for programmatic use with no configured store.
+    Provides a file-backed `ConversationStore` for programmatic embedding at the given `dir`.
   </TabItem>
 </Tabs>
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | `"jsonl"` \| `"memory"` | Yes | Storage backend. The CLI defaults to `jsonl`. |
-| `dir` | `string` | JSONL only | Directory for conversation JSONL files. |
+| `type` | `"jsonl"` \| `"memory"` | Yes | `ConversationStore` backend for embedded use. Defaults to `memory`. |
+| `dir` | `string` | JSONL only | Directory for the embedded JSONL store's files. |
 
 ## sessionStore
 

--- a/docs/src/content/docs/config/nimblebrain-json.mdx
+++ b/docs/src/content/docs/config/nimblebrain-json.mdx
@@ -162,7 +162,7 @@ Each provider key is optional. If a provider's `apiKey` is omitted, the SDK fall
 
 Conversations are **workspace-owned and persisted automatically** — you do not configure where they live. Every turn is written to a per-conversation JSONL file at `{workDir}/workspaces/<wsId>/conversations/<ownerId>/<convId>.jsonl` in the **event-sourced** format (one append-only event log per conversation), which is what enables crash-resilient run replay and history [compaction](/config/features/). Legacy message-format JSONL files are still read. This persistence does not depend on the `store` setting below.
 
-The optional top-level `store` field selects the `ConversationStore` the runtime holds for **programmatic / SDK embedding**. It defaults to in-memory, and the platform CLI does not write conversation history through it (workspace stores handle that). Set it only when embedding the runtime as a library.
+The optional top-level `store` field sets the runtime's boot-time `ConversationStore` handle. **It does not change where conversations are stored** — that is always workspace-owned, as above — so most deployments omit it. It defaults to in-memory and is reserved for programmatic embedding of the runtime as a library.
 
 <Tabs>
   <TabItem label="In-memory (default)">

--- a/docs/src/content/docs/connect/external-clients.mdx
+++ b/docs/src/content/docs/connect/external-clients.mdx
@@ -5,7 +5,7 @@ description: Use NimbleBrain's tools from Claude Desktop, Claude Code, Cursor, o
 
 import { Aside, Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
-NimbleBrain can act as a tool server for external apps that speak the MCP protocol, like Claude Desktop, Claude Code, Cursor, or VS Code. Point a client at your instance once and every tool from every app installed in your workspaces becomes available inside that client, without switching to the web UI.
+NimbleBrain can act as a tool server for external apps that speak the MCP protocol, like Claude Desktop, Claude Code, Cursor, or VS Code. Point a client at your instance, name a workspace, and every tool from every app installed there becomes available inside that client, without switching to the web UI.
 
 NimbleBrain exposes a single programmatic surface for this: the `/mcp` Streamable HTTP endpoint. For the protocol-level reference (methods, sessions, OAuth discovery), see [The /mcp Endpoint](/connect/mcp-endpoint).
 
@@ -27,13 +27,12 @@ Clients that support MCP OAuth discovery (Claude Code, Claude Desktop, Cursor) h
 ## What you need
 
 - **Instance URL** — the address of your NimbleBrain instance (for example, `https://your-team.nimblebrain.ai`). Append `/mcp` to form the endpoint URL.
-
-That is all the client config needs. You do not set a workspace header.
+- **Workspace ID** — the `X-Workspace-Id` header that scopes the session to one workspace. Find it under **Settings → This Workspace → General** in the "MCP Connection" card.
 
 <Aside type="note" title="Where workspace context comes from">
-NimbleBrain `/mcp` sessions are bound to your **identity**, not to a single workspace. Your tool list aggregates across every workspace you belong to. Each tool name carries its own workspace scope: a workspace tool is named `ws_<id>-<source>__<tool>` (for example, `ws_1a2b...-crm__search`), so the call routes to the right workspace by name. Identity-owned tools (`conversations__*`, `files__*`, `automations__*`) are bare and live outside any workspace.
+A NimbleBrain `/mcp` session is bound to your **identity**, but each request names its workspace with the `X-Workspace-Id` header — validated against your membership. `tools/list` returns that workspace's tools (named `ws_<id>-<source>__<tool>`, for example `ws_1a2b...-crm__search`) plus your identity tools (`conversations__*`, `files__*`, `automations__*`, which are bare). A `tools/call` to any **other** workspace is refused with `-32602 workspace_access_denied`.
 
-You do **not** set an `X-Workspace-Id` header. The endpoint ignores it. If you need a specific workspace's ID for reference, find it under **Settings → This Workspace → General** in the "MCP Connection" card.
+If you send no `X-Workspace-Id` (or one you aren't a member of), the session exposes identity tools only. Clients that can't set a header still get a usable, identity-scoped surface.
 </Aside>
 
 <Aside type="note">
@@ -90,7 +89,7 @@ Any client that implements Streamable HTTP transport and either OAuth 2.0 (RFC 9
 
 ## What's exposed
 
-When an external client connects, it gets the tools installed across your workspaces, the same tools the agent uses in the web UI. The client sees a flat tool list; NimbleBrain routes each call to the right app internally based on the namespaced tool name.
+When an external client connects, it gets the tools installed in the workspace it named with `X-Workspace-Id`, plus your identity tools — the same tools the agent uses in the web UI. The client sees a flat tool list; NimbleBrain routes each call to the right app internally based on the namespaced tool name.
 
 Two filters apply:
 

--- a/docs/src/content/docs/deploy/docker.mdx
+++ b/docs/src/content/docs/deploy/docker.mdx
@@ -5,7 +5,7 @@ description: Deploy NimbleBrain on a single machine with Docker Compose.
 
 import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
-NimbleBrain ships two container images: **`ghcr.io/nimblebraininc/nimblebrain`** (agent engine + API on port 27247, internal) and **`ghcr.io/nimblebraininc/nimblebrain-web`** (React UI served by Caddy, exposed on port 27246). Docker Compose runs both on a single machine with a shared internal network.
+NimbleBrain ships two container images: **`ghcr.io/nimblebraininc/nimblebrain-runtime`** (agent engine + API on port 27247, internal) and **`ghcr.io/nimblebraininc/nimblebrain-web`** (React UI served by Caddy, exposed on port 27246). Docker Compose runs both on a single machine with a shared internal network.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ Create a project directory and add this file:
 ```yaml title="docker-compose.yml"
 services:
   platform:
-    image: ghcr.io/nimblebraininc/nimblebrain:latest
+    image: ghcr.io/nimblebraininc/nimblebrain-runtime:latest
     build: .
     restart: unless-stopped
     volumes:
@@ -60,7 +60,7 @@ The platform reads its working directory from the `workspace` volume mounted at 
 
 | Service | Image | Port | Purpose |
 |---------|-------|------|---------|
-| `platform` | `ghcr.io/nimblebraininc/nimblebrain` | 27247 (internal) | Agent engine, HTTP API, MCP bundle manager |
+| `platform` | `ghcr.io/nimblebraininc/nimblebrain-runtime` | 27247 (internal) | Agent engine, HTTP API, MCP bundle manager |
 | `web` | `ghcr.io/nimblebraininc/nimblebrain-web` | 27246 (host) → 8080 (container) | React SPA served by Caddy, proxies `/v1/*` to platform |
 
 The `web` container runs Caddy, which serves the static UI files and reverse-proxies all `/v1/*` API requests to the platform container. The platform container is **not** exposed to the host — all traffic flows through the web container.
@@ -225,7 +225,7 @@ docker compose up -d
 
 ## Platform image details
 
-The `ghcr.io/nimblebraininc/nimblebrain` image is built on `python:3.13-slim` (Python is the base so Python-based MCP bundles run natively) and adds the Bun runtime plus the tooling bundles shell out to:
+The `ghcr.io/nimblebraininc/nimblebrain-runtime` image is built on `python:3.13-slim` (Python is the base so Python-based MCP bundles run natively) and adds the Bun runtime plus the tooling bundles shell out to:
 
 | Component | Version | Purpose |
 |-----------|---------|---------|

--- a/docs/src/content/docs/deploy/security.mdx
+++ b/docs/src/content/docs/deploy/security.mdx
@@ -42,10 +42,10 @@ For the OIDC and WorkOS adapters, sign-in is an authorization-code flow, not a l
 
 ### Failed authentication logging
 
-Every failed authentication attempt is logged to stderr with the client IP and timestamp:
+Every failed authentication attempt is logged to stderr with the client IP in a structured field:
 
 ```
-[nimblebrain] AUTH FAIL ip=203.0.113.42 timestamp=2026-03-25T22:00:00.000Z
+[auth] authentication failed { ip: "203.0.113.42" }
 ```
 
 The IP comes from the `X-Forwarded-For` header (set by your reverse proxy) or `"direct"` for direct connections. Monitor these logs for brute-force attempts.
@@ -278,23 +278,6 @@ MCP bundles run as subprocesses with access to the filesystem and network inside
 
 Each bundle in the mpak registry has an MTF (mpak Trust Framework) trust score from 0 to 100. The score is stored in `nimblebrain.json` alongside the bundle entry and displayed in the web UI's app list.
 
-### Protected bundles
-
-Mark bundles as `protected` in your configuration to prevent the agent from uninstalling them:
-
-```json title="nimblebrain.json"
-{
-  "bundles": [
-    {
-      "name": "@nimblebraininc/ipinfo",
-      "protected": true
-    }
-  ]
-}
-```
-
-A protected bundle cannot be uninstalled through the connectors catalog (`manage_connectors`). You must edit the workspace configuration and restart to remove it.
-
 ### Bundle isolation
 
 Bundles run as child processes inside the platform container. They share the container's filesystem, network namespace, and user. To limit blast radius:
@@ -315,6 +298,5 @@ Use this checklist before exposing NimbleBrain to any network:
 | TLS enabled | `curl -I https://nb.example.com` returns a valid certificate |
 | `X-Forwarded-For` header set by proxy | Check auth failure logs for real IPs, not `"direct"` |
 | Bundle list reviewed | `cat nimblebrain.json` — only bundles you trust are listed |
-| Critical bundles marked `protected` | Check for `"protected": true` on bundles you don't want the agent to remove |
 | Firewall restricts inbound ports | Only 443 (HTTPS) and 22 (SSH) reachable from the internet |
 | Backups configured | Test your volume backup and restore procedure |

--- a/docs/src/content/docs/guide/interface.mdx
+++ b/docs/src/content/docs/guide/interface.mdx
@@ -16,6 +16,7 @@ When you sign in to NimbleBrain, you land on the main workspace view. The interf
 The sidebar is your main navigation. From top to bottom:
 
 - **Avatar / workspace navigator** — At the **top-left**, your avatar anchors the sidebar. Open it to switch workspaces, reach **Profile settings**, or **Sign out**.
+- **Search** — A search chip (`⌘P` / `Ctrl-P`) that opens the command palette to jump to anything or run a command.
 - **Home** — Returns to the workspace home screen.
 - **Conversations** — Opens your conversation history (owned by you, across all workspaces).
 - **Automations** — Opens your scheduled agent runs.

--- a/docs/src/content/docs/guide/shortcuts.mdx
+++ b/docs/src/content/docs/guide/shortcuts.mdx
@@ -7,6 +7,12 @@ Use these shortcuts to navigate the interface without reaching for the mouse.
 
 ![Keyboard shortcuts modal](../../../assets/guide/shortcuts-modal.png)
 
+## Navigation
+
+| Shortcut | Action |
+|----------|--------|
+| **Cmd+P** / **Ctrl+P** | Open the command palette |
+
 ## Chat
 
 | Shortcut | Action |
@@ -28,7 +34,7 @@ Use these shortcuts to navigate the interface without reaching for the mouse.
 | **Enter** | Send message |
 | **Shift+Enter** | New line (without sending) |
 | `/clear` (typed in input) | Start a new conversation |
-| **Cmd+V** / **Ctrl+V** | Paste image from clipboard as attachment |
+| **Cmd+V** / **Ctrl+V** | Paste a file from the clipboard as an attachment |
 
 ## General
 

--- a/docs/src/content/docs/using/automations.mdx
+++ b/docs/src/content/docs/using/automations.mdx
@@ -20,9 +20,9 @@ An automation has:
 
 ## Who an automation runs as
 
-Automations are **owned by the user who creates them**, not by a workspace. A scheduled run fires as its owner, focused on the workspace it was created in, but with full reach across every workspace that owner belongs to.
+Each automation is **owned by a workspace and a user** — it lives at `workspaces/<wsId>/automations/<ownerId>/`, and that path is the wall. A scheduled run fires as its owner, focused on the workspace it was created in, and is walled to that **provenance workspace**: it reaches only the tools and connectors installed there, with no reach into the owner's other workspaces.
 
-This has one practical consequence: if an automation needs to reach a connector (for example, to post to Teams or Slack), that connector must be installed in a **shared** workspace the owner is a member of. A connector that lives only in someone's personal workspace is never reachable by another user's automation.
+This has one practical consequence: if an automation needs to reach a connector (for example, to post to Teams or Slack), that connector must be installed in the **same workspace the automation was created in**. A connector connected only in another workspace — including the owner's personal workspace — is never reachable by that automation, and a run that tries is recorded as a failure.
 
 <Aside type="note">
 Automation runs use your **timezone** for cron scheduling. The default is `Pacific/Honolulu`, overridable by the operator with the `NB_TIMEZONE` environment variable. A schedule can also carry its own IANA timezone.
@@ -75,5 +75,5 @@ Every run is recorded with its status, start and completion times, iteration cou
 ## What's next
 
 - [Chat](/using/chat) — the interactive counterpart to a scheduled run
-- [Connectors](/using/connectors) — install the connectors an automation posts to in a shared workspace
-- [Workspaces](/using/workspaces) — owner reach and shared-workspace semantics
+- [Connectors](/using/connectors) — install the connectors an automation posts to in its own workspace
+- [Workspaces](/using/workspaces) — workspace ownership and the per-workspace wall

--- a/docs/src/content/docs/using/connectors.mdx
+++ b/docs/src/content/docs/using/connectors.mdx
@@ -24,19 +24,20 @@ A connected service is **shared by everyone in the workspace** — its tools are
 4. Sign in and approve the requested access. You're returned to NimbleBrain, and the connector's row updates to **Connected** once the handshake settles.
 </Steps>
 
-Installing or connecting a service requires the **Admin** or **Owner** role in the workspace.
+Installing or connecting a service requires the **admin** role in the workspace.
 
 On a connector's **Configure** page you can see who you're connected as, **Disconnect** (reversible — reconnecting re-runs the sign-in flow), and review or adjust which of the connector's tools are allowed.
 
-## The three auth modes
+## The four auth modes
 
-Connectors authenticate in one of three ways. As an end user you rarely need to care which — the **Install / Connect** button does the right thing — but it helps to know what's happening:
+Connectors authenticate in one of four ways. As an end user you rarely need to care which — the **Install / Connect** button does the right thing — but it helps to know what's happening:
 
 | Mode | What it means | What you do |
 |------|---------------|-------------|
 | **dcr** | Dynamic Client Registration. The platform registers an OAuth client with the vendor on the fly. | Click **Install**, sign in. No setup. |
 | **static** | The vendor requires a pre-registered OAuth app. A workspace admin configures the app's client ID and secret once. | An admin clicks **Set up** first; after that, everyone connects with **Install**. |
 | **composio** | The service is brokered through Composio, a managed-connector provider. | Click **Install**. OAuth toolkits send you through the vendor's sign-in; API-key toolkits open a short form where you paste the service's API key (and any region/host it needs). Requires the platform operator to have configured Composio. |
+| **provider** | A platform-managed connector whose credential is minted server-side by a named credential provider — no vendor sign-in, no operator OAuth app, no per-user secret. | Click **Install**. The platform produces the credential for you; there is nothing to enter. |
 
 For a **static**-auth connector that hasn't been set up yet, non-admins see "Operator setup required" until an admin completes the one-time **Set up** step.
 

--- a/docs/src/content/docs/using/conversations.mdx
+++ b/docs/src/content/docs/using/conversations.mdx
@@ -9,13 +9,13 @@ NimbleBrain automatically persists every conversation. Each conversation is stor
 
 ## Where conversations live
 
-Conversations are **owned by you**, not by a workspace. Every conversation lives at the top level of the work directory, keyed by its ID:
+Conversations are **partitioned by workspace** and authorized by their owner. Every conversation lives under the workspace it ran in and the user who created it, keyed by its ID:
 
 ```
-~/.nimblebrain/conversations/conv_a1b2c3d4e5f67890.jsonl
+~/.nimblebrain/workspaces/ws_3f9a1c7e0b2d4856/conversations/user_abc123/conv_a1b2c3d4e5f67890.jsonl
 ```
 
-A conversation records which workspace's tools the agent could reach when a turn ran (`workspaceId` in its metadata), but that is a tool-scoping breadcrumb, not a location. The file always lives under `conversations/` regardless of which workspace you were in, and it follows you across every workspace you belong to.
+The path is the authority: `workspaces/<wsId>/conversations/<ownerId>/<convId>.jsonl`. The owner (`ownerId`) is the single authorization principal — only they can read or resume the conversation — while the workspace (`workspaceId`) is where it is stored and which tools the agent could reach when a turn ran.
 
 <Aside type="note">
 Conversation IDs follow the pattern `conv_` followed by 16 hex characters (for example `conv_a1b2c3d4e5f67890`). They are generated from a UUIDv4 with the dashes stripped.

--- a/docs/src/content/docs/using/installing-apps.mdx
+++ b/docs/src/content/docs/using/installing-apps.mdx
@@ -34,7 +34,7 @@ The chat panel and app content work side by side. Ask the agent a question about
        - For a stdio bundle, the install completes in place and you land on the app's **Configure** page to fill in any required fields.
     </Steps>
 
-    Installs are scoped to the workspace named by the URL you're viewing (`/w/<slug>/...`). Installing an app requires the **Admin** or **Owner** role in that workspace.
+    Installs are scoped to the workspace named by the URL you're viewing (`/w/<wsId>/...`, where `<wsId>` is the opaque workspace ID with its `ws_` prefix dropped). Installing an app requires the **admin** role in that workspace.
   </TabItem>
   <TabItem label="Ask the agent">
     The agent can install apps for you. Just ask:

--- a/docs/src/content/docs/using/managing-apps.mdx
+++ b/docs/src/content/docs/using/managing-apps.mdx
@@ -60,35 +60,13 @@ Uninstall a bundle through the agent or the web UI:
 The agent uses `manage_connectors` (the `uninstall` action). There is no CLI command for this.
 
 Uninstalling a bundle:
-1. Checks the `protected` flag — rejects if protected
-2. Stops the MCP server process
-3. Removes the source from the tool registry
-4. Removes the entry from `nimblebrain.json` atomically
-5. Clears the bundle's [credential file](/config/credentials/) for this workspace (best-effort; a failure logs a warning but doesn't block the uninstall)
-6. Emits a `bundle.uninstalled` event
+1. Stops the MCP server process
+2. Removes the source from the tool registry
+3. Removes the entry from `nimblebrain.json` atomically
+4. Clears the bundle's [credential file](/config/credentials/) for this workspace (best-effort; a failure logs a warning but doesn't block the uninstall)
+5. Emits a `bundle.uninstalled` event
 
-Bundle **data** (Upjack entity state, bundle-owned files under `{workDir}/workspaces/{wsId}/data/{bundle}`) is preserved. Only credentials are cleared. Credentials in other workspaces are untouched.
-
-## Protected bundles
-
-Mark a bundle as protected in `nimblebrain.json` to prevent it from being uninstalled:
-
-```json
-{
-  "bundles": [
-    {
-      "name": "@nimblebraininc/ipinfo",
-      "protected": true
-    }
-  ]
-}
-```
-
-Attempting to uninstall a protected bundle produces an error:
-
-```
-Cannot uninstall "ipinfo": bundle is protected
-```
+Every connector is user-removable — install and uninstall are symmetric for all bundle classes, with no exempt or pinned bundles. Bundle **data** (Upjack entity state, bundle-owned files under `{workDir}/workspaces/{wsId}/data/{bundle}`) is preserved. Only credentials are cleared. Credentials in other workspaces are untouched.
 
 ## Trust scores
 

--- a/docs/src/content/docs/using/telemetry.mdx
+++ b/docs/src/content/docs/using/telemetry.mdx
@@ -15,8 +15,7 @@ Telemetry events fall into four categories:
 
 | Event | Properties |
 |-------|-----------|
-| `cli.command` | Command name (`serve` or `dev`), flag names only (never values), NimbleBrain version, OS, architecture, Bun version |
-| `cli.startup` | Command, bundle count, skill count, startup time in ms |
+| `cli.startup` | Mode (`serve`), bundle count, startup time in ms |
 
 ### Agent loop events
 
@@ -109,7 +108,7 @@ On first run, when the `.telemetry-id` file is created, NimbleBrain prints this 
 ```
 NimbleBrain collects anonymous usage telemetry to improve the platform.
 No personal data, conversation content, or file paths are ever sent.
-Set NB_TELEMETRY_DISABLED=1 to disable.  Learn more: https://nimblebrain.ai/telemetry
+Set NB_TELEMETRY_DISABLED=1 (or DO_NOT_TRACK=1) to disable.  Learn more: https://nimblebrain.ai/telemetry
 ```
 
 This notice appears exactly once per work directory.

--- a/docs/src/content/docs/using/workspaces.mdx
+++ b/docs/src/content/docs/using/workspaces.mdx
@@ -14,7 +14,7 @@ A workspace is an isolated environment within a NimbleBrain instance. It contain
 - **Apps and connectors** — each workspace has its own set of installed MCP bundles and connectors
 - **Members** — users with assigned roles who can access the workspace
 
-When you send a chat message, it runs in the context of your focused workspace, and the agent's active tool set is scoped to the apps installed there. **Conversations are not part of a workspace** — they belong to you and follow you across every workspace you're a member of. See [Conversations](/using/conversations) for how ownership works.
+When you send a chat message, it runs in the context of your focused workspace, and the agent's active tool set is scoped to the apps installed there. **Conversations are partitioned by workspace** — each one is stored under the workspace it ran in and authorized by its owner. See [Conversations](/using/conversations) for how ownership and storage work.
 
 <Aside type="note">
 Workspace IDs are opaque tokens of the form `ws_<16-hex>` (for example `ws_3f9a1c7e0b2d4856`). The ID is assigned once at creation and never derived from the name — renaming a workspace does not change its ID or its URL. Treat the ID as opaque: never parse it for meaning. Your personal workspace is the one exception, with a stable `ws_user_<userId>` form.
@@ -22,22 +22,21 @@ Workspace IDs are opaque tokens of the form `ws_<16-hex>` (for example `ws_3f9a1
 
 ## Roles
 
-Every workspace member has one of three roles:
+Every workspace member has one of two roles:
 
 | Role | Capabilities |
 |------|-------------|
-| **Owner** | Full access. Can manage members, apps, and settings. Cannot be removed. |
-| **Admin** | Can manage members and apps. |
+| **Admin** | Can manage members, apps, and connectors. |
 | **Member** | Can chat and use tools. Cannot manage other members. |
 
 ## What workspaces isolate
 
-| Scoped to workspace | Owned by you (cross-workspace) |
-|---------------------|--------------------------------|
+| Scoped to workspace | Identity-level (cross-workspace) |
+|---------------------|----------------------------------|
 | Installed apps and connectors | Your user account and login |
-| Members and roles | Your conversations and history |
-| Per-workspace credentials | Your files and automations |
-| | Your profile settings (name, theme, timezone) |
+| Members and roles | Your profile settings (name, theme, timezone) |
+| Per-workspace credentials | |
+| Conversations, files, and automations | |
 
 ## Creating a workspace
 
@@ -62,12 +61,12 @@ The tool supports these actions:
 | Action | Description |
 |--------|-------------|
 | `add` | Add a user to the workspace with a specified role |
-| `remove` | Remove a user from the workspace (cannot remove the owner) |
+| `remove` | Remove a user from the workspace |
 | `update` | Change a member's role |
 | `list` | List all members and their roles |
 
 <Aside type="note">
-Only workspace admins and the owner can manage members. Regular members cannot add or remove other users.
+Only workspace admins can manage members. Regular members cannot add or remove other users.
 </Aside>
 
 ## Workspace-scoped apps
@@ -96,10 +95,10 @@ NimbleBrain guarantees every authenticated user has at least one workspace. The 
 
 ## Connecting external MCP clients
 
-The `/mcp` endpoint is **identity-bound**, not workspace-bound. A single connection aggregates your tools across every workspace you belong to, and the tool name itself carries the workspace scope. You do **not** need to send an `X-Workspace-Id` header — it is ignored on `/mcp`. See [Connecting External Clients](/connect/external-clients) for setup.
+The `/mcp` endpoint authenticates you by **identity**, but each request scopes to one workspace via the `X-Workspace-Id` header — validated against your membership. `tools/list` returns that workspace's tools plus your identity tools, and a `tools/call` to any other workspace is refused. A request with no `X-Workspace-Id` exposes identity tools only. See [Connecting External Clients](/connect/external-clients) for setup.
 
 ## What's next
 
-- [Conversations](/using/conversations) — conversations are owned by you, not by a workspace
+- [Conversations](/using/conversations) — conversations are partitioned by workspace and authorized by owner
 - [Managing Apps](/using/managing-apps) — install and configure bundles per workspace
 - [Connecting External Clients](/connect/external-clients) — connect Claude Desktop, Cursor, and other MCP clients

--- a/src/api/routes/mcp.ts
+++ b/src/api/routes/mcp.ts
@@ -85,11 +85,12 @@ export function mcpRoutes(ctx: AppContext) {
     async (c) => {
       const features = ctx.runtime.getFeatures();
 
-      // Stage 2: `/mcp` sessions are identity-bound only. The `X-Workspace-Id`
-      // header is no longer consulted here — the host logs once at debug
-      // (`NB_DEBUG=mcp`) if a client still sends one. Tool calls derive their
-      // target workspace from the namespaced tool name on every call (parsed
-      // and routed by the orchestrator).
+      // `/mcp` sessions are identity-bound, walled to a per-request workspace:
+      // each request names its focused workspace via the `X-Workspace-Id` header.
+      // The host honors that header and validates the caller's membership before
+      // scoping the request to that workspace; with no header the session sees
+      // identity-level tools only. Tool calls also carry their target workspace
+      // in the namespaced tool name (parsed and routed by the orchestrator).
       const identity = c.var.identity;
       if (!identity || !ctx.workspaceStore) {
         return apiError(

--- a/src/bundles/types.ts
+++ b/src/bundles/types.ts
@@ -316,8 +316,9 @@ export interface HostManifestMeta {
    * check at runtime and fall back gracefully (e.g. structured tool error
    * teaching the agent to retry with inline content).
    *
-   * Presence of this field requires `host_version: "1.1"` (enforced by
-   * the JSON Schema's `if/then`).
+   * This field belongs to `host_version: "1.1"` by convention. The host
+   * is forward-compatible and does not reject a version/field mismatch —
+   * nothing in the JSON Schema binds the two.
    */
   host_capabilities?: Record<string, HostCapabilityRequirement>;
 }

--- a/src/workspace/scaffold.ts
+++ b/src/workspace/scaffold.ts
@@ -4,10 +4,11 @@ import { join } from "node:path";
 /**
  * Subdirectories created inside every workspace.
  *
- * `conversations/` was removed in Stage 1 Task 005 — conversations
- * live at `{workDir}/conversations/`, not under each workspace. The
- * `WorkspaceScope` enum still lists `"conversations"` for the
- * migration script's legacy-path detection; no live code writes there.
+ * `conversations/` is intentionally absent: conversation logs are not
+ * pre-scaffolded. The `conversations` `WorkspaceScope` resolves under
+ * `workspaces/<wsId>/conversations/<ownerId>/`, where each log is written
+ * lazily on first write. No live code writes a flat top-level
+ * `{workDir}/conversations/` dir.
  */
 export const WORKSPACE_DIRS = ["data", "credentials", "skills", "files"] as const;
 


### PR DESCRIPTION
## What

A full accuracy audit of `docs/` against the codebase at current `main`. Most pages were accurate; this PR fixes the claims that had drifted from the implementation. Every change was verified against source before editing, and the docs site builds clean (54 pages, all internal links valid).

## Root causes

Most High-severity findings trace to two areas where the docs lagged the code:

**1. Workspace ownership + the `/mcp` workspace wall.** Conversations, files, and automations are workspace-owned (`workspaces/<wsId>/...`). `/mcp` honors and membership-validates `X-Workspace-Id` per request (no header ⇒ identity-level tools only; cross-workspace calls denied `-32602`) — it does **not** aggregate tools across workspaces.
- `connect/external-clients.mdx` claimed the header is ignored and tools aggregate → corrected to mirror `mcp-endpoint.mdx`.
- `using/workspaces.mdx`, `using/conversations.mdx`, `using/automations.mdx`, `config/environment.mdx`, `concepts.mdx` → corrected ownership/location/reach claims.
- Scheduled automations are walled to their provenance workspace (no cross-workspace reach).

**2. MCP-App manifest shape.**
- `settings` is a **placement slot**, not a top-level object (the top-level object is silently ignored by the host).
- `primaryView` is **not consumed** — the virtual `primary` path resolves to the **first placement's** `resourceUri`.
- `host_version: "1.1"` is **not** schema-enforced against the `host_capabilities` block.
- `category` is a reserved, unconsumed free-form field (no enum).
- Fixes `apps/manifest`, `apps/custom-instructions`, `apps/overview`, `apps/ui-resources`, `apps/host-capabilities`, `apps/placements`, plus the persisted `ui` shape in `concepts.mdx`, `concepts/mcp-apps.mdx`, `config/bundles.mdx`.

## Other corrections

- **`protected` bundle field does not exist** — `lifecycle.ts` is explicit that every connector is user-removable (no guard). Removed from `config/bundles`, `deploy/security` (a whole subsection + checklist row), `using/managing-apps` (uninstall step), and `concepts`.
- **`config/logging`** described the unwired `StructuredLogSink`. Rewritten for the active `WorkspaceLogSink`: path `{dir}/workspace/YYYY-MM-DD.jsonl`, the real workspace-event set; removed the nonexistent `iteration.done` and run-cost/token metrics.
- **`store` defaults to in-memory**, not `jsonl`, and conversation persistence is workspace-owned regardless of it — corrected the "CLI defaults to jsonl" claim in `config/nimblebrain-json`.
- **`using/connectors`**: four auth modes (adds `provider`); workspace roles are `admin`/`member` only (no "Owner") — also fixed in `using/installing-apps`.
- **`cli/overview`**: corrected config-resolution order (adds project-local `./.nimblebrain/`, bare-CWD fallback) and the auto-created default config (`{$schema, version}` only).
- **`deploy/security`**: failed-auth log line is `[auth] authentication failed` (structured `ip` field), not `AUTH FAIL`.
- **`using/telemetry`**: there is no `cli.command` event (only `cli.startup`); first-run notice includes `DO_NOT_TRACK`.
- **`guide/shortcuts` + `guide/interface`**: document the `Cmd/Ctrl+P` command palette; paste attaches any file, not only images.
- **`deploy/docker`**: aligned the platform image to `nimblebrain-runtime` (matches the shipped `docker-compose.yml`).

## Code change

`src/api/routes/mcp.ts` carried a stale comment claiming `X-Workspace-Id` is "no longer consulted" — the runtime does consult and membership-validate it. Comment-only fix; no behavior change.

## Verification

`cd docs && bun run build` → 54 pages, all internal links valid.