### PR TITLE
web: compress and long-cache static SPA assets in Caddy

### DIFF
--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -38,8 +38,16 @@
 		header Cache-Control "no-store"
 		respond `window.__NB_CONFIG__ = {"tenantId":"{$NB_TENANT_ID:}","environment":"{$NB_SENTRY_ENV:}","release":"{$NB_VERSION:}","sentry":{"dsn":"{$NB_SENTRY_DSN:}","enabled":"{$NB_SENTRY_ENABLED:false}","tracesSampleRate":"{$NB_SENTRY_TRACES_SAMPLE_RATE:0}"},"posthog":{"key":"{$NB_POSTHOG_KEY:}","enabled":"{$NB_POSTHOG_ENABLED:false}"}};` 200
 	}
+	# Static SPA assets. Compression + immutable caching are scoped to THIS handler
+	# only — deliberately not applied to the reverse-proxied /v1 and /mcp routes,
+	# whose SSE/streamable-HTTP responses must not be buffered by an encoder.
 	handle {
+		encode zstd gzip
 		root * /srv
+		# Content-hashed build output (index-<hash>.js/.css) is immutable — cache hard.
+		# index.html itself falls through uncached so a new deploy is picked up at once.
+		@immutable path /assets/*
+		header @immutable Cache-Control "public, max-age=31536000, immutable"
 		try_files {path} /index.html
 		file_server
 	}

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -44,10 +44,15 @@
 	handle {
 		encode zstd gzip
 		root * /srv
-		# Content-hashed build output (index-<hash>.js/.css) is immutable — cache hard.
-		# index.html itself falls through uncached so a new deploy is picked up at once.
+		# Content-hashed build output (index-<hash>.js/.css) is immutable — cache forever.
 		@immutable path /assets/*
 		header @immutable Cache-Control "public, max-age=31536000, immutable"
+		# The HTML entry (and any non-hashed file) must revalidate every load: a deploy
+		# rewrites index.html to point at the new hashed chunks, so it has to be re-fetched
+		# to be picked up — no-cache forces an ETag revalidation instead of leaving it to
+		# heuristic cache freshness, which could otherwise serve a stale app after a deploy.
+		@html not path /assets/*
+		header @html Cache-Control "no-cache"
 		try_files {path} /index.html
 		file_server
 	}


### PR DESCRIPTION
## Problem

The web tier serves the built SPA **uncompressed and uncached**. The main chunk is **2,541,484 bytes (~2.5 MB) on the wire** — verified live: no `content-encoding` even when the client sends `Accept-Encoding: br, gzip`, and no `Cache-Control` on the content-hashed assets. It's a render-blocking resource (the app can't paint until it loads), so first open is slow on any non-fast link, and every subsequent open re-downloads the full bundle.

Measured on the current bundle:

| | Bytes | vs raw |
|---|--:|--:|
| raw (today) | 2,541,484 | 1.0× |
| gzip -9 | 669,556 | **3.8×** smaller |
| brotli -11 | 553,558 | **4.6×** smaller |

## Change

Scoped to the static-file `handle` block only:

- **`encode zstd gzip`** — 4–5× smaller render-blocking payload.
- **`Cache-Control: public, max-age=31536000, immutable` on `/assets/*`** — filenames are content-hashed (`index-<hash>.js`), so they're safe to cache forever; repeat opens hit browser cache. `index.html` falls through uncached (new deploys picked up immediately); `config.js` keeps its `no-store`.

Compression is **deliberately not** applied to the reverse-proxied `/v1` and `/mcp` routes — those carry the SSE run-event stream and the streamable-HTTP MCP transport, which must not be buffered by an encoder. That's why `encode` lives inside the static handler, not at the site level.

## Not in scope (follow-up)

This is the zero-risk 80/20 (compression). The bundle is 2.5 MB in the first place because **`streamdown` → `mermaid@11` → `d3` + `dagre`** (plus the `marked` / `unified` / `remark` / `rehype` markdown pipeline and `katex`) all land in **one eager chunk** — vite has no `build.rollupOptions.manualChunks` and nothing is dynamically imported, so mermaid/d3 ship to every user even though most turns render no diagram. Splitting the diagram/math renderer behind a dynamic import is the real size fix and wants its own PR + testing.

## Verification

- Caddyfile syntax is standard; `caddy validate` not run (no Caddy CLI locally) — please confirm on image build. Standard Caddy includes both gzip and zstd encoders.
- `bun run verify` does not cover the Caddyfile (config-only change).