### PR TITLE
Runtime: a request timeout surfaces instead of restarting the bundle (fixes the web-mcp cascade)

### DIFF
--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -1332,13 +1332,15 @@ export class McpSource implements ToolSource {
         return shape.reauth(err);
       }
       if (action === "surface") {
-        // Giving up on a genuine connection failure we won't retry (a
-        // non-idempotent op — e.g. a task-augmented call whose transport broke).
-        // Mark the source crashed so HealthMonitor heals it for later calls; the
-        // transport is actually broken even though we don't retry this call.
-        // `auth-lost` is a credential problem, not a transport crash — excluded,
-        // so a static-auth 401 surfaces without thrashing restarts.
-        if (kind !== "auth-lost") this.emitSourceCrashed(String(err));
+        // Mark the source crashed ONLY for a genuine connection-down class we
+        // won't retry (e.g. a task-augmented call whose transport broke), so
+        // HealthMonitor heals it for later calls. A `timeout` (the tool is slow,
+        // transport is fine) and `auth-lost` (a credential problem) are NOT the
+        // transport crashing — restarting the source for them would tear it down
+        // for its other tools (the #581 cascade), so they surface without it.
+        if (kind === "session-lost" || kind === "transient" || kind === "transport-dead") {
+          this.emitSourceCrashed(String(err));
+        }
         return shape.surface(err);
       }
       // action === "recover": re-establish + retry, riding the roll window.
@@ -2150,6 +2152,7 @@ export type ConnectionFailure =
   | "transient"
   | "transport-dead"
   | "auth-lost"
+  | "timeout"
   | "unknown"
   | "none";
 
