### PR TITLE
refactor(bundles): remove the dead bundle state-machine methods

### DIFF
--- a/src/adapters/metrics-events.ts
+++ b/src/adapters/metrics-events.ts
@@ -76,12 +76,9 @@ export class MetricsEventSink implements EventSink {
         // The HealthMonitor reports bundle/connector liveness via `run.error`
         // with a nested `event` discriminator (bundle.crashed / restarting /
         // dead / recovered) and no runId. `bundle.crashed` is the canonical
-        // crash signal: the lifecycle's own `bundle.crashed` event *type* is
-        // emitted only by `recordCrash`, which currently has no callers, so
-        // counting here is 1:1 with a real detection and can't double-count.
-        // (If `recordCrash` is ever wired as the canonical emit, move the count
-        // there and drop it here.) Counts once per HealthMonitor sweep a source
-        // is found down — the per-sweep cadence the alert thresholds on.
+        // crash signal and counting here is 1:1 with a real detection — counts
+        // once per HealthMonitor sweep a source is found down, the per-sweep
+        // cadence the alert thresholds on.
         if (type === "run.error" && data.event === "bundle.crashed") {
           recordBundleCrash(data.source as string | undefined, data.remote === true);
         }

--- a/src/bundles/lifecycle.ts
+++ b/src/bundles/lifecycle.ts
@@ -1074,48 +1074,6 @@ export class BundleLifecycleManager {
   }
 
   /**
-   * Record a crash detected by HealthMonitor.
-   * Emits bundle.crashed event and updates state.
-   */
-  recordCrash(serverName: string, wsId: string): void {
-    const instance = this.instances.get(`${serverName}|${wsId}`);
-    if (!instance) return;
-    this.transition(instance, "crashed");
-    this.eventSink.emit({
-      type: "bundle.crashed",
-      data: { wsId, serverName, bundleName: instance.bundleName },
-    });
-  }
-
-  /**
-   * Record a successful recovery by HealthMonitor.
-   * Emits bundle.recovered event and updates state.
-   */
-  recordRecovery(serverName: string, wsId: string): void {
-    const instance = this.instances.get(`${serverName}|${wsId}`);
-    if (!instance) return;
-    this.transition(instance, "running");
-    this.eventSink.emit({
-      type: "bundle.recovered",
-      data: { wsId, serverName, bundleName: instance.bundleName },
-    });
-  }
-
-  /**
-   * Record that a bundle has exhausted restart attempts.
-   * Emits bundle.dead event and updates state.
-   */
-  recordDead(serverName: string, wsId: string): void {
-    const instance = this.instances.get(`${serverName}|${wsId}`);
-    if (!instance) return;
-    this.transition(instance, "dead");
-    this.eventSink.emit({
-      type: "bundle.dead",
-      data: { wsId, serverName, bundleName: instance.bundleName },
-    });
-  }
-
-  /**
    * Record a Connection state transition for a URL bundle. Owns:
    *   - Updating the named Connection's state on the BundleInstance
    *   - Recomputing `BundleInstance.state` via `summarizeConnectionState`

--- a/src/tools/health-monitor.ts
+++ b/src/tools/health-monitor.ts
@@ -1,18 +1,18 @@
 import type { EventSink } from "../engine/types.ts";
 import type { McpSource } from "./mcp-source.ts";
 
-export type BundleState = "healthy" | "restarting" | "dead";
+export type ProcessLiveness = "healthy" | "restarting" | "dead";
 
 export interface BundleHealth {
   name: string;
-  state: BundleState;
+  state: ProcessLiveness;
   uptime: number | null;
   restartCount: number;
 }
 
 interface BundleRecord {
   source: McpSource;
-  state: BundleState;
+  state: ProcessLiveness;
   restartCount: number;
 }
 
@@ -44,7 +44,7 @@ export class HealthMonitor {
     this.baseDelayMs = opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
     this.records = sources.map((source) => ({
       source,
-      state: "healthy" as BundleState,
+      state: "healthy" as ProcessLiveness,
       restartCount: 0,
     }));
   }

--- a/test/integration/lifecycle.test.ts
+++ b/test/integration/lifecycle.test.ts
@@ -418,54 +418,6 @@ describe("BundleLifecycleManager — start and stop", () => {
 describe("BundleLifecycleManager — state transitions", () => {
 	beforeEach(setupTestDir);
 
-	it("recordCrash transitions to crashed and emits event", async () => {
-		const bundleDir = createEchoBundleOnDisk(join(testDir, "echo-crash"));
-		const registry = new ToolRegistry();
-		const sink = makeEventCollector();
-		const lifecycle = new BundleLifecycleManager(sink, undefined);
-
-		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
-		expect(instance.state).toBe("running");
-
-		lifecycle.recordCrash(instance.serverName, "ws_test");
-		expect(instance.state).toBe("crashed");
-		expect(eventTypes(sink)).toContain("bundle.crashed");
-
-		await registry.removeSource(instance.serverName);
-	}, 15_000);
-
-	it("recordRecovery transitions crashed to running and emits event", async () => {
-		const bundleDir = createEchoBundleOnDisk(join(testDir, "echo-recover"));
-		const registry = new ToolRegistry();
-		const sink = makeEventCollector();
-		const lifecycle = new BundleLifecycleManager(sink, undefined);
-
-		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
-		lifecycle.recordCrash(instance.serverName, "ws_test");
-
-		lifecycle.recordRecovery(instance.serverName, "ws_test");
-		expect(instance.state).toBe("running");
-		expect(eventTypes(sink)).toContain("bundle.recovered");
-
-		await registry.removeSource(instance.serverName);
-	}, 15_000);
-
-	it("recordDead transitions to dead and emits event", async () => {
-		const bundleDir = createEchoBundleOnDisk(join(testDir, "echo-dead"));
-		const registry = new ToolRegistry();
-		const sink = makeEventCollector();
-		const lifecycle = new BundleLifecycleManager(sink, undefined);
-
-		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
-		lifecycle.recordCrash(instance.serverName, "ws_test");
-
-		lifecycle.recordDead(instance.serverName, "ws_test");
-		expect(instance.state).toBe("dead");
-		expect(eventTypes(sink)).toContain("bundle.dead");
-
-		await registry.removeSource(instance.serverName);
-	}, 15_000);
-
 	it("dead bundle requires explicit startBundle to run again", async () => {
 		const bundleDir = createEchoBundleOnDisk(join(testDir, "echo-dead-restart"));
 		const registry = new ToolRegistry();
@@ -473,7 +425,7 @@ describe("BundleLifecycleManager — state transitions", () => {
 		const lifecycle = new BundleLifecycleManager(sink, undefined);
 
 		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
-		lifecycle.recordDead(instance.serverName, "ws_test");
+		lifecycle.transition(instance, "dead");
 		expect(instance.state).toBe("dead");
 
 		// Explicit startBundle should bring it back
@@ -750,33 +702,6 @@ describe("BundleLifecycleManager — error resilience", () => {
 
 		expect(lifecycle.getInstance("nonexistent", "ws_test")).toBeUndefined();
 	});
-
-	it("recordCrash on unknown server does not throw", () => {
-		const sink = makeEventCollector();
-		const lifecycle = new BundleLifecycleManager(sink, undefined);
-
-		// Should not throw — graceful no-op for unknown server
-		expect(() => lifecycle.recordCrash("unknown-server", "ws_test")).not.toThrow();
-	});
-
-	it("state machine rejects invalid transitions", async () => {
-		const bundleDir = createEchoBundleOnDisk(join(testDir, "echo-invalid-transition"));
-		const registry = new ToolRegistry();
-		const sink = makeEventCollector();
-		const lifecycle = new BundleLifecycleManager(sink, undefined);
-
-		const instance = await lifecycle.installLocal(bundleDir, registry, "ws_test");
-
-		// running → recordRecovery should be a no-op (can't recover if not crashed)
-		lifecycle.recordRecovery(instance.serverName, "ws_test");
-		expect(instance.state).toBe("running"); // Should remain running
-
-		// running → recordDead should transition (crash + dead)
-		lifecycle.recordDead(instance.serverName, "ws_test");
-		expect(instance.state).toBe("dead");
-
-		await registry.removeSource(instance.serverName);
-	}, 15_000);
 
 	it("config file is not corrupted when installLocal fails mid-operation", async () => {
 		const configPath = join(testDir, "nimblebrain-resilience.json");


### PR DESCRIPTION
## Dead code + a name-collision trap

`recordCrash` / `recordRecovery` / `recordDead` on `BundleLifecycleManager` have **no production callers** — the only callers were 9 tests of the methods themselves, plus a stale comment. The `running → crashed → dead` transitions they documented were never applied on any real path: HealthMonitor reports liveness via `run.error` with a nested `event` discriminator, and instance/connection state is set through `transition()` and `recordConnectionStateChange()`.

Separately, `health-monitor.ts` declared its own file-local `type BundleState = "healthy" | "restarting" | "dead"`, colliding by name with the 8-value `BundleState` in `bundles/types.ts` — a comprehension trap for anyone reading either.

## Change

- Delete the three dead methods and their self-referential tests.
- Rename HealthMonitor's `BundleState` → `ProcessLiveness` (file-local, no external importers).
- Update the now-stale `metrics-events.ts` comment (the crash metric reads HealthMonitor's `run.error`/`bundle.crashed` nested discriminator — unaffected).
- `transition()` (8 callers) is untouched; one revival test re-points its setup to `transition(instance, "dead")`.

## Scope / follow-up

Pure deletion + rename, no behavior change. Out of scope (noted for a follow-up): the top-level `bundle.crashed` / `bundle.recovered` / `bundle.dead` `EngineEvent` types are now unemitted — the union/schema pruning is deliberately left for a separate change. This is "Card 4" from `research/architecture-designs/04-lifecycle-decompose.md`; the `lifecycle.ts` decomposition (Card 7) is a later wave.

## Tests
`bun run check` + `bun run lint` pass; `test/integration/lifecycle.test.ts` green (23 pass); `grep` for the three method names is empty.