### PR TITLE
refactor(runtime): drop the vestigial boot-time conversation store

### DIFF
--- a/docs/src/content/docs/concepts.mdx
+++ b/docs/src/content/docs/concepts.mdx
@@ -268,7 +268,7 @@ Conversations are workspace-owned. Every turn is written to a per-conversation J
 ~/.nimblebrain/workspaces/<wsId>/conversations/<ownerId>/<convId>.jsonl
 ```
 
-The owner (`ownerId`) is the authorization principal — only they can read or resume the conversation — while the workspace (`wsId`) is where it is stored. Persistence does not depend on any top-level `store` setting; programmatic/SDK embedding can supply an in-memory `ConversationStore` instead.
+The owner (`ownerId`) is the authorization principal — only they can read or resume the conversation — while the workspace (`wsId`) is where it is stored. Persistence is automatic; there is nothing to configure.
 
 ### JSONL format
 

--- a/docs/src/content/docs/config/nimblebrain-json.mdx
+++ b/docs/src/content/docs/config/nimblebrain-json.mdx
@@ -100,7 +100,6 @@ A sibling `nimblebrain.overrides.json` next to the resolved config file is **dee
 | `maxToolResultSize` | `integer` | `1000000` | Max characters for a single tool result. `0` disables the cap. |
 | `thinking` | `"off" \| "adaptive" \| "enabled"` | — | Extended-thinking mode for reasoning-capable models. `off`: never reason. `adaptive`: model decides per call. `enabled`: always reason (cap with `thinkingBudgetTokens`). Typically set via the admin `set_model_config` tool, which writes it to `nimblebrain.overrides.json`. |
 | `thinkingBudgetTokens` | `integer` | — | Token budget when `thinking: "enabled"`. Counts toward `maxOutputTokens`. Anthropic requires a minimum of 1,024. |
-| `store` | `object` | event-sourced (`jsonl` via CLI) | Conversation storage backend. See [store](#store). |
 | `sessionStore` | `object` | `{ "type": "memory", "ttlSeconds": 28800 }` | MCP session metadata store for `/mcp`. See [sessionStore](#sessionstore). |
 | `logging` | `object` | — | Structured logging config. See [logging](#logging). |
 | `http` | `object` | `{ "port": 27247, "host": "127.0.0.1" }` | HTTP server config. Omit for programmatic-only use. |
@@ -158,40 +157,9 @@ Each provider key is optional. If a provider's `apiKey` is omitted, the SDK fall
   Prefer environment variables for API keys in production. Config files end up in version control and backup snapshots by accident.
 </Aside>
 
-## store
+## Conversation storage
 
-Conversations are **workspace-owned and persisted automatically** — you do not configure where they live. Every turn is written to a per-conversation JSONL file at `{workDir}/workspaces/<wsId>/conversations/<ownerId>/<convId>.jsonl` in the **event-sourced** format (one append-only event log per conversation), which is what enables crash-resilient run replay and history [compaction](/config/features/). Legacy message-format JSONL files are still read. This persistence does not depend on the `store` setting below.
-
-The optional top-level `store` field sets the runtime's boot-time `ConversationStore` handle. **It does not change where conversations are stored** — that is always workspace-owned, as above — so most deployments omit it. It defaults to in-memory and is reserved for programmatic embedding of the runtime as a library.
-
-<Tabs>
-  <TabItem label="In-memory (default)">
-    ```json
-    {
-      "store": { "type": "memory" }
-    }
-    ```
-
-    The default. The platform's workspace-owned conversation persistence is unaffected; this only governs the embedded `ConversationStore` handle.
-  </TabItem>
-  <TabItem label="JSONL">
-    ```json
-    {
-      "store": {
-        "type": "jsonl",
-        "dir": "~/.nimblebrain/conversations"
-      }
-    }
-    ```
-
-    Provides a file-backed `ConversationStore` for programmatic embedding at the given `dir`.
-  </TabItem>
-</Tabs>
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | `"jsonl"` \| `"memory"` | Yes | `ConversationStore` backend for embedded use. Defaults to `memory`. |
-| `dir` | `string` | JSONL only | Directory for the embedded JSONL store's files. |
+Conversations are **workspace-owned and persisted automatically** — there is nothing to configure. Every turn is written to a per-conversation JSONL file at `{workDir}/workspaces/<wsId>/conversations/<ownerId>/<convId>.jsonl` in the **event-sourced** format (one append-only event log per conversation), which is what enables crash-resilient run replay and history [compaction](/config/features/). Legacy message-format JSONL files are still read.
 
 ## sessionStore
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -165,7 +165,6 @@ export function loadConfig(flags: CliFlags = {}): RuntimeConfig {
     model: fileConfig.model ?? { provider: "anthropic" },
     providers: fileConfig.providers as RuntimeConfig["providers"],
     allowInsecureRemotes: fileConfig.allowInsecureRemotes as boolean | undefined,
-    store: fileConfig.store,
     models: fileConfig.models as RuntimeConfig["models"],
     defaultModel: flags.model ?? fileConfig.defaultModel,
     maxIterations: fileConfig.maxIterations,

--- a/src/config/nimblebrain-config.schema.json
+++ b/src/config/nimblebrain-config.schema.json
@@ -152,28 +152,6 @@
       "default": false,
       "description": "Allow HTTP (non-TLS) remote bundle connections. Dev only."
     },
-    "store": {
-      "description": "Conversation storage backend.",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": ["type", "dir"],
-          "properties": {
-            "type": { "const": "jsonl" },
-            "dir": { "type": "string", "description": "Directory for JSONL conversation files." }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": ["type"],
-          "properties": {
-            "type": { "const": "memory" }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "models": {
       "type": "object",
       "description": "Role-based model slots.",

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -23,9 +23,7 @@ import { createPrivilegeHook, NoopConfirmationGate } from "../config/privilege.t
 import { generateTitle } from "../conversation/auto-title.ts";
 import { compactConversationMessages } from "../conversation/compaction.ts";
 import { EventSourcedConversationStore } from "../conversation/event-sourced-store.ts";
-import { JsonlConversationStore } from "../conversation/jsonl-store.ts";
 import { type ConversationLocation, ConversationLocator } from "../conversation/locator.ts";
-import { InMemoryConversationStore } from "../conversation/memory-store.ts";
 import { workspaceConversationsDir } from "../conversation/paths.ts";
 import type {
   Conversation,
@@ -242,11 +240,9 @@ class DelegateTracker implements EventSink {
 
 export class Runtime {
   private resolveModelFn: (modelString: string) => LanguageModelV3;
-  private store: ConversationStore;
   private skillMatcher: SkillMatcher;
   private config: RuntimeConfig;
   private contextSkills: Skill[];
-  private eventStore: EventSourcedConversationStore | null;
   /** Process-wide convId → workspace resolver; lazily built over the workspaces root. */
   private _conversationLocator?: ConversationLocator;
   private _fileLocator?: FileLocator;
@@ -342,11 +338,9 @@ export class Runtime {
 
   private constructor(
     resolveModelFn: (modelString: string) => LanguageModelV3,
-    store: ConversationStore,
     skillMatcher: SkillMatcher,
     config: RuntimeConfig,
     contextSkills: Skill[],
-    eventStore: EventSourcedConversationStore | null,
     hooks: EngineHooks,
     defaultEvents: EventSink,
     lifecycle: BundleLifecycleManager,
@@ -363,11 +357,9 @@ export class Runtime {
     currentWorkspaceId: () => string | null,
   ) {
     this.resolveModelFn = resolveModelFn;
-    this.store = store;
     this.skillMatcher = skillMatcher;
     this.config = config;
     this.contextSkills = contextSkills;
-    this.eventStore = eventStore;
     this.hooks = hooks;
     this.defaultEvents = defaultEvents;
     this.lifecycle = lifecycle;
@@ -422,7 +414,7 @@ export class Runtime {
     const workspaceStore = new WorkspaceStore(workDir);
     const identityProvider = createIdentityProvider(instanceConfig, userStore, workspaceStore);
 
-    const { events: baseEvents, eventStore } = buildEventSink(config);
+    const baseEvents = buildEventSink(config);
 
     // Create delegate tracker and include it in the event pipeline
     const delegateTracker = new DelegateTracker();
@@ -430,9 +422,6 @@ export class Runtime {
     // memory whether or not `/metrics` is scraped, so it's safe in a local
     // `bun run dev` with no Prometheus/k8s.
     const sinkList: EventSink[] = [baseEvents, delegateTracker, new MetricsEventSink()];
-    if (eventStore) {
-      sinkList.push(eventStore);
-    }
     if (telemetryManager.isEnabled()) {
       sinkList.push(new PostHogEventSink(telemetryManager));
     }
@@ -678,7 +667,6 @@ export class Runtime {
       // resolved `maxOutputTokens`). See `resolveMessageBudget`.
     };
 
-    const store = buildStore(config);
     const { contextSkills, skillMatcher } = buildSkills(config);
 
     // Request-scoped context — all identity/workspace reads go through AsyncLocalStorage.
@@ -719,11 +707,9 @@ export class Runtime {
     // Create Runtime with empty workspace registries first — needed by system tools
     const rt = new Runtime(
       resolveModelFn,
-      store,
       skillMatcher,
       config,
       contextSkills,
-      eventStore,
       hooks,
       events,
       lifecycle,
@@ -1658,25 +1644,10 @@ export class Runtime {
       ...(request.signal ? { signal: request.signal } : {}),
     };
 
-    // Conversations are workspace-owned, so `store` (from `resolveChatStore`) is
-    // always a per-call workspace store and is always the event sink. The
-    // `this.eventStore`/`this.store` sentinel path below is VESTIGIAL —
-    // `this.eventStore` is always null and `isWorkspaceRequest` always true.
-    // TODO(cleanup): collapse to "always use the per-call workspace store" and drop
-    // the boot-store fields. Deferred from this PR because removing `this.store`
-    // is entangled with the `config.store` "embedding-only" story (also deferred).
-    const isWorkspaceRequest =
-      store instanceof EventSourcedConversationStore && store !== this.store;
-    let activeEventStore: EventSourcedConversationStore | null = null;
-    if (isWorkspaceRequest) {
-      // Disable global store for this request, use workspace store instead
-      if (this.eventStore) this.eventStore.setActiveConversation("");
-      activeEventStore = store as EventSourcedConversationStore;
-      activeEventStore.setActiveConversation(conversation.id);
-    } else if (this.eventStore) {
-      activeEventStore = this.eventStore;
-      this.eventStore.setActiveConversation(conversation.id);
-    }
+    // Conversations are workspace-owned: `store` (from `resolveChatStore`) is the
+    // per-call workspace event store, and is both the active event sink for this
+    // turn's engine events and a member of the per-request sink chain.
+    store.setActiveConversation(conversation.id);
 
     // Build per-request sink chain. The engine itself returns cumulative
     // usage and llmMs in its EngineResult — no need for a side-channel
@@ -1684,9 +1655,7 @@ export class Runtime {
     const sinks: EventSink[] = requestSink
       ? [requestSink, this.defaultEvents]
       : [this.defaultEvents];
-    if (isWorkspaceRequest) {
-      sinks.push(store as EventSourcedConversationStore);
-    }
+    sinks.push(store);
 
     const model = engineConfig.model;
     const resolvedModel = this.resolveModelFn(model);
@@ -1777,28 +1746,9 @@ export class Runtime {
       iterations: result.iterations,
     };
 
-    // If an event store handled the engine events (via emit()), the llm.response
-    // events are already in the conversation file — no need for a separate append.
-    // Only append the assistant message explicitly when no event store was active
-    // (e.g., logging disabled, or legacy store without EventSink).
-    const eventStoreHandled = !!activeEventStore;
-    if (!eventStoreHandled) {
-      await store.append(conversation, {
-        role: "assistant",
-        content: result.output
-          ? [{ type: "text", text: result.output }]
-          : [{ type: "text", text: "(tool use only)" }],
-        timestamp: new Date().toISOString(),
-        metadata: {
-          skill: skill?.manifest.name ?? null,
-          toolCalls: result.toolCalls,
-          usage: result.usage,
-          model,
-          llmMs: result.llmMs,
-          iterations: result.iterations,
-        },
-      });
-    }
+    // The workspace event store persisted the engine events (including the
+    // assistant turn) via emit() as they streamed, so there is no separate
+    // assistant-message append here.
 
     // Fire-and-forget title generation on first turn (use "fast" slot for cost
     // savings). Decoupled from the turn lifecycle: when it resolves we persist
@@ -4118,10 +4068,12 @@ function initWorkDir(config: RuntimeConfig): void {
   syncCoreSkills(resolvedWorkDir);
 }
 
-function buildEventSink(config: RuntimeConfig): {
-  events: EventSink;
-  eventStore: EventSourcedConversationStore | null;
-} {
+// Build the boot-time event sink: operator-supplied sinks plus the daily
+// workspace log. Conversation event persistence is NOT wired here — conversations
+// are workspace-owned, so each chat/task turn routes its engine events through its
+// own per-call workspace store (see `_chatInner`). There is no flat top-level
+// conversation store.
+function buildEventSink(config: RuntimeConfig): EventSink {
   const sinks: EventSink[] = config.events ? [...config.events] : [];
   if (!config.logging?.disabled) {
     const workDir = resolveWorkDir(config);
@@ -4130,23 +4082,7 @@ function buildEventSink(config: RuntimeConfig): {
     // Workspace events (bundle lifecycle, bridge calls, audit) go to daily workspace log
     sinks.push(new WorkspaceLogSink({ dir: logDir, retentionDays }));
   }
-  const events: EventSink = sinks.length > 0 ? new MultiEventSink(sinks) : new NoopEventSink();
-  // No boot-time conversation event store: conversations are workspace-owned, so
-  // every chat/task turn routes engine events through its own per-call workspace
-  // store (the `isWorkspaceRequest` sink, always taken now). `this.eventStore`
-  // stays null; there is no flat top-level conversations dir.
-  return { events, eventStore: null };
-}
-
-function buildStore(config: RuntimeConfig): ConversationStore {
-  if (config.store?.type === "memory") return new InMemoryConversationStore();
-  if (config.store?.type === "jsonl") return new JsonlConversationStore(config.store.dir);
-  if (config.store?.type === "custom") return config.store.adapter;
-  // Default: conversations are workspace-owned (per-call workspace stores), so there is
-  // no flat top-level store. `this.store` is only the sentinel the chat path
-  // compares against (`store !== this.store` ⇒ use the per-call workspace store as
-  // the event sink), so an in-memory placeholder is correct and never written.
-  return new InMemoryConversationStore();
+  return sinks.length > 0 ? new MultiEventSink(sinks) : new NoopEventSink();
 }
 
 function buildSkills(config: RuntimeConfig): {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,7 +1,6 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { FeatureFlags } from "../config/features.ts";
 import type { ConfirmationGate } from "../config/privilege.ts";
-import type { ConversationStore } from "../conversation/types.ts";
 import type { EventSink } from "../engine/types.ts";
 import type { ContentPart, FileReference } from "../files/types.ts";
 import type { UserIdentity } from "../identity/provider.ts";
@@ -43,12 +42,6 @@ export interface RuntimeConfig {
 
   /** Directories to scan for skill files. */
   skillDirs?: string[];
-
-  /** Conversation storage. Default: in-memory. */
-  store?:
-    | { type: "jsonl"; dir: string }
-    | { type: "memory" }
-    | { type: "custom"; adapter: ConversationStore };
 
   /** Role-based model slots. Takes precedence over `defaultModel`. */
   models?: ModelSlots;

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -251,7 +251,6 @@ describe("config validation", () => {
   it("passes validation on a full valid config", () => {
     const configPath = writeTestConfig("valid-full.json", {
       model: { provider: "anthropic", apiKey: "sk-test" },
-      store: { type: "jsonl", dir: "/tmp/convos" },
       defaultModel: "claude-opus-4-6",
       maxIterations: 20,
       maxInputTokens: 100000,


### PR DESCRIPTION
## What

Removes the runtime's boot-time conversation store and the top-level `store` config field — both verified to do nothing, and flagged for exactly this cleanup by an inline `TODO(cleanup)` in `runtime.ts`.

## Why it's safe

Conversations are workspace-owned. Every chat/task turn resolves a per-call `EventSourcedConversationStore` from the conversation's path (`resolveChatStore`) and uses it as the engine event sink. The boot-time fields were inert:

- `this.store` was **only** a sentinel the chat path compared against (`store !== this.store`); it was never a persistence target. Traced: assigned once, read once (the sentinel), no `.append`/`.create`/`.get`.
- `this.eventStore` was **always `null`** (`buildEventSink` returned `eventStore: null` unconditionally), so the `isWorkspaceRequest` branch was always true and the `else` branch + the assistant-append fallback were dead.
- `config.store` (`jsonl` / `memory` / `custom`) fed **only** `buildStore` → `this.store`, so setting it changed nothing observable. Even `type: "custom"` (the embedding hook) was never written to.

## Changes

- **runtime.ts**: collapse the chat path to always use the per-call workspace store; remove `this.store`, `this.eventStore`, the `buildStore` factory, the dead assistant-append fallback, and now-unused imports. `buildEventSink` returns a plain `EventSink`.
- **types.ts / schema / cli/config.ts**: remove the `store` config field.
- **docs**: `config/nimblebrain-json` and `concepts` updated — conversation persistence is automatic and workspace-owned, nothing to configure.
- **test**: drop `store` from the full-config CLI fixture.

Net: **−146 / +19**, all dead-code removal.

## Compatibility

Non-breaking. An existing `nimblebrain.json` that still carries a `store` block logs an ignored-unknown-key warning (`[config] Warning: unknown key "store" ... (ignored)`) and loads unchanged — config validation warns on unknown keys, it doesn't reject. The conversation **store classes** (`JsonlConversationStore`, `InMemoryConversationStore`) are unchanged and still exported from `src/index.ts`; only the boot-store *wiring* is removed.

## Verification

`bun run verify` (static + unit + web + bundles + integration) and `cd docs && bun run build` all pass:
- unit/web: 581 pass · bundles: 6 pass · integration: 596 pass / 12 skip / 0 fail
- docs: 54 pages, all internal links valid