### PR TITLE
fix(permissions): enforce connector disallow on the engine and /mcp doors

### DIFF
--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -94,6 +94,7 @@ import {
   UnknownToolSource,
   WorkspaceAccessDenied,
 } from "../orchestrator/index.ts";
+import { assertToolAllowed } from "../permissions/assert-tool-allowed.ts";
 import { type RequestContext, runWithRequestContext } from "../runtime/request-context.ts";
 import type { Runtime } from "../runtime/runtime.ts";
 import { IDENTITY_SOURCES } from "../tools/identity-sources.ts";
@@ -868,6 +869,30 @@ function createServer(
     const sourceName = sepIndex >= 0 ? innerToolName.slice(0, sepIndex) : null;
     const localName = sepIndex >= 0 ? innerToolName.slice(sepIndex + 2) : innerToolName;
     const wsId = workspaceContext.workspaceId;
+
+    // Connector permission gate. Runs BEFORE the task-vs-inline negotiation
+    // below so an operator's `disallow` is honored whether or not the tool is
+    // task-augmented — a disallowed task tool must be denied just like an
+    // inline one. Mirrors the engine door (`IdentityToolRouter`) and the REST
+    // registry gate, so all three doors enforce the same workspace policy.
+    if (sourceName) {
+      const denied = await assertToolAllowed(
+        runtime.getPermissionStore(),
+        wsId,
+        sourceName,
+        localName,
+      );
+      if (denied) {
+        return {
+          content: denied.content,
+          ...(denied.structuredContent !== undefined
+            ? { structuredContent: denied.structuredContent }
+            : {}),
+          isError: denied.isError,
+        };
+      }
+    }
+
     const wsRegistry = runtime.getRegistryForWorkspace(wsId);
     const taskAwareSource = sourceName ? wsRegistry.findTaskAwareSource(sourceName) : null;
     // Inspect the cached tool definition (if the source is MCP-backed) to

--- a/src/orchestrator/route.ts
+++ b/src/orchestrator/route.ts
@@ -32,6 +32,7 @@
 
 import type { ToolSchema } from "../engine/types.ts";
 import type { IdentityContext } from "../identity/context.ts";
+import type { PermissionStore } from "../permissions/permission-store.ts";
 import { parseNamespacedToolName, UnknownNamespacedToolName } from "../tools/namespace.ts";
 import type { ToolSource } from "../tools/types.ts";
 import type { WorkspaceContext } from "../workspace/context.ts";
@@ -190,6 +191,16 @@ export interface OrchestratorRuntime {
 
   /** Fresh `IdentityContext` for the authenticated identity. No workspace. */
   getIdentityContext(identityId: string): IdentityContext;
+
+  /**
+   * The workspace connector-permission store. Callers that dispatch a
+   * workspace-scoped tool consult it (via `assertToolAllowed`) to enforce an
+   * operator's per-tool `disallow` before `source.execute`. Optional: test
+   * stubs and non-production runtimes may omit it, in which case the
+   * permission gate is skipped (allow) — the production `Runtime` always
+   * provides it via `getPermissionStore`.
+   */
+  getPermissionStore?(): PermissionStore;
 
   /**
    * The walled tool surface for a session bounded to `wsId`: that workspace's

--- a/src/permissions/assert-tool-allowed.ts
+++ b/src/permissions/assert-tool-allowed.ts
@@ -1,0 +1,38 @@
+import { textContent } from "../engine/content-helpers.ts";
+import type { ToolResult } from "../engine/types.ts";
+import type { PermissionStore } from "./permission-store.ts";
+
+/**
+ * The single workspace connector-permission check. Returns the denied
+ * `ToolResult` (the structured `tool_permission_denied` envelope) when the
+ * workspace has set the tool's policy to `disallow`, otherwise `null` (allow).
+ *
+ * Every door that dispatches a WORKSPACE-scoped tool call — the chat engine
+ * (`IdentityToolRouter`), the external `/mcp` server, and the REST registry —
+ * runs this BEFORE `source.execute`, so an operator's `disallow` is honored
+ * uniformly rather than only on the door that happens to route through
+ * `ToolRegistry.execute`. `serverName` is the connector/source prefix;
+ * `toolName` is the bare local tool (no source prefix).
+ */
+export async function assertToolAllowed(
+  permissionStore: PermissionStore,
+  wsId: string,
+  serverName: string,
+  toolName: string,
+): Promise<ToolResult | null> {
+  const owner = { scope: "workspace" as const, wsId };
+  const policy = await permissionStore.get(owner, serverName, toolName);
+  if (policy !== "disallow") return null;
+  return {
+    content: textContent(
+      `Tool "${serverName}__${toolName}" is disabled by policy. Adjust in Settings → Connectors → ${serverName} → Configure.`,
+    ),
+    isError: true,
+    structuredContent: {
+      error: "tool_permission_denied",
+      connector: serverName,
+      tool: toolName,
+      scope: owner.scope,
+    },
+  };
+}

--- a/src/runtime/identity-tool-router.ts
+++ b/src/runtime/identity-tool-router.ts
@@ -36,6 +36,7 @@ import {
   type OrchestratorRuntime,
   routeToolCall,
 } from "../orchestrator/index.ts";
+import { assertToolAllowed } from "../permissions/assert-tool-allowed.ts";
 import {
   getRequestContext,
   type RequestContext,
@@ -147,9 +148,29 @@ export class IdentityToolRouter implements ToolRouter {
     // `routed.toolName` is the inner `<source>__<tool>` form (the
     // namespace primitive only strips the `ws_<id>-` prefix).
     // `ToolSource.execute` takes the bare local tool name (no source
-    // prefix) — mirroring `ToolRegistry.execute`'s contract.
+    // prefix) — mirroring `ToolRegistry.execute`'s contract. Split on the
+    // FIRST `__` so `sourcePrefix` is the connector/source name.
     const sepIndex = routed.toolName.indexOf("__");
+    const sourcePrefix = sepIndex >= 0 ? routed.toolName.slice(0, sepIndex) : routed.toolName;
     const bareToolName = sepIndex >= 0 ? routed.toolName.slice(sepIndex + 2) : routed.toolName;
+
+    // Connector permission gate. The engine door must honor an operator's
+    // per-tool `disallow` just like the REST registry gate does — otherwise a
+    // tool an admin disabled stays callable by the agent loop. Only
+    // workspace-routed calls carry a connector permission; identity-door tools
+    // (conversations / files / automations) have none — allow them through.
+    if (routed.kind === "workspace") {
+      const permissionStore = this.runtime.getPermissionStore?.();
+      if (permissionStore) {
+        const denied = await assertToolAllowed(
+          permissionStore,
+          routed.context.workspaceId,
+          sourcePrefix,
+          bareToolName,
+        );
+        if (denied) return denied;
+      }
+    }
 
     // Restamp the per-call scope from the ROUTED namespace, not ambient
     // state. Workspace agent / model overrides ride along on the workspace

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,6 +1,7 @@
 import { textContent } from "../engine/content-helpers.ts";
 import type { ToolCall, ToolResult, ToolRouter, ToolSchema } from "../engine/types.ts";
 import { log } from "../observability/log.ts";
+import { assertToolAllowed } from "../permissions/assert-tool-allowed.ts";
 import type { PermissionStore } from "../permissions/permission-store.ts";
 import type { McpSource } from "./mcp-source.ts";
 import { rankToolSearchResults } from "./search-ranking.ts";
@@ -209,26 +210,12 @@ export class ToolRegistry implements ToolRouter {
       };
     }
 
-    // Permission gate: when configured, look up the per-tool policy
-    // for the connector. Stage 2: every source is workspace-scoped —
-    // the legacy user-pool path was deleted along with `UserPoolSource`.
+    // Permission gate: when configured, consult the shared workspace
+    // connector-permission check — the same one the chat engine and /mcp
+    // doors run, so a `disallow` is denied identically on every door.
     if (this.permissionStore && this.wsId) {
-      const owner = { scope: "workspace" as const, wsId: this.wsId };
-      const policy = await this.permissionStore.get(owner, prefix, localName);
-      if (policy === "disallow") {
-        return {
-          content: textContent(
-            `Tool "${prefix}__${localName}" is disabled by policy. Adjust in Settings → Connectors → ${prefix} → Configure.`,
-          ),
-          isError: true,
-          structuredContent: {
-            error: "tool_permission_denied",
-            connector: prefix,
-            tool: localName,
-            scope: owner.scope,
-          },
-        };
-      }
+      const denied = await assertToolAllowed(this.permissionStore, this.wsId, prefix, localName);
+      if (denied) return denied;
     }
 
     return source.execute(localName, call.input, signal);

--- a/test/integration/tool-permission-all-doors.test.ts
+++ b/test/integration/tool-permission-all-doors.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NoopEventSink } from "../../src/adapters/noop-events.ts";
+import { AgentEngine } from "../../src/engine/engine.ts";
+import { textContent } from "../../src/engine/content-helpers.ts";
+import type {
+  EngineConfig,
+  ToolResult,
+  ToolSchema,
+} from "../../src/engine/types.ts";
+import { IdentityContext } from "../../src/identity/context.ts";
+import type { OrchestratorRuntime } from "../../src/orchestrator/index.ts";
+import { PermissionStore } from "../../src/permissions/permission-store.ts";
+import { IdentityToolRouter } from "../../src/runtime/identity-tool-router.ts";
+import { ToolRegistry } from "../../src/tools/registry.ts";
+import type { Tool, ToolSource } from "../../src/tools/types.ts";
+import { WorkspaceContext } from "../../src/workspace/context.ts";
+import { createEchoModel } from "../helpers/echo-model.ts";
+
+/**
+ * The connector permission policy (`disallow`) must be enforced on EVERY
+ * door that dispatches a workspace tool — not only the REST door that routes
+ * through `ToolRegistry.execute`. This drives the highest-traffic door (the
+ * chat engine → `IdentityToolRouter` → `routed.source.execute`) and asserts a
+ * `disallow`ed tool is blocked BEFORE the source runs, with the same
+ * `tool_permission_denied` envelope the registry gate returns.
+ *
+ * Registry parity (the REST door) is asserted alongside so the two doors are
+ * provably in agreement. The external `/mcp` door shares the same
+ * `assertToolAllowed` gate (wired in `mcp-server.ts` before task negotiation);
+ * an HTTP-level `/mcp` parity case is left as a follow-up — it needs the full
+ * `startServer()` transport, which this engine-path test deliberately avoids.
+ */
+
+const WS_ID = "ws_acme";
+const IDENTITY_ID = "usr_admin";
+
+/** A workspace source with one safe and one destructive tool; logs executions. */
+class MockSource implements ToolSource {
+  readonly name = "mock";
+  readonly callLog: string[] = [];
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async tools(): Promise<Tool[]> {
+    return [
+      { name: "mock__safe_read", description: "Safe read.", inputSchema: {}, source: this.name },
+      {
+        name: "mock__destructive_write",
+        description: "Destructive write.",
+        inputSchema: {},
+        source: this.name,
+      },
+    ];
+  }
+  async execute(toolName: string): Promise<ToolResult> {
+    this.callLog.push(toolName);
+    return { content: textContent(`mock ${toolName} ok`), isError: false };
+  }
+}
+
+/** Namespaced schemas the engine treats as the active reachable set. */
+const ACTIVE_TOOLS: ToolSchema[] = [
+  { name: `${WS_ID}-mock__safe_read`, description: "Safe read.", inputSchema: {} },
+  { name: `${WS_ID}-mock__destructive_write`, description: "Destructive write.", inputSchema: {} },
+];
+
+const ENGINE_CONFIG: EngineConfig = {
+  model: "test-model",
+  maxIterations: 4,
+  maxInputTokens: 500_000,
+  maxOutputTokens: 16_384,
+};
+
+/**
+ * Minimal `OrchestratorRuntime` that resolves one workspace source and exposes
+ * the real `PermissionStore`. `routeToolCall` only touches
+ * `getWorkspaceContext`, `getRegistryForWorkspace`, and `getPermissionStore`
+ * on the workspace path; the identity accessors are present to satisfy the
+ * structural type and never invoked here.
+ */
+function makeRuntime(workDir: string, source: ToolSource, store: PermissionStore): OrchestratorRuntime {
+  return {
+    getWorkspaceContext: (wsId: string) => new WorkspaceContext({ wsId, workDir }),
+    getRegistryForWorkspace: () => ({
+      getSource: (n: string) => (n === source.name ? source : undefined),
+    }),
+    getIdentitySource: () => undefined,
+    getIdentityContext: (identityId: string) => new IdentityContext({ userId: identityId, workDir }),
+    listToolsForWorkspace: async () => ACTIVE_TOOLS,
+    getPermissionStore: () => store,
+  };
+}
+
+interface Harness {
+  workDir: string;
+  store: PermissionStore;
+  source: MockSource;
+  router: IdentityToolRouter;
+}
+
+function buildHarness(): Harness {
+  const workDir = mkdtempSync(join(tmpdir(), "nb-perm-doors-"));
+  const store = new PermissionStore(workDir);
+  const source = new MockSource();
+  const router = new IdentityToolRouter({
+    identityId: IDENTITY_ID,
+    workspaceId: WS_ID,
+    runtime: makeRuntime(workDir, source, store),
+  });
+  return { workDir, store, source, router };
+}
+
+/** Run one chat turn whose model emits a single tool call by namespaced name. */
+async function runTurnCalling(
+  router: IdentityToolRouter,
+  toolName: string,
+): Promise<{ captured: ToolResult | null }> {
+  let captured: ToolResult | null = null;
+  const model = createEchoModel({
+    responses: [{ toolCalls: [{ toolCallId: "call_1", toolName, input: "{}" }] }],
+  });
+  const engine = new AgentEngine(model, router, new NoopEventSink());
+  await engine.run(
+    {
+      ...ENGINE_CONFIG,
+      hooks: {
+        afterToolCall: (_call, result) => {
+          captured = result;
+          return result;
+        },
+      },
+    },
+    "You are a test.",
+    [{ role: "user", content: [{ type: "text", text: "do it" }] }],
+    ACTIVE_TOOLS,
+  );
+  return { captured };
+}
+
+describe("connector permission gate — enforced on the engine door", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = buildHarness();
+  });
+
+  afterEach(() => {
+    rmSync(h.workDir, { recursive: true, force: true });
+  });
+
+  test("disallow blocks a chat-turn tool call before source.execute", async () => {
+    await h.store.setConnector(
+      { scope: "workspace", wsId: WS_ID },
+      "mock",
+      { destructive_write: "disallow" },
+    );
+
+    const { captured } = await runTurnCalling(h.router, `${WS_ID}-mock__destructive_write`);
+
+    expect(captured).not.toBeNull();
+    expect(captured!.isError).toBe(true);
+    expect(captured!.structuredContent).toMatchObject({
+      error: "tool_permission_denied",
+      connector: "mock",
+      tool: "destructive_write",
+      scope: "workspace",
+    });
+    // The gate short-circuited BEFORE dispatch — the source never ran.
+    expect(h.source.callLog).toEqual([]);
+  });
+
+  test("a tool without a disallow policy still runs through the engine door", async () => {
+    await h.store.setConnector(
+      { scope: "workspace", wsId: WS_ID },
+      "mock",
+      { destructive_write: "disallow" },
+    );
+
+    const { captured } = await runTurnCalling(h.router, `${WS_ID}-mock__safe_read`);
+
+    expect(captured).not.toBeNull();
+    expect(captured!.isError).toBe(false);
+    expect(h.source.callLog).toEqual(["safe_read"]);
+  });
+
+  test("registry door (REST) denies the same call identically — doors agree", async () => {
+    await h.store.setConnector(
+      { scope: "workspace", wsId: WS_ID },
+      "mock",
+      { destructive_write: "disallow" },
+    );
+
+    const registry = new ToolRegistry();
+    const registrySource = new MockSource();
+    registry.addSource(registrySource);
+    registry.setPermissionContext(WS_ID, h.store);
+
+    const result = await registry.execute({ name: "mock__destructive_write", input: {} });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({ error: "tool_permission_denied" });
+    expect(registrySource.callLog).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Security fix — connector permission bypass on two of three doors

The per-tool connector permission policy (`disallow`, set in *Settings → Connectors → Configure*) is enforced only in `ToolRegistry.execute`, which **only the REST door** (`POST /v1/tools/call`) reaches. The two doors that matter most call `source.execute` directly and skip the gate:

| Door | Path | Gate today |
|---|---|---|
| REST `/v1/tools/call` | `handlers.ts` → `ToolRegistry.execute` | enforced |
| Chat / delegate / automation | engine → `IdentityToolRouter` → `routed.source.execute` | **skipped** |
| External `/mcp` (Cursor, Claude Desktop, iframe bridge) | `mcp-server.ts` → `source.execute` | **skipped** |

So a tool an operator explicitly disabled stayed callable by the agent loop and by any external MCP client.

## Change

- New `src/permissions/assert-tool-allowed.ts` — the single workspace connector-permission check, returning the same `tool_permission_denied` envelope the registry gate uses.
- Wired before `source.execute` on both bypassed doors (workspace-scoped calls only; identity-door tools have no connector). The `/mcp` gate runs **before** task-vs-inline negotiation, so a `disallow`ed task-augmented tool is denied too.
- `getPermissionStore?()` added to `OrchestratorRuntime` (optional → no production construction-site changes; stubs skip → allow, matching the registry's existing posture).
- The `ToolRegistry.execute` gate is left in place as belt-and-suspenders.

## Scope

This is the minimal hole-plug (PR-1 of the dispatch-chokepoint design). It deliberately does **not** introduce the unified `dispatchToolCall` chokepoint, the name-parser change, or removal of the registry gate — those are follow-ups. From `research/architecture-designs/01-dispatch-chokepoint.md`.

## Tests

New `test/integration/tool-permission-all-doors.test.ts` drives enforcement through the real engine → `IdentityToolRouter` → `routeToolCall` → `source.execute` path and asserts the source **never runs** when policy is `disallow`, plus registry-door parity. `bun run check` + `bun run lint` pass; existing `policy-enforcement-end-to-end` and mcp/router suites stay green.