### PR TITLE
ci: validate web Caddyfile

### DIFF
--- a/.github/workflows/caddyfile-ci.yml
+++ b/.github/workflows/caddyfile-ci.yml
@@ -1,0 +1,30 @@
+name: Caddyfile CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "web/Caddyfile"
+      - ".github/workflows/caddyfile-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "web/Caddyfile"
+      - ".github/workflows/caddyfile-ci.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  validate-caddyfile:
+    name: Validate Caddyfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate web/Caddyfile
+        run: |
+          docker run --rm \
+            -v "$PWD/web/Caddyfile:/etc/caddy/Caddyfile:ro" \
+            caddy:2-alpine \
+            caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile


### PR DESCRIPTION
## Summary
- add a focused Caddyfile CI workflow for changes to web/Caddyfile
- validate with caddy:2-alpine, matching the production web image
- include the workflow file in the path filter so updates to the check run it too

Closes #604

## Validation
- Not run locally: Docker is not installed in this environment (docker: command not found).