@@ -2197,11 +2200,24 @@ export function classifyConnectionFailure(err: unknown): ConnectionFailure {
   // non-404 status. Gating on the status would silently strand those. Matching the
   // message also takes precedence over the `-32600 → none` branch below, so a
   // session loss carrying the -32600 code still recovers instead of surfacing.
-  // (`-32001` is the canonical session-expired code; the SDK also reuses it for
-  // RequestTimeout — both are recover-eligible, and the tool path caps replays at
-  // one, so a processed-then-timed-out call isn't re-sent repeatedly.)
-  if (code === -32001 || /session not found/i.test(msg)) {
+  if (/session not found/i.test(msg)) {
     return "session-lost";
+  }
+  // timeout — the SDK throws `McpError(-32001, "Request timed out")` when a call
+  // exceeds the request timeout. This is NOT a session loss (that's the message
+  // above) and NOT a transport crash: the request was sent, the response is just
+  // slow. Restarting abandons the in-flight call and tears the source down for
+  // every other tool, but can't make a slow tool faster — so it surfaces (policy),
+  // never restarts. A transport that actually closes or errors still recovers via
+  // its own signal (onclose → `emitSourceCrashed`; ECONNRESET / "fetch failed" /
+  // -32000 → `transport-dead`). NOTE there is no liveness probe, so a half-open
+  // socket whose ONLY symptom is a client-side -32001 is not auto-reaped today —
+  // but restarting wouldn't speed up a slow tool anyway (that IS the #581 cascade);
+  // a real liveness probe is the fix for that narrow case. Checked after the
+  // session-message match so an artificial -32001+session-text still classifies
+  // session-lost. (See #581 — a tool timeout was cascading bundle restarts in prod.)
+  if (code === -32001) {
+    return "timeout";
   }
   // transient — a mid-roll gateway blip (502/503/504, `bad_gateway`). Back off.
   if (
@@ -2267,6 +2283,10 @@ export function policyFor(
   ctx: { idempotent: boolean; hasReauthableProvider: boolean },
 ): RecoveryAction {
   if (kind === "auth-lost") return ctx.hasReauthableProvider ? "reauth" : "surface";
+  // A request timeout never restarts (the tool is slow, not the transport broken;
+  // restarting would tear the source down for its other tools). Surface it so the
+  // agent can decide — retry a smaller batch, or the tool should be task-augmented.
+  if (kind === "timeout") return "surface";
   // session-lost / transient / transport-dead: re-establishable iff the op is safe to repeat.
   return ctx.idempotent ? "recover" : "surface";
 }

--- a/src/tools/mcp-source.ts
+++ b/src/tools/mcp-source.ts
@@ -2158,16 +2158,21 @@ export type ConnectionFailure =
 
 /**
  * Classify a thrown error into a connection-failure class. Order matters:
- * `session-lost` and `transient` are checked first (most specific), then
- * `auth-lost`, then the standard protocol codes, then recognized torn-transport
- * shapes, with `unknown` as the residue.
+ * `session-lost` (by message) is checked first, then the `-32001` `timeout`, then
+ * `transient`, `auth-lost`, the standard protocol codes, and recognized
+ * torn-transport shapes, with `unknown` as the residue.
  *
  * - **session-lost** — the server forgot our Streamable-HTTP session (it rolled).
- *   Matched on the "session not found" MESSAGE (plus the `-32001` code), NOT the
- *   HTTP status: the fleet servers' Python SDK returns it as HTTP 404 with a
+ *   Matched on the "session not found" MESSAGE, NOT the HTTP status or code: the
+ *   fleet servers' Python SDK returns it as HTTP 404 with a
  *   `{"code":-32600,"message":"Session not found"}` body (so the client's
  *   `StreamableHTTPError.code` is 404 and the `-32600` is body text), but remote
  *   bundles are untrusted/heterogeneous — the message is the reliable signal.
+ * - **timeout** — `McpError(-32001, "Request timed out")`: the request was sent
+ *   but the response is slow (the tool, not the transport). Surfaces, never
+ *   restarts — restarting strands the source's other tools without speeding the
+ *   slow one (#581). Checked after the session message so a `-32001` carrying
+ *   session text still classifies session-lost.
  * - **transient** — a mid-roll gateway blip (502/503/504, `bad_gateway`). Back off.
  * - **auth-lost** — a rejected credential. Detectable only as `UnauthorizedError`;
  *   note its recovery *policy* is config-dependent — a static-auth remote can't

--- a/test/unit/mcp-failure-taxonomy.test.ts
+++ b/test/unit/mcp-failure-taxonomy.test.ts
@@ -20,10 +20,21 @@ describe("classifyConnectionFailure — op-independent connection classes", () =
     message: 'Error POSTing to endpoint: {"code":-32001,"message":"Session not found"}',
   };
 
-  it("classifies session loss (canonical 404 + a non-canonical -32001)", () => {
+  it("classifies session loss by message (status/code-independent)", () => {
     expect(classifyConnectionFailure(sessionLost404)).toBe("session-lost");
+    // The session-message match wins even when the code is -32001 (which alone is a timeout).
     expect(classifyConnectionFailure(new McpError(-32001, "Session not found"))).toBe(
       "session-lost",
+    );
+  });
+
+  it("classifies a request timeout (-32001) as 'timeout', NOT session-lost or transport-dead", () => {
+    // The SDK throws McpError(-32001, "Request timed out") on a request timeout.
+    // It's the tool being slow, not a session loss or a broken transport — so it
+    // must surface (policyFor), never restart the source (#581 cascade).
+    expect(classifyConnectionFailure(new McpError(-32001, "Request timed out"))).toBe("timeout");
+    expect(classifyConnectionFailure({ code: -32001, message: "MCP error -32001: Request timed out" })).toBe(
+      "timeout",
     );
   });
 

--- a/test/unit/mcp-source-recovery.test.ts
+++ b/test/unit/mcp-source-recovery.test.ts
@@ -83,6 +83,12 @@ describe("policyFor — recovery policy", () => {
     expect(policyFor("auth-lost", idem)).toBe("surface");
     expect(policyFor("auth-lost", task)).toBe("surface");
   });
+
+  it("timeout always surfaces (never restarts), regardless of idempotency", () => {
+    expect(policyFor("timeout", idem)).toBe("surface");
+    expect(policyFor("timeout", task)).toBe("surface");
+    expect(policyFor("timeout", reauthable)).toBe("surface");
+  });
 });
 
 describe("execute (tools/call) — unified recovery", () => {

--- a/test/unit/mcp-source-recovery.test.ts
+++ b/test/unit/mcp-source-recovery.test.ts
@@ -100,6 +100,28 @@ describe("execute (tools/call) — unified recovery", () => {
     }
   });
 
+  it("surfaces a request timeout WITHOUT restarting the source (no #581 cascade)", async () => {
+    // A slow tool that times out must NOT restart the bundle — that would tear it
+    // down for its sibling tools. Surface a clean error; source stays alive + no crash.
+    const events: EngineEvent[] = [];
+    const sink: EventSink = { emit: (e) => events.push(e) };
+    const source = remoteSource({
+      callTool: () => Promise.reject(new McpError(-32001, "Request timed out")),
+      sink,
+    });
+    const restart = spyRestart(source, true);
+    try {
+      const result = await source.execute("web_fetch", {});
+      expect(result.isError).toBe(true);
+      expect(restart).not.toHaveBeenCalled(); // timeout → surface, never restart
+      expect(events.filter((e) => (e.data as { event?: string }).event === "source.crashed")).toHaveLength(
+        0,
+      );
+    } finally {
+      restart.mockRestore();
+    }
+  });
+
   it("recovers a torn transport: re-establish + retry returns the result", async () => {
     let calls = 0;
     const source = remoteSource({


### PR DESCRIPTION
Closes #581.

## Problem (observed in prod)

A `tools/call` that exceeds the ~60s MCP request timeout throws `McpError(-32001, "Request timed out")`. The classifier mapped `-32001 → session-lost → recover`, so the runtime **restarted the bundle source on the timeout** — which tore it down for its *other* tools. One slow `web_fetch` knocked out `web_search` + `deep_research` on the same source (siblings fast-failed in the restart window), producing the "crash loop, all web tools down" a user reported.

```
18:01:43 tool.done: …web-mcp__web_fetch (error, 60036ms)   ← 60s inline timeout (-32001)
18:00:43 source restarted: ai-nimblebrain-web-mcp
18:00:43 tool.done: …web-mcp__web_search   (error, 27ms)   ← fast-fail, source mid-restart
18:00:28 tool.done: …web-mcp__deep_research (error, 4ms)   ← fast-fail
```

(The web-server side — a slow fallback fetch with no deadline under the 60s cap — is platform#212. This PR is the **runtime amplifier**: a timeout shouldn't restart the bundle.)

## Fix

A request timeout is the tool being *slow*, not a session loss or a broken transport — restarting can't make it faster, and it strands the source's sibling tools.

- `-32001` now classifies as a distinct **`timeout`** kind. (The real session loss is the `/session not found/i` message — matched first; `-32001` was never session loss, the SDK uses it for `RequestTimeout`. This corrects a wrong assumption from #572.)
- Policy: **`timeout → surface`** — `recover` never restarts and never marks the source crashed, so it stays up for its other tools. The agent gets a clean "Request timed out" and can retry a smaller batch (or the tool should be task-augmented).
- A transport that actually closes/errors still recovers via its own signal (`onclose` / ECONNRESET / `-32000` → `transport-dead`).

## Known limitation (deliberate)

There is no liveness probe, so a half-open socket whose *only* symptom is a client-side `-32001` is not auto-reaped — but restarting wouldn't speed a slow tool anyway (that's exactly the #581 cascade). A real liveness probe is the proper fix for that narrow case; noted in the code and worth a follow-up.

## Review

Built on #576's recovery path. Adversarially reviewed (verdict: ship): cascade broken; no real session-recovery regression (session loss is message-matched); the no-retry and crash-emit invariants hold for every prior kind (the emit guard is equivalent minus the new `timeout`). The one finding — a comment that overstated the HealthMonitor backstop — is corrected.

Tests: `-32001 → timeout` (and `-32001`+session-message → still `session-lost`); a tool timeout surfaces with **no restart and no `source.crashed`** (the cascade scenario). 3865 unit tests + verify:static green.