### PR TITLE
fix(conversation): unify and harden the conversation-fence escape

### DIFF
--- a/src/conversation/auto-title.ts
+++ b/src/conversation/auto-title.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { type TokenUsage, tokenUsageFromV3 } from "../usage/types.ts";
+import { escapeClosingTags } from "./escape-closing-tags.ts";
 
 /**
  * Generate a short conversation title using the provided model.
@@ -60,10 +61,6 @@ function formatTitleTranscript(userMessage: string, assistantResponse: string): 
     "</assistant-message>",
     "</conversation-transcript>",
   ].join("\n");
-}
-
-function escapeClosingTags(value: string): string {
-  return value.replaceAll("</", "<\\/");
 }
 
 export function sanitizeGeneratedTitle(rawTitle: string, userMessage: string): string {

--- a/src/conversation/compaction.ts
+++ b/src/conversation/compaction.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { type TokenUsage, tokenUsageFromV3 } from "../usage/types.ts";
+import { escapeClosingTags } from "./escape-closing-tags.ts";
 import type { HistoryCompactedEvent, StoredMessage } from "./types.ts";
 
 /**
@@ -133,10 +134,6 @@ export function planCompaction(
     boundaryIndex,
     boundaryTs: messages[boundaryIndex]!.timestamp ?? "",
   };
-}
-
-function escapeClosingTags(value: string): string {
-  return value.replaceAll("</", "<\\/");
 }
 
 const SUMMARY_OPEN = "<conversation-summary>";

--- a/src/conversation/escape-closing-tags.ts
+++ b/src/conversation/escape-closing-tags.ts
@@ -1,0 +1,23 @@
+/**
+ * Neutralise every closing-tag form in untrusted `value` so it cannot break out
+ * of the XML fence the conversation prompts wrap it in.
+ *
+ * The conversation fences — `<conversation-summary>` (compaction replay seed),
+ * `<conversation-transcript>` / `<user-message>` / `<assistant-message>`
+ * (summarizer and title-generation transcripts) — wrap content that traces back
+ * to untrusted user and tool text. A body carrying its own closing tag could
+ * otherwise close the fence early and inject top-level instructions.
+ *
+ * Unlike the system-prompt containment tags (tag-specific, see `wrapContained`
+ * in `prompt/compose.ts`), a transcript can carry arbitrary tags, so this
+ * neutralises ANY closing form `</…`. Two properties make it robust against the
+ * model's fuzzy parsing:
+ *   - whitespace-tolerant: `</tag>`, `< /tag>`, `</ tag>`, `</\ntag>` all match.
+ *   - entity rewrite: the `<` becomes `&lt;`, so no literal `<` survives for the
+ *     model to read as a tag boundary (stronger than a backslash disruptor).
+ *
+ * Idempotent: a re-escaped body has no remaining `<` before a `/` to match.
+ */
+export function escapeClosingTags(value: string): string {
+  return value.replace(/<\s*\//g, "&lt;/");
+}

--- a/test/unit/auto-title.test.ts
+++ b/test/unit/auto-title.test.ts
@@ -54,7 +54,10 @@ describe("generateTitle", () => {
 		expect(transcript).toContain("<conversation-transcript>");
 		expect(transcript).toContain("<user-message>");
 		expect(transcript).toContain("<assistant-message>");
-		expect(transcript).toContain("<\\/user-message>");
+		// the injected closing tag is neutralised to the entity form, so it
+		// cannot close the <user-message> fence and break out.
+		expect(transcript).toContain("&lt;/user-message>");
+		expect(transcript).not.toContain("instructions </user-message>");
 	});
 
 	it("reports the title call's usage via onUsage", async () => {

--- a/test/unit/compaction.test.ts
+++ b/test/unit/compaction.test.ts
@@ -95,7 +95,8 @@ describe("compactionSummaryMessages", () => {
     expect(text.startsWith("<conversation-summary>")).toBe(true);
     expect(text.trimEnd().endsWith("</conversation-summary>")).toBe(true);
     // the injected closing tag in the BODY is escaped so it can't break out
-    expect(text).toContain("<\\/conversation-summary> injection");
+    expect(text).toContain("&lt;/conversation-summary> injection");
+    expect(text).not.toContain("X. </conversation-summary> injection");
   });
 });
 

--- a/test/unit/escape-closing-tags.test.ts
+++ b/test/unit/escape-closing-tags.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { escapeClosingTags } from "../../src/conversation/escape-closing-tags.ts";
+
+describe("escapeClosingTags", () => {
+  test("neutralises a canonical closing tag", () => {
+    expect(escapeClosingTags("a</conversation-summary>b")).toBe("a&lt;/conversation-summary>b");
+  });
+
+  test("neutralises whitespace-evasion forms the consumer (an LLM) would still honour", () => {
+    // The old `replaceAll("</", "<\\/")` passed every one of these through.
+    for (const close of [
+      "</user-message>",
+      "< /user-message>",
+      "</ user-message>",
+      "<  /user-message>",
+      "</\nuser-message>",
+    ]) {
+      const out = escapeClosingTags(`x${close}y`);
+      expect(out).toContain("&lt;/");
+      // no literal `<` immediately preceding a `/` survives for a fuzzy parser
+      expect(/<\s*\//.test(out)).toBe(false);
+    }
+  });
+
+  test("escapes every occurrence, not just the first", () => {
+    expect(escapeClosingTags("</a></b>")).toBe("&lt;/a>&lt;/b>");
+  });
+
+  test("leaves opening tags and bare text untouched", () => {
+    expect(escapeClosingTags("<user-message>plain text 1 < 2")).toBe(
+      "<user-message>plain text 1 < 2",
+    );
+  });
+
+  test("is idempotent — a re-escaped body is unchanged", () => {
+    const once = escapeClosingTags("</conversation-transcript>");
+    expect(escapeClosingTags(once)).toBe(once);
+  });
+});

--- a/test/unit/escape-closing-tags.test.ts
+++ b/test/unit/escape-closing-tags.test.ts
@@ -11,6 +11,7 @@ describe("escapeClosingTags", () => {
     for (const close of [
       "</user-message>",
       "< /user-message>",
+      "<\n/user-message>",
       "</ user-message>",
       "<  /user-message>",
       "</\nuser-message>",


### PR DESCRIPTION
## Follow-up from #592 review

The #592 reviewer flagged that the `<conversation-summary>` / `<conversation-transcript>` / `<user-message>` / `<assistant-message>` fences (`compaction.ts`, `auto-title.ts`) use a separate, **weaker** escape than the system-prompt containment primitive — out of scope for #592, tracked here.

These fences wrap genuinely untrusted content (the compaction replay seed and the title/summarizer transcripts wrap `slice(0,200)` of user/assistant messages and full tool output). The escape was:

- **Duplicated** verbatim in two files: `escapeClosingTags(v) = v.replaceAll("</", "<\\/")`.
- **Evadable** — an LLM is a fuzzy parser, and `</TAG>`, `< /tag>`, `</ tag>`, `</tag\n>` all passed straight through the exact-substring match.
- **Weak in form** — it inserted a backslash (`<\/tag>`) rather than removing the angle bracket, leaving a literal `<` the model may still read as a boundary.

## Change

- One shared `src/conversation/escape-closing-tags.ts` replaces both copies.
- Strengthened to `replace(/<\s*\//g, "&lt;/")`: whitespace-tolerant and rewriting `<` → `&lt;` so no active `<` survives — the same posture as `wrapContained` on the system-prompt side. Idempotent; generic over any tag (a transcript can carry arbitrary tags, so this is deliberately not tag-specific).

## Tests

New `escape-closing-tags.test.ts` covers the canonical form, the whitespace-evasion forms the old escape missed, multi-occurrence, opening-tag/​bare-text passthrough, and idempotence. The existing seed/title breakout tests are updated to assert the entity form (and that the raw breakout sequence is gone). `check` / `lint` / `check:code-style` pass; compaction, auto-title, compaction-wiring, and event-sourced-store suites green.

Note: the compaction summary seed rides replayed (cached) history, so this is a one-time prefix-cache invalidation for conversations that compact after deploy — bounded, same trade-off as #592. From `research/architecture-designs/03-containment-escape.md` lineage